### PR TITLE
container: resolve rootfs symlinks

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1295,6 +1295,10 @@ func (c *Container) mount() (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "error mounting storage for container %s", c.ID())
 	}
+	mountPoint, err = filepath.EvalSymlinks(mountPoint)
+	if err != nil {
+		return "", errors.Wrapf(err, "error resolving storage path for container %s", c.ID())
+	}
 	return mountPoint, nil
 }
 


### PR DESCRIPTION
Prevent a runc error that doesn't like symlinks as part
of the rootfs.

Closes: https://github.com/containers/libpod/issues/1389

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>