### PR TITLE
Do not use tmpcopyup for user-specified tmpfs mounts

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -242,7 +242,7 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 			Destination: spliti[0],
 			Type:        "tmpfs",
 			Source:      "tmpfs",
-			Options:     append(options, "tmpcopyup"),
+			Options:     options,
 		}
 		g.AddMount(tmpfsMnt)
 	}


### PR DESCRIPTION
This is not Docker's behavior, and can trigger a runc bug related to tmpcopyup
