### PR TITLE
Remove unused function in runtime.go

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -714,8 +714,3 @@ func (r *Runtime) generateName() (string, error) {
 func (r *Runtime) ImageRuntime() *image.Runtime {
 	return r.imageRuntime
 }
-
-// GetLayers returns the layers available in the store
-func (r *Runtime) GetLayers() ([]storage.Layer, error) {
-	return r.store.Layers()
-}


### PR DESCRIPTION
Don't really want this to be part of the public API, and nothing uses it, so axe it.