### PR TITLE
Ensure return errors match API docs

### DIFF
--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -434,8 +434,7 @@ method ListContainerProcesses(name: string, opts: []string) -> (container: []str
 method GetContainerLogs(name: string) -> (container: []string)
 
 # ListContainerChanges takes a name or ID of a container and returns changes between the container and
-# its base image. It returns a struct of changed, deleted, and added path names. If the
-# container cannot be found, a [ContainerNotFound](#ContainerNotFound) error will be returned.
+# its base image. It returns a struct of changed, deleted, and added path names.
 method ListContainerChanges(name: string) -> (container: ContainerChanges)
 
 # ExportContainer creates an image from a container.  It takes the name or ID of a container and a

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -58,7 +58,7 @@ func (i *LibpodAPI) ListImages(call iopodman.VarlinkCall) error {
 func (i *LibpodAPI) GetImage(call iopodman.VarlinkCall, name string) error {
 	newImage, err := i.Runtime.ImageRuntime().NewFromLocal(name)
 	if err != nil {
-		return call.ReplyErrorOccurred(err.Error())
+		return call.ReplyImageNotFound(err.Error())
 	}
 	labels, err := newImage.Labels(getContext())
 	if err != nil {


### PR DESCRIPTION
In the API docs, we generally state the type of error that should be returned
if a container or image cannot be found.  In several cases, the code did not
match the API doc, when the API doc was correct.

Signed-off-by: baude <bbaude@redhat.com>