### PR TITLE
Add notes to check version on problem

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,20 +4,27 @@ BUG REPORT INFORMATION
 ---------------------------------------------------
 Use the commands below to provide key information from your environment:
 You do NOT have to include this information if this is a FEATURE REQUEST
+-->
+
+**NOTE** A large number of issues reported against Podman are often found to already be fixed
+in more current versions of the project.  Before reporting an issue, please verify the
+version you are running with `podman version` and compare it to the latest release
+documented on the top of Podman's [README.md](../README.md).  If they differ, please
+update your version of Podman to the latest possible and retry your command before creating
+an issue.
 
 If you are filing a bug against `podman build`, please instead file a bug
 against Buildah (https://github.com/projectatomic/buildah/issues). Podman build
 executes Buildah to perform container builds, and as such the Buildah
 maintainers are best equipped to handle these bugs.
--->
 
 **Is this a BUG REPORT or FEATURE REQUEST?**:
 
-> Uncomment only one, leave it on its own line:
->
-> /kind bug
->
-> /kind feature
+[//]: # Uncomment only one, leave it on its own line:
+
+[//]: # **kind bug**
+
+[//]: # **kind feature**
 
 **Description**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![PODMAN logo](logo/podman-logo-source.svg)
 # libpod - library for running OCI-based containers in Pods
 
+### Latest Version: 0.9.1
 ### Status: Active Development
 
 ## What is the scope of this project?

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -5,7 +5,18 @@
 ## A list of common issues and solutions for Podman
 
 ---
-### 1) No such image or Bare keys cannot contain ':'
+### 1) Variety of issues - Validate Version
+
+A large number of issues reported against Podman are often found to already be fixed
+in more current versions of the project.  Before reporting an issue, please verify the
+version you are running with `podman version` and compare it to the lastest release
+documented on the top of Podman's [README.md](README.md). 
+
+If they differ, please update your version of PODMAN to the latest possible
+and retry your command before reporting the issue.
+
+---
+### 2) No such image or Bare keys cannot contain ':'
 
 When doing a `podman pull` or `podman build` command and a "common" image can not be pulled,
 it is likely that the `/etc/containers/registries.conf` file is either not installed or possibly
@@ -33,7 +44,7 @@ error pulling image "fedora": unable to pull fedora: error getting default regis
     *  i.e. `registries = ['registry.fedoraproject.org', 'quay.io', 'registry.access.redhat.com']`
 
 ---
-### 2) http: server gave HTTP response to HTTPS client
+### 3) http: server gave HTTP response to HTTPS client
 
 When doing a Podman command such as `build`, `commit`, `pull`, or `push` to a registry,
 tls verification is turned on by default.  If authentication is not used with

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,7 @@
 package version
 
 // Version is the version of the build.
+// NOTE: remember to bump the version at the top
+// of the top-level README.md file when this is
+// bumped.
 const Version = "0.9.2-dev"


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add a note scattered about the site to have people check their version before reporting an issue against Podman.  I included a "Latest Version" number on the README.md file and tried to get that auto update, but failed to find an easy way.  So went with a note reminder in version/version.go to update the README.md as well.  We do a similar thing in Buildah.