### PR TITLE
Revert "spec: bind mount /sys only for rootless containers"

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -35,7 +35,7 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 			Options:     []string{"nosuid", "noexec", "nodev", "rw"},
 		}
 		g.AddMount(sysMnt)
-	} else if rootless.IsRootless() && !config.UsernsMode.IsHost() && config.NetMode.IsHost() {
+	} else if !config.UsernsMode.IsHost() && config.NetMode.IsHost() {
 		addCgroup = false
 		g.RemoveMount("/sys")
 		sysMnt := spec.Mount{


### PR DESCRIPTION
It breaks "podman  run --net=host --uidmap=0:1:70000 --gidmap=0:20000:70000 busybox echo hi"

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>