### PR TITLE
Add system test with ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,8 +178,11 @@ ginkgo:
 
 localintegration: varlink_generate test-binaries clientintegration ginkgo
 
-localsystem:
+localsystem: .install.ginkgo .install.gomega
 	ginkgo -v -noColor test/system/
+
+system.test-binary: .install.ginkgo .install.gomega
+	$(GO) test -c ./test/system
 
 clientintegration:
 	$(MAKE) -C contrib/python/podman integration

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 OCIUMOUNTINSTALLDIR=$(PREFIX)/share/oci-umount/oci-umount.d
 
 SELINUXOPT ?= $(shell test -x /usr/sbin/selinuxenabled && selinuxenabled && echo -Z)
-PACKAGES ?= $(shell $(GO) list -tags "${BUILDTAGS}" ./... | grep -v github.com/containers/libpod/vendor | grep -v e2e )
+PACKAGES ?= $(shell $(GO) list -tags "${BUILDTAGS}" ./... | grep -v github.com/containers/libpod/vendor | grep -v e2e | grep -v system )
 
 COMMIT_NO ?= $(shell git rev-parse HEAD 2> /dev/null || true)
 GIT_COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
@@ -177,6 +177,9 @@ ginkgo:
 	ginkgo -v -tags "$(BUILDTAGS)" -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.
 
 localintegration: varlink_generate test-binaries clientintegration ginkgo
+
+localsystem:
+	ginkgo -v -noColor test/system/
 
 clientintegration:
 	$(MAKE) -C contrib/python/podman integration

--- a/test/README.md
+++ b/test/README.md
@@ -1,8 +1,33 @@
 ![PODMAN logo](../logo/podman-logo-source.svg)
-# Integration Tests
+# Test utils
+Test utils provide common functions and structs for testing. It includes two structs:
+* `PodmanTest`: Handle the *podman* command and other global resources like temporary
+directory. It provides basic methods, like checking podman image and pod status. Test
+suites should create their owner test *struct* as a composite of `PodmanTest`, and their
+owner PodmanMakeOptions().
 
-Our primary means of performing integration testing for libpod is with the
-[Ginkgo](https://github.com/onsi/ginkgo) BDD testing framework. This allows
+* `PodmanSession`: Store execution session data and related *methods*. Such like get command
+output and so on. It can be used directly in the test suite, only embed it to your owner
+session struct if you need expend it.
+
+## Unittest for test/utils
+To ensure neither *tests* nor *utils* break, There are unit-tests for each *functions* and
+*structs* in `test/utils`. When you adding functions or structs to this *package*, please
+update both unit-tests for it and this documentation.
+
+### Run unit test for test/utils
+Run unit test for test/utils.
+
+```
+make localunit
+```
+
+## Structure of the test utils and test suites
+The test *utils* package is at the same level of test suites. Each test suites also have their
+owner common functions and structs stored in `libpod_suite_test.go`.
+
+# Ginkgo test framework
+[Ginkgo](https://github.com/onsi/ginkgo) is a BDD testing framework. This allows
 us to use native Golang to perform our tests and there is a strong affiliation
 between Ginkgo and the Go test framework.
 
@@ -32,8 +57,16 @@ The gomega sources can be simply installed with the command:
 GOPATH=~/go go get github.com/onsi/gomega/...
 ```
 
-### Running the integration tests
+# Integration Tests
+Test suite for integration test for podman command line. It has its own structs:
+* `PodmanTestIntegration`: Integration test *struct* as a composite of `PodmanTest`. It
+set up the global options for *podman* command to ignore the environment influence from
+different test system.
 
+* `PodmanSessionIntegration`: This *struct* has it own *methods* for checking command
+output with given format JSON by using *structs* defined in inspect package.
+
+## Running the integration tests
 You can run the entire suite of integration tests with the following command:
 
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -100,3 +100,21 @@ make shell
 ```
 
 This will run a container and give you a shell and you can follow the instructions above.
+
+# System test
+System tests are used for testing the *podman* CLI in the context of a complete system. It
+requires that *podman*, all dependencies, and configurations are in place.  The intention of
+system testing is to match as closely as possible with real-world user/developer use-cases
+and environments. The orchestration of the environments and tests is left to external
+tooling.
+
+* `PodmanTestSystem`: System test *struct* as a composite of `PodmanTest`. It will not add any
+options to the command by default. When you run system test, you can set GLOBALOPTIONS,
+PODMAN_SUBCMD_OPTIONS or PODMAN_BINARY in ENV to run the test suite for different test matrices.
+
+## Run system test
+You can run the test with following command:
+
+```
+make localsystem
+```

--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman attach", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman attach", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/containers/libpod/pkg/criu"
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman checkpoint", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman checkpoint", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 		if !criu.CheckForCriu() {
 			Skip("CRIU is missing or too old.")

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman commit", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman commit", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman create", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman create", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman diff", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman diff", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman exec", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman exec", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/export_test.go
+++ b/test/e2e/export_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman export", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman export", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/history_test.go
+++ b/test/e2e/history_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman history", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman history", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 
+	. "github.com/containers/libpod/test/utils"
 	"github.com/docker/go-units"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,7 +15,7 @@ var _ = Describe("Podman images", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -22,7 +23,7 @@ var _ = Describe("Podman images", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/import_test.go
+++ b/test/e2e/import_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman import", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman import", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman Info", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman Info", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 	})
 
 	AfterEach(func() {

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman inspect", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman inspect", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman kill", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman kill", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -1,22 +1,18 @@
 package integration
 
 import (
-	"bufio"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/inspect"
-	"github.com/containers/storage/pkg/parsers/kernel"
+	. "github.com/containers/libpod/test/utils"
 	"github.com/containers/storage/pkg/reexec"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -35,14 +31,9 @@ var (
 	defaultWaitTimeout = 90
 )
 
-// PodmanSession wrapps the gexec.session so we can extend it
-type PodmanSession struct {
-	*gexec.Session
-}
-
-// PodmanTest struct for command line options
-type PodmanTest struct {
-	PodmanBinary        string
+// PodmanTestIntegration struct for command line options
+type PodmanTestIntegration struct {
+	PodmanTest
 	ConmonBinary        string
 	CrioRoot            string
 	CNIConfigDir        string
@@ -50,17 +41,13 @@ type PodmanTest struct {
 	RunRoot             string
 	StorageOptions      string
 	SignaturePolicyPath string
-	ArtifactPath        string
-	TempDir             string
 	CgroupManager       string
 	Host                HostOS
 }
 
-// HostOS is a simple struct for the test os
-type HostOS struct {
-	Distribution string
-	Version      string
-	Arch         string
+// PodmanSessionIntegration sturct for command line session
+type PodmanSessionIntegration struct {
+	*PodmanSession
 }
 
 // TestLibpod ginkgo master function
@@ -80,7 +67,7 @@ var _ = BeforeSuite(func() {
 	//Cache images
 	cwd, _ := os.Getwd()
 	INTEGRATION_ROOT = filepath.Join(cwd, "../../")
-	podman := PodmanCreate("/tmp")
+	podman := PodmanTestCreate("/tmp")
 	podman.ArtifactPath = ARTIFACT_DIR
 	if _, err := os.Stat(ARTIFACT_DIR); os.IsNotExist(err) {
 		if err = os.Mkdir(ARTIFACT_DIR, 0777); err != nil {
@@ -110,13 +97,8 @@ var _ = BeforeSuite(func() {
 	}
 })
 
-// CreateTempDirin
-func CreateTempDirInTempDir() (string, error) {
-	return ioutil.TempDir("", "podman_test")
-}
-
-// PodmanCreate creates a PodmanTest instance for the tests
-func PodmanCreate(tempDir string) PodmanTest {
+// PodmanTestCreate creates a PodmanTestIntegration instance for the tests
+func PodmanTestCreate(tempDir string) *PodmanTestIntegration {
 
 	host := GetHostDistributionInfo()
 	cwd, _ := os.Getwd()
@@ -157,8 +139,12 @@ func PodmanCreate(tempDir string) PodmanTest {
 
 	CNIConfigDir := "/etc/cni/net.d"
 
-	p := PodmanTest{
-		PodmanBinary:        podmanBinary,
+	p := &PodmanTestIntegration{
+		PodmanTest: PodmanTest{
+			PodmanBinary: podmanBinary,
+			ArtifactPath: ARTIFACT_DIR,
+			TempDir:      tempDir,
+		},
 		ConmonBinary:        conmonBinary,
 		CrioRoot:            filepath.Join(tempDir, "crio"),
 		CNIConfigDir:        CNIConfigDir,
@@ -166,73 +152,50 @@ func PodmanCreate(tempDir string) PodmanTest {
 		RunRoot:             filepath.Join(tempDir, "crio-run"),
 		StorageOptions:      storageOptions,
 		SignaturePolicyPath: filepath.Join(INTEGRATION_ROOT, "test/policy.json"),
-		ArtifactPath:        ARTIFACT_DIR,
-		TempDir:             tempDir,
 		CgroupManager:       cgroupManager,
 		Host:                host,
 	}
 
 	// Setup registries.conf ENV variable
 	p.setDefaultRegistriesConfigEnv()
+	// Rewrite the PodmanAsUser function
+	p.PodmanMakeOptions = p.makeOptions
 	return p
 }
 
 //MakeOptions assembles all the podman main options
-func (p *PodmanTest) MakeOptions() []string {
-	return strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --cni-config-dir %s --cgroup-manager %s",
+func (p *PodmanTestIntegration) makeOptions(args []string) []string {
+	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --cni-config-dir %s --cgroup-manager %s",
 		p.CrioRoot, p.RunRoot, p.RunCBinary, p.ConmonBinary, p.CNIConfigDir, p.CgroupManager), " ")
-}
-
-// Podman is the exec call to podman on the filesystem, uid and gid the credentials to use
-func (p *PodmanTest) PodmanAsUser(args []string, uid, gid uint32, env []string) *PodmanSession {
-	podmanOptions := p.MakeOptions()
 	if os.Getenv("HOOK_OPTION") != "" {
 		podmanOptions = append(podmanOptions, os.Getenv("HOOK_OPTION"))
 	}
 	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
 	podmanOptions = append(podmanOptions, args...)
-	if env == nil {
-		fmt.Printf("Running: %s %s\n", p.PodmanBinary, strings.Join(podmanOptions, " "))
-	} else {
-		fmt.Printf("Running: (env: %v) %s %s\n", env, p.PodmanBinary, strings.Join(podmanOptions, " "))
-	}
-	var command *exec.Cmd
-
-	if uid != 0 || gid != 0 {
-		nsEnterOpts := append([]string{"--userspec", fmt.Sprintf("%d:%d", uid, gid), "/", p.PodmanBinary}, podmanOptions...)
-		command = exec.Command("chroot", nsEnterOpts...)
-	} else {
-		command = exec.Command(p.PodmanBinary, podmanOptions...)
-	}
-	if env != nil {
-		command.Env = env
-	}
-
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	if err != nil {
-		Fail(fmt.Sprintf("unable to run podman command: %s\n%v", strings.Join(podmanOptions, " "), err))
-	}
-	return &PodmanSession{session}
+	return podmanOptions
 }
 
 // Podman is the exec call to podman on the filesystem
-func (p *PodmanTest) Podman(args []string) *PodmanSession {
-	return p.PodmanAsUser(args, 0, 0, nil)
+func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration {
+	podmanSession := p.PodmanBase(args)
+	return &PodmanSessionIntegration{podmanSession}
 }
 
-//WaitForContainer waits on a started container
-func WaitForContainer(p *PodmanTest) bool {
-	for i := 0; i < 10; i++ {
-		if p.NumberOfRunningContainers() == 1 {
-			return true
-		}
-		time.Sleep(1 * time.Second)
+// PodmanPID execs podman and returns its PID
+func (p *PodmanTestIntegration) PodmanPID(args []string) (*PodmanSessionIntegration, int) {
+	podmanOptions := p.MakeOptions(args)
+	fmt.Printf("Running: %s %s\n", p.PodmanBinary, strings.Join(podmanOptions, " "))
+	command := exec.Command(p.PodmanBinary, podmanOptions...)
+	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+	if err != nil {
+		Fail(fmt.Sprintf("unable to run podman command: %s", strings.Join(podmanOptions, " ")))
 	}
-	return false
+	podmanSession := &PodmanSession{session}
+	return &PodmanSessionIntegration{podmanSession}, command.Process.Pid
 }
 
 // Cleanup cleans up the temporary store
-func (p *PodmanTest) Cleanup() {
+func (p *PodmanTestIntegration) Cleanup() {
 	// Remove all containers
 	stopall := p.Podman([]string{"stop", "-a", "--timeout", "0"})
 	stopall.WaitWithDefaultTimeout()
@@ -248,7 +211,7 @@ func (p *PodmanTest) Cleanup() {
 }
 
 // CleanupPod cleans up the temporary store
-func (p *PodmanTest) CleanupPod() {
+func (p *PodmanTestIntegration) CleanupPod() {
 	// Remove all containers
 	session := p.Podman([]string{"pod", "rm", "-fa"})
 	session.Wait(90)
@@ -258,103 +221,26 @@ func (p *PodmanTest) CleanupPod() {
 	}
 }
 
-// GrepString takes session output and behaves like grep. it returns a bool
-// if successful and an array of strings on positive matches
-func (s *PodmanSession) GrepString(term string) (bool, []string) {
-	var (
-		greps   []string
-		matches bool
-	)
-
-	for _, line := range strings.Split(s.OutputToString(), "\n") {
-		if strings.Contains(line, term) {
-			matches = true
-			greps = append(greps, line)
-		}
-	}
-	return matches, greps
-}
-
-// Pull Images pulls multiple images
-func (p *PodmanTest) PullImages(images []string) error {
+// PullImages pulls multiple images
+func (p *PodmanTestIntegration) PullImages(images []string) error {
 	for _, i := range images {
 		p.PullImage(i)
 	}
 	return nil
 }
 
-// Pull Image a single image
+// PullImage pulls a single image
 // TODO should the timeout be configurable?
-func (p *PodmanTest) PullImage(image string) error {
+func (p *PodmanTestIntegration) PullImage(image string) error {
 	session := p.Podman([]string{"pull", image})
 	session.Wait(60)
 	Expect(session.ExitCode()).To(Equal(0))
 	return nil
 }
 
-// OutputToString formats session output to string
-func (s *PodmanSession) OutputToString() string {
-	fields := strings.Fields(fmt.Sprintf("%s", s.Out.Contents()))
-	return strings.Join(fields, " ")
-}
-
-// OutputToStringArray returns the output as a []string
-// where each array item is a line split by newline
-func (s *PodmanSession) OutputToStringArray() []string {
-	var results []string
-	output := fmt.Sprintf("%s", s.Out.Contents())
-	for _, line := range strings.Split(output, "\n") {
-		if line != "" {
-			results = append(results, line)
-		}
-	}
-	return results
-}
-
-// ErrorGrepString takes session stderr output and behaves like grep. it returns a bool
-// if successful and an array of strings on positive matches
-func (s *PodmanSession) ErrorGrepString(term string) (bool, []string) {
-	var (
-		greps   []string
-		matches bool
-	)
-
-	for _, line := range strings.Split(s.ErrorToString(), "\n") {
-		if strings.Contains(line, term) {
-			matches = true
-			greps = append(greps, line)
-		}
-	}
-	return matches, greps
-}
-
-// ErrorToString formats session stderr to string
-func (s *PodmanSession) ErrorToString() string {
-	fields := strings.Fields(fmt.Sprintf("%s", s.Err.Contents()))
-	return strings.Join(fields, " ")
-}
-
-// ErrorToStringArray returns the stderr output as a []string
-// where each array item is a line split by newline
-func (s *PodmanSession) ErrorToStringArray() []string {
-	output := fmt.Sprintf("%s", s.Err.Contents())
-	return strings.Split(output, "\n")
-}
-
-// IsJSONOutputValid attempts to unmarshal the session buffer
-// and if successful, returns true, else false
-func (s *PodmanSession) IsJSONOutputValid() bool {
-	var i interface{}
-	if err := json.Unmarshal(s.Out.Contents(), &i); err != nil {
-		fmt.Println(err)
-		return false
-	}
-	return true
-}
-
 // InspectContainerToJSON takes the session output of an inspect
 // container and returns json
-func (s *PodmanSession) InspectContainerToJSON() []inspect.ContainerData {
+func (s *PodmanSessionIntegration) InspectContainerToJSON() []inspect.ContainerData {
 	var i []inspect.ContainerData
 	err := json.Unmarshal(s.Out.Contents(), &i)
 	Expect(err).To(BeNil())
@@ -362,7 +248,7 @@ func (s *PodmanSession) InspectContainerToJSON() []inspect.ContainerData {
 }
 
 // InspectPodToJSON takes the sessions output from a pod inspect and returns json
-func (s *PodmanSession) InspectPodToJSON() libpod.PodInspect {
+func (s *PodmanSessionIntegration) InspectPodToJSON() libpod.PodInspect {
 	var i libpod.PodInspect
 	err := json.Unmarshal(s.Out.Contents(), &i)
 	Expect(err).To(BeNil())
@@ -371,30 +257,15 @@ func (s *PodmanSession) InspectPodToJSON() libpod.PodInspect {
 
 // InspectImageJSON takes the session output of an inspect
 // image and returns json
-func (s *PodmanSession) InspectImageJSON() []inspect.ImageData {
+func (s *PodmanSessionIntegration) InspectImageJSON() []inspect.ImageData {
 	var i []inspect.ImageData
 	err := json.Unmarshal(s.Out.Contents(), &i)
 	Expect(err).To(BeNil())
 	return i
 }
 
-func (s *PodmanSession) WaitWithDefaultTimeout() {
-	s.Wait(defaultWaitTimeout)
-	fmt.Println("output:", s.OutputToString())
-}
-
-// SystemExec is used to exec a system command to check its exit code or output
-func (p *PodmanTest) SystemExec(command string, args []string) *PodmanSession {
-	c := exec.Command(command, args...)
-	session, err := gexec.Start(c, GinkgoWriter, GinkgoWriter)
-	if err != nil {
-		Fail(fmt.Sprintf("unable to run command: %s %s", command, strings.Join(args, " ")))
-	}
-	return &PodmanSession{session}
-}
-
 // CreateArtifact creates a cached image in the artifact dir
-func (p *PodmanTest) CreateArtifact(image string) error {
+func (p *PodmanTestIntegration) CreateArtifact(image string) error {
 	if os.Getenv("NO_TEST_CACHE") != "" {
 		return nil
 	}
@@ -415,7 +286,7 @@ func (p *PodmanTest) CreateArtifact(image string) error {
 }
 
 // RestoreArtifact puts the cached image into our test store
-func (p *PodmanTest) RestoreArtifact(image string) error {
+func (p *PodmanTestIntegration) RestoreArtifact(image string) error {
 	fmt.Printf("Restoring %s...\n", image)
 	dest := strings.Split(image, "/")
 	destName := fmt.Sprintf("/tmp/%s.tar", strings.Replace(strings.Join(strings.Split(dest[len(dest)-1], "/"), ""), ":", "-", -1))
@@ -425,7 +296,7 @@ func (p *PodmanTest) RestoreArtifact(image string) error {
 }
 
 // RestoreAllArtifacts unpacks all cached images
-func (p *PodmanTest) RestoreAllArtifacts() error {
+func (p *PodmanTestIntegration) RestoreAllArtifacts() error {
 	if os.Getenv("NO_TEST_CACHE") != "" {
 		return nil
 	}
@@ -439,7 +310,7 @@ func (p *PodmanTest) RestoreAllArtifacts() error {
 
 // CreatePod creates a pod with no infra container
 // it optionally takes a pod name
-func (p *PodmanTest) CreatePod(name string) (*PodmanSession, int, string) {
+func (p *PodmanTestIntegration) CreatePod(name string) (*PodmanSessionIntegration, int, string) {
 	var podmanArgs = []string{"pod", "create", "--infra=false", "--share", ""}
 	if name != "" {
 		podmanArgs = append(podmanArgs, "--name", name)
@@ -451,7 +322,7 @@ func (p *PodmanTest) CreatePod(name string) (*PodmanSession, int, string) {
 
 //RunTopContainer runs a simple container in the background that
 // runs top.  If the name passed != "", it will have a name
-func (p *PodmanTest) RunTopContainer(name string) *PodmanSession {
+func (p *PodmanTestIntegration) RunTopContainer(name string) *PodmanSessionIntegration {
 	var podmanArgs = []string{"run"}
 	if name != "" {
 		podmanArgs = append(podmanArgs, "--name", name)
@@ -460,7 +331,7 @@ func (p *PodmanTest) RunTopContainer(name string) *PodmanSession {
 	return p.Podman(podmanArgs)
 }
 
-func (p *PodmanTest) RunTopContainerInPod(name, pod string) *PodmanSession {
+func (p *PodmanTestIntegration) RunTopContainerInPod(name, pod string) *PodmanSessionIntegration {
 	var podmanArgs = []string{"run", "--pod", pod}
 	if name != "" {
 		podmanArgs = append(podmanArgs, "--name", name)
@@ -471,7 +342,7 @@ func (p *PodmanTest) RunTopContainerInPod(name, pod string) *PodmanSession {
 
 //RunLsContainer runs a simple container in the background that
 // simply runs ls. If the name passed != "", it will have a name
-func (p *PodmanTest) RunLsContainer(name string) (*PodmanSession, int, string) {
+func (p *PodmanTestIntegration) RunLsContainer(name string) (*PodmanSessionIntegration, int, string) {
 	var podmanArgs = []string{"run"}
 	if name != "" {
 		podmanArgs = append(podmanArgs, "--name", name)
@@ -482,7 +353,7 @@ func (p *PodmanTest) RunLsContainer(name string) (*PodmanSession, int, string) {
 	return session, session.ExitCode(), session.OutputToString()
 }
 
-func (p *PodmanTest) RunLsContainerInPod(name, pod string) (*PodmanSession, int, string) {
+func (p *PodmanTestIntegration) RunLsContainerInPod(name, pod string) (*PodmanSessionIntegration, int, string) {
 	var podmanArgs = []string{"run", "--pod", pod}
 	if name != "" {
 		podmanArgs = append(podmanArgs, "--name", name)
@@ -493,147 +364,9 @@ func (p *PodmanTest) RunLsContainerInPod(name, pod string) (*PodmanSession, int,
 	return session, session.ExitCode(), session.OutputToString()
 }
 
-//NumberOfContainersRunning returns an int of how many
-// containers are currently running.
-func (p *PodmanTest) NumberOfContainersRunning() int {
-	var containers []string
-	ps := p.Podman([]string{"ps", "-q"})
-	ps.WaitWithDefaultTimeout()
-	Expect(ps.ExitCode()).To(Equal(0))
-	for _, i := range ps.OutputToStringArray() {
-		if i != "" {
-			containers = append(containers, i)
-		}
-	}
-	return len(containers)
-}
-
-// NumberOfContainers returns an int of how many
-// containers are currently defined.
-func (p *PodmanTest) NumberOfContainers() int {
-	var containers []string
-	ps := p.Podman([]string{"ps", "-aq"})
-	ps.WaitWithDefaultTimeout()
-	Expect(ps.ExitCode()).To(Equal(0))
-	for _, i := range ps.OutputToStringArray() {
-		if i != "" {
-			containers = append(containers, i)
-		}
-	}
-	return len(containers)
-}
-
-// NumberOfPods returns an int of how many
-// pods are currently defined.
-func (p *PodmanTest) NumberOfPods() int {
-	var pods []string
-	ps := p.Podman([]string{"pod", "ps", "-q"})
-	ps.WaitWithDefaultTimeout()
-	Expect(ps.ExitCode()).To(Equal(0))
-	for _, i := range ps.OutputToStringArray() {
-		if i != "" {
-			pods = append(pods, i)
-		}
-	}
-	return len(pods)
-}
-
-// NumberOfRunningContainers returns an int of how many containers are currently
-// running
-func (p *PodmanTest) NumberOfRunningContainers() int {
-	var containers []string
-	ps := p.Podman([]string{"ps", "-q"})
-	ps.WaitWithDefaultTimeout()
-	Expect(ps.ExitCode()).To(Equal(0))
-	for _, i := range ps.OutputToStringArray() {
-		if i != "" {
-			containers = append(containers, i)
-		}
-	}
-	return len(containers)
-}
-
-// StringInSlice determines if a string is in a string slice, returns bool
-func StringInSlice(s string, sl []string) bool {
-	for _, i := range sl {
-		if i == s {
-			return true
-		}
-	}
-	return false
-}
-
-//LineInOutputStartsWith returns true if a line in a
-// session output starts with the supplied string
-func (s *PodmanSession) LineInOuputStartsWith(term string) bool {
-	for _, i := range s.OutputToStringArray() {
-		if strings.HasPrefix(i, term) {
-			return true
-		}
-	}
-	return false
-}
-
-//LineInOutputContains returns true if a line in a
-// session output starts with the supplied string
-func (s *PodmanSession) LineInOutputContains(term string) bool {
-	for _, i := range s.OutputToStringArray() {
-		if strings.Contains(i, term) {
-			return true
-		}
-	}
-	return false
-}
-
-//tagOutPutToMap parses each string in imagesOutput and returns
-// a map of repo:tag pairs.  Notice, the first array item will
-// be skipped as it's considered to be the header.
-func tagOutputToMap(imagesOutput []string) map[string]string {
-	m := make(map[string]string)
-	// iterate over output but skip the header
-	for _, i := range imagesOutput[1:] {
-		tmp := []string{}
-		for _, x := range strings.Split(i, " ") {
-			if x != "" {
-				tmp = append(tmp, x)
-			}
-		}
-		// podman-images(1) return a list like output
-		// in the format of "Repository Tag [...]"
-		if len(tmp) < 2 {
-			continue
-		}
-		m[tmp[0]] = tmp[1]
-	}
-	return m
-}
-
-//LineInOutputContainsTag returns true if a line in the
-// session's output contains the repo-tag pair as returned
-// by podman-images(1).
-func (s *PodmanSession) LineInOutputContainsTag(repo, tag string) bool {
-	tagMap := tagOutputToMap(s.OutputToStringArray())
-	for r, t := range tagMap {
-		if repo == r && tag == t {
-			return true
-		}
-	}
-	return false
-}
-
-//GetContainerStatus returns the containers state.
-// This function assumes only one container is active.
-func (p *PodmanTest) GetContainerStatus() string {
-	var podmanArgs = []string{"ps"}
-	podmanArgs = append(podmanArgs, "--all", "--format={{.Status}}")
-	session := p.Podman(podmanArgs)
-	session.WaitWithDefaultTimeout()
-	return session.OutputToString()
-}
-
 // BuildImage uses podman build and buildah to build an image
 // called imageName based on a string dockerfile
-func (p *PodmanTest) BuildImage(dockerfile, imageName string, layers string) {
+func (p *PodmanTestIntegration) BuildImage(dockerfile, imageName string, layers string) {
 	dockerfilePath := filepath.Join(p.TempDir, "Dockerfile")
 	err := ioutil.WriteFile(dockerfilePath, []byte(dockerfile), 0755)
 	Expect(err).To(BeNil())
@@ -642,34 +375,12 @@ func (p *PodmanTest) BuildImage(dockerfile, imageName string, layers string) {
 	Expect(session.ExitCode()).To(Equal(0))
 }
 
-//GetHostDistributionInfo returns a struct with its distribution name and version
-func GetHostDistributionInfo() HostOS {
-	f, err := os.Open("/etc/os-release")
-	defer f.Close()
-	if err != nil {
-		return HostOS{}
-	}
-
-	l := bufio.NewScanner(f)
-	host := HostOS{}
-	host.Arch = runtime.GOARCH
-	for l.Scan() {
-		if strings.HasPrefix(l.Text(), "ID=") {
-			host.Distribution = strings.Replace(strings.TrimSpace(strings.Join(strings.Split(l.Text(), "=")[1:], "")), "\"", "", -1)
-		}
-		if strings.HasPrefix(l.Text(), "VERSION_ID=") {
-			host.Version = strings.Replace(strings.TrimSpace(strings.Join(strings.Split(l.Text(), "=")[1:], "")), "\"", "", -1)
-		}
-	}
-	return host
-}
-
-func (p *PodmanTest) setDefaultRegistriesConfigEnv() {
+func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
 	defaultFile := filepath.Join(INTEGRATION_ROOT, "test/registries.conf")
 	os.Setenv("REGISTRIES_CONFIG_PATH", defaultFile)
 }
 
-func (p *PodmanTest) setRegistriesConfigEnv(b []byte) {
+func (p *PodmanTestIntegration) setRegistriesConfigEnv(b []byte) {
 	outfile := filepath.Join(p.TempDir, "registries.conf")
 	os.Setenv("REGISTRIES_CONFIG_PATH", outfile)
 	ioutil.WriteFile(outfile, b, 0644)
@@ -677,82 +388,4 @@ func (p *PodmanTest) setRegistriesConfigEnv(b []byte) {
 
 func resetRegistriesConfigEnv() {
 	os.Setenv("REGISTRIES_CONFIG_PATH", "")
-}
-
-// IsKernelNewThan compares the current kernel version to one provided.  If
-// the kernel is equal to or greater, returns true
-func IsKernelNewThan(version string) (bool, error) {
-	inputVersion, err := kernel.ParseRelease(version)
-	if err != nil {
-		return false, err
-	}
-	kv, err := kernel.GetKernelVersion()
-	if err == nil {
-		return false, err
-	}
-	// CompareKernelVersion compares two kernel.VersionInfo structs.
-	// Returns -1 if a < b, 0 if a == b, 1 it a > b
-	result := kernel.CompareKernelVersion(*kv, *inputVersion)
-	if result >= 0 {
-		return true, nil
-	}
-	return false, nil
-
-}
-
-//Wait process or service inside container start, and ready to be used.
-func WaitContainerReady(p *PodmanTest, id string, expStr string, timeout int, step int) bool {
-	startTime := time.Now()
-	s := p.Podman([]string{"logs", id})
-	s.WaitWithDefaultTimeout()
-	fmt.Println(startTime)
-	for {
-		if time.Since(startTime) >= time.Duration(timeout)*time.Second {
-			return false
-		}
-		if strings.Contains(s.OutputToString(), expStr) {
-			return true
-		}
-		time.Sleep(time.Duration(step) * time.Second)
-		s = p.Podman([]string{"logs", id})
-		s.WaitWithDefaultTimeout()
-	}
-}
-
-//IsCommandAvaible check if command exist
-func IsCommandAvailable(command string) bool {
-	check := exec.Command("bash", "-c", strings.Join([]string{"command -v", command}, " "))
-	err := check.Run()
-	if err != nil {
-		return false
-	}
-	return true
-}
-
-// WriteJsonFile write json format data to a json file
-func WriteJsonFile(data []byte, filePath string) error {
-	var jsonData map[string]interface{}
-	json.Unmarshal(data, &jsonData)
-	formatJson, _ := json.MarshalIndent(jsonData, "", "	")
-	return ioutil.WriteFile(filePath, formatJson, 0644)
-}
-
-func getTestContext() context.Context {
-	return context.Background()
-}
-
-func containerized() bool {
-	container := os.Getenv("container")
-	if container != "" {
-		return true
-	}
-	b, err := ioutil.ReadFile("/proc/1/cgroup")
-	if err != nil {
-		// shrug, if we cannot read that file, return false
-		return false
-	}
-	if strings.Index(string(b), "docker") > -1 {
-		return true
-	}
-	return false
 }

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman load", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman load", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 
@@ -55,7 +56,7 @@ var _ = Describe("Podman load", func() {
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 
-		compress := podmanTest.SystemExec("gzip", []string{outfile})
+		compress := SystemExec("gzip", []string{outfile})
 		compress.WaitWithDefaultTimeout()
 		outfile = outfile + ".gz"
 
@@ -253,7 +254,7 @@ var _ = Describe("Podman load", func() {
 		save := podmanTest.Podman([]string{"save", "-o", outfile, BB})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
-		session := podmanTest.SystemExec("xz", []string{outfile})
+		session := SystemExec("xz", []string{outfile})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman logs", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman logs", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman mount", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman mount", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman namespaces", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman namespaces", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman pause", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	pausedState := "Paused"
@@ -23,7 +24,7 @@ var _ = Describe("Podman pause", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman pod create", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman pod create", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman pod create", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman pod create", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 		podmanTest.RestoreArtifact(infra)
 	})

--- a/test/e2e/pod_inspect_test.go
+++ b/test/e2e/pod_inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman pod inspect", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman pod inspect", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pod_kill_test.go
+++ b/test/e2e/pod_kill_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman pod kill", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman pod kill", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pod_pause_test.go
+++ b/test/e2e/pod_pause_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman pod pause", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	pausedState := "Paused"
@@ -22,7 +23,7 @@ var _ = Describe("Podman pod pause", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pod_pod_namespaces.go
+++ b/test/e2e/pod_pod_namespaces.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman pod create", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman pod create", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 		podmanTest.RestoreArtifact(infra)
 	})

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman ps", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman ps", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pod_restart_test.go
+++ b/test/e2e/pod_restart_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman pod restart", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman pod restart", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pod_rm_test.go
+++ b/test/e2e/pod_rm_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman pod rm", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman pod rm", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pod_start_test.go
+++ b/test/e2e/pod_start_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman pod start", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman pod start", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pod_stats_test.go
+++ b/test/e2e/pod_stats_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman pod stats", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman pod stats", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pod_stop_test.go
+++ b/test/e2e/pod_stop_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman pod stop", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman pod stop", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pod_top_test.go
+++ b/test/e2e/pod_top_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman top", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman top", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/port_test.go
+++ b/test/e2e/port_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman port", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman port", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"sort"
 
+	. "github.com/containers/libpod/test/utils"
 	"github.com/docker/go-units"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,7 +16,7 @@ var _ = Describe("Podman ps", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -23,7 +24,7 @@ var _ = Describe("Podman ps", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"fmt"
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"strings"
@@ -13,7 +14,7 @@ var _ = Describe("Podman pull", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman pull", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 
@@ -101,7 +102,7 @@ var _ = Describe("Podman pull", func() {
 		session = podmanTest.Podman([]string{"rmi", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		clean := podmanTest.SystemExec("rm", []string{"/tmp/alp.tar"})
+		clean := SystemExec("rm", []string{"/tmp/alp.tar"})
 		clean.WaitWithDefaultTimeout()
 		Expect(clean.ExitCode()).To(Equal(0))
 	})
@@ -119,12 +120,12 @@ var _ = Describe("Podman pull", func() {
 		session = podmanTest.Podman([]string{"rmi", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		clean := podmanTest.SystemExec("rm", []string{"/tmp/oci-alp.tar"})
+		clean := SystemExec("rm", []string{"/tmp/oci-alp.tar"})
 		clean.WaitWithDefaultTimeout()
 	})
 
 	It("podman pull from local directory", func() {
-		setup := podmanTest.SystemExec("mkdir", []string{"-p", "/tmp/podmantestdir"})
+		setup := SystemExec("mkdir", []string{"-p", "/tmp/podmantestdir"})
 		setup.WaitWithDefaultTimeout()
 		session := podmanTest.Podman([]string{"push", "alpine", "dir:/tmp/podmantestdir"})
 		session.WaitWithDefaultTimeout()
@@ -139,7 +140,7 @@ var _ = Describe("Podman pull", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		clean := podmanTest.SystemExec("rm", []string{"-fr", "/tmp/podmantestdir"})
+		clean := SystemExec("rm", []string{"-fr", "/tmp/podmantestdir"})
 		clean.WaitWithDefaultTimeout()
 	})
 

--- a/test/e2e/refresh_test.go
+++ b/test/e2e/refresh_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman refresh", func() {
 	var (
 		tmpdir     string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman refresh", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tmpdir)
+		podmanTest = PodmanTestCreate(tmpdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 
@@ -43,13 +44,13 @@ var _ = Describe("Podman refresh", func() {
 		createSession.WaitWithDefaultTimeout()
 		Expect(createSession.ExitCode()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
-		Expect(podmanTest.NumberOfRunningContainers()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 
 		refreshSession := podmanTest.Podman([]string{"container", "refresh"})
 		refreshSession.WaitWithDefaultTimeout()
 		Expect(refreshSession.ExitCode()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
-		Expect(podmanTest.NumberOfRunningContainers()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
 	Specify("Refresh with running container restarts container", func() {
@@ -57,7 +58,7 @@ var _ = Describe("Podman refresh", func() {
 		createSession.WaitWithDefaultTimeout()
 		Expect(createSession.ExitCode()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
-		Expect(podmanTest.NumberOfRunningContainers()).To(Equal(1))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		// HACK: ensure container starts before we move on
 		time.Sleep(1 * time.Second)
@@ -66,6 +67,6 @@ var _ = Describe("Podman refresh", func() {
 		refreshSession.WaitWithDefaultTimeout()
 		Expect(refreshSession.ExitCode()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
-		Expect(podmanTest.NumberOfRunningContainers()).To(Equal(1))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 	})
 })

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman restart", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman restart", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 
@@ -74,7 +75,7 @@ var _ = Describe("Podman restart", func() {
 
 	It("Podman restart running container", func() {
 		_ = podmanTest.RunTopContainer("test1")
-		ok := WaitForContainer(&podmanTest)
+		ok := WaitForContainer(podmanTest)
 		Expect(ok).To(BeTrue())
 		startTime := podmanTest.Podman([]string{"inspect", "--format='{{.State.StartedAt}}'", "test1"})
 		startTime.WaitWithDefaultTimeout()

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman rm", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman rm", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman rmi", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman rmi", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"syscall"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -30,7 +31,7 @@ var _ = Describe("Podman rootless", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -38,7 +39,7 @@ var _ = Describe("Podman rootless", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.CgroupManager = "cgroupfs"
 		podmanTest.StorageOptions = ROOTLESS_STORAGE_OPTIONS
 		podmanTest.RestoreAllArtifacts()
@@ -68,7 +69,7 @@ var _ = Describe("Podman rootless", func() {
 		return os.Lchown(p, 1000, 1000)
 	}
 
-	type rootlessCB func(test PodmanTest, xdgRuntimeDir string, home string, mountPath string)
+	type rootlessCB func(test *PodmanTestIntegration, xdgRuntimeDir string, home string, mountPath string)
 
 	runInRootlessContext := func(cb rootlessCB) {
 		// Check if we can create an user namespace
@@ -91,7 +92,7 @@ var _ = Describe("Podman rootless", func() {
 
 		tempdir, err := CreateTempDirInTempDir()
 		Expect(err).To(BeNil())
-		rootlessTest := PodmanCreate(tempdir)
+		rootlessTest := PodmanTestCreate(tempdir)
 		rootlessTest.CgroupManager = "cgroupfs"
 		rootlessTest.StorageOptions = ROOTLESS_STORAGE_OPTIONS
 		err = filepath.Walk(tempdir, chownFunc)
@@ -116,7 +117,7 @@ var _ = Describe("Podman rootless", func() {
 	}
 
 	It("podman rootless pod", func() {
-		f := func(rootlessTest PodmanTest, xdgRuntimeDir string, home string, mountPath string) {
+		f := func(rootlessTest *PodmanTestIntegration, xdgRuntimeDir string, home string, mountPath string) {
 			env := os.Environ()
 			env = append(env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", xdgRuntimeDir))
 			env = append(env, fmt.Sprintf("HOME=%s", home))
@@ -157,7 +158,7 @@ var _ = Describe("Podman rootless", func() {
 	})
 
 	runRootlessHelper := func(args []string) {
-		f := func(rootlessTest PodmanTest, xdgRuntimeDir string, home string, mountPath string) {
+		f := func(rootlessTest *PodmanTestIntegration, xdgRuntimeDir string, home string, mountPath string) {
 			runtime.LockOSThread()
 			defer runtime.UnlockOSThread()
 			env := os.Environ()

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreArtifact(fedoraMinimal)
 	})
 
@@ -32,7 +33,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 	})
 
 	Specify("valid --cgroup-parent using cgroupfs", func() {
-		if !containerized() {
+		if !Containerized() {
 			Skip("Must be containerized to run this test.")
 		}
 		cgroup := "/zzz"
@@ -45,7 +46,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 
 	Specify("no --cgroup-parent", func() {
 		cgroup := "/libpod_parent"
-		if !containerized() && podmanTest.CgroupManager != "cgroupfs" {
+		if !Containerized() && podmanTest.CgroupManager != "cgroupfs" {
 			cgroup = "/machine.slice"
 		}
 		run := podmanTest.Podman([]string{"run", fedoraMinimal, "cat", "/proc/self/cgroup"})
@@ -56,7 +57,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 	})
 
 	Specify("valid --cgroup-parent using slice", func() {
-		if containerized() || podmanTest.CgroupManager == "cgroupfs" {
+		if Containerized() || podmanTest.CgroupManager == "cgroupfs" {
 			Skip("Requires Systemd cgroup manager support")
 		}
 		cgroup := "aaaa.slice"

--- a/test/e2e/run_cleanup_test.go
+++ b/test/e2e/run_cleanup_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman run exit", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman run exit", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 
@@ -32,14 +33,14 @@ var _ = Describe("Podman run exit", func() {
 	})
 
 	It("podman run -d mount cleanup test", func() {
-		mount := podmanTest.SystemExec("mount", nil)
+		mount := SystemExec("mount", nil)
 		mount.WaitWithDefaultTimeout()
 		out1 := mount.OutputToString()
 		result := podmanTest.Podman([]string{"create", "-dt", ALPINE, "echo", "hello"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 
-		mount = podmanTest.SystemExec("mount", nil)
+		mount = SystemExec("mount", nil)
 		mount.WaitWithDefaultTimeout()
 		out2 := mount.OutputToString()
 		Expect(out1).To(Equal(out2))

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman run cpu", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman run cpu", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman run device", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman run device", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman run dns", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman run dns", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman run entrypoint", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman run entrypoint", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreArtifact(ALPINE)
 	})
 

--- a/test/e2e/run_exit_test.go
+++ b/test/e2e/run_exit_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman run exit", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman run exit", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/run_memory_test.go
+++ b/test/e2e/run_memory_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman run memory", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman run memory", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman rmi", func() {
 	var (
 		tempdir     string
 		err         error
-		podmanTest  PodmanTest
+		podmanTest  *PodmanTestIntegration
 		hostname, _ = os.Hostname()
 	)
 
@@ -21,7 +22,7 @@ var _ = Describe("Podman rmi", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 
@@ -54,7 +55,7 @@ var _ = Describe("Podman rmi", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--expose", "222-223", "-P", ALPINE, "/bin/sh"})
 		session.Wait(30)
 		Expect(session.ExitCode()).To(Equal(0))
-		results := podmanTest.SystemExec("iptables", []string{"-t", "nat", "-L"})
+		results := SystemExec("iptables", []string{"-t", "nat", "-L"})
 		results.Wait(30)
 		Expect(results.ExitCode()).To(Equal(0))
 		Expect(results.OutputToString()).To(ContainSubstring("222"))
@@ -65,12 +66,12 @@ var _ = Describe("Podman rmi", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "-p", "80:8000", ALPINE, "/bin/sh"})
 		session.Wait(30)
 		Expect(session.ExitCode()).To(Equal(0))
-		results := podmanTest.SystemExec("iptables", []string{"-t", "nat", "-L"})
+		results := SystemExec("iptables", []string{"-t", "nat", "-L"})
 		results.Wait(30)
 		Expect(results.ExitCode()).To(Equal(0))
 		Expect(results.OutputToString()).To(ContainSubstring("8000"))
 
-		ncBusy := podmanTest.SystemExec("nc", []string{"-l", "-p", "80"})
+		ncBusy := SystemExec("nc", []string{"-l", "-p", "80"})
 		ncBusy.Wait(10)
 		Expect(ncBusy.ExitCode()).ToNot(Equal(0))
 	})

--- a/test/e2e/run_ns_test.go
+++ b/test/e2e/run_ns_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman run ns", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman run ns", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreArtifact(fedoraMinimal)
 	})
 
@@ -49,7 +50,7 @@ var _ = Describe("Podman run ns", func() {
 	})
 
 	It("podman run ipcns test", func() {
-		setup := podmanTest.SystemExec("ls", []string{"--inode", "-d", "/dev/shm"})
+		setup := SystemExec("ls", []string{"--inode", "-d", "/dev/shm"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 		hostShm := setup.OutputToString()
@@ -61,7 +62,7 @@ var _ = Describe("Podman run ns", func() {
 	})
 
 	It("podman run ipcns ipcmk host test", func() {
-		setup := podmanTest.SystemExec("ipcmk", []string{"-M", "1024"})
+		setup := SystemExec("ipcmk", []string{"-M", "1024"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 		output := strings.Split(setup.OutputToString(), " ")
@@ -70,7 +71,7 @@ var _ = Describe("Podman run ns", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		setup = podmanTest.SystemExec("ipcrm", []string{"-m", ipc})
+		setup = SystemExec("ipcrm", []string{"-m", ipc})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 	})

--- a/test/e2e/run_passwd_test.go
+++ b/test/e2e/run_passwd_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"fmt"
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman run passwd", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman run passwd", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -104,12 +104,12 @@ var _ = Describe("Podman privileged container tests", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		privs := strings.Split(cap.OutputToString(), ":")
+		privs := strings.Split(session.OutputToString(), ":")
 		session = podmanTest.Podman([]string{"run", "--security-opt", "no-new-privileges", "busybox", "grep", "NoNewPrivs", "/proc/self/status"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		noprivs := strings.Split(cap.OutputToString(), ":")
+		noprivs := strings.Split(session.OutputToString(), ":")
 		Expect(privs[1]).To(Not(Equal(noprivs[1])))
 	})
 

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman privileged container tests", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman privileged container tests", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 
@@ -42,7 +43,7 @@ var _ = Describe("Podman privileged container tests", func() {
 	})
 
 	It("podman privileged CapEff", func() {
-		cap := podmanTest.SystemExec("grep", []string{"CapEff", "/proc/self/status"})
+		cap := SystemExec("grep", []string{"CapEff", "/proc/self/status"})
 		cap.WaitWithDefaultTimeout()
 		Expect(cap.ExitCode()).To(Equal(0))
 
@@ -53,7 +54,7 @@ var _ = Describe("Podman privileged container tests", func() {
 	})
 
 	It("podman cap-add CapEff", func() {
-		cap := podmanTest.SystemExec("grep", []string{"CapEff", "/proc/self/status"})
+		cap := SystemExec("grep", []string{"CapEff", "/proc/self/status"})
 		cap.WaitWithDefaultTimeout()
 		Expect(cap.ExitCode()).To(Equal(0))
 
@@ -87,13 +88,13 @@ var _ = Describe("Podman privileged container tests", func() {
 
 	It("run no-new-privileges test", func() {
 		// Check if our kernel is new enough
-		k, err := IsKernelNewThan("4.14")
+		k, err := IsKernelNewerThan("4.14")
 		Expect(err).To(BeNil())
 		if !k {
 			Skip("Kernel is not new enough to test this feature")
 		}
 
-		cap := podmanTest.SystemExec("grep", []string{"NoNewPrivs", "/proc/self/status"})
+		cap := SystemExec("grep", []string{"NoNewPrivs", "/proc/self/status"})
 		cap.WaitWithDefaultTimeout()
 		if cap.ExitCode() != 0 {
 			Skip("Can't determine NoNewPrivs")

--- a/test/e2e/run_restart_test.go
+++ b/test/e2e/run_restart_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman run restart containers", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman run restart containers", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 
@@ -43,7 +44,7 @@ var _ = Describe("Podman run restart containers", func() {
 
 	It("Podman start after signal kill", func() {
 		_ = podmanTest.RunTopContainer("test1")
-		ok := WaitForContainer(&podmanTest)
+		ok := WaitForContainer(podmanTest)
 		Expect(ok).To(BeTrue())
 
 		killSession := podmanTest.Podman([]string{"kill", "-s", "9", "test1"})

--- a/test/e2e/run_selinux_test.go
+++ b/test/e2e/run_selinux_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -13,7 +14,7 @@ var _ = Describe("Podman run", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman run", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 		if !selinux.GetEnabled() {
 			Skip("SELinux not enabled")

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	. "github.com/containers/libpod/test/utils"
 	"github.com/mrunalp/fileutils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,7 +17,7 @@ var _ = Describe("Podman run", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -24,7 +25,7 @@ var _ = Describe("Podman run", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 
@@ -355,7 +356,7 @@ var _ = Describe("Podman run", func() {
 		keyFile := filepath.Join(targetDir, "key.pem")
 		err = ioutil.WriteFile(keyFile, []byte(mountString), 0755)
 		Expect(err).To(BeNil())
-		execSession := podmanTest.SystemExec("ln", []string{"-s", targetDir, filepath.Join(secretsDir, "mysymlink")})
+		execSession := SystemExec("ln", []string{"-s", targetDir, filepath.Join(secretsDir, "mysymlink")})
 		execSession.WaitWithDefaultTimeout()
 		Expect(execSession.ExitCode()).To(Equal(0))
 

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"fmt"
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman UserNS support", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman UserNS support", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -20,7 +21,7 @@ var _ = Describe("podman container runlabel", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -28,7 +29,7 @@ var _ = Describe("podman container runlabel", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman save", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -21,7 +22,7 @@ var _ = Describe("Podman save", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -13,7 +14,7 @@ var _ = Describe("Podman search", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 	const regFileContents = `
 	[registries.search]
@@ -40,7 +41,7 @@ var _ = Describe("Podman search", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 
@@ -136,7 +137,7 @@ var _ = Describe("Podman search", func() {
 		fakereg.WaitWithDefaultTimeout()
 		Expect(fakereg.ExitCode()).To(Equal(0))
 
-		if !WaitContainerReady(&podmanTest, "registry", "listening on", 20, 1) {
+		if !WaitContainerReady(podmanTest, "registry", "listening on", 20, 1) {
 			Skip("Can not start docker registry.")
 		}
 
@@ -159,7 +160,7 @@ var _ = Describe("Podman search", func() {
 		registry.WaitWithDefaultTimeout()
 		Expect(registry.ExitCode()).To(Equal(0))
 
-		if !WaitContainerReady(&podmanTest, "registry3", "listening on", 20, 1) {
+		if !WaitContainerReady(podmanTest, "registry3", "listening on", 20, 1) {
 			Skip("Can not start docker registry.")
 		}
 
@@ -182,7 +183,7 @@ var _ = Describe("Podman search", func() {
 		registry.WaitWithDefaultTimeout()
 		Expect(registry.ExitCode()).To(Equal(0))
 
-		if !WaitContainerReady(&podmanTest, "registry4", "listening on", 20, 1) {
+		if !WaitContainerReady(podmanTest, "registry4", "listening on", 20, 1) {
 			Skip("Can not start docker registry.")
 		}
 
@@ -214,7 +215,7 @@ var _ = Describe("Podman search", func() {
 		registry.WaitWithDefaultTimeout()
 		Expect(registry.ExitCode()).To(Equal(0))
 
-		if !WaitContainerReady(&podmanTest, "registry5", "listening on", 20, 1) {
+		if !WaitContainerReady(podmanTest, "registry5", "listening on", 20, 1) {
 			Skip("Can not start docker registry.")
 		}
 		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
@@ -245,7 +246,7 @@ var _ = Describe("Podman search", func() {
 		registry.WaitWithDefaultTimeout()
 		Expect(registry.ExitCode()).To(Equal(0))
 
-		if !WaitContainerReady(&podmanTest, "registry6", "listening on", 20, 1) {
+		if !WaitContainerReady(podmanTest, "registry6", "listening on", 20, 1) {
 			Skip("Can not start docker registry.")
 		}
 		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
@@ -276,7 +277,7 @@ var _ = Describe("Podman search", func() {
 		registryLocal.WaitWithDefaultTimeout()
 		Expect(registryLocal.ExitCode()).To(Equal(0))
 
-		if !WaitContainerReady(&podmanTest, "registry7", "listening on", 20, 1) {
+		if !WaitContainerReady(podmanTest, "registry7", "listening on", 20, 1) {
 			Skip("Can not start docker registry.")
 		}
 
@@ -284,7 +285,7 @@ var _ = Describe("Podman search", func() {
 		registryLocal.WaitWithDefaultTimeout()
 		Expect(registryLocal.ExitCode()).To(Equal(0))
 
-		if !WaitContainerReady(&podmanTest, "registry8", "listening on", 20, 1) {
+		if !WaitContainerReady(podmanTest, "registry8", "listening on", 20, 1) {
 			Skip("Can not start docker registry.")
 		}
 		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:6000/my-alpine"})

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman start", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman start", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman stats", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman stats", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman stop", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman stop", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/tag_test.go
+++ b/test/e2e/tag_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman tag", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman tag", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/top_test.go
+++ b/test/e2e/top_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman top", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman top", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman version", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman version", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 	})
 
 	AfterEach(func() {

--- a/test/e2e/wait_test.go
+++ b/test/e2e/wait_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +13,7 @@ var _ = Describe("Podman wait", func() {
 	var (
 		tempdir    string
 		err        error
-		podmanTest PodmanTest
+		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
@@ -20,7 +21,7 @@ var _ = Describe("Podman wait", func() {
 		if err != nil {
 			os.Exit(1)
 		}
-		podmanTest = PodmanCreate(tempdir)
+		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
 	})
 

--- a/test/goecho/goecho.go
+++ b/test/goecho/goecho.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+func main() {
+	args := os.Args[1:]
+	exitCode := 0
+
+	for i := 0; i < len(args); i++ {
+		fmt.Fprintln(os.Stdout, args[i])
+		fmt.Fprintln(os.Stderr, args[i])
+	}
+
+	if len(args) > 1 {
+		num, _ := strconv.Atoi(args[1])
+		if args[0] == "exitcode" {
+			exitCode = num
+		}
+		if args[0] == "sleep" {
+			time.Sleep(time.Duration(num) * time.Second)
+		}
+	}
+	os.Exit(exitCode)
+}

--- a/test/system/libpod_suite_test.go
+++ b/test/system/libpod_suite_test.go
@@ -1,0 +1,217 @@
+package system
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	PODMAN_BINARY string
+	GLOBALOPTIONS = []string{"--cgroup-manager",
+		"--cni-config-dir",
+		"--config", "-c",
+		"--conmon",
+		"--cpu-profile",
+		"--log-level",
+		"--root",
+		"--tmpdir",
+		"--runroot",
+		"--runtime",
+		"--storage-driver",
+		"--storage-opt",
+		"--syslog",
+	}
+	PODMAN_SUBCMD = []string{"attach",
+		"commit",
+		"container",
+		"build",
+		"create",
+		"diff",
+		"exec",
+		"export",
+		"history",
+		"image",
+		"images",
+		"import",
+		"info",
+		"inspect",
+		"kill",
+		"load",
+		"login",
+		"logout",
+		"logs",
+		"mount",
+		"pause",
+		"ps",
+		"pod",
+		"port",
+		"pull",
+		"push",
+		"restart",
+		"rm",
+		"rmi",
+		"run",
+		"save",
+		"search",
+		"start",
+		"stats",
+		"stop",
+		"tag",
+		"top",
+		"umount",
+		"unpause",
+		"version",
+		"wait",
+		"h",
+	}
+	INTEGRATION_ROOT   string
+	ARTIFACT_DIR       = "/tmp/.artifacts"
+	ALPINE             = "docker.io/library/alpine:latest"
+	BB                 = "docker.io/library/busybox:latest"
+	BB_GLIBC           = "docker.io/library/busybox:glibc"
+	fedoraMinimal      = "registry.fedoraproject.org/fedora-minimal:latest"
+	nginx              = "quay.io/baude/alpine_nginx:latest"
+	redis              = "docker.io/library/redis:alpine"
+	registry           = "docker.io/library/registry:2"
+	infra              = "k8s.gcr.io/pause:3.1"
+	defaultWaitTimeout = 90
+)
+
+// PodmanTestSystem struct for command line options
+type PodmanTestSystem struct {
+	PodmanTest
+	GlobalOptions    map[string]string
+	PodmanCmdOptions map[string][]string
+}
+
+// TestLibpod ginkgo master function
+func TestLibpod(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Libpod Suite")
+}
+
+var _ = BeforeSuite(func() {
+})
+
+// PodmanTestCreate creates a PodmanTestSystem instance for the tests
+func PodmanTestCreate(tempDir string) *PodmanTestSystem {
+	var envKey string
+	globalOptions := make(map[string]string)
+	podmanCmdOptions := make(map[string][]string)
+
+	for _, n := range GLOBALOPTIONS {
+		envKey = strings.Replace(strings.ToUpper(strings.Trim(n, "-")), "-", "_", -1)
+		if isEnvSet(envKey) {
+			globalOptions[n] = os.Getenv(envKey)
+		}
+	}
+
+	for _, n := range PODMAN_SUBCMD {
+		envKey = strings.Replace("PODMAN_SUBCMD_OPTIONS", "SUBCMD", strings.ToUpper(n), -1)
+		if isEnvSet(envKey) {
+			podmanCmdOptions[n] = strings.Split(os.Getenv(envKey), " ")
+		}
+	}
+
+	podmanBinary := "podman"
+	if os.Getenv("PODMAN_BINARY") != "" {
+		podmanBinary = os.Getenv("PODMAN_BINARY")
+	}
+
+	p := &PodmanTestSystem{
+		PodmanTest: PodmanTest{
+			PodmanBinary: podmanBinary,
+			ArtifactPath: ARTIFACT_DIR,
+			TempDir:      tempDir,
+		},
+		GlobalOptions:    globalOptions,
+		PodmanCmdOptions: podmanCmdOptions,
+	}
+
+	p.PodmanMakeOptions = p.makeOptions
+
+	return p
+}
+
+func (p *PodmanTestSystem) Podman(args []string) *PodmanSession {
+	return p.PodmanBase(args)
+}
+
+//MakeOptions assembles all the podman options
+func (p *PodmanTestSystem) makeOptions(args []string) []string {
+	var addOptions, subArgs []string
+	for _, n := range GLOBALOPTIONS {
+		if p.GlobalOptions[n] != "" {
+			addOptions = append(addOptions, n, p.GlobalOptions[n])
+		}
+	}
+
+	if len(args) == 0 {
+		return addOptions
+	}
+
+	subCmd := args[0]
+	addOptions = append(addOptions, subCmd)
+	if subCmd == "unmount" {
+		subCmd = "umount"
+	}
+	if subCmd == "help" {
+		subCmd = "h"
+	}
+
+	if _, ok := p.PodmanCmdOptions[subCmd]; ok {
+		m := make(map[string]bool)
+		subArgs = p.PodmanCmdOptions[subCmd]
+		for i := 0; i < len(subArgs); i++ {
+			m[subArgs[i]] = true
+		}
+		for i := 1; i < len(args); i++ {
+			if _, ok := m[args[i]]; !ok {
+				subArgs = append(subArgs, args[i])
+			}
+		}
+	} else {
+		subArgs = args[1:]
+	}
+
+	addOptions = append(addOptions, subArgs...)
+
+	return addOptions
+}
+
+// Cleanup cleans up the temporary store
+func (p *PodmanTestSystem) Cleanup() {
+	// Remove all containers
+	stopall := p.Podman([]string{"stop", "-a", "--timeout", "0"})
+	stopall.WaitWithDefaultTimeout()
+
+	session := p.Podman([]string{"rm", "-fa"})
+	session.Wait(90)
+	// Nuke tempdir
+	if err := os.RemoveAll(p.TempDir); err != nil {
+		fmt.Printf("%q\n", err)
+	}
+}
+
+// CleanupPod cleans up the temporary store
+func (p *PodmanTestSystem) CleanupPod() {
+	// Remove all containers
+	session := p.Podman([]string{"pod", "rm", "-fa"})
+	session.Wait(90)
+	// Nuke tempdir
+	if err := os.RemoveAll(p.TempDir); err != nil {
+		fmt.Printf("%q\n", err)
+	}
+}
+
+// Check if the key is set in Env
+func isEnvSet(key string) bool {
+	_, set := os.LookupEnv(key)
+	return set
+}

--- a/test/system/version_test.go
+++ b/test/system/version_test.go
@@ -1,0 +1,51 @@
+package system
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman version test", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest *PodmanTestSystem
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanTestCreate(tempdir)
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+		f := CurrentGinkgoTestDescription()
+		timedResult := fmt.Sprintf("Test: %s completed in %f seconds", f.TestText, f.Duration.Seconds())
+		GinkgoWriter.Write([]byte(timedResult))
+	})
+
+	It("Smoking test: podman version with extra args", func() {
+		logc := podmanTest.Podman([]string{"version", "anything", "-", "--"})
+		logc.WaitWithDefaultTimeout()
+		Expect(logc.ExitCode()).To(Equal(0))
+		ver := logc.OutputToString()
+		Expect(regexp.MatchString("Version:.*?Go Version:.*?OS/Arch", ver)).To(BeTrue())
+	})
+
+	It("Negative test: podman version with extra flag", func() {
+		logc := podmanTest.Podman([]string{"version", "--foo"})
+		logc.WaitWithDefaultTimeout()
+		Expect(logc.ExitCode()).NotTo(Equal(0))
+		err, _ := logc.GrepString("Incorrect Usage: flag provided but not defined: -foo")
+		Expect(err).To(BeTrue())
+	})
+
+})

--- a/test/utils/common_function_test.go
+++ b/test/utils/common_function_test.go
@@ -1,0 +1,150 @@
+package utils_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Common functions test", func() {
+	var defaultOSPath string
+	var defaultCgroupPath string
+
+	BeforeEach(func() {
+		defaultOSPath = OSReleasePath
+		defaultCgroupPath = ProcessOneCgroupPath
+	})
+
+	AfterEach(func() {
+		OSReleasePath = defaultOSPath
+		ProcessOneCgroupPath = defaultCgroupPath
+	})
+
+	It("Test CreateTempDirInTempDir", func() {
+		tmpDir, _ := CreateTempDirInTempDir()
+		_, err := os.Stat(tmpDir)
+		Expect(os.IsNotExist(err)).ShouldNot(BeTrue(), "Directory is not created as expect")
+	})
+
+	It("Test SystemExec", func() {
+		session := SystemExec(GoechoPath, []string{})
+		Expect(session.Command.Process).ShouldNot(BeNil(), "SystemExec can not start a process")
+	})
+
+	It("Test StringInSlice", func() {
+		testSlice := []string{"apple", "peach", "pear"}
+		Expect(StringInSlice("apple", testSlice)).To(BeTrue(), "apple should in ['apple', 'peach', 'pear']")
+		Expect(StringInSlice("banana", testSlice)).ShouldNot(BeTrue(), "banana should not in ['apple', 'peach', 'pear']")
+		Expect(StringInSlice("anything", []string{})).ShouldNot(BeTrue(), "anything should not in empty slice")
+	})
+
+	DescribeTable("Test GetHostDistributionInfo",
+		func(path, id, ver string, empty bool) {
+			txt := fmt.Sprintf("ID=%s\nVERSION_ID=%s", id, ver)
+			if !empty {
+				f, _ := os.Create(path)
+				f.WriteString(txt)
+				f.Close()
+			}
+
+			OSReleasePath = path
+			host := GetHostDistributionInfo()
+			if empty {
+				Expect(host).To(Equal(HostOS{}), "HostOs should be empty.")
+			} else {
+				Expect(host.Distribution).To(Equal(strings.Trim(id, "\"")))
+				Expect(host.Version).To(Equal(strings.Trim(ver, "\"")))
+			}
+		},
+		Entry("Configure file is not exist.", "/tmp/notexist", "", "", true),
+		Entry("Item value with and without \"", "/tmp/os-release.test", "fedora", "\"28\"", false),
+		Entry("Item empty with and without \"", "/tmp/os-release.test", "", "\"\"", false),
+	)
+
+	DescribeTable("Test IsKernelNewerThan",
+		func(kv string, expect, isNil bool) {
+			newer, err := IsKernelNewerThan(kv)
+			Expect(newer).To(Equal(expect), "Version compare results is not as expect.")
+			Expect(err == nil).To(Equal(isNil), "Error is not as expect.")
+		},
+		Entry("Invlid kernel version: 0", "0", false, false),
+		Entry("Older kernel version:0.0", "0.0", true, true),
+		Entry("Newer kernel version: 100.17.14", "100.17.14", false, true),
+		Entry("Invlid kernel version: I am not a kernel version", "I am not a kernel version", false, false),
+	)
+
+	DescribeTable("Test TestIsCommandAvailable",
+		func(cmd string, expect bool) {
+			cmdExist := IsCommandAvailable(cmd)
+			Expect(cmdExist).To(Equal(expect))
+		},
+		Entry("Command exist", GoechoPath, true),
+		Entry("Command exist", "Fakecmd", false),
+	)
+
+	It("Test WriteJsonFile", func() {
+		type testJson struct {
+			Item1 int
+			Item2 []string
+		}
+		compareData := &testJson{}
+
+		testData := &testJson{
+			Item1: 5,
+			Item2: []string{"test"},
+		}
+
+		testByte, _ := json.Marshal(testData)
+		err := WriteJsonFile(testByte, "/tmp/testJson")
+
+		Expect(err).To(BeNil(), "Failed to write JSON to file.")
+
+		read, err := os.Open("/tmp/testJson")
+		defer read.Close()
+
+		Expect(err).To(BeNil(), "Can not find the JSON file after we write it.")
+
+		bytes, _ := ioutil.ReadAll(read)
+		json.Unmarshal(bytes, compareData)
+
+		Expect(reflect.DeepEqual(testData, compareData)).To(BeTrue(), "Data chaned after we store it to file.")
+	})
+
+	DescribeTable("Test Containerized",
+		func(path string, setEnv, createFile, expect bool) {
+			if setEnv && (os.Getenv("container") == "") {
+				os.Setenv("container", "test")
+				defer os.Setenv("container", "")
+			}
+			if !setEnv && (os.Getenv("container") != "") {
+				containerized := os.Getenv("container")
+				os.Setenv("container", "")
+				defer os.Setenv("container", containerized)
+			}
+			txt := "1:test:/"
+			if expect {
+				txt = "2:docker:/"
+			}
+			if createFile {
+				f, _ := os.Create(path)
+				f.WriteString(txt)
+				f.Close()
+			}
+			ProcessOneCgroupPath = path
+			Expect(Containerized()).To(Equal(expect))
+		},
+		Entry("Set container in env", "", true, false, true),
+		Entry("Can not read from file", "/tmp/notexist", false, false, false),
+		Entry("Docker in cgroup file", "/tmp/cgroup.test", false, true, true),
+		Entry("Docker not in cgroup file", "/tmp/cgroup.test", false, true, false),
+	)
+
+})

--- a/test/utils/podmansession_test.go
+++ b/test/utils/podmansession_test.go
@@ -1,0 +1,90 @@
+package utils_test
+
+import (
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PodmanSession test", func() {
+	var session *PodmanSession
+
+	BeforeEach(func() {
+		session = StartFakeCmdSession([]string{"PodmanSession", "test", "Podman Session"})
+		session.WaitWithDefaultTimeout()
+	})
+
+	It("Test OutputToString", func() {
+		Expect(session.OutputToString()).To(Equal("PodmanSession test Podman Session"))
+	})
+
+	It("Test OutputToStringArray", func() {
+		Expect(session.OutputToStringArray()).To(Equal([]string{"PodmanSession", "test", "Podman Session"}))
+	})
+
+	It("Test ErrorToString", func() {
+		Expect(session.ErrorToString()).To(Equal("PodmanSession test Podman Session"))
+	})
+
+	It("Test ErrorToStringArray", func() {
+		Expect(session.ErrorToStringArray()).To(Equal([]string{"PodmanSession", "test", "Podman Session", ""}))
+	})
+
+	It("Test GrepString", func() {
+		match, backStr := session.GrepString("Session")
+		Expect(match).To(BeTrue())
+		Expect(backStr).To(Equal([]string{"PodmanSession", "Podman Session"}))
+
+		match, backStr = session.GrepString("I am not here")
+		Expect(match).To(Not(BeTrue()))
+		Expect(backStr).To(BeNil())
+
+	})
+
+	It("Test ErrorGrepString", func() {
+		match, backStr := session.ErrorGrepString("Session")
+		Expect(match).To(BeTrue())
+		Expect(backStr).To(Equal([]string{"PodmanSession", "Podman Session"}))
+
+		match, backStr = session.ErrorGrepString("I am not here")
+		Expect(match).To(Not(BeTrue()))
+		Expect(backStr).To(BeNil())
+
+	})
+
+	It("Test LineInOutputStartsWith", func() {
+		Expect(session.LineInOuputStartsWith("Podman")).To(BeTrue())
+		Expect(session.LineInOuputStartsWith("Session")).To(Not(BeTrue()))
+	})
+
+	It("Test LineInOutputContains", func() {
+		Expect(session.LineInOutputContains("Podman")).To(BeTrue())
+		Expect(session.LineInOutputContains("Session")).To(BeTrue())
+		Expect(session.LineInOutputContains("I am not here")).To(Not(BeTrue()))
+	})
+
+	It("Test LineInOutputContainsTag", func() {
+		session = StartFakeCmdSession([]string{"HEAD LINE", "docker.io/library/busybox   latest   e1ddd7948a1c   5 weeks ago   1.38MB"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.LineInOutputContainsTag("docker.io/library/busybox", "latest")).To(BeTrue())
+		Expect(session.LineInOutputContainsTag("busybox", "latest")).To(Not(BeTrue()))
+	})
+
+	It("Test IsJSONOutputValid", func() {
+		session = StartFakeCmdSession([]string{`{"page":1,"fruits":["apple","peach","pear"]}`})
+		session.WaitWithDefaultTimeout()
+		Expect(session.IsJSONOutputValid()).To(BeTrue())
+
+		session = StartFakeCmdSession([]string{"I am not JSON"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.IsJSONOutputValid()).To(Not(BeTrue()))
+	})
+
+	It("Test WaitWithDefaultTimeout", func() {
+		session = StartFakeCmdSession([]string{"sleep", "2"})
+		Expect(session.ExitCode()).Should(Equal(-1))
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).Should(Equal(0))
+	})
+
+})

--- a/test/utils/podmantest_test.go
+++ b/test/utils/podmantest_test.go
@@ -1,0 +1,74 @@
+package utils_test
+
+import (
+	"os"
+
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PodmanTest test", func() {
+	var podmanTest *FakePodmanTest
+
+	BeforeEach(func() {
+		podmanTest = FakePodmanTestCreate()
+	})
+
+	AfterEach(func() {
+		FakeOutputs = make(map[string][]string)
+	})
+
+	It("Test PodmanAsUser", func() {
+		FakeOutputs["check"] = []string{"check"}
+		os.Setenv("HOOK_OPTION", "hook_option")
+		env := os.Environ()
+		session := podmanTest.PodmanAsUser([]string{"check"}, 1000, 1000, env)
+		os.Unsetenv("HOOK_OPTION")
+		session.WaitWithDefaultTimeout()
+		Expect(session.Command.Process).ShouldNot(BeNil())
+	})
+
+	It("Test NumberOfContainersRunning", func() {
+		FakeOutputs["ps -q"] = []string{"one", "two"}
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
+	})
+
+	It("Test NumberOfContainers", func() {
+		FakeOutputs["ps -aq"] = []string{"one", "two"}
+		Expect(podmanTest.NumberOfContainers()).To(Equal(2))
+	})
+
+	It("Test NumberOfPods", func() {
+		FakeOutputs["pod ps -q"] = []string{"one", "two"}
+		Expect(podmanTest.NumberOfPods()).To(Equal(2))
+	})
+
+	It("Test WaitForContainer", func() {
+		FakeOutputs["ps -q"] = []string{"one", "two"}
+		Expect(WaitForContainer(podmanTest)).To(BeTrue())
+
+		FakeOutputs["ps -q"] = []string{"one"}
+		Expect(WaitForContainer(podmanTest)).To(BeTrue())
+
+		FakeOutputs["ps -q"] = []string{""}
+		Expect(WaitForContainer(podmanTest)).To(Not(BeTrue()))
+	})
+
+	It("Test GetContainerStatus", func() {
+		FakeOutputs["ps --all --format={{.Status}}"] = []string{"Need func update"}
+		Expect(podmanTest.GetContainerStatus()).To(Equal("Need func update"))
+	})
+
+	It("Test WaitContainerReady", func() {
+		FakeOutputs["logs testimage"] = []string{""}
+		Expect(WaitContainerReady(podmanTest, "testimage", "ready", 2, 1)).To(Not(BeTrue()))
+
+		FakeOutputs["logs testimage"] = []string{"I am ready"}
+		Expect(WaitContainerReady(podmanTest, "testimage", "am ready", 2, 1)).To(BeTrue())
+
+		FakeOutputs["logs testimage"] = []string{"I am ready"}
+		Expect(WaitContainerReady(podmanTest, "testimage", "", 2, 1)).To(BeTrue())
+	})
+
+})

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1,0 +1,431 @@
+package utils
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/containers/storage/pkg/parsers/kernel"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var (
+	defaultWaitTimeout   = 90
+	OSReleasePath        = "/etc/os-release"
+	ProcessOneCgroupPath = "/proc/1/cgroup"
+)
+
+// PodmanTestCommon contains common functions will be updated later in
+// the inheritance structs
+type PodmanTestCommon interface {
+	MakeOptions(args []string) []string
+	WaitForContainer() bool
+	WaitContainerReady(id string, expStr string, timeout int, step int) bool
+}
+
+// PodmanTest struct for command line options
+type PodmanTest struct {
+	PodmanMakeOptions func(args []string) []string
+	PodmanBinary      string
+	ArtifactPath      string
+	TempDir           string
+}
+
+// PodmanSession wraps the gexec.session so we can extend it
+type PodmanSession struct {
+	*gexec.Session
+}
+
+// HostOS is a simple struct for the test os
+type HostOS struct {
+	Distribution string
+	Version      string
+	Arch         string
+}
+
+// MakeOptions assembles all podman options
+func (p *PodmanTest) MakeOptions(args []string) []string {
+	return p.PodmanMakeOptions(args)
+}
+
+// PodmanAsUser exec podman as user. uid and gid is set for credentials useage. env is used
+// to record the env for debugging
+func (p *PodmanTest) PodmanAsUser(args []string, uid, gid uint32, env []string) *PodmanSession {
+	var command *exec.Cmd
+	podmanOptions := p.MakeOptions(args)
+
+	if env == nil {
+		fmt.Printf("Running: %s %s\n", p.PodmanBinary, strings.Join(podmanOptions, " "))
+	} else {
+		fmt.Printf("Running: (env: %v) %s %s\n", env, p.PodmanBinary, strings.Join(podmanOptions, " "))
+	}
+	if uid != 0 || gid != 0 {
+		nsEnterOpts := append([]string{"--userspec", fmt.Sprintf("%d:%d", uid, gid), "/", p.PodmanBinary}, podmanOptions...)
+		command = exec.Command("chroot", nsEnterOpts...)
+	} else {
+		command = exec.Command(p.PodmanBinary, podmanOptions...)
+	}
+	if env != nil {
+		command.Env = env
+	}
+
+	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+	if err != nil {
+		Fail(fmt.Sprintf("unable to run podman command: %s\n%v", strings.Join(podmanOptions, " "), err))
+	}
+	return &PodmanSession{session}
+}
+
+// PodmanBase exec podman with default env.
+func (p *PodmanTest) PodmanBase(args []string) *PodmanSession {
+	return p.PodmanAsUser(args, 0, 0, nil)
+}
+
+// WaitForContainer waits on a started container
+func (p *PodmanTest) WaitForContainer() bool {
+	for i := 0; i < 10; i++ {
+		if p.NumberOfContainersRunning() > 0 {
+			return true
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return false
+}
+
+// NumberOfContainersRunning returns an int of how many
+// containers are currently running.
+func (p *PodmanTest) NumberOfContainersRunning() int {
+	var containers []string
+	ps := p.PodmanBase([]string{"ps", "-q"})
+	ps.WaitWithDefaultTimeout()
+	Expect(ps.ExitCode()).To(Equal(0))
+	for _, i := range ps.OutputToStringArray() {
+		if i != "" {
+			containers = append(containers, i)
+		}
+	}
+	return len(containers)
+}
+
+// NumberOfContainers returns an int of how many
+// containers are currently defined.
+func (p *PodmanTest) NumberOfContainers() int {
+	var containers []string
+	ps := p.PodmanBase([]string{"ps", "-aq"})
+	ps.WaitWithDefaultTimeout()
+	Expect(ps.ExitCode()).To(Equal(0))
+	for _, i := range ps.OutputToStringArray() {
+		if i != "" {
+			containers = append(containers, i)
+		}
+	}
+	return len(containers)
+}
+
+// NumberOfPods returns an int of how many
+// pods are currently defined.
+func (p *PodmanTest) NumberOfPods() int {
+	var pods []string
+	ps := p.PodmanBase([]string{"pod", "ps", "-q"})
+	ps.WaitWithDefaultTimeout()
+	Expect(ps.ExitCode()).To(Equal(0))
+	for _, i := range ps.OutputToStringArray() {
+		if i != "" {
+			pods = append(pods, i)
+		}
+	}
+	return len(pods)
+}
+
+// GetContainerStatus returns the containers state.
+// This function assumes only one container is active.
+func (p *PodmanTest) GetContainerStatus() string {
+	var podmanArgs = []string{"ps"}
+	podmanArgs = append(podmanArgs, "--all", "--format={{.Status}}")
+	session := p.PodmanBase(podmanArgs)
+	session.WaitWithDefaultTimeout()
+	return session.OutputToString()
+}
+
+// WaitContainerReady waits process or service inside container start, and ready to be used.
+func (p *PodmanTest) WaitContainerReady(id string, expStr string, timeout int, step int) bool {
+	startTime := time.Now()
+	s := p.PodmanBase([]string{"logs", id})
+	s.WaitWithDefaultTimeout()
+
+	for {
+		if time.Since(startTime) >= time.Duration(timeout)*time.Second {
+			fmt.Printf("Container %s is not ready in %ds", id, timeout)
+			return false
+		}
+
+		if strings.Contains(s.OutputToString(), expStr) {
+			return true
+		}
+		time.Sleep(time.Duration(step) * time.Second)
+		s = p.PodmanBase([]string{"logs", id})
+		s.WaitWithDefaultTimeout()
+	}
+}
+
+// WaitForContainer is a wrapper function for accept inheritance PodmanTest struct.
+func WaitForContainer(p PodmanTestCommon) bool {
+	return p.WaitForContainer()
+}
+
+// WaitForContainerReady is a wrapper function for accept inheritance PodmanTest struct.
+func WaitContainerReady(p PodmanTestCommon, id string, expStr string, timeout int, step int) bool {
+	return p.WaitContainerReady(id, expStr, timeout, step)
+}
+
+// OutputToString formats session output to string
+func (s *PodmanSession) OutputToString() string {
+	fields := strings.Fields(fmt.Sprintf("%s", s.Out.Contents()))
+	return strings.Join(fields, " ")
+}
+
+// OutputToStringArray returns the output as a []string
+// where each array item is a line split by newline
+func (s *PodmanSession) OutputToStringArray() []string {
+	var results []string
+	output := fmt.Sprintf("%s", s.Out.Contents())
+	for _, line := range strings.Split(output, "\n") {
+		if line != "" {
+			results = append(results, line)
+		}
+	}
+	return results
+}
+
+// ErrorToString formats session stderr to string
+func (s *PodmanSession) ErrorToString() string {
+	fields := strings.Fields(fmt.Sprintf("%s", s.Err.Contents()))
+	return strings.Join(fields, " ")
+}
+
+// ErrorToStringArray returns the stderr output as a []string
+// where each array item is a line split by newline
+func (s *PodmanSession) ErrorToStringArray() []string {
+	output := fmt.Sprintf("%s", s.Err.Contents())
+	return strings.Split(output, "\n")
+}
+
+// GrepString takes session output and behaves like grep. it returns a bool
+// if successful and an array of strings on positive matches
+func (s *PodmanSession) GrepString(term string) (bool, []string) {
+	var (
+		greps   []string
+		matches bool
+	)
+
+	for _, line := range s.OutputToStringArray() {
+		if strings.Contains(line, term) {
+			matches = true
+			greps = append(greps, line)
+		}
+	}
+	return matches, greps
+}
+
+// ErrorGrepString takes session stderr output and behaves like grep. it returns a bool
+// if successful and an array of strings on positive matches
+func (s *PodmanSession) ErrorGrepString(term string) (bool, []string) {
+	var (
+		greps   []string
+		matches bool
+	)
+
+	for _, line := range s.ErrorToStringArray() {
+		if strings.Contains(line, term) {
+			matches = true
+			greps = append(greps, line)
+		}
+	}
+	return matches, greps
+}
+
+//LineInOutputStartsWith returns true if a line in a
+// session output starts with the supplied string
+func (s *PodmanSession) LineInOuputStartsWith(term string) bool {
+	for _, i := range s.OutputToStringArray() {
+		if strings.HasPrefix(i, term) {
+			return true
+		}
+	}
+	return false
+}
+
+//LineInOutputContains returns true if a line in a
+// session output starts with the supplied string
+func (s *PodmanSession) LineInOutputContains(term string) bool {
+	for _, i := range s.OutputToStringArray() {
+		if strings.Contains(i, term) {
+			return true
+		}
+	}
+	return false
+}
+
+//LineInOutputContainsTag returns true if a line in the
+// session's output contains the repo-tag pair as returned
+// by podman-images(1).
+func (s *PodmanSession) LineInOutputContainsTag(repo, tag string) bool {
+	tagMap := tagOutputToMap(s.OutputToStringArray())
+	for r, t := range tagMap {
+		if repo == r && tag == t {
+			return true
+		}
+	}
+	return false
+}
+
+// IsJSONOutputValid attempts to unmarshal the session buffer
+// and if successful, returns true, else false
+func (s *PodmanSession) IsJSONOutputValid() bool {
+	var i interface{}
+	if err := json.Unmarshal(s.Out.Contents(), &i); err != nil {
+		fmt.Println(err)
+		return false
+	}
+	return true
+}
+
+// WaitWithDefaultTimeout waits for process finished with defaultWaitTimeout
+func (s *PodmanSession) WaitWithDefaultTimeout() {
+	s.Wait(defaultWaitTimeout)
+	fmt.Println("output:", s.OutputToString())
+}
+
+// CreateTempDirinTempDir create a temp dir with prefix podman_test
+func CreateTempDirInTempDir() (string, error) {
+	return ioutil.TempDir("", "podman_test")
+}
+
+// SystemExec is used to exec a system command to check its exit code or output
+func SystemExec(command string, args []string) *PodmanSession {
+	c := exec.Command(command, args...)
+	session, err := gexec.Start(c, GinkgoWriter, GinkgoWriter)
+	if err != nil {
+		Fail(fmt.Sprintf("unable to run command: %s %s", command, strings.Join(args, " ")))
+	}
+	return &PodmanSession{session}
+}
+
+// StringInSlice determines if a string is in a string slice, returns bool
+func StringInSlice(s string, sl []string) bool {
+	for _, i := range sl {
+		if i == s {
+			return true
+		}
+	}
+	return false
+}
+
+//tagOutPutToMap parses each string in imagesOutput and returns
+// a map of repo:tag pairs.  Notice, the first array item will
+// be skipped as it's considered to be the header.
+func tagOutputToMap(imagesOutput []string) map[string]string {
+	m := make(map[string]string)
+	// iterate over output but skip the header
+	for _, i := range imagesOutput[1:] {
+		tmp := []string{}
+		for _, x := range strings.Split(i, " ") {
+			if x != "" {
+				tmp = append(tmp, x)
+			}
+		}
+		// podman-images(1) return a list like output
+		// in the format of "Repository Tag [...]"
+		if len(tmp) < 2 {
+			continue
+		}
+		m[tmp[0]] = tmp[1]
+	}
+	return m
+}
+
+//GetHostDistributionInfo returns a struct with its distribution name and version
+func GetHostDistributionInfo() HostOS {
+	f, err := os.Open(OSReleasePath)
+	defer f.Close()
+	if err != nil {
+		return HostOS{}
+	}
+
+	l := bufio.NewScanner(f)
+	host := HostOS{}
+	host.Arch = runtime.GOARCH
+	for l.Scan() {
+		if strings.HasPrefix(l.Text(), "ID=") {
+			host.Distribution = strings.Replace(strings.TrimSpace(strings.Join(strings.Split(l.Text(), "=")[1:], "")), "\"", "", -1)
+		}
+		if strings.HasPrefix(l.Text(), "VERSION_ID=") {
+			host.Version = strings.Replace(strings.TrimSpace(strings.Join(strings.Split(l.Text(), "=")[1:], "")), "\"", "", -1)
+		}
+	}
+	return host
+}
+
+// IsKernelNewerThan compares the current kernel version to one provided.  If
+// the kernel is equal to or greater, returns true
+func IsKernelNewerThan(version string) (bool, error) {
+	inputVersion, err := kernel.ParseRelease(version)
+	if err != nil {
+		return false, err
+	}
+	kv, err := kernel.GetKernelVersion()
+	if err != nil {
+		return false, err
+	}
+
+	// CompareKernelVersion compares two kernel.VersionInfo structs.
+	// Returns -1 if a < b, 0 if a == b, 1 it a > b
+	result := kernel.CompareKernelVersion(*kv, *inputVersion)
+	if result >= 0 {
+		return true, nil
+	}
+	return false, nil
+
+}
+
+//IsCommandAvaible check if command exist
+func IsCommandAvailable(command string) bool {
+	check := exec.Command("bash", "-c", strings.Join([]string{"command -v", command}, " "))
+	err := check.Run()
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// WriteJsonFile write json format data to a json file
+func WriteJsonFile(data []byte, filePath string) error {
+	var jsonData map[string]interface{}
+	json.Unmarshal(data, &jsonData)
+	formatJson, _ := json.MarshalIndent(jsonData, "", "	")
+	return ioutil.WriteFile(filePath, formatJson, 0644)
+}
+
+// Containerized check the podman command run inside container
+func Containerized() bool {
+	container := os.Getenv("container")
+	if container != "" {
+		return true
+	}
+	b, err := ioutil.ReadFile(ProcessOneCgroupPath)
+	if err != nil {
+		// shrug, if we cannot read that file, return false
+		return false
+	}
+	if strings.Index(string(b), "docker") > -1 {
+		return true
+	}
+	return false
+}

--- a/test/utils/utils_suite_test.go
+++ b/test/utils/utils_suite_test.go
@@ -1,0 +1,52 @@
+package utils_test
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var FakeOutputs map[string][]string
+var GoechoPath = "../goecho/goecho"
+
+type FakePodmanTest struct {
+	PodmanTest
+}
+
+func FakePodmanTestCreate() *FakePodmanTest {
+	FakeOutputs = make(map[string][]string)
+	p := &FakePodmanTest{
+		PodmanTest: PodmanTest{
+			PodmanBinary: GoechoPath,
+		},
+	}
+
+	p.PodmanMakeOptions = p.makeOptions
+	return p
+}
+
+func (p *FakePodmanTest) makeOptions(args []string) []string {
+	return FakeOutputs[strings.Join(args, " ")]
+}
+
+func StartFakeCmdSession(args []string) *PodmanSession {
+	var outWriter, errWriter io.Writer
+	command := exec.Command(GoechoPath, args...)
+	session, err := gexec.Start(command, outWriter, errWriter)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return &PodmanSession{session}
+}
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Unit test for test utils package")
+}


### PR DESCRIPTION
The system test write with ginkgo. Most of the functions are from the e2e test. Update the default way to run podman command to fit the request of system test. The tests can be filter by --focus and --skip to fit different test target.
We also be able to set global options and cmd options by export it to ENV to fit different test matrix.

| Varible Name              | Useage  |
| :------------------------ | :-------------------------------------------------------- |
| PODMAN\_BINARY | Used to set podman binary path. Can be used for test installed rpm |
| PODMAN\_$SUBCMD\_OPTIONS | Command line options for each podman command. $SUBCMD is the short command from "podman -h". | 
| $GLOBALOPTIONS | Global options from "podman -h". The Varible Name is the option name which replace "-" with "\_" and with upper case |


***CIRRUS: SYSTEM TEST***
