### PR TITLE
document `--rm` semantics

### DIFF
--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -475,6 +475,10 @@ its root filesystem mounted as read only prohibiting any writes.
 
 Automatically remove the container when it exits. The default is *false*.
 
+Note that the container will not be removed when it could not be created or
+started successfully. This allows the user to inspect the container after
+failure. The `--rm` flag is incompatible with the `-d` flag.
+
 **--rootfs**
 
 If specified, the first argument refers to an exploded container on the file system.

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -496,6 +496,10 @@ its root filesystem mounted as read only prohibiting any writes.
 
 Automatically remove the container when it exits. The default is *false*.
 
+Note that the container will not be removed when it could not be created or
+started successfully. This allows the user to inspect the container after
+failure. The `--rm` flag is incompatible with the `-d` flag.
+
 **--rootfs**
 
 If specified, the first argument refers to an exploded container on the file system.


### PR DESCRIPTION
The `--rm` flag will only cause a container to be removed when it has
been created and started successfully.  Otherwise, it will not be
removed to allow the container to be inspected and to analyze the root
cause of the failure.  Document those semantics more clearly in the
manpages to avoid confusion for users.

Fixes: #1359
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>