### PR TITLE
run different cgroup tests depending on conditions

### DIFF
--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -727,3 +727,19 @@ func WriteJsonFile(data []byte, filePath string) error {
 func getTestContext() context.Context {
 	return context.Background()
 }
+
+func containerized() bool {
+	container := os.Getenv("container")
+	if container != "" {
+		return true
+	}
+	b, err := ioutil.ReadFile("/proc/1/cgroup")
+	if err != nil {
+		// shrug, if we cannot read that file, return false
+		return false
+	}
+	if strings.Index(string(b), "docker") > -1 {
+		return true
+	}
+	return false
+}

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -32,6 +32,9 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 	})
 
 	Specify("valid --cgroup-parent using cgroupfs", func() {
+		if !containerized() {
+			Skip("Must be containerized to run this test.")
+		}
 		cgroup := "/zzz"
 		run := podmanTest.Podman([]string{"run", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/self/cgroup"})
 		run.WaitWithDefaultTimeout()
@@ -42,6 +45,9 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 
 	Specify("no --cgroup-parent", func() {
 		cgroup := "/libpod_parent"
+		if !containerized() {
+			cgroup = "/machine.slice"
+		}
 		run := podmanTest.Podman([]string{"run", fedoraMinimal, "cat", "/proc/self/cgroup"})
 		run.WaitWithDefaultTimeout()
 		Expect(run.ExitCode()).To(Equal(0))
@@ -50,7 +56,9 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 	})
 
 	Specify("valid --cgroup-parent using slice", func() {
-		Skip("Requires Systemd cgroup manager support")
+		if containerized() {
+			Skip("Requires Systemd cgroup manager support")
+		}
 		cgroup := "aaaa.slice"
 		run := podmanTest.Podman([]string{"run", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/1/cgroup"})
 		run.WaitWithDefaultTimeout()


### PR DESCRIPTION
when running podman's integration tests, we need to be able to understand
our environment because the podman command will differ as will the results.

there is no 100% way to know if we are in a container, but using a combination
of container= and checking /proc seemed reasonable for our test suite.  non of this
code is run in podman proper.

Signed-off-by: baude <bbaude@redhat.com>