### PR TITLE
error when exec'ing a command with no tty

### DIFF
--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var (
@@ -56,6 +57,14 @@ var (
 )
 
 func execCmd(c *cli.Context) error {
+	// Until conmon can handle interactive exec console
+	// sessions, we need to inform the user when there is not
+	// a tty available.  This is not to be confused with the
+	// container's tty.
+	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+		return errors.Errorf("no tty exists where podman was run. if using ssh, try passing -t")
+	}
+
 	args := c.Args()
 	var ctr *libpod.Container
 	var err error


### PR DESCRIPTION
Due to the way container tty access is currently wired in podman, we
must have a tty available where the user executes podman.  Failure to
do so results in a hard podman lock where no container related commands
can be run.

When we can leverage conmon for console handling, this requirement can
be removed.

Signed-off-by: baude <bbaude@redhat.com>