### PR TITLE
Fix handling of multiple filters in podman ps

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -134,7 +134,7 @@ var (
 			Name:  "all, a",
 			Usage: "Show all the containers, default is only running containers",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:  "filter, f",
 			Usage: "Filter output based on conditions given",
 		},
@@ -222,7 +222,6 @@ func psCmd(c *cli.Context) error {
 
 	opts := shared.PsOptions{
 		All:       c.Bool("all"),
-		Filter:    c.String("filter"),
 		Format:    format,
 		Last:      c.Int("last"),
 		Latest:    c.Bool("latest"),
@@ -246,8 +245,8 @@ func psCmd(c *cli.Context) error {
 		})
 	}
 
-	if opts.Filter != "" {
-		filters := strings.Split(opts.Filter, ",")
+	filters := c.StringSlice("filter")
+	if len(filters) > 0 {
 		for _, f := range filters {
 			filterSplit := strings.SplitN(f, "=", 2)
 			if len(filterSplit) < 2 {
@@ -317,7 +316,7 @@ func generateContainerFilterFuncs(filter, filterValue string, runtime *libpod.Ru
 			return strings.Contains(c.ID(), filterValue)
 		}, nil
 	case "label":
-		var filterArray []string = strings.Split(filterValue, "=")
+		var filterArray []string = strings.SplitN(filterValue, "=", 2)
 		var filterKey string = filterArray[0]
 		if len(filterArray) > 1 {
 			filterValue = filterArray[1]

--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -20,7 +20,6 @@ import (
 // PsOptions describes the struct being formed for ps
 type PsOptions struct {
 	All       bool
-	Filter    string
 	Format    string
 	Last      int
 	Latest    bool

--- a/docs/podman-ps.1.md
+++ b/docs/podman-ps.1.md
@@ -81,7 +81,9 @@ Display namespace information
 
 **--filter, -f**
 
-Filter output based on conditions given
+Filter what containers are shown in the output.
+Multiple filters can be given with multiple uses of the --filter flag.
+If multiple filters are given, only containers which match all of the given filters will be shown.
 
 Valid filters are listed below:
 

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -181,6 +181,25 @@ var _ = Describe("Podman ps", func() {
 		Expect(result.OutputToStringArray()[0]).To(Equal(fullCid))
 	})
 
+	It("podman ps multiple filters", func() {
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "test1", "--label", "key1=value1", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		fullCid := session.OutputToString()
+
+		session2 := podmanTest.Podman([]string{"run", "-d", "--name", "test2", "--label", "key1=value1", ALPINE, "top"})
+		session2.WaitWithDefaultTimeout()
+		Expect(session2.ExitCode()).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"ps", "-aq", "--no-trunc", "--filter", "name=test1", "--filter", "label=key1=value1"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		output := result.OutputToStringArray()
+		Expect(len(output)).To(Equal(1))
+		Expect(output[0]).To(Equal(fullCid))
+	})
+
 	It("podman ps mutually exclusive flags", func() {
 		session := podmanTest.Podman([]string{"ps", "-aqs"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Docker expects multiple filters to be passed with multiple uses of the --filter flag (e.g. --filter=label=a=b --filter=label=c=d) and not a single comma-separated list of filters as we expected. Convert to the Docker format, and make some small cleanups to our handling of filters along the way.

Fixes #1341 