### PR TITLE
Mention that systemd is the default cgroup manager

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -144,7 +144,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "cgroup-manager",
-			Usage: "cgroup manager to use (cgroupfs or systemd, default cgroupfs)",
+			Usage: "cgroup manager to use (cgroupfs or systemd, default systemd)",
 		},
 		cli.StringFlag{
 			Name:  "cni-config-dir",

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -25,7 +25,7 @@ Print usage statement
 
 **--cgroup-manager**
 
-CGroup manager to use for container cgroups. Supported values are cgroupfs (default) or systemd. Setting this flag can cause certain commands to break when called on containers created by the other CGroup manager type.
+CGroup manager to use for container cgroups. Supported values are cgroupfs or systemd (default). Setting this flag can cause certain commands to break when called on containers created by the other CGroup manager type.
 
 **--config value, -c**=**"config.file"**
 


### PR DESCRIPTION
Update docs to reflect our changed default CGroup manager.

Fixes: #1292