### PR TITLE
Added GOPATH/bin to PATH in install.md

### DIFF
--- a/install.md
+++ b/install.md
@@ -110,11 +110,13 @@ GOPATH
 	    └── libpod
 ```
 
-First, configure a `GOPATH` (if you are using go1.8 or later, this defaults to `~/go`).
+First, configure a `GOPATH` (if you are using go1.8 or later, this defaults to `~/go`)
+and then add $GOPATH/bin to your $PATH environment variable.
 
 ```bash
 export GOPATH=~/go
 mkdir -p $GOPATH
+export PATH=$PATH:$GOPATH/bin
 ```
 
 Next, clone the source code using:


### PR DESCRIPTION
Aded GOPATH/bin to PATH in install.md

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Addreses #1407.   When doing a make, make clean, make, an error would arise concerning easyjson.  Adding the $GOPATH/bin to the $PATH environment variable clears this up and per @mheon should have been in the docs for a while now anyway.