### PR TITLE
Explicitly request the release of container's resources and trigger post-stop hooks

### DIFF
--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -132,6 +132,13 @@ func runCmd(c *cli.Context) error {
 		exitCode = int(ecode)
 	}
 
+	// Release container's resources and run post-stop hooks
+	if err := ctr.Delete(ctx); err != nil {
+		if errors.Cause(err) != libpod.ErrCtrStateInvalid {
+			return err
+		}
+	}
+
 	if createConfig.Rm {
 		return runtime.RemoveContainer(ctx, ctr, true)
 	}

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -639,6 +639,30 @@ func (c *Container) Cleanup() error {
 	return c.cleanup()
 }
 
+// Delete asks the OCI runtime to release this container resources
+// It also runs the post-stop hooks
+func (c *Container) Delete(ctx context.Context) error {
+       if !c.batched {
+               c.lock.Lock()
+               defer c.lock.Unlock()
+               if err := c.syncContainer(); err != nil {
+                       return err
+               }
+       }
+
+       // Check if state is good
+       if c.state.State == ContainerStateRunning || c.state.State == ContainerStatePaused {
+               return errors.Wrapf(ErrCtrStateInvalid, "container %s is running or paused, refusing to delete", c.ID())
+       }
+
+       // Check if we have active exec sessions
+       if len(c.state.ExecSessions) != 0 {
+               return errors.Wrapf(ErrCtrStateInvalid, "container %s has active exec sessions, refusing to delete", c.ID())
+       }
+
+       return c.delete(ctx)
+}
+
 // Batch starts a batch operation on the given container
 // All commands in the passed function will execute under the same lock and
 // without syncronyzing state after each operation


### PR DESCRIPTION
Extend the Container API with "Delete", and make use of it on interactive "podman run" sessions, so when they terminate the container's resources are released and the post-stop hooks run.

Not doing this may cause the OCI runtime to keep holding some resources until the container is removed. This is very visible with Kata, as the QEMU process and its proxy will keep running until "delete" is called for the runtime.