### PR TITLE
podman in rootless mode will only work with cgroupfs at this point.

### DIFF
--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -105,6 +105,10 @@ func GetRuntimeWithStorageOpts(c *cli.Context, storageOpts *storage.StoreOptions
 
 	if c.GlobalIsSet("cgroup-manager") {
 		options = append(options, libpod.WithCgroupManager(c.GlobalString("cgroup-manager")))
+	} else {
+		if rootless.IsRootless() {
+			options = append(options, libpod.WithCgroupManager("cgroupfs"))
+		}
 	}
 
 	// TODO flag to set libpod static dir?


### PR DESCRIPTION
If user does not pass in cgroup manager and running in rootless mode,
then we need to force the cgroupfs support until/unless we get support
for rootless systemd support.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>