### PR TITLE
fix docs for podman build

### DIFF
--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -230,7 +230,7 @@ Add an image *label* (e.g. label=*value*) to the image metadata. Can be used mul
 
 **--layers**
 
-Cache intermediate images during the build process (Default is `false`).
+Cache intermediate images during the build process (Default is `true`).
 
 Note: You can also override the default value of layers by setting the BUILDAH\_LAYERS
 environment variable. `export BUILDAH_LAYERS=true`


### PR DESCRIPTION
podman build docs should now reflect that the --layers default value is true.

Signed-off-by: baude <bbaude@redhat.com>