### PR TITLE
Explicitly set default CNI network name in libpod.conf

### DIFF
--- a/libpod.conf
+++ b/libpod.conf
@@ -58,6 +58,15 @@ cni_plugin_dir = [
 	       "/opt/cni/bin"
 ]
 
+# Default CNI network for libpod.
+# If multiple CNI network configs are present, libpod will use the network with
+# the name given here for containers unless explicitly overridden.
+# The default here is set to the name we set in the
+# 87-podman-bridge.conflist included in the repository.
+# Not setting this, or setting it to the empty string, will use normal CNI
+# precedence rules for selecting between multiple networks.
+cni_default_network = "podman"
+
 # Default libpod namespace
 # If libpod is joined to a namespace, it will see only containers and pods
 # that were created in the same namespace, and will create new containers and

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -139,11 +139,11 @@ type RuntimeConfig struct {
 	// CNIPluginDir sets a number of directories where the CNI network
 	// plugins can be located
 	CNIPluginDir []string `toml:"cni_plugin_dir"`
-	// HooksDir Path to the directory containing hooks configuration files
-	HooksDir string `toml:"hooks_dir"`
 	// CNIDefaultNetwork is the network name of the default CNI network
 	// to attach pods to
 	CNIDefaultNetwork string `toml:"cni_default_network,omitempty"`
+	// HooksDir Path to the directory containing hooks configuration files
+	HooksDir string `toml:"hooks_dir"`
 	// HooksDirNotExistFatal switches between fatal errors and non-fatal
 	// warnings if the configured HooksDir does not exist.
 	HooksDirNotExistFatal bool `toml:"hooks_dir_not_exist_fatal"`


### PR DESCRIPTION
Makes Podman network selection more deterministic in cases where multiple CNI networks are present. Should resolve issues with our config file being overridden by the CRI-O config file.