### PR TITLE
rpm-spec: update distro-specific dependencies

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -64,12 +64,12 @@ Requires: containers-common
 Requires: containernetworking-cni >= 0.6.0-3
 Requires: iptables
 Requires: oci-systemd-hook
-%if 0%{?rhel} && 0%{?rhel} < 8
+%if 0%{?rhel} <= 7
 Requires: container-selinux
-Requires: slirp4netns
 %else
 Recommends: container-selinux
 Recommends: slirp4netns
+Recommends: fuse-overlayfs
 %endif
 
 # vendored libraries


### PR DESCRIPTION
remove slirp4netns as hard dep as it isn't available on rhel7.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>