### PR TITLE
Small updates to OCI spec generation

### DIFF
--- a/pkg/spec/config_linux.go
+++ b/pkg/spec/config_linux.go
@@ -60,6 +60,9 @@ func (c *CreateConfig) addPrivilegedDevices(g *generate.Generator) error {
 	for _, d := range hostDevices {
 		g.AddDevice(Device(d))
 	}
+
+	// Add resources device - need to clear the existing one first.
+	g.Spec().Linux.Resources.Devices = nil
 	g.AddLinuxResourcesDevice(true, "", nil, nil, "rwm")
 	return nil
 }

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -337,9 +337,6 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 		configSpec.Mounts = mounts
 	}
 
-	if err := g.SetLinuxRootPropagation("shared"); err != nil {
-		return nil, errors.Wrapf(err, "failed to set propagation to rslave")
-	}
 	if canAddResources {
 		// BLOCK IO
 		blkio, err := config.CreateBlockIO()


### PR DESCRIPTION
Firstly, when adding the privileged catch-all resource device, first remove the spec's default catch-all resource device.

Second, remove our default rootfs propogation config - Docker does not set this by default, so I don't think we should either.

Two of the last significant changes from my examination of our OCI spec vs Docker's.