### PR TITLE
Fix handling of socket connection refusal.

### DIFF
--- a/contrib/python/podman/podman/client.py
+++ b/contrib/python/podman/podman/client.py
@@ -175,12 +175,12 @@ class Client():
             if not System(self._client).ping():
                 raise ConnectionRefusedError(
                     errno.ECONNREFUSED,
-                    'Failed varlink connection "{}"'.format(address), address)
+                    ('Failed varlink connection "{}"').format(address))
         except FileNotFoundError:
             raise ConnectionError(
                 errno.ECONNREFUSED,
                 ('Failed varlink connection "{}".'
-                 ' Is podman service running?').format(address), address)
+                 ' Is podman socket or service running?').format(address))
 
     def __enter__(self):
         """Return `self` upon entering the runtime context."""


### PR DESCRIPTION
Currently if the socket was never started you get an error about
the service being started.  But if the service was started and later
stopped, you get a useless error.

This change causes the error to always be the same for connection refused.

The error message was also repeating the address twice which looked bad.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>