### PR TITLE
rootless: fix top

### DIFF
--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
@@ -82,6 +83,18 @@ func execCmd(c *cli.Context) error {
 	}
 	if err != nil {
 		return errors.Wrapf(err, "unable to exec into %s", args[0])
+	}
+
+	pid, err := ctr.PID()
+	if err != nil {
+		return err
+	}
+	became, ret, err := rootless.JoinNS(uint(pid))
+	if err != nil {
+		return err
+	}
+	if became {
+		os.Exit(ret)
 	}
 
 	// ENVIRONMENT VARIABLES

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -34,6 +34,7 @@ var cmdsNotRequiringRootless = map[string]bool{
 	"kill":    true,
 	"search":  true,
 	"stop":    true,
+	"top":     true,
 }
 
 func main() {

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -32,6 +32,8 @@ var cmdsNotRequiringRootless = map[string]bool{
 	"login":   true,
 	"logout":  true,
 	"kill":    true,
+	"pause":   true,
+	"unpause": true,
 	"search":  true,
 	"stop":    true,
 	"top":     true,

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -35,6 +35,7 @@ var cmdsNotRequiringRootless = map[string]bool{
 	"pause":   true,
 	"unpause": true,
 	"search":  true,
+	"stats":   true,
 	"stop":    true,
 	"top":     true,
 }

--- a/cmd/podman/pause.go
+++ b/cmd/podman/pause.go
@@ -25,6 +25,10 @@ var (
 )
 
 func pauseCmd(c *cli.Context) error {
+	if os.Getuid() != 0 {
+		return errors.New("pause is not supported for rootless containers")
+	}
+
 	runtime, err := libpodruntime.GetRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/stats.go
+++ b/cmd/podman/stats.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -60,6 +61,10 @@ var (
 func statsCmd(c *cli.Context) error {
 	if err := validateFlags(c, statsFlags); err != nil {
 		return err
+	}
+
+	if os.Getuid() != 0 {
+		return errors.New("stats is not supported for rootless containers")
 	}
 
 	all := c.Bool("all")

--- a/cmd/podman/unpause.go
+++ b/cmd/podman/unpause.go
@@ -25,6 +25,10 @@ var (
 )
 
 func unpauseCmd(c *cli.Context) error {
+	if os.Getuid() != 0 {
+		return errors.New("unpause is not supported for rootless containers")
+	}
+
 	runtime, err := libpodruntime.GetRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -691,15 +691,6 @@ func (r *OCIRuntime) execContainer(c *Container, cmd, capAdd, env []string, tty 
 	logrus.Debugf("Starting runtime %s with following arguments: %v", r.path, args)
 
 	execCmd := exec.Command(r.path, args...)
-	if rootless.IsRootless() {
-		args = append([]string{"--preserve-credentials", "--user=/proc/self/fd/3", r.path}, args...)
-		f, err := rootless.GetUserNSForPid(uint(c.state.PID))
-		if err != nil {
-			return nil, err
-		}
-		execCmd = exec.Command("nsenter", args...)
-		execCmd.ExtraFiles = append(execCmd.ExtraFiles, f)
-	}
 	execCmd.Stdout = os.Stdout
 	execCmd.Stderr = os.Stderr
 	execCmd.Stdin = os.Stdin

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -92,7 +92,7 @@ func JoinNS(pid uint) (bool, int, error) {
 		return false, -1, nil
 	}
 
-	userNS, err := GetUserNSForPid(pid)
+	userNS, err := getUserNSForPid(pid)
 	if err != nil {
 		return false, -1, err
 	}
@@ -238,7 +238,7 @@ func getParentUserNs(fd uintptr) (uintptr, error) {
 	return (uintptr)(unsafe.Pointer(ret)), nil
 }
 
-// GetUserNSForPid returns an open FD for the first direct child user namespace that created the process
+// getUserNSForPid returns an open FD for the first direct child user namespace that created the process
 // Each container creates a new user namespace where the runtime runs.  The current process in the container
 // might have created new user namespaces that are child of the initial namespace we created.
 // This function finds the initial namespace created for the container that is a child of the current namespace.
@@ -250,7 +250,7 @@ func getParentUserNs(fd uintptr) (uintptr, error) {
 //                                    b
 //                                   /
 //        NS READ USING THE PID ->  c
-func GetUserNSForPid(pid uint) (*os.File, error) {
+func getUserNSForPid(pid uint) (*os.File, error) {
 	currentNS, err := readUserNs("/proc/self/ns/user")
 	if err != nil {
 		return nil, err

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -23,6 +23,7 @@ import (
 /*
 extern int reexec_in_user_namespace(int ready);
 extern int reexec_in_user_namespace_wait(int pid);
+extern int reexec_userns_join(int userns);
 */
 import "C"
 
@@ -82,6 +83,32 @@ func tryMappingTool(tool string, pid int, hostID int, mappings []idtools.IDMap) 
 		Args: args,
 	}
 	return cmd.Run()
+}
+
+// JoinNS re-exec podman in a new userNS and join the user namespace of the specified
+// PID.
+func JoinNS(pid uint) (bool, int, error) {
+	if os.Getuid() == 0 || os.Getenv("_LIBPOD_USERNS_CONFIGURED") != "" {
+		return false, -1, nil
+	}
+
+	userNS, err := GetUserNSForPid(pid)
+	if err != nil {
+		return false, -1, err
+	}
+	defer userNS.Close()
+
+	pidC := C.reexec_userns_join(C.int(userNS.Fd()))
+	if int(pidC) < 0 {
+		return false, -1, errors.Errorf("cannot re-exec process")
+	}
+
+	ret := C.reexec_in_user_namespace_wait(pidC)
+	if ret < 0 {
+		return false, -1, errors.New("error waiting for the re-exec process")
+	}
+
+	return true, int(ret), nil
 }
 
 // BecomeRootInUserNS re-exec podman in a new userNS.  It returns whether podman was re-executed
@@ -183,7 +210,7 @@ func BecomeRootInUserNS() (bool, int, error) {
 
 	ret := C.reexec_in_user_namespace_wait(pidC)
 	if ret < 0 {
-		return false, -1, errors.Wrapf(err, "error waiting for the re-exec process")
+		return false, -1, errors.New("error waiting for the re-exec process")
 	}
 
 	return true, int(ret), nil

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -3,8 +3,6 @@
 package rootless
 
 import (
-	"os"
-
 	"github.com/pkg/errors"
 )
 
@@ -37,9 +35,4 @@ func SkipStorageSetup() bool {
 // PID.
 func JoinNS(pid uint) (bool, int, error) {
 	return false, -1, errors.New("this function is not supported on this os")
-}
-
-// GetUserNSForPid returns an open FD for the first direct child user namespace that created the process
-func GetUserNSForPid(pid uint) (*os.File, error) {
-	return nil, errors.New("this function is not supported on this os")
 }

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -33,6 +33,12 @@ func SkipStorageSetup() bool {
 	return false
 }
 
+// JoinNS re-exec podman in a new userNS and join the user namespace of the specified
+// PID.
+func JoinNS(pid uint) (bool, int, error) {
+	return false, -1, errors.New("this function is not supported on this os")
+}
+
 // GetUserNSForPid returns an open FD for the first direct child user namespace that created the process
 func GetUserNSForPid(pid uint) (*os.File, error) {
 	return nil, errors.New("this function is not supported on this os")


### PR DESCRIPTION
and also disable pause/unpause/stats as they cannot be (currently) used with rootless containers.

The only missing command to be triaged now is "pod"