### PR TITLE
Vendor in latest containers/psgo code

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,7 @@ github.com/containernetworking/cni v0.7.0-alpha1
 github.com/containernetworking/plugins 1562a1e60ed101aacc5e08ed9dbeba8e9f3d4ec1
 github.com/containers/image 134f99bed228d6297dc01d152804f6f09f185418
 github.com/containers/storage 17c7d1fee5603ccf6dd97edc14162fc1510e7e23
-github.com/containers/psgo 382fc951fe0a8aba62043862ce1a56f77524db87
+github.com/containers/psgo master
 github.com/coreos/go-systemd v14
 github.com/cri-o/ocicni master
 github.com/cyphar/filepath-securejoin v0.2.1

--- a/vendor/github.com/containers/psgo/README.md
+++ b/vendor/github.com/containers/psgo/README.md
@@ -46,6 +46,8 @@ root   1     0      0.000   17.249905587s   ?     0s     sleep
 ### Format descriptors
 The ps library is compatible with all AIX format descriptors of the ps command-line utility (see `man 1 ps` for details) but it also supports some additional descriptors that can be useful when seeking specific process-related information.
 
+- **capamb**
+  - Set of ambient capabilities. See capabilities(7) for more information.
 - **capbnd**
   - Set of bounding capabilities. See capabilities(7) for more information.
 - **capeff**

--- a/vendor/github.com/containers/psgo/internal/proc/ns.go
+++ b/vendor/github.com/containers/psgo/internal/proc/ns.go
@@ -13,3 +13,12 @@ func ParsePIDNamespace(pid string) (string, error) {
 	}
 	return pidNS, nil
 }
+
+// ParseUserNamespace returns the content of /proc/$pid/ns/user.
+func ParseUserNamespace(pid string) (string, error) {
+	userNS, err := os.Readlink(fmt.Sprintf("/proc/%s/ns/user", pid))
+	if err != nil {
+		return "", err
+	}
+	return userNS, nil
+}

--- a/vendor/github.com/containers/psgo/internal/types/types.go
+++ b/vendor/github.com/containers/psgo/internal/types/types.go
@@ -1,0 +1,8 @@
+package types
+
+// PsContext controls some internals of the psgo library.
+type PsContext struct {
+	// JoinUserNS will force /proc and /dev parsing from within each PIDs
+	// user namespace.
+	JoinUserNS bool
+}


### PR DESCRIPTION
This fixes a couple of issues with podman top.

podman top --latest USER HUSER

Now shows you the User inside of the containers usernamespace as well as the user on the host.

podman top --latest capeff capbnd

Now has headings that differentiatiate between the Capabiltiies.  We also have support for
ambient capabilities.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>