### PR TITLE
Add a way to disable port reservation

### DIFF
--- a/libpod.conf
+++ b/libpod.conf
@@ -80,3 +80,11 @@ pause_image = "k8s.gcr.io/pause:3.1"
 
 # Default command to run the pause container
 pause_command = "/pause"
+
+# Determines whether libpod will reserve ports on the host when they are
+# forwarded to containers. When enabled, when ports are forwarded to containers,
+# they are held open by conmon as long as the container is running, ensuring that
+# they cannot be reused by other programs on the host. However, this can cause
+# significant memory usage if a container has many ports forwarded to it.
+# Disabling this can save memory.
+#enable_port_reservation = true


### PR DESCRIPTION
We've increased the default rlimits to allow Podman to hold many ports open without hitting limits and crashing, but this doesn't solve the amount of memory that holding open potentially
thousands of ports will use. Offer a switch to optionally disable port reservation for performance- and memory-constrained use cases.