### PR TITLE
rpm-spec: use skopeo-containers instead of containers-common

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -60,7 +60,7 @@ BuildRequires: ostree-devel
 BuildRequires: pkgconfig
 BuildRequires: make
 Requires: runc
-Requires: containers-common
+Requires: skopeo-containers
 Requires: containernetworking-cni >= 0.6.0-3
 Requires: iptables
 Requires: oci-systemd-hook


### PR DESCRIPTION
skopeo-containers is available everywhere, but not containers-common

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>