### PR TITLE
Keep selinux mount label when privileged also

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -244,18 +244,15 @@ func loadAppArmor(config *cc.CreateConfig) error {
 	return nil
 }
 
-func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string) error {
-	var (
-		labelOpts []string
-		err       error
-	)
+func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string) ([]string, error) {
+	var labelOpts []string
 
 	if config.PidMode.IsHost() {
 		labelOpts = append(labelOpts, label.DisableSecOpt()...)
 	} else if config.PidMode.IsContainer() {
 		ctr, err := config.Runtime.LookupContainer(config.PidMode.Container())
 		if err != nil {
-			return errors.Wrapf(err, "container %q not found", config.PidMode.Container())
+			return nil, errors.Wrapf(err, "container %q not found", config.PidMode.Container())
 		}
 		labelOpts = append(labelOpts, label.DupSecOpt(ctr.ProcessLabel())...)
 	}
@@ -265,7 +262,7 @@ func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string) error {
 	} else if config.IpcMode.IsContainer() {
 		ctr, err := config.Runtime.LookupContainer(config.IpcMode.Container())
 		if err != nil {
-			return errors.Wrapf(err, "container %q not found", config.IpcMode.Container())
+			return nil, errors.Wrapf(err, "container %q not found", config.IpcMode.Container())
 		}
 		labelOpts = append(labelOpts, label.DupSecOpt(ctr.ProcessLabel())...)
 	}
@@ -276,7 +273,7 @@ func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string) error {
 		} else {
 			con := strings.SplitN(opt, "=", 2)
 			if len(con) != 2 {
-				return fmt.Errorf("Invalid --security-opt 1: %q", opt)
+				return nil, fmt.Errorf("Invalid --security-opt 1: %q", opt)
 			}
 
 			switch con[0] {
@@ -287,13 +284,13 @@ func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string) error {
 			case "seccomp":
 				config.SeccompProfilePath = con[1]
 			default:
-				return fmt.Errorf("Invalid --security-opt 2: %q", opt)
+				return nil, fmt.Errorf("Invalid --security-opt 2: %q", opt)
 			}
 		}
 	}
 
 	if err := loadAppArmor(config); err != nil {
-		return err
+		return nil, err
 	}
 
 	if config.SeccompProfilePath == "" {
@@ -301,19 +298,18 @@ func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string) error {
 			config.SeccompProfilePath = libpod.SeccompOverridePath
 		} else {
 			if !os.IsNotExist(err) {
-				return errors.Wrapf(err, "can't check if %q exists", libpod.SeccompOverridePath)
+				return nil, errors.Wrapf(err, "can't check if %q exists", libpod.SeccompOverridePath)
 			}
 			if _, err := os.Stat(libpod.SeccompDefaultPath); err != nil {
 				if !os.IsNotExist(err) {
-					return errors.Wrapf(err, "can't check if %q exists", libpod.SeccompDefaultPath)
+					return nil, errors.Wrapf(err, "can't check if %q exists", libpod.SeccompDefaultPath)
 				}
 			} else {
 				config.SeccompProfilePath = libpod.SeccompDefaultPath
 			}
 		}
 	}
-	config.ProcessLabel, config.MountLabel, err = label.InitLabels(labelOpts)
-	return err
+	return labelOpts, nil
 }
 
 // isPortInPortBindings determines if an exposed host port is in user
@@ -781,11 +777,21 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 		VolumesFrom: c.StringSlice("volumes-from"),
 	}
 
+	labelOpts := []string{}
 	if !config.Privileged {
-		if err := parseSecurityOpt(config, c.StringSlice("security-opt")); err != nil {
+		labelOpts, err = parseSecurityOpt(config, c.StringSlice("security-opt"))
+		if err != nil {
 			return nil, err
 		}
 	}
+	config.ProcessLabel, config.MountLabel, err = label.InitLabels(labelOpts)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error initializing mount and process labels")
+	}
+	if config.Privileged {
+		config.ProcessLabel = ""
+	}
+
 	config.SecurityOpts = c.StringSlice("security-opt")
 	warnings, err := verifyContainerResources(config, false)
 	if err != nil {

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -85,6 +85,18 @@ var _ = Describe("Podman privileged container tests", func() {
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 20))
 	})
 
+	It("podman run privileged container check mount label and process label", func() {
+		session := podmanTest.Podman([]string{"run", "--privileged", fedoraMinimal, "cat", "/proc/self/attr/current"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("system_r:spc_t"))
+
+		session = podmanTest.Podman([]string{"run", "--privileged", fedoraMinimal, "cat", "/proc/1/mountinfo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("object_r:container_file_t"))
+	})
+
 	It("run no-new-privileges test", func() {
 		// Check if our kernel is new enough
 		k, err := IsKernelNewThan("4.14")


### PR DESCRIPTION
Set the SELiux mount label for privileged containers
as well as they are applied to mounts and rootfs.
Only the process label should be wiped out.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>