### PR TITLE
spec: bind mount /sys only for rootless containers

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -34,7 +34,7 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 			Options:     []string{"nosuid", "noexec", "nodev", "rw"},
 		}
 		g.AddMount(sysMnt)
-	} else if !config.UsernsMode.IsHost() && config.NetMode.IsHost() {
+	} else if rootless.IsRootless() && !config.UsernsMode.IsHost() && config.NetMode.IsHost() {
 		addCgroup = false
 		g.RemoveMount("/sys")
 		sysMnt := spec.Mount{


### PR DESCRIPTION
root can always mount a new instance.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>