### PR TITLE
Fix handling of devices

### DIFF
--- a/pkg/spec/config_linux.go
+++ b/pkg/spec/config_linux.go
@@ -28,10 +28,15 @@ func Device(d *configs.Device) spec.LinuxDevice {
 }
 
 func addDevice(g *generate.Generator, device string) error {
-	dev, err := devices.DeviceFromPath(device, "rwm")
+	src, dst, permissions, err := parseDevice(device)
 	if err != nil {
-		return errors.Wrapf(err, "%s is not a valid device", device)
+		return err
 	}
+	dev, err := devices.DeviceFromPath(src, permissions)
+	if err != nil {
+		return errors.Wrapf(err, "%s is not a valid device", src)
+	}
+	dev.Path = dst
 	linuxdev := spec.LinuxDevice{
 		Path:     dev.Path,
 		Type:     string(dev.Type),

--- a/pkg/spec/parse.go
+++ b/pkg/spec/parse.go
@@ -126,3 +126,58 @@ func getLoggingPath(opts []string) string {
 	}
 	return ""
 }
+
+// parseDevice parses device mapping string to a src, dest & permissions string
+func parseDevice(device string) (string, string, string, error) { //nolint
+	src := ""
+	dst := ""
+	permissions := "rwm"
+	arr := strings.Split(device, ":")
+	switch len(arr) {
+	case 3:
+		if !validDeviceMode(arr[2]) {
+			return "", "", "", fmt.Errorf("invalid device mode: %s", arr[2])
+		}
+		permissions = arr[2]
+		fallthrough
+	case 2:
+		if validDeviceMode(arr[1]) {
+			permissions = arr[1]
+		} else {
+			if arr[1][0] != '/' {
+				return "", "", "", fmt.Errorf("invalid device mode: %s", arr[2])
+			}
+			dst = arr[1]
+		}
+		fallthrough
+	case 1:
+		src = arr[0]
+	default:
+		return "", "", "", fmt.Errorf("invalid device specification: %s", device)
+	}
+
+	if dst == "" {
+		dst = src
+	}
+	return src, dst, permissions, nil
+}
+
+// validDeviceMode checks if the mode for device is valid or not.
+// Valid mode is a composition of r (read), w (write), and m (mknod).
+func validDeviceMode(mode string) bool {
+	var legalDeviceMode = map[rune]bool{
+		'r': true,
+		'w': true,
+		'm': true,
+	}
+	if mode == "" {
+		return false
+	}
+	for _, c := range mode {
+		if !legalDeviceMode[c] {
+			return false
+		}
+		legalDeviceMode[c] = false
+	}
+	return true
+}

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Podman kill", func() {
+var _ = Describe("Podman run device", func() {
 	var (
 		tempdir    string
 		err        error
@@ -42,5 +42,31 @@ var _ = Describe("Podman kill", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Equal("/dev/kmsg"))
+	})
+
+	It("podman run device rename test", func() {
+		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/kmsg:/dev/kmsg1", ALPINE, "ls", "--color=never", "/dev/kmsg1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("/dev/kmsg1"))
+	})
+
+	It("podman run device permission test", func() {
+		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/kmsg:r", ALPINE, "ls", "--color=never", "/dev/kmsg"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("/dev/kmsg"))
+	})
+
+	It("podman run device rename and permission test", func() {
+		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/kmsg:/dev/kmsg1:r", ALPINE, "ls", "--color=never", "/dev/kmsg1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("/dev/kmsg1"))
+	})
+	It("podman run device rename and bad permission test", func() {
+		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/kmsg:/dev/kmsg1:rd", ALPINE, "ls", "--color=never", "/dev/kmsg1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
 })


### PR DESCRIPTION
Devices are supposed to be able to be passed in via the form of

--device /dev/foo
--device /dev/foo:/dev/bar
--device /dev/foo:rwm
--device /dev/foo:/dev/bar:rwm

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>