### PR TITLE
Add --interval flag to podman wait

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ install.tools: .install.gitvalidation .install.gometalinter .install.md2man .ins
 	fi
 
 .install.easyjson: .gopathok
-	if [ ! -x "$(GOBIN)/ffjson" ]; then\
+	if [ ! -x "$(GOBIN)/easyffjson" ]; then\
 		  $(GO) get -u github.com/mailru/easyjson/...; \
 	fi
 

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -223,7 +223,7 @@ func runCmd(c *cli.Context) error {
 		return err
 	}
 
-	if ecode, err := ctr.Wait(); err != nil {
+	if ecode, err := ctr.Wait(libpod.WaitTimeout); err != nil {
 		if errors.Cause(err) == libpod.ErrNoSuchCtr {
 			// The container may have been removed
 			// Go looking for an exit file

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -115,7 +115,7 @@ func startCmd(c *cli.Context) error {
 				return errors.Wrapf(err, "unable to start container %s", ctr.ID())
 			}
 
-			if ecode, err := ctr.Wait(); err != nil {
+			if ecode, err := ctr.Wait(libpod.WaitTimeout); err != nil {
 				logrus.Errorf("unable to get exit code of container %s: %q", ctr.ID(), err)
 			} else {
 				exitCode = int(ecode)

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2012,7 +2012,9 @@ _podman_wait() {
      local boolean_options="
         --help
         -h
-        -l
+        -i
+	-l
+        --interval
         --latest"
     case "$cur" in
         -*)

--- a/docs/podman-wait.1.md
+++ b/docs/podman-wait.1.md
@@ -17,6 +17,9 @@ After the container stops, the container's return code is printed.
 
   Print usage statement
 
+**--interval, i**"
+  Microseconds to wait before polling for completion
+
 **--latest, -l**
 
   Instead of providing the container name or ID, use the last created container. If you use methods other than Podman

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -36,6 +36,8 @@ const (
 	ContainerStateStopped ContainerStatus = iota
 	// ContainerStatePaused indicates that the container has been paused
 	ContainerStatePaused ContainerStatus = iota
+	// WaitTimeout is the wait timeout before checking for container exit
+	WaitTimeout = time.Second / time.Millisecond
 )
 
 // CgroupfsDefaultCgroupParent is the cgroup parent for CGroupFS in libpod

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -592,12 +592,11 @@ func (c *Container) Inspect(size bool) (*inspect.ContainerInspectData, error) {
 }
 
 // Wait blocks on a container to exit and returns its exit code
-func (c *Container) Wait() (int32, error) {
+func (c *Container) Wait(waitTimeout time.Duration) (int32, error) {
 	if !c.valid {
 		return -1, ErrCtrRemoved
 	}
-
-	err := wait.PollImmediateInfinite(100*time.Millisecond,
+	err := wait.PollImmediateInfinite(waitTimeout*time.Millisecond,
 		func() (bool, error) {
 			stopped, err := c.isStopped()
 			if err != nil {

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -341,7 +341,7 @@ func (i *LibpodAPI) WaitContainer(call iopodman.VarlinkCall, name string) error 
 	if err != nil {
 		return call.ReplyContainerNotFound(name)
 	}
-	exitCode, err := ctr.Wait()
+	exitCode, err := ctr.Wait(libpod.WaitTimeout)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}


### PR DESCRIPTION
Waiting uses a lot of CPU, so drop back to checking once/second
and allow user to pass in the interval.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>