### PR TITLE
Create pod CGroups with the systemd driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ jobs:
       env: ALLOWED_TO_FAIL=true
     - stage: Integration Test
       script:
-        - make all
         - make integration
       go: 1.9.x
   allow_failures:

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -43,7 +43,7 @@ const CgroupfsDefaultCgroupParent = "/libpod_parent"
 
 // SystemdDefaultCgroupParent is the cgroup parent for the systemd cgroup
 // manager in libpod
-const SystemdDefaultCgroupParent = "system.slice"
+const SystemdDefaultCgroupParent = "machine.slice"
 
 // LinuxNS represents a Linux namespace
 type LinuxNS int

--- a/libpod/pod_internal.go
+++ b/libpod/pod_internal.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"time"
@@ -67,8 +68,11 @@ func (p *Pod) refresh() error {
 	if p.config.UsePodCgroup {
 		switch p.runtime.config.CgroupManager {
 		case SystemdCgroupsManager:
-			// NOOP for now, until proper systemd cgroup management
-			// is implemented
+			cgroupPath, err := systemdSliceFromPath(p.config.CgroupParent, fmt.Sprintf("libpod_pod_%s", p.ID()))
+			if err != nil {
+				logrus.Errorf("Error creating CGroup for pod %s: %v", p.ID(), err)
+			}
+			p.state.CgroupPath = cgroupPath
 		case CgroupfsCgroupsManager:
 			p.state.CgroupPath = filepath.Join(p.config.CgroupParent, p.ID())
 

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -9,12 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/cgroups"
 	"github.com/containers/image/signature"
 	"github.com/containers/image/types"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // Runtime API constants
@@ -123,62 +121,6 @@ func WaitForFile(path string, timeout time.Duration) error {
 		close(chControl)
 		return errors.Wrapf(ErrInternal, "timed out waiting for file %s", path)
 	}
-}
-
-// systemdSliceFromPath makes a new systemd slice under the given parent with
-// the given name.
-// The parent must be a slice. The name must NOT include ".slice"
-func systemdSliceFromPath(parent, name string) (string, error) {
-	cgroupPath, err := assembleSystemdCgroupName(parent, name)
-	if err != nil {
-		return "", err
-	}
-
-	logrus.Debugf("Created cgroup path %s for parent %s and name %s", cgroupPath, parent, name)
-
-	if err := makeSystemdCgroup(cgroupPath); err != nil {
-		return "", errors.Wrapf(err, "error creating cgroup %s", cgroupPath)
-	}
-
-	logrus.Debugf("Created cgroup %s", cgroupPath)
-
-	return cgroupPath, nil
-}
-
-// makeSystemdCgroup creates a systemd CGroup at the given location.
-func makeSystemdCgroup(path string) error {
-	controller, err := cgroups.NewSystemd(SystemdDefaultCgroupParent)
-	if err != nil {
-		return err
-	}
-
-	return controller.Create(path, &spec.LinuxResources{})
-}
-
-// deleteSystemdCgroup deletes the systemd cgroup at the given location
-func deleteSystemdCgroup(path string) error {
-	controller, err := cgroups.NewSystemd(SystemdDefaultCgroupParent)
-	if err != nil {
-		return err
-	}
-
-	return controller.Delete(path)
-}
-
-// assembleSystemdCgroupName creates a systemd cgroup path given a base and
-// a new component to add.
-// The base MUST be systemd slice (end in .slice)
-func assembleSystemdCgroupName(baseSlice, newSlice string) (string, error) {
-	const sliceSuffix = ".slice"
-
-	if !strings.HasSuffix(baseSlice, sliceSuffix) {
-		return "", errors.Wrapf(ErrInvalidArg, "cannot assemble cgroup path with base %q - must end in .slice", baseSlice)
-	}
-
-	noSlice := strings.TrimSuffix(baseSlice, sliceSuffix)
-	final := fmt.Sprintf("%s/%s-%s%s", baseSlice, noSlice, newSlice, sliceSuffix)
-
-	return final, nil
 }
 
 type byDestination []spec.Mount

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/cgroups"
 	"github.com/containers/image/signature"
 	"github.com/containers/image/types"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // Runtime API constants
@@ -121,6 +123,62 @@ func WaitForFile(path string, timeout time.Duration) error {
 		close(chControl)
 		return errors.Wrapf(ErrInternal, "timed out waiting for file %s", path)
 	}
+}
+
+// systemdSliceFromPath makes a new systemd slice under the given parent with
+// the given name.
+// The parent must be a slice. The name must NOT include ".slice"
+func systemdSliceFromPath(parent, name string) (string, error) {
+	cgroupPath, err := assembleSystemdCgroupName(parent, name)
+	if err != nil {
+		return "", err
+	}
+
+	logrus.Debugf("Created cgroup path %s for parent %s and name %s", cgroupPath, parent, name)
+
+	if err := makeSystemdCgroup(cgroupPath); err != nil {
+		return "", errors.Wrapf(err, "error creating cgroup %s", cgroupPath)
+	}
+
+	logrus.Debugf("Created cgroup %s", cgroupPath)
+
+	return cgroupPath, nil
+}
+
+// makeSystemdCgroup creates a systemd CGroup at the given location.
+func makeSystemdCgroup(path string) error {
+	controller, err := cgroups.NewSystemd(SystemdDefaultCgroupParent)
+	if err != nil {
+		return err
+	}
+
+	return controller.Create(path, &spec.LinuxResources{})
+}
+
+// deleteSystemdCgroup deletes the systemd cgroup at the given location
+func deleteSystemdCgroup(path string) error {
+	controller, err := cgroups.NewSystemd(SystemdDefaultCgroupParent)
+	if err != nil {
+		return err
+	}
+
+	return controller.Delete(path)
+}
+
+// assembleSystemdCgroupName creates a systemd cgroup path given a base and
+// a new component to add.
+// The base MUST be systemd slice (end in .slice)
+func assembleSystemdCgroupName(baseSlice, newSlice string) (string, error) {
+	const sliceSuffix = ".slice"
+
+	if !strings.HasSuffix(baseSlice, sliceSuffix) {
+		return "", errors.Wrapf(ErrInvalidArg, "cannot assemble cgroup path with base %q - must end in .slice", baseSlice)
+	}
+
+	noSlice := strings.TrimSuffix(baseSlice, sliceSuffix)
+	final := fmt.Sprintf("%s/%s-%s%s", baseSlice, noSlice, newSlice, sliceSuffix)
+
+	return final, nil
 }
 
 type byDestination []spec.Mount

--- a/libpod/util_linux.go
+++ b/libpod/util_linux.go
@@ -1,0 +1,69 @@
+// +build linux
+
+package libpod
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containerd/cgroups"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// systemdSliceFromPath makes a new systemd slice under the given parent with
+// the given name.
+// The parent must be a slice. The name must NOT include ".slice"
+func systemdSliceFromPath(parent, name string) (string, error) {
+	cgroupPath, err := assembleSystemdCgroupName(parent, name)
+	if err != nil {
+		return "", err
+	}
+
+	logrus.Debugf("Created cgroup path %s for parent %s and name %s", cgroupPath, parent, name)
+
+	if err := makeSystemdCgroup(cgroupPath); err != nil {
+		return "", errors.Wrapf(err, "error creating cgroup %s", cgroupPath)
+	}
+
+	logrus.Debugf("Created cgroup %s", cgroupPath)
+
+	return cgroupPath, nil
+}
+
+// makeSystemdCgroup creates a systemd CGroup at the given location.
+func makeSystemdCgroup(path string) error {
+	controller, err := cgroups.NewSystemd(SystemdDefaultCgroupParent)
+	if err != nil {
+		return err
+	}
+
+	return controller.Create(path, &spec.LinuxResources{})
+}
+
+// deleteSystemdCgroup deletes the systemd cgroup at the given location
+func deleteSystemdCgroup(path string) error {
+	controller, err := cgroups.NewSystemd(SystemdDefaultCgroupParent)
+	if err != nil {
+		return err
+	}
+
+	return controller.Delete(path)
+}
+
+// assembleSystemdCgroupName creates a systemd cgroup path given a base and
+// a new component to add.
+// The base MUST be systemd slice (end in .slice)
+func assembleSystemdCgroupName(baseSlice, newSlice string) (string, error) {
+	const sliceSuffix = ".slice"
+
+	if !strings.HasSuffix(baseSlice, sliceSuffix) {
+		return "", errors.Wrapf(ErrInvalidArg, "cannot assemble cgroup path with base %q - must end in .slice", baseSlice)
+	}
+
+	noSlice := strings.TrimSuffix(baseSlice, sliceSuffix)
+	final := fmt.Sprintf("%s/%s-%s%s", baseSlice, noSlice, newSlice, sliceSuffix)
+
+	return final, nil
+}

--- a/libpod/util_unsupported.go
+++ b/libpod/util_unsupported.go
@@ -1,0 +1,23 @@
+// +build !linux
+
+package libpod
+
+import (
+	"github.com/pkg/errors"
+)
+
+func systemdSliceFromPath(parent, name string) (string, error) {
+	return "", errors.Wrapf(ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
+}
+
+func makeSystemdCgroup(path string) error {
+	return errors.Wrapf(ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
+}
+
+func deleteSystemdCgroup(path string) error {
+	return errors.Wrapf(ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
+}
+
+func assembleSystemdCgroupName(baseSlice, newSlice string) (string, error) {
+	return "", errors.Wrapf(ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
+}


### PR DESCRIPTION
Like the name says. Expand pod support so we now create per-pod CGroups when managed by systemd.

Also change the default parent to machine.slice (more correct than system.slice - it's where containers are supposed to go)