### PR TITLE
Add `podman rm --volumes` flag

### DIFF
--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -13,14 +13,18 @@ import (
 var (
 	rmFlags = []cli.Flag{
 		cli.BoolFlag{
-			Name:  "force, f",
-			Usage: "Force removal of a running container.  The default is false",
-		},
-		cli.BoolFlag{
 			Name:  "all, a",
 			Usage: "Remove all containers",
 		},
+		cli.BoolFlag{
+			Name:  "force, f",
+			Usage: "Force removal of a running container.  The default is false",
+		},
 		LatestFlag,
+		cli.BoolFlag{
+			Name:  "volumes, v",
+			Usage: "Remove the volumes associated with the container (Not implemented yet)",
+		},
 	}
 	rmDescription = fmt.Sprintf(`
 Podman rm will remove one or more containers from the host.

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1744,6 +1744,8 @@ _podman_rm() {
     -f
     --latest
     -l
+    --volumes
+    -v
     "
 
     local options_with_args="

--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -23,6 +23,11 @@ Remove all containers.  Can be used in conjunction with -f as well.
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods.
+
+**--volumes, -v**
+
+Remove the volumes associated with the container. (Not yet implemented)
+
 ## EXAMPLE
 
 podman rm mywebserver


### PR DESCRIPTION
While this is not implemented yet, it is needed for working with existing
docker scripts.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>