### PR TITLE
Fix mount propagation.

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -107,7 +107,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 			Type:        "bind",
 			Source:      srcPath,
 			Destination: dstPath,
-			Options:     []string{"rw", "bind"},
+			Options:     []string{"rw", "bind", "private"},
 		}
 		if !MountExists(g.Mounts(), dstPath) {
 			g.AddMount(newMount)

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -243,7 +243,7 @@ func addSecretsFromMountsFile(filePath, mountLabel, containerWorkingDir, mountPr
 			Source:      filepath.Join(mountPrefix, ctrDir),
 			Destination: ctrDir,
 			Type:        "bind",
-			Options:     []string{"bind"},
+			Options:     []string{"bind", "private"},
 		}
 
 		mounts = append(mounts, m)
@@ -278,7 +278,7 @@ func addFIPSModeSecret(mounts *[]rspec.Mount, containerWorkingDir string) error 
 			Source:      ctrDirOnHost,
 			Destination: secretsDir,
 			Type:        "bind",
-			Options:     []string{"bind"},
+			Options:     []string{"bind", "private"},
 		}
 		*mounts = append(*mounts, m)
 	}

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -214,7 +214,7 @@ func (c *CreateConfig) GetVolumeMounts(specMounts []spec.Mount) ([]spec.Mount, e
 			Destination: vol,
 			Type:        string(TypeTmpfs),
 			Source:      string(TypeTmpfs),
-			Options:     []string{"rw", "noexec", "nosuid", "nodev", "tmpcopyup"},
+			Options:     []string{"private", "rw", "noexec", "nosuid", "nodev", "tmpcopyup"},
 		}
 		m = append(m, mount)
 	}
@@ -272,7 +272,7 @@ func (c *CreateConfig) GetTmpfsMounts() []spec.Mount {
 	var m []spec.Mount
 	for _, i := range c.Tmpfs {
 		// Default options if nothing passed
-		options := []string{"rw", "noexec", "nosuid", "nodev", "size=65536k"}
+		options := []string{"private", "rw", "noexec", "nosuid", "nodev", "size=65536k"}
 		spliti := strings.Split(i, ":")
 		destPath := spliti[0]
 		if len(spliti) > 1 {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -566,4 +566,34 @@ USER mail`
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
+
+	It("podman run findmnt nothing shared", func() {
+		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
+		err := os.MkdirAll(vol1, 0755)
+		Expect(err).To(BeNil())
+		vol2 := filepath.Join(podmanTest.TempDir, "vol-test2")
+		err = os.MkdirAll(vol2, 0755)
+		Expect(err).To(BeNil())
+
+		session := podmanTest.Podman([]string{"run", "--volume", vol1 + ":/myvol1:z", "--volume", vol2 + ":/myvol2:z", fedoraMinimal, "findmnt", "-o", "TARGET,PROPAGATION"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ := session.GrepString("shared")
+		Expect(match).Should(BeFalse())
+	})
+
+	It("podman run findmnt shared", func() {
+		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
+		err := os.MkdirAll(vol1, 0755)
+		Expect(err).To(BeNil())
+		vol2 := filepath.Join(podmanTest.TempDir, "vol-test2")
+		err = os.MkdirAll(vol2, 0755)
+		Expect(err).To(BeNil())
+
+		session := podmanTest.Podman([]string{"run", "--volume", vol1 + ":/myvol1:z", "--volume", vol2 + ":/myvol2:shared,z", fedoraMinimal, "findmnt", "-o", "TARGET,PROPAGATION"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ := session.GrepString("shared")
+		Expect(match).Should(BeTrue())
+	})
 })


### PR DESCRIPTION
All volumes mount points should default to "private".

Root Propagation needs to default to "shared", since users
could mount a volume in as shared.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>