### PR TITLE
Add a way to disable SELinux labeling

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -244,7 +244,7 @@ func loadAppArmor(config *cc.CreateConfig) error {
 	return nil
 }
 
-func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string) error {
+func parseSecurityOpt(config *cc.CreateConfig, enableSELinux bool, securityOpts []string) error {
 	var (
 		labelOpts []string
 		err       error
@@ -312,7 +312,11 @@ func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string) error {
 			}
 		}
 	}
-	config.ProcessLabel, config.MountLabel, err = label.InitLabels(labelOpts)
+
+	if enableSELinux {
+		config.ProcessLabel, config.MountLabel, err = label.InitLabels(labelOpts)
+	}
+
 	return err
 }
 
@@ -782,7 +786,8 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 	}
 
 	if !config.Privileged {
-		if err := parseSecurityOpt(config, c.StringSlice("security-opt")); err != nil {
+		rtc := runtime.GetConfig()
+		if err := parseSecurityOpt(config, rtc.EnableSELinux, c.StringSlice("security-opt")); err != nil {
 			return nil, err
 		}
 	}

--- a/libpod.conf
+++ b/libpod.conf
@@ -88,3 +88,6 @@ pause_command = "/pause"
 # significant memory usage if a container has many ports forwarded to it.
 # Disabling this can save memory.
 #enable_port_reservation = true
+
+# Whether to use SELinux for labeling container processes
+#enable_selinux = true

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -67,6 +67,7 @@ type OCIRuntime struct {
 	logSizeMax    int64
 	noPivot       bool
 	reservePorts  bool
+	enableSELinux bool
 }
 
 // syncInfo is used to return data from monitor process to daemon
@@ -76,7 +77,7 @@ type syncInfo struct {
 }
 
 // Make a new OCI runtime with provided options
-func newOCIRuntime(name string, path string, conmonPath string, conmonEnv []string, cgroupManager string, tmpDir string, logSizeMax int64, noPivotRoot bool, reservePorts bool) (*OCIRuntime, error) {
+func newOCIRuntime(name string, path string, conmonPath string, conmonEnv []string, cgroupManager string, tmpDir string, logSizeMax int64, noPivotRoot bool, reservePorts bool, enableSELinux bool) (*OCIRuntime, error) {
 	runtime := new(OCIRuntime)
 	runtime.name = name
 	runtime.path = path
@@ -87,6 +88,7 @@ func newOCIRuntime(name string, path string, conmonPath string, conmonEnv []stri
 	runtime.logSizeMax = logSizeMax
 	runtime.noPivot = noPivotRoot
 	runtime.reservePorts = reservePorts
+	runtime.enableSELinux = enableSELinux
 
 	runtime.exitsDir = filepath.Join(runtime.tmpDir, "exits")
 	runtime.socketsDir = filepath.Join(runtime.tmpDir, "socket")
@@ -342,7 +344,7 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string) (er
 		fds := activation.Files(false)
 		cmd.ExtraFiles = append(cmd.ExtraFiles, fds...)
 	}
-	if selinux.GetEnabled() {
+	if r.enableSELinux && selinux.GetEnabled() {
 		// Set the label of the conmon process to be level :s0
 		// This will allow the container processes to talk to fifo-files
 		// passed into the container by conmon

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -172,6 +172,8 @@ type RuntimeConfig struct {
 	// However, this can cause significant memory usage if a container has
 	// many ports forwarded to it. Disabling this can save memory.
 	EnablePortReservation bool `toml:"enable_port_reservation"`
+	// EnableSELinux sets whether to use SELinux for labeling container processes
+	EnableSELinux bool `toml:"enable_selinux"`
 }
 
 var (
@@ -209,6 +211,7 @@ var (
 		InfraCommand:          DefaultInfraCommand,
 		InfraImage:            DefaultInfraImage,
 		EnablePortReservation: true,
+		EnableSELinux:         true,
 	}
 )
 
@@ -477,7 +480,7 @@ func makeRuntime(runtime *Runtime) (err error) {
 		runtime.conmonPath, runtime.config.ConmonEnvVars,
 		runtime.config.CgroupManager, runtime.config.TmpDir,
 		runtime.config.MaxLogSize, runtime.config.NoPivotRoot,
-		runtime.config.EnablePortReservation)
+		runtime.config.EnablePortReservation, runtime.config.EnableSELinux)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This allows using OCI runtimes with a different security model (like
Kata), without rebuilding libpod nor disabling SELinux system-wide.

Signed-off-by: Sergio Lopez <slp@redhat.com>