### PR TITLE
--network=host should assume host's hostname

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -575,6 +575,16 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 		return nil, errors.Errorf("invalid image-volume type %q. Pick one of bind, tmpfs, or ignore", c.String("image-volume"))
 	}
 
+	hostname := c.String("hostname")
+	// If the user does not set the hostname and they set the network to host, the
+	// container's hostname should be the same as the host
+	if !c.IsSet("hostname") && c.String("network") == "host" {
+		hostname, err = os.Hostname()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	config := &cc.CreateConfig{
 		Runtime:           runtime,
 		Annotations:       annotations,
@@ -594,7 +604,7 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 		Env:               env,
 		//ExposedPorts:   ports,
 		GroupAdd:       c.StringSlice("group-add"),
-		Hostname:       c.String("hostname"),
+		Hostname:       hostname,
 		HostAdd:        c.StringSlice("add-host"),
 		IDMappings:     idmappings,
 		Image:          imageName,

--- a/pkg/varlinkapi/containers_create.go
+++ b/pkg/varlinkapi/containers_create.go
@@ -135,6 +135,14 @@ func varlinkCreateToCreateConfig(ctx context.Context, create iopodman.Create, ru
 		workDir = "/"
 	}
 
+	hostname := create.Hostname
+	if networkMode == "host" && hostname == "" {
+		hostname, err = os.Hostname()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	imageID := data.ID
 	config := &cc.CreateConfig{
 		Runtime:           runtime,
@@ -153,7 +161,7 @@ func varlinkCreateToCreateConfig(ctx context.Context, create iopodman.Create, ru
 		Entrypoint:        create.Entrypoint,
 		Env:               create.Env,
 		GroupAdd:          create.Group_add,
-		Hostname:          create.Hostname,
+		Hostname:          hostname,
 		HostAdd:           create.Host_add,
 		IDMappings:        idmappings,
 		Image:             imageName,

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -98,4 +98,18 @@ var _ = Describe("Podman rmi", func() {
 		Expect(containerConfig[0].NetworkSettings.Ports[0].HostPort).ToNot(Equal("80"))
 	})
 
+	It("podman run host network; container should have same hostname as host", func() {
+		hostname, _ := os.Hostname()
+		session := podmanTest.Podman([]string{"run", "-it", "--net=host", ALPINE, "hostname"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.OutputToString()).To(Equal(hostname))
+	})
+
+	It("podman run host network; user input hostname overrides host's hostname", func() {
+		hostname := "foobar"
+		session := podmanTest.Podman([]string{"run", "-it", "--net=host", "--hostname", "foobar", ALPINE, "hostname"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.OutputToString()).To(Equal(hostname))
+	})
+
 })


### PR DESCRIPTION
when running a container with --network=host, the container should assume
the host's hostname unless otherwise specified with --hostname.

Signed-off-by: baude <bbaude@redhat.com>