### PR TITLE
run/create: reserve `-h` flag for hostname

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -216,8 +216,12 @@ var createFlags = []cli.Flag{
 		Name:  "group-add",
 		Usage: "Add additional groups to join (default [])",
 	},
+	cli.BoolFlag{
+		Name:   "help",
+		Hidden: true,
+	},
 	cli.StringFlag{
-		Name:  "hostname",
+		Name:  "hostname, h",
 		Usage: "Set container hostname",
 	},
 	cli.StringFlag{

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -49,6 +49,7 @@ var createCommand = cli.Command{
 	Flags:                  createFlags,
 	Action:                 createCmd,
 	ArgsUsage:              "IMAGE [COMMAND [ARG...]]",
+	HideHelp:               true,
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,
 }
@@ -56,6 +57,12 @@ var createCommand = cli.Command{
 func createCmd(c *cli.Context) error {
 	// TODO should allow user to create based off a directory on the host not just image
 	// Need CLI support for this
+
+	// Docker-compatibility: the "-h" flag for run/create is reserved for
+	// the hostname (see https://github.com/containers/libpod/issues/1367).
+	if c.Bool("help") {
+		cli.ShowCommandHelpAndExit(c, "run", 0)
+	}
 
 	if err := validateFlags(c, createFlags); err != nil {
 		return err

--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -71,6 +71,7 @@ var podCreateCommand = cli.Command{
 	Description:            podCreateDescription,
 	Flags:                  podCreateFlags,
 	Action:                 podCreateCmd,
+	HideHelp:               true,
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,
 }
@@ -78,6 +79,12 @@ var podCreateCommand = cli.Command{
 func podCreateCmd(c *cli.Context) error {
 	var options []libpod.PodCreateOption
 	var err error
+
+	// Docker-compatibility: the "-h" flag for run/create is reserved for
+	// the hostname (see https://github.com/containers/libpod/issues/1367).
+	if c.Bool("help") {
+		cli.ShowCommandHelpAndExit(c, "run", 0)
+	}
 
 	if err = validateFlags(c, createFlags); err != nil {
 		return err

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -34,12 +34,20 @@ var runCommand = cli.Command{
 	Flags:                  runFlags,
 	Action:                 runCmd,
 	ArgsUsage:              "IMAGE [COMMAND [ARG...]]",
+	HideHelp:               true,
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,
 }
 
 func runCmd(c *cli.Context) error {
 	var imageName string
+
+	// Docker-compatibility: the "-h" flag for run/create is reserved for
+	// the hostname (see https://github.com/containers/libpod/issues/1367).
+	if c.Bool("help") {
+		cli.ShowCommandHelpAndExit(c, "run", 0)
+	}
+
 	if err := validateFlags(c, createFlags); err != nil {
 		return err
 	}

--- a/cmd/podman/run_test.go
+++ b/cmd/podman/run_test.go
@@ -17,9 +17,10 @@ var (
 	cmd         = []string{"podman", "test", "alpine"}
 	CLI         *cli.Context
 	testCommand = cli.Command{
-		Name:   "test",
-		Flags:  createFlags,
-		Action: testCmd,
+		Name:     "test",
+		Flags:    createFlags,
+		Action:   testCmd,
+		HideHelp: true,
 	}
 )
 


### PR DESCRIPTION
Move the `-h` short flag from `--help` to `--hostname` for podman-run,
podman-create and podman-pod-create to be compatible with Docker.

Fixes: #1367
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>