### PR TITLE
Remove duplicate code between create.go and run.go

### DIFF
--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -18,6 +19,21 @@ func GetRuntime(c *cli.Context) (*libpod.Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
+	return GetRuntimeWithStorageOpts(c, &storageOpts)
+}
+
+// GetContainerRuntime generates a new libpod runtime configured by command line options for containers
+func GetContainerRuntime(c *cli.Context) (*libpod.Runtime, error) {
+	mappings, err := util.ParseIDMapping(c.StringSlice("uidmap"), c.StringSlice("gidmap"), c.String("subuidmap"), c.String("subgidmap"))
+	if err != nil {
+		return nil, err
+	}
+	storageOpts, err := GetDefaultStoreOptions()
+	if err != nil {
+		return nil, err
+	}
+	storageOpts.UIDMap = mappings.UIDMap
+	storageOpts.GIDMap = mappings.GIDMap
 	return GetRuntimeWithStorageOpts(c, &storageOpts)
 }
 


### PR DESCRIPTION
Create two new createInit for checking if the cotnainer is initialized
correctly.
createContainer which creates the actual container and containerConfig

Also added libpodruntime.GetContainerRuntime to put common runtime code
into separate function.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>