### PR TITLE
Fix a bug with hook ALWAYS matching with a process

### DIFF
--- a/pkg/hooks/1.0.0/when.go
+++ b/pkg/hooks/1.0.0/when.go
@@ -74,7 +74,7 @@ func (when *When) Match(config *rspec.Spec, annotations map[string]string, hasBi
 		}
 	}
 
-	if config.Process != nil {
+	if config.Process != nil && len(when.Commands) > 0 {
 		if len(config.Process.Args) == 0 {
 			return false, errors.New("process.args must have at least one entry")
 		}

--- a/pkg/hooks/1.0.0/when_test.go
+++ b/pkg/hooks/1.0.0/when_test.go
@@ -24,16 +24,22 @@ func TestNoMatch(t *testing.T) {
 
 func TestAlways(t *testing.T) {
 	config := &rspec.Spec{}
+	processStruct := &rspec.Process{
+		Args: []string{"/bin/sh", "a", "b"},
+	}
 	for _, always := range []bool{true, false} {
 		for _, or := range []bool{true, false} {
-			t.Run(fmt.Sprintf("always %t, or %t", always, or), func(t *testing.T) {
-				when := When{Always: &always, Or: or}
-				match, err := when.Match(config, map[string]string{}, false)
-				if err != nil {
-					t.Fatal(err)
-				}
-				assert.Equal(t, always, match)
-			})
+			for _, process := range []*rspec.Process{processStruct, nil} {
+				t.Run(fmt.Sprintf("always %t, or %t, has process %t", always, or, (process != nil)), func(t *testing.T) {
+					config.Process = process
+					when := When{Always: &always, Or: or}
+					match, err := when.Match(config, map[string]string{}, false)
+					if err != nil {
+						t.Fatal(err)
+					}
+					assert.Equal(t, always, match)
+				})
+			}
 		}
 	}
 }


### PR DESCRIPTION
When a non-nil process was used and a hook was set to match always, this would not actually match. Fix this.

Fixes: #1308