### PR TITLE
varlink: fix --timeout usage

### DIFF
--- a/cmd/podman/varlink.go
+++ b/cmd/podman/varlink.go
@@ -24,7 +24,7 @@ var (
 	varlinkFlags = []cli.Flag{
 		cli.IntFlag{
 			Name:  "timeout, t",
-			Usage: "time until the varlink session expires in milliseconds. default is 1 second; 0 means no timeout.",
+			Usage: "time until the varlink session expires in milliseconds.  Use 0 to disable the timeout.",
 			Value: 1000,
 		},
 	}


### PR DESCRIPTION
The varlink usage help looks like:

--timeout value, -t value  time until the varlink session expires in
  milliseconds. default is 1 second; 0 means no timeout. (default:
  1000)

Fix it to not repeat twice the default value, which is also wrong.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>