### PR TITLE
Up time between checks for podman wait

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -597,7 +597,7 @@ func (c *Container) Wait() (int32, error) {
 		return -1, ErrCtrRemoved
 	}
 
-	err := wait.PollImmediateInfinite(1,
+	err := wait.PollImmediateInfinite(100*time.Millisecond,
 		func() (bool, error) {
 			stopped, err := c.isStopped()
 			if err != nil {


### PR DESCRIPTION
Prior to this patch, we were polling continuously to check if a container had died. This patch changes this to poll 10 times a second, which should be more than sufficient and drastically reduce CPU utilization.

Fixes #1391 