### PR TITLE
vendor latest github.com/urfave/cli

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -63,7 +63,7 @@ github.com/stretchr/testify 4d4bfba8f1d1027c4fdbe371823030df51419987
 github.com/syndtr/gocapability e7cb7fa329f456b3855136a2642b197bad7366ba
 github.com/tchap/go-patricia v2.2.6
 github.com/ulule/deepcopier master
-github.com/urfave/cli fix-short-opts-parsing https://github.com/vrothberg/cli
+github.com/urfave/cli 934abfb2f102315b5794e15ebc7949e4ca253920
 github.com/vbatts/tar-split v0.10.2
 github.com/vishvananda/netlink master
 github.com/vishvananda/netns master


### PR DESCRIPTION
Change from an external patched branch to the upstream master. The
vendored code is indentical to the previous one.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>