### PR TITLE
We should fail Podman with ExitCode 125 by default

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -54,7 +54,7 @@ func usageErrorHandler(context *cli.Context, err error, _ bool) error {
 
 func commandNotFoundHandler(context *cli.Context, command string) {
 	fmt.Fprintf(os.Stderr, "Command %q not found.\nSee `%s --help`.\n", command, context.App.Name)
-	os.Exit(1)
+	os.Exit(exitCode)
 }
 
 // validateFlags searches for StringFlags or StringSlice flags that never had

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -75,6 +75,38 @@ output logging information to syslog as well as the console
 
 Print the version
 
+## Exit Status
+
+The exit code from `podman gives information about why the container
+failed to run or why it exited.  When `podman` commands exit with a non-zero code,
+the exit codes follow the `chroot` standard, see below:
+
+**_125_** if the error is with podman **_itself_**
+
+    $ podman run --foo busybox; echo $?
+    # flag provided but not defined: --foo
+      See 'podman run --help'.
+      125
+
+**_126_** if executing a **_container command_** and the the **_command_** cannot be invoked
+
+    $ podman run busybox /etc; echo $?
+    # exec: "/etc": permission denied
+      podman: Error response from daemon: Contained command could not be invoked
+      126
+
+**_127_** if executing a **_container command_** and the the **_command_** cannot be found
+    $ podman run busybox foo; echo $?
+    # exec: "foo": executable file not found in $PATH
+      podman: Error response from daemon: Contained command not found or does not exist
+      127
+
+**_Exit code_** of **_container command_** otherwise
+
+    $ podman run busybox /bin/sh -c 'exit 3'
+    # 3
+
+
 ## COMMANDS
 
 | Command                                   | Description                                                                    |


### PR DESCRIPTION
$ ./bin/podman  --foo
$ echo $?
125
$ ./bin/podman  foo
Command "foo" not found.
See `podman --help`.
$ echo $?
1

After this change

$ ./bin/podman  foo
Command "foo" not found.
See `podman --help`.
$ echo $?
125

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>