### PR TITLE
exposes tcp port only if no proto specified.

### DIFF
--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -474,10 +474,7 @@ func (c *CreateConfig) CreatePortBindings() ([]ocicni.PortMapping, error) {
 			}
 
 			pm.HostPort = int32(hostPort)
-			// CNI requires us to make both udp and tcp structs
-			pm.Protocol = "udp"
-			portBindings = append(portBindings, pm)
-			pm.Protocol = "tcp"
+			pm.Protocol = containerPb.Proto()
 			portBindings = append(portBindings, pm)
 		}
 	}

--- a/test/e2e/port_test.go
+++ b/test/e2e/port_test.go
@@ -54,7 +54,6 @@ var _ = Describe("Podman port", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		port := strings.Split(result.OutputToStringArray()[0], ":")[1]
-		Expect(result.LineInOuputStartsWith(fmt.Sprintf("80/udp -> 0.0.0.0:%s", port))).To(BeTrue())
 		Expect(result.LineInOuputStartsWith(fmt.Sprintf("80/tcp -> 0.0.0.0:%s", port))).To(BeTrue())
 	})
 


### PR DESCRIPTION
Also it fix the issue of exposing both tc/udp port even if only one proto specified.

Fixes #735 

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>