### PR TITLE
rootless: fix --uts=host and --pid=host

### DIFF
--- a/Dockerfile.Fedora
+++ b/Dockerfile.Fedora
@@ -30,6 +30,7 @@ RUN dnf -y install btrfs-progs-devel \
               procps-ng \
               nmap-ncat \
               xz \
+              slirp4netns \
               iptables && dnf clean all
 
 # Install CNI plugins

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -79,6 +79,16 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 		}
 		g.AddMount(devMqueue)
 	}
+	if inUserNS && config.PidMode.IsHost() {
+		g.RemoveMount("/proc")
+		procMount := spec.Mount{
+			Destination: "/proc",
+			Type:        "bind",
+			Source:      "/proc",
+			Options:     []string{"rbind", "nosuid", "noexec", "nodev"},
+		}
+		g.AddMount(procMount)
+	}
 
 	if addCgroup {
 		cgroupMnt := spec.Mount{

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -69,6 +69,16 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 		}
 		g.AddMount(devPts)
 	}
+	if inUserNS && config.IpcMode.IsHost() {
+		g.RemoveMount("/dev/mqueue")
+		devMqueue := spec.Mount{
+			Destination: "/dev/mqueue",
+			Type:        "bind",
+			Source:      "/dev/mqueue",
+			Options:     []string{"bind", "nosuid", "noexec", "nodev"},
+		}
+		g.AddMount(devMqueue)
+	}
 
 	if addCgroup {
 		cgroupMnt := spec.Mount{

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -163,4 +163,8 @@ var _ = Describe("Podman rootless", func() {
 	It("podman rootless rootfs --uts host", func() {
 		runRootless([]string{"--uts", "host"})
 	})
+
+	It("podman rootless rootfs --ipc host", func() {
+		runRootless([]string{"--ipc", "host"})
+	})
 })

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -159,4 +159,8 @@ var _ = Describe("Podman rootless", func() {
 	It("podman rootless rootfs --net host --privileged", func() {
 		runRootless([]string{"--net", "host", "--privileged"})
 	})
+
+	It("podman rootless rootfs --uts host", func() {
+		runRootless([]string{"--uts", "host"})
+	})
 })


### PR DESCRIPTION
Fix --uts=host and --pid=host with rootless containers.

Unfortunately the fix for `--pid=host` is not enough (so no tests were added) as it requires this patch in runc: https://github.com/opencontainers/runc/pull/1832