### PR TITLE
Make failure to retrieve individual ctrs/pods nonfatal

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -705,7 +705,11 @@ func (s *BoltState) AllContainers() ([]*Container, error) {
 				// We just won't include the container in the
 				// results.
 				if errors.Cause(err) != ErrNSMismatch {
-					return err
+					// Even if it's not an NS mismatch, it's
+					// not worth erroring over.
+					// If we do, a single bad container JSON
+					// could render libpod unusable.
+					logrus.Errorf("Error retrieving container %s from the database: %v", string(id), err)
 				}
 			} else {
 				ctrs = append(ctrs, ctr)
@@ -1655,7 +1659,7 @@ func (s *BoltState) AllPods() ([]*Pod, error) {
 
 			if err := s.getPodFromDB(id, pod, podBucket); err != nil {
 				if errors.Cause(err) != ErrNSMismatch {
-					return err
+					logrus.Errorf("Error retrieving pod %s from the database: %v", string(id), err)
 				}
 			} else {
 				pods = append(pods, pod)


### PR DESCRIPTION
This ensures that we can still use Podman even if a container or pod with bad config JSON makes it into the state. We still can't remove these containers, but at least we can do our best to make
things usable.

This is an initial step towards fixing #1283 - I think a more complete step would be an API to go through the state, detect inconsistencies like this, and purge them to restore a consistent state.