### PR TITLE
rootless: not require userns for help/version

### DIFF
--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -34,6 +34,16 @@ var _ = Describe("Podman rootless", func() {
 		GinkgoWriter.Write([]byte(timedResult))
 	})
 
+	It("podman rootless help|version", func() {
+		commands := []string{"help", "version"}
+		for _, v := range commands {
+			env := os.Environ()
+			cmd := podmanTest.PodmanAsUser([]string{v}, 1000, 1000, env)
+			cmd.WaitWithDefaultTimeout()
+			Expect(cmd.ExitCode()).To(Equal(0))
+		}
+	})
+
 	It("podman rootless rootfs", func() {
 		// Check if we can create an user namespace
 		err := exec.Command("unshare", "-r", "echo", "hello").Run()


### PR DESCRIPTION
these commands do not require to be root in an userns

Closes: https://github.com/containers/libpod/issues/1263

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>