### PR TITLE
Resolve /etc/resolv.conf before reading

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1007,13 +1007,10 @@ type resolvConf struct {
 
 // generateResolvConf generates a containers resolv.conf
 func (c *Container) generateResolvConf() (string, error) {
-	// Copy /etc/resolv.conf to the container's rundir
-	resolvPath := "/etc/resolv.conf"
-
-	// Check if the host system is using system resolve and if so
-	// copy its resolv.conf
-	if _, err := os.Stat("/run/systemd/resolve/resolv.conf"); err == nil {
-		resolvPath = "/run/systemd/resolve/resolv.conf"
+	// Determine the endpoint for resolv.conf in case it is a symlink
+	resolvPath, err := filepath.EvalSymlinks("/etc/resolv.conf")
+	if err != nil {
+		return "", err
 	}
 	orig, err := ioutil.ReadFile(resolvPath)
 	if err != nil {


### PR DESCRIPTION
In some cases, /etc/resolv.conf can be a symlink to something like
/run/systemd/resolve/resolv.conf.  We currently check for that file
and if it exists, use it instead of /etc/resolv.conf. However, we are
no seeing cases where the systemd resolv.conf exists but /etc/resolv.conf
is NOT a symlink.

Therefore, we now obtain the endpoint for /etc/resolv.conf whether it is a
symlink or not.  That endpoint is now what is read to generate a container's
resolv.conf.

Signed-off-by: baude <bbaude@redhat.com>