### PR TITLE
WIP - Setup Codecov coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,10 @@ jobs:
 
 notifications:
   irc: "chat.freenode.net#podman"
+
+after_success:
+    - make ginkgo
+    - cp ./test/e2e/coverage.txt .
+    - bash <(curl -s https://codecov.io/bash) -t 52d2da88-a97c-442b-8c9f-1f77a5a26b7c
+    - ls -alF ./test/e2e/coverage.txt
+    - cat ./test/e2e/coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -146,10 +146,10 @@ localunit: varlink_generate
 	$(GO) test -tags "$(BUILDTAGS)" -cover $(PACKAGES)
 
 ginkgo:
-	ginkgo -v test/e2e/
+	ginkgo -v test/e2e/ -cover -coverprofile=coverage.txt -covermode=atomic
 
 localintegration: varlink_generate test-binaries clientintegration
-	ginkgo -v -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.
+	ginkgo -v -coverprofile=coverage.txt -covermode=atomic -flakeAttempts 3 -progress -trace -noColor test/e2e/.
 
 clientintegration:
 	$(MAKE) -C contrib/python integration


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Setup code coverage testing via Codecov.  I'm having difficulties getting this to work for Buildah, but think it might here due to how the e2e testing is setup in libpod.   I've marked it a WIP for now, if it works, we can evaluate it's usefulness and timeliness.