### PR TITLE
Fix handling of hostname in --net=host

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -1,6 +1,7 @@
 package createconfig
 
 import (
+	"os"
 	"strings"
 
 	"github.com/docker/docker/daemon/caps"
@@ -73,6 +74,14 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 		g.AddAnnotation(key, val)
 	}
 	g.SetRootReadonly(config.ReadOnlyRootfs)
+	if config.Hostname == "" {
+		if config.NetMode.IsHost() {
+			config.Hostname, err = os.Hostname()
+			if err != nil {
+				return nil, errors.Wrap(err, "unable to retrieve hostname")
+			}
+		}
+	}
 	g.SetHostname(config.Hostname)
 	if config.Hostname != "" {
 		g.AddProcessEnv("HOSTNAME", config.Hostname)


### PR DESCRIPTION
Hostname should be set to the hosts hostname when network is none.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>