### PR TITLE
rootless: do not raise an error if the entrypoint is specified

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -629,7 +629,7 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 		command = append(command, data.ContainerConfig.Cmd...)
 	}
 
-	if len(command) == 0 {
+	if data != nil && len(command) == 0 {
 		return nil, errors.Errorf("No command specified on command line or as CMD or ENTRYPOINT in this image")
 	}
 
@@ -681,7 +681,7 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 	}
 
 	var systemd bool
-	if c.BoolT("systemd") && ((filepath.Base(command[0]) == "init") || (filepath.Base(command[0]) == "systemd")) {
+	if command != nil && c.BoolT("systemd") && ((filepath.Base(command[0]) == "init") || (filepath.Base(command[0]) == "systemd")) {
 		systemd = true
 		if signalString == "" {
 			stopSignal, err = signal.ParseSignal("RTMIN+3")


### PR DESCRIPTION
do not error out when the storage is not initialized and the
entrypoint command is not available for the specified image.  Check it
when we re-exec in an user namespace and can access the storage.

Closes: https://github.com/containers/libpod/issues/1452

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>