### PR TITLE
rootless: do not create an userns for search, stop, kill, login, logout

### DIFF
--- a/cmd/podman/kill.go
+++ b/cmd/podman/kill.go
@@ -6,6 +6,7 @@ import (
 
 	"fmt"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -45,6 +46,7 @@ func killCmd(c *cli.Context) error {
 		return err
 	}
 
+	rootless.SetSkipStorageSetup(true)
 	runtime, err := libpodruntime.GetRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -29,6 +29,8 @@ var cmdsNotRequiringRootless = map[string]bool{
 	"help":    true,
 	"version": true,
 	"exec":    true,
+	"login":   true,
+	"logout":  true,
 	"kill":    true,
 	"stop":    true,
 }

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -25,7 +25,13 @@ var (
 	exitCode = 125
 )
 
-var cmdsNotRequiringRootless = map[string]bool{"help": true, "version": true, "exec": true, "stop": true}
+var cmdsNotRequiringRootless = map[string]bool{
+	"help":    true,
+	"version": true,
+	"exec":    true,
+	"kill":    true,
+	"stop":    true,
+}
 
 func main() {
 	debug := false

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -32,6 +32,7 @@ var cmdsNotRequiringRootless = map[string]bool{
 	"login":   true,
 	"logout":  true,
 	"kill":    true,
+	"search":  true,
 	"stop":    true,
 }
 

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -25,7 +25,7 @@ var (
 	exitCode = 125
 )
 
-var cmdsNotRequiringRootless = map[string]bool{"help": true, "version": true, "exec": true}
+var cmdsNotRequiringRootless = map[string]bool{"help": true, "version": true, "exec": true, "stop": true}
 
 func main() {
 	debug := false

--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/containers/image/docker"
 	"github.com/containers/libpod/cmd/podman/formats"
-	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod/common"
 	sysreg "github.com/containers/libpod/pkg/registries"
 	"github.com/docker/distribution/reference"
@@ -107,12 +106,6 @@ func searchCmd(c *cli.Context) error {
 	if err := validateFlags(c, searchFlags); err != nil {
 		return err
 	}
-
-	runtime, err := libpodruntime.GetRuntime(c)
-	if err != nil {
-		return errors.Wrapf(err, "could not get runtime")
-	}
-	defer runtime.Shutdown(false)
 
 	format := genSearchFormat(c.String("format"))
 	opts := searchOpts{

--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -55,6 +56,7 @@ func stopCmd(c *cli.Context) error {
 		return err
 	}
 
+	rootless.SetSkipStorageSetup(true)
 	runtime, err := libpodruntime.GetRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -127,6 +127,14 @@ var _ = Describe("Podman rootless", func() {
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
+			cmd = podmanTest.PodmanAsUser([]string{"stop", "-l", "-t", "0"}, 1000, 1000, env)
+			cmd.WaitWithDefaultTimeout()
+			Expect(cmd.ExitCode()).To(Equal(0))
+
+			cmd = podmanTest.PodmanAsUser([]string{"start", "-l"}, 1000, 1000, env)
+			cmd.WaitWithDefaultTimeout()
+			Expect(cmd.ExitCode()).To(Equal(0))
+
 			if !canExec() {
 				Skip("ioctl(NS_GET_PARENT) not supported.")
 			}

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -58,6 +58,13 @@ var _ = Describe("Podman rootless", func() {
 		}
 	})
 
+	chownFunc := func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Lchown(p, 1000, 1000)
+	}
+
 	runRootless := func(args []string) {
 		// Check if we can create an user namespace
 		err := exec.Command("unshare", "-r", "echo", "hello").Run()
@@ -74,13 +81,6 @@ var _ = Describe("Podman rootless", func() {
 		mount.WaitWithDefaultTimeout()
 		Expect(mount.ExitCode()).To(Equal(0))
 		mountPath := mount.OutputToString()
-
-		chownFunc := func(p string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			return os.Lchown(p, 1000, 1000)
-		}
 
 		err = filepath.Walk(tempdir, chownFunc)
 		if err != nil {
@@ -159,6 +159,26 @@ var _ = Describe("Podman rootless", func() {
 		umount.WaitWithDefaultTimeout()
 		Expect(umount.ExitCode()).To(Equal(0))
 	}
+
+	It("podman rootless search", func() {
+		xdgRuntimeDir, err := ioutil.TempDir("/run", "")
+		Expect(err).To(BeNil())
+		defer os.RemoveAll(xdgRuntimeDir)
+		err = filepath.Walk(xdgRuntimeDir, chownFunc)
+		Expect(err).To(BeNil())
+
+		home, err := CreateTempDirInTempDir()
+		Expect(err).To(BeNil())
+		err = filepath.Walk(xdgRuntimeDir, chownFunc)
+		Expect(err).To(BeNil())
+
+		env := os.Environ()
+		env = append(env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", xdgRuntimeDir))
+		env = append(env, fmt.Sprintf("HOME=%s", home))
+		cmd := podmanTest.PodmanAsUser([]string{"search", "docker.io/busybox"}, 1000, 1000, env)
+		cmd.WaitWithDefaultTimeout()
+		Expect(cmd.ExitCode()).To(Equal(0))
+	})
 
 	It("podman rootless rootfs", func() {
 		runRootless([]string{})

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -127,6 +127,14 @@ var _ = Describe("Podman rootless", func() {
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
+			cmd = podmanTest.PodmanAsUser([]string{"kill", "-l"}, 1000, 1000, env)
+			cmd.WaitWithDefaultTimeout()
+			Expect(cmd.ExitCode()).To(Equal(0))
+
+			cmd = podmanTest.PodmanAsUser([]string{"start", "-l"}, 1000, 1000, env)
+			cmd.WaitWithDefaultTimeout()
+			Expect(cmd.ExitCode()).To(Equal(0))
+
 			cmd = podmanTest.PodmanAsUser([]string{"stop", "-l", "-t", "0"}, 1000, 1000, env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))


### PR DESCRIPTION
These commands do not require to access the storage so it is fine to not re-exec into a new user namespace with multiple UIDs/GIDs available.

There are probably more commands that are safe to run without a new userns but they must be triaged, I'll open more PRs once they are triaged