### PR TITLE
Makefile: Call contrib/python's clean regardless of HAS_PYTHON3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,12 +138,10 @@ clean:
 		libpod/container_easyjson.go \
 		libpod/pod_easyjson.go \
 		$(MANPAGES) ||:
-ifdef HAS_PYTHON3
-		$(MAKE) -C contrib/python/podman clean
-		$(MAKE) -C contrib/python/pypodman clean
-endif
 	find . -name \*~ -delete
 	find . -name \#\* -delete
+	$(MAKE) -C contrib/python/podman clean
+	$(MAKE) -C contrib/python/pypodman clean
 
 libpodimage:
 	docker build -t ${LIBPOD_IMAGE} .

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ ifneq (,$(findstring varlink,$(BUILDTAGS)))
 	PODMAN_VARLINK_DEPENDENCIES = cmd/podman/varlink/iopodman.go
 endif
 
-PYTHON ?= /usr/bin/python3
 HAS_PYTHON3 := $(shell command -v python3 2>/dev/null)
 
 BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions

--- a/contrib/python/podman/Makefile
+++ b/contrib/python/podman/Makefile
@@ -1,4 +1,4 @@
-PYTHON ?= /usr/bin/python3
+PYTHON ?= $(shell command -v python3 2>/dev/null || command -v python)
 DESTDIR ?= /
 
 .PHONY: python-podman
@@ -26,7 +26,7 @@ uninstall:
 
 .PHONY: clean
 clean:
-	$(PYTHON) setup.py clean --all
 	rm -rf podman.egg-info dist
 	find . -depth -name __pycache__ -exec rm -rf {} \;
 	find . -depth -name \*.pyc -exec rm -f {} \;
+	$(PYTHON) ./setup.py clean --all

--- a/contrib/python/podman/setup.py
+++ b/contrib/python/podman/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import os
 
 from setuptools import find_packages, setup

--- a/contrib/python/pypodman/Makefile
+++ b/contrib/python/pypodman/Makefile
@@ -1,4 +1,4 @@
-PYTHON ?= /usr/bin/python3
+PYTHON ?= $(shell command -v python3 2>/dev/null || command -v python)
 DESTDIR := /
 
 .PHONY: python-pypodman
@@ -25,7 +25,7 @@ clobber: uninstall clean
 
 .PHONY: clean
 clean:
-	$(PYTHON) setup.py clean --all
 	rm -rf pypodman.egg-info dist
 	find . -depth -name __pycache__ -exec rm -rf {} \;
 	find . -depth -name \*.pyc -exec rm -f {} \;
+	$(PYTHON) ./setup.py clean --all

--- a/contrib/python/pypodman/setup.py
+++ b/contrib/python/pypodman/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import os
 
 from setuptools import find_packages, setup


### PR DESCRIPTION
The only Python dependency in `contrib/python`'s `clean` is:

```Makefile
$(PYTHON) setup.py clean --all
```

and our `setup.py` works on both major Python versions:

```console
$ make -C contrib/python PYTHON=python2 clean
make: Entering directory '/.../src/github.com/projectatomic/libpod/contrib/python'
python2 setup.py clean --all
running clean
'build/lib' does not exist -- can't clean it
'build/bdist.linux-aarch64' does not exist -- can't clean it
'build/scripts-2.7' does not exist -- can't clean it
rm -rf podman.egg-info dist
find . -depth -name __pycache__ -exec rm -rf {} \;
make: Leaving directory '/.../src/github.com/projectatomic/libpod/contrib/python'
$ echo $?
0
```

Spun off from [here][1], cc @baude.

[1]: https://github.com/projectatomic/libpod/pull/813#discussion_r189488041