### PR TITLE
Test RPM build and install for regressions

### DIFF
--- a/.copr/prepare.sh
+++ b/.copr/prepare.sh
@@ -8,7 +8,7 @@ fi
 git fetch --unshallow || :
 
 COMMIT=$(git rev-parse HEAD)
-COMMIT_SHORT=$(git rev-parse --short HEAD)
+COMMIT_SHORT=$(git rev-parse --short=8 HEAD)
 COMMIT_NUM=$(git rev-list HEAD --count)
 COMMIT_DATE=$(date +%s)
 

--- a/.papr.yml
+++ b/.papr.yml
@@ -73,4 +73,13 @@ container:
 tests:
     - sh contrib/build_rpm.sh
 required: true
-context: "RPM regressions"
+context: "Fedora RPM regressions"
+
+---
+
+container:
+    image: registry.centos.org/centos:7
+tests:
+    - sh contrib/build_rpm.sh
+required: true
+context: "CentOS RPM regressions"

--- a/contrib/build_rpm.sh
+++ b/contrib/build_rpm.sh
@@ -1,23 +1,57 @@
 #!/bin/bash
 set -x
-dnf -y install device-mapper-devel \
-		git \
-		glib2-devel \
-		glibc-static \
-		golang \
-		golang-github-cpuguy83-go-md2man \
-		gpgme-devel \
-		libassuan-devel \
-        libseccomp-devel \
-        libselinux-devel \
-        make \
-        ostree-devel \
-        golang-github-cpuguy83-go-md2man \
-        rpm-build \
-        btrfs-progs-devel \
-        python3-devel \
+
+pkg_manager=`command -v dnf`
+if [ -z "$pkg_manager" ]; then
+    pkg_manager=`command -v yum`
+fi
+
+echo "Package manager binary: $pkg_manager"
+
+
+if [ $pkg_manager == "/usr/bin/yum" ]; then
+    echo "[virt7-container-common-candidate]
+name=virt7-container-common-candidate
+baseurl=https://cbs.centos.org/repos/virt7-container-common-candidate/x86_64/os/
+enabled=1
+gpgcheck=0" > /etc/yum.repos.d/container_virt.repo
+fi
+
+declare -a PKGS=(device-mapper-devel \
+                git \
+                glib2-devel \
+                glibc-static \
+                golang \
+                golang-github-cpuguy83-go-md2man \
+                gpgme-devel \
+                libassuan-devel \
+                libseccomp-devel \
+                libselinux-devel \
+                make \
+                ostree-devel \
+                golang-github-cpuguy83-go-md2man \
+                rpm-build \
+                btrfs-progs-devel \
+                go-compilers-golang-compiler \
+                )
+
+if [ $pkg_manager == "/usr/bin/dnf" ]; then
+    PKGS+=(python3-devel \
         python3-varlink \
-        go-compilers-golang-compiler
+        )
+fi
+
+echo ${PKGS[*]}
+$pkg_manager install -y ${PKGS[*]}
 
 make -f .copr/Makefile
 rpmbuild --rebuild podman-*.src.rpm
+
+# Test to make sure the install of the binary works
+$pkg_manager -y install ~/rpmbuild/RPMS/x86_64/podman-*.x86_64.rpm
+
+
+# If we built python/varlink packages, we should test their installs too
+if [ $pkg_manager == "/usr/bin/dnf" ]; then
+    $pkg_manager -y install ~/rpmbuild/RPMS/noarch/python*
+fi

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -61,7 +61,7 @@ BuildRequires: pkgconfig
 BuildRequires: make
 Requires: runc
 Requires: skopeo-containers
-Requires: containernetworking-cni >= 0.6.0-3
+Requires: containernetworking-plugins >= 0.6.0-3
 Requires: iptables
 Requires: oci-systemd-hook
 %if 0%{?rhel} <= 7


### PR DESCRIPTION
On Fedora and now Centos (added), we build RPMs based on the spec in
contrib/spec to make sure we protect against regressions when creating
RPMs.  Once the RPM is built, we then test actually installing the RPM
to ensure that no deps are missing for install.

Signed-off-by: baude <bbaude@redhat.com>