### PR TITLE
rootless: fix exec

### DIFF
--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -66,6 +67,7 @@ func execCmd(c *cli.Context) error {
 	if c.Bool("latest") {
 		argStart = 0
 	}
+	rootless.SetSkipStorageSetup(true)
 	cmd := args[argStart:]
 	runtime, err := libpodruntime.GetRuntime(c)
 	if err != nil {

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -25,7 +25,7 @@ var (
 	exitCode = 125
 )
 
-var cmdsNotRequiringRootless = map[string]bool{"help": true, "version": true}
+var cmdsNotRequiringRootless = map[string]bool{"help": true, "version": true, "exec": true}
 
 func main() {
 	debug := false

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -335,11 +335,7 @@ func (c *Container) Exec(tty, privileged bool, env, cmd []string, user string) e
 
 	execCmd, err := c.runtime.ociRuntime.execContainer(c, cmd, capList, env, tty, hostUser, sessionID)
 	if err != nil {
-		return errors.Wrapf(err, "error creating exec command for container %s", c.ID())
-	}
-
-	if err := execCmd.Start(); err != nil {
-		return errors.Wrapf(err, "error starting exec command for container %s", c.ID())
+		return errors.Wrapf(err, "error exec %s", c.ID())
 	}
 
 	pidFile := c.execPidPath(sessionID)

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -34,6 +34,20 @@ func IsRootless() bool {
 	return os.Getuid() != 0 || os.Getenv("_LIBPOD_USERNS_CONFIGURED") != ""
 }
 
+var (
+	skipStorageSetup = false
+)
+
+// SetSkipStorageSetup tells the runtime to not setup containers/storage
+func SetSkipStorageSetup(v bool) {
+	skipStorageSetup = v
+}
+
+// SkipStorageSetup tells if we should skip the containers/storage setup
+func SkipStorageSetup() bool {
+	return skipStorageSetup
+}
+
 // GetRootlessUID returns the UID of the user in the parent userNS
 func GetRootlessUID() int {
 	uidEnv := os.Getenv("_LIBPOD_ROOTLESS_UID")

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -3,6 +3,8 @@
 package rootless
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 )
 
@@ -29,4 +31,9 @@ func SetSkipStorageSetup(bool) {
 // SkipStorageSetup tells if we should skip the containers/storage setup
 func SkipStorageSetup() bool {
 	return false
+}
+
+// GetUserNSForPid returns an open FD for the first direct child user namespace that created the process
+func GetUserNSForPid(pid uint) (*os.File, error) {
+	return nil, errors.New("this function is not supported on this os")
 }

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -21,3 +21,12 @@ func BecomeRootInUserNS() (bool, int, error) {
 func GetRootlessUID() int {
 	return -1
 }
+
+// SetSkipStorageSetup tells the runtime to not setup containers/storage
+func SetSkipStorageSetup(bool) {
+}
+
+// SkipStorageSetup tells if we should skip the containers/storage setup
+func SkipStorageSetup() bool {
+	return false
+}

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -117,6 +117,10 @@ var _ = Describe("Podman rootless", func() {
 			Expect(cmd.ExitCode()).To(Equal(0))
 			Expect(cmd.LineInOutputContains("hello")).To(BeTrue())
 
+			cmd = podmanTest.PodmanAsUser([]string{"rm", "-l", "-f"}, 1000, 1000, env)
+			cmd.WaitWithDefaultTimeout()
+			Expect(cmd.ExitCode()).To(Equal(0))
+
 			allArgs = append([]string{"run", "-d"}, args...)
 			allArgs = append(allArgs, "--security-opt", "seccomp=unconfined", "--rootfs", mountPath, "unshare", "-r", "unshare", "-r", "top")
 			cmd = podmanTest.PodmanAsUser(allArgs, 1000, 1000, env)

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -102,6 +102,19 @@ var _ = Describe("Podman rootless", func() {
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.LineInOutputContains("hello")).To(BeTrue())
 			Expect(cmd.ExitCode()).To(Equal(0))
+
+			allArgsD := append([]string{"run", "-d"}, args...)
+			allArgsD = append(allArgsD, "--rootfs", mountPath, "sleep", "1d")
+			cmd = podmanTest.PodmanAsUser(allArgsD, 1000, 1000, env)
+			cmd.WaitWithDefaultTimeout()
+			Expect(cmd.ExitCode()).To(Equal(0))
+			cid := cmd.OutputToStringArray()[0]
+
+			allArgsE := []string{"exec", cid, "echo", "hello"}
+			cmd = podmanTest.PodmanAsUser(allArgsE, 1000, 1000, env)
+			cmd.WaitWithDefaultTimeout()
+			Expect(cmd.ExitCode()).To(Equal(0))
+			Expect(cmd.LineInOutputContains("hello")).To(BeTrue())
 		}
 
 		runRootless(mountPath)


### PR DESCRIPTION
We cannot re-exec into a new user namespace to gain privileges and
access an existing as the new namespace is not the owner of the
existing container.

"unshare" is used to join the user namespace of the target container.

The current implementation assumes that the main process of the
container didn't create a new user namespace.

Since in the setup phase we are not running with euid=0, we must skip
the setup for containers/storage.

Closes: https://github.com/containers/libpod/issues/1329
Closes: https://github.com/containers/libpod/issues/1337

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>