### PR TITLE
Touch up cert-dir in man pages

### DIFF
--- a/docs/podman-login.1.md
+++ b/docs/podman-login.1.md
@@ -33,9 +33,9 @@ Username for registry
 
 Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
 
-**--cert-dir**
+**--cert-dir** *path*
 
-Pathname of a directory containing TLS certificates and keys used to connect to the registry.
+Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
 Default certificates directory is _/etc/containers/certs.d_.
 
 **--tls-verify**

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -50,9 +50,9 @@ Image stored in local container/storage
 Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
 
-**--cert-dir**
+**--cert-dir** *path*
 
-Pathname of a directory containing TLS certificates and keys.
+Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
 Default certificates directory is _/etc/containers/certs.d_.
 
 **--creds**

--- a/docs/podman-push.1.md
+++ b/docs/podman-push.1.md
@@ -55,9 +55,9 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
-**cert-dir="PATHNAME"**
+**--cert-dir** *path*
 
-Pathname of a directory containing TLS certificates and keys.
+Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
 Default certificates directory is _/etc/containers/certs.d_.
 
 **--compress**


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

The cert-dir parameter description was recently updated in the podman build man page.  Updating the other pages for clarity and consistency.  