### PR TITLE
commandNotFoundHandler: use stderr and exit code 1

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -52,7 +53,8 @@ func usageErrorHandler(context *cli.Context, err error, _ bool) error {
 }
 
 func commandNotFoundHandler(context *cli.Context, command string) {
-	fmt.Fprintf(context.App.Writer, "Command %q not found.\nSee `%s --help`.\n", command, context.App.Name)
+	fmt.Fprintf(os.Stderr, "Command %q not found.\nSee `%s --help`.\n", command, context.App.Name)
+	os.Exit(1)
 }
 
 // validateFlags searches for StringFlags or StringSlice flags that never had


### PR DESCRIPTION
Fixes: #1395
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>