### PR TITLE
Fix displaying size on size calculation error

### DIFF
--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -284,8 +284,11 @@ func getImagesTemplateOutput(ctx context.Context, runtime *libpod.Runtime, image
 		for repo, tags := range image.ReposToMap(img.Names()) {
 			for _, tag := range tags {
 				size, err := img.Size(ctx)
+				var sizeStr string
 				if err != nil {
-					size = nil
+					sizeStr = err.Error()
+				} else {
+					sizeStr = units.HumanSizeWithPrecision(float64(*size), 3)
 				}
 				params := imagesTemplateParams{
 					Repository:  repo,
@@ -294,7 +297,7 @@ func getImagesTemplateOutput(ctx context.Context, runtime *libpod.Runtime, image
 					Digest:      img.Digest(),
 					CreatedTime: createdTime,
 					Created:     units.HumanDuration(time.Since((createdTime))) + " ago",
-					Size:        units.HumanSizeWithPrecision(float64(*size), 3),
+					Size:        sizeStr,
 				}
 				imagesOutput = append(imagesOutput, params)
 			}


### PR DESCRIPTION
With this change if an error is raised when fetching the size of the
image, the error string will be printed as the size (instead of
panicing). In this particular case, the error string is "unable to
determine size".

This fixes bug #1405