### PR TITLE
 Vendor latest containers/storage

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -11,7 +11,7 @@ github.com/containerd/continuity master
 github.com/containernetworking/cni v0.7.0-alpha1
 github.com/containernetworking/plugins 1562a1e60ed101aacc5e08ed9dbeba8e9f3d4ec1
 github.com/containers/image 85d7559d44fd71f30e46e43d809bfbf88d11d916
-github.com/containers/storage 243c4cd616afdf06b4a975f18c4db083d26b1641
+github.com/containers/storage 02db7cbb0bb082681f9855131fec8c8e1a3f4cb6
 github.com/containers/psgo 5dde6da0bc8831b35243a847625bcf18183bd1ee
 github.com/coreos/go-systemd v14
 github.com/cri-o/ocicni master


### PR DESCRIPTION
Containers image has a fix docker tarfile: use the cached digest if existing
Containers storage has a fix for doing image diffs
Buildah
* Fixes to COPY and ADD to properly follow symbolic links is SRC is a symbolic link
* Print out a digest message on successful push.
* We should not drop the Bounding set when running as a non priv user in podman build

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>