### PR TITLE
Swap default mount propagation from private to rprivate

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -243,7 +243,7 @@ func addSecretsFromMountsFile(filePath, mountLabel, containerWorkingDir, mountPr
 			Source:      filepath.Join(mountPrefix, ctrDir),
 			Destination: ctrDir,
 			Type:        "bind",
-			Options:     []string{"bind", "private"},
+			Options:     []string{"bind", "rprivate"},
 		}
 
 		mounts = append(mounts, m)
@@ -278,7 +278,7 @@ func addFIPSModeSecret(mounts *[]rspec.Mount, containerWorkingDir string) error 
 			Source:      ctrDirOnHost,
 			Destination: secretsDir,
 			Type:        "bind",
-			Options:     []string{"bind", "private"},
+			Options:     []string{"bind", "rprivate"},
 		}
 		*mounts = append(*mounts, m)
 	}

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -189,7 +189,7 @@ func (c *CreateConfig) GetVolumeMounts(specMounts []spec.Mount) ([]spec.Mount, e
 			}
 		}
 		if rootProp == "" {
-			options = append(options, "private")
+			options = append(options, "rprivate")
 		}
 
 		m = append(m, spec.Mount{
@@ -214,7 +214,7 @@ func (c *CreateConfig) GetVolumeMounts(specMounts []spec.Mount) ([]spec.Mount, e
 			Destination: vol,
 			Type:        string(TypeTmpfs),
 			Source:      string(TypeTmpfs),
-			Options:     []string{"private", "rw", "noexec", "nosuid", "nodev", "tmpcopyup"},
+			Options:     []string{"rprivate", "rw", "noexec", "nosuid", "nodev", "tmpcopyup"},
 		}
 		m = append(m, mount)
 	}
@@ -272,7 +272,7 @@ func (c *CreateConfig) GetTmpfsMounts() []spec.Mount {
 	var m []spec.Mount
 	for _, i := range c.Tmpfs {
 		// Default options if nothing passed
-		options := []string{"private", "rw", "noexec", "nosuid", "nodev", "size=65536k"}
+		options := []string{"rprivate", "rw", "noexec", "nosuid", "nodev", "size=65536k"}
 		spliti := strings.Split(i, ":")
 		destPath := spliti[0]
 		if len(spliti) > 1 {

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -43,7 +43,7 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 			Destination: "/sys",
 			Type:        "sysfs",
 			Source:      "sysfs",
-			Options:     []string{"private", "nosuid", "noexec", "nodev", "rw"},
+			Options:     []string{"rprivate", "nosuid", "noexec", "nodev", "rw"},
 		}
 		g.AddMount(sysMnt)
 	} else if !canMountSys {
@@ -57,7 +57,7 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 			Destination: "/sys",
 			Type:        "bind",
 			Source:      "/sys",
-			Options:     []string{"nosuid", "noexec", "nodev", r, "rbind"},
+			Options:     []string{"rprivate", "nosuid", "noexec", "nodev", r, "rbind"},
 		}
 		g.AddMount(sysMnt)
 	}
@@ -67,7 +67,7 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 			Destination: "/dev/pts",
 			Type:        "devpts",
 			Source:      "devpts",
-			Options:     []string{"private", "nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620"},
+			Options:     []string{"rprivate", "nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620"},
 		}
 		g.AddMount(devPts)
 	}
@@ -97,7 +97,7 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 			Destination: "/sys/fs/cgroup",
 			Type:        "cgroup",
 			Source:      "cgroup",
-			Options:     []string{"private", "nosuid", "noexec", "nodev", "relatime", cgroupPerm},
+			Options:     []string{"rprivate", "nosuid", "noexec", "nodev", "relatime", cgroupPerm},
 		}
 		g.AddMount(cgroupMnt)
 	}
@@ -231,7 +231,7 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 	}
 	for _, i := range config.Tmpfs {
 		// Default options if nothing passed
-		options := []string{"rw", "private", "noexec", "nosuid", "nodev", "size=65536k"}
+		options := []string{"rw", "rprivate", "noexec", "nosuid", "nodev", "size=65536k"}
 		spliti := strings.SplitN(i, ":", 2)
 		if len(spliti) > 1 {
 			if _, _, err := mount.ParseTmpfsOptions(spliti[1]); err != nil {
@@ -385,7 +385,7 @@ func setupSystemd(config *CreateConfig, g *generate.Generator) error {
 	if err != nil {
 		return err
 	}
-	options := []string{"rw", "private", "noexec", "nosuid", "nodev"}
+	options := []string{"rw", "rprivate", "noexec", "nosuid", "nodev"}
 	for _, dest := range []string{"/run", "/run/lock", "/sys/fs/cgroup/systemd"} {
 		if libpod.MountExists(mounts, dest) {
 			continue

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -13,7 +13,7 @@ func TestCreateConfig_GetVolumeMounts(t *testing.T) {
 		Destination: "/foobar",
 		Type:        "bind",
 		Source:      "foobar",
-		Options:     []string{"ro", "rbind", "private"},
+		Options:     []string{"ro", "rbind", "rprivate"},
 	}
 	config := CreateConfig{
 		Volumes: []string{"foobar:/foobar:ro"},


### PR DESCRIPTION
This matches Docker behavior more closely and should resolve an issue we were seeing with /sys mounts

Partial fix for #1447 