### PR TITLE
rmi remove all not error when no images are present

### DIFF
--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -111,6 +111,13 @@ func rmiCmd(c *cli.Context) error {
 		}
 	}
 
+	// If the user calls remove all and there are none, it should not be a
+	// non-zero exit
+	if !deleted && removeAll {
+		return nil
+	}
+	// the user tries to remove images that do not exist, that should be a
+	// non-zero exit
 	if !deleted {
 		return errors.Errorf("no valid images to delete")
 	}

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -238,4 +238,14 @@ var _ = Describe("Podman rmi", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToString())).To(Equal(0))
 	})
+
+	It("podman rmi -a with no images should be exit 0", func() {
+		session := podmanTest.Podman([]string{"rmi", "-fa"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session2 := podmanTest.Podman([]string{"rmi", "-fa"})
+		session2.WaitWithDefaultTimeout()
+		Expect(session2.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
When running podman rm -a on a storage where no images exist,
the exit code should NOT be non-zero.

Signed-off-by: baude <bbaude@redhat.com>