### PR TITLE
rootless: fix joining namespaces with container:NAME and ns:PATH

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -838,6 +838,13 @@ func joinOrCreateRootlessUserNamespace(createConfig *cc.CreateConfig, runtime *l
 		}
 	}
 
+	namespacesStr := []string{string(createConfig.IpcMode), string(createConfig.NetMode), string(createConfig.UsernsMode), string(createConfig.PidMode), string(createConfig.UtsMode)}
+	for _, i := range namespacesStr {
+		if cc.IsNS(i) {
+			return rootless.JoinNSPath(cc.NS(i))
+		}
+	}
+
 	namespaces := []namespace{createConfig.IpcMode, createConfig.NetMode, createConfig.UsernsMode, createConfig.PidMode, createConfig.UtsMode}
 	for _, i := range namespaces {
 		if i.IsContainer() {

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -802,6 +802,11 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 	return config, nil
 }
 
+type namespace interface {
+	IsContainer() bool
+	Container() string
+}
+
 func joinOrCreateRootlessUserNamespace(createConfig *cc.CreateConfig, runtime *libpod.Runtime) (bool, int, error) {
 	if os.Geteuid() == 0 {
 		return false, 0, nil
@@ -833,5 +838,19 @@ func joinOrCreateRootlessUserNamespace(createConfig *cc.CreateConfig, runtime *l
 		}
 	}
 
+	namespaces := []namespace{createConfig.IpcMode, createConfig.NetMode, createConfig.UsernsMode, createConfig.PidMode, createConfig.UtsMode}
+	for _, i := range namespaces {
+		if i.IsContainer() {
+			ctr, err := runtime.LookupContainer(i.Container())
+			if err != nil {
+				return false, -1, err
+			}
+			pid, err := ctr.PID()
+			if err != nil {
+				return false, -1, err
+			}
+			return rootless.JoinNS(uint(pid))
+		}
+	}
 	return rootless.BecomeRootInUserNS()
 }

--- a/pkg/namespaces/namespaces.go
+++ b/pkg/namespaces/namespaces.go
@@ -28,6 +28,16 @@ func (n UsernsMode) Valid() bool {
 	return true
 }
 
+// IsContainer indicates whether container uses a container userns.
+func (n UsernsMode) IsContainer() bool {
+	return false
+}
+
+// Container is the id of the container which network this container is connected to.
+func (n UsernsMode) Container() string {
+	return ""
+}
+
 // UTSMode represents the UTS namespace of the container.
 type UTSMode string
 
@@ -191,8 +201,8 @@ func (n NetworkMode) IsContainer() bool {
 	return len(parts) > 1 && parts[0] == "container"
 }
 
-// ConnectedContainer is the id of the container which network this container is connected to.
-func (n NetworkMode) ConnectedContainer() string {
+// Container is the id of the container which network this container is connected to.
+func (n NetworkMode) Container() string {
 	parts := strings.SplitN(string(n), ":", 2)
 	if len(parts) > 1 {
 		return parts[1]

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -111,6 +111,32 @@ func JoinNS(pid uint) (bool, int, error) {
 	return true, int(ret), nil
 }
 
+// JoinNSPath re-exec podman in a new userNS and join the owner user namespace of the
+// specified path.
+func JoinNSPath(path string) (bool, int, error) {
+	if os.Geteuid() == 0 || os.Getenv("_LIBPOD_USERNS_CONFIGURED") != "" {
+		return false, -1, nil
+	}
+
+	userNS, err := getUserNSForPath(path)
+	if err != nil {
+		return false, -1, err
+	}
+	defer userNS.Close()
+
+	pidC := C.reexec_userns_join(C.int(userNS.Fd()))
+	if int(pidC) < 0 {
+		return false, -1, errors.Errorf("cannot re-exec process")
+	}
+
+	ret := C.reexec_in_user_namespace_wait(pidC)
+	if ret < 0 {
+		return false, -1, errors.New("error waiting for the re-exec process")
+	}
+
+	return true, int(ret), nil
+}
+
 // BecomeRootInUserNS re-exec podman in a new userNS.  It returns whether podman was re-executed
 // into a new user namespace and the return code from the re-executed podman process.
 // If podman was re-executed the caller needs to propagate the error code returned by the child
@@ -229,6 +255,15 @@ func readUserNsFd(fd uintptr) (string, error) {
 	return readUserNs(filepath.Join("/proc/self/fd", fmt.Sprintf("%d", fd)))
 }
 
+func getOwner(fd uintptr) (uintptr, error) {
+	const nsGetUserns = 0xb701
+	ret, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(nsGetUserns), 0)
+	if errno != 0 {
+		return 0, errno
+	}
+	return (uintptr)(unsafe.Pointer(ret)), nil
+}
+
 func getParentUserNs(fd uintptr) (uintptr, error) {
 	const nsGetParent = 0xb702
 	ret, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(nsGetParent), 0)
@@ -238,7 +273,31 @@ func getParentUserNs(fd uintptr) (uintptr, error) {
 	return (uintptr)(unsafe.Pointer(ret)), nil
 }
 
-// getUserNSForPid returns an open FD for the first direct child user namespace that created the process
+func getUserNSForPath(path string) (*os.File, error) {
+	u, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot open %s", path)
+	}
+	defer u.Close()
+	fd, err := getOwner(u.Fd())
+	if err != nil {
+		return nil, err
+	}
+
+	return getUserNSFirstChild(fd)
+}
+
+func getUserNSForPid(pid uint) (*os.File, error) {
+	path := filepath.Join("/proc", fmt.Sprintf("%d", pid), "ns/user")
+	u, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot open %s", path)
+	}
+
+	return getUserNSFirstChild(u.Fd())
+}
+
+// getUserNSFirstChild returns an open FD for the first direct child user namespace that created the process
 // Each container creates a new user namespace where the runtime runs.  The current process in the container
 // might have created new user namespaces that are child of the initial namespace we created.
 // This function finds the initial namespace created for the container that is a child of the current namespace.
@@ -250,19 +309,12 @@ func getParentUserNs(fd uintptr) (uintptr, error) {
 //                                    b
 //                                   /
 //        NS READ USING THE PID ->  c
-func getUserNSForPid(pid uint) (*os.File, error) {
+func getUserNSFirstChild(fd uintptr) (*os.File, error) {
 	currentNS, err := readUserNs("/proc/self/ns/user")
 	if err != nil {
 		return nil, err
 	}
 
-	path := filepath.Join("/proc", fmt.Sprintf("%d", pid), "ns/user")
-	u, err := os.Open(path)
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot open %s", path)
-	}
-
-	fd := u.Fd()
 	ns, err := readUserNsFd(fd)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot read user namespace")

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	gosignal "os/signal"
 	"os/user"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"syscall"
@@ -252,7 +251,7 @@ func readUserNs(path string) (string, error) {
 }
 
 func readUserNsFd(fd uintptr) (string, error) {
-	return readUserNs(filepath.Join("/proc/self/fd", fmt.Sprintf("%d", fd)))
+	return readUserNs(fmt.Sprintf("/proc/self/fd/%d", fd))
 }
 
 func getOwner(fd uintptr) (uintptr, error) {
@@ -288,7 +287,7 @@ func getUserNSForPath(path string) (*os.File, error) {
 }
 
 func getUserNSForPid(pid uint) (*os.File, error) {
-	path := filepath.Join("/proc", fmt.Sprintf("%d", pid), "ns/user")
+	path := fmt.Sprintf("/proc/%d/ns/user", pid)
 	u, err := os.Open(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot open %s", path)

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -36,3 +36,9 @@ func SkipStorageSetup() bool {
 func JoinNS(pid uint) (bool, int, error) {
 	return false, -1, errors.New("this function is not supported on this os")
 }
+
+// JoinNSPath re-exec podman in a new userNS and join the owner user namespace of the
+// specified path.
+func JoinNSPath(path string) (bool, int, error) {
+	return false, -1, errors.New("this function is not supported on this os")
+}

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -380,9 +380,9 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime) ([]lib
 	if IsNS(string(c.NetMode)) {
 		// pass
 	} else if c.NetMode.IsContainer() {
-		connectedCtr, err := c.Runtime.LookupContainer(c.NetMode.ConnectedContainer())
+		connectedCtr, err := c.Runtime.LookupContainer(c.NetMode.Container())
 		if err != nil {
-			return nil, errors.Wrapf(err, "container %q not found", c.NetMode.ConnectedContainer())
+			return nil, errors.Wrapf(err, "container %q not found", c.NetMode.Container())
 		}
 		options = append(options, libpod.WithNetNSFrom(connectedCtr))
 	} else if !c.NetMode.IsHost() && !c.NetMode.IsNone() {


### PR DESCRIPTION
Support joining existing namespaces with container:NAME and ns:PATH.

```
$ podman run --name foo --rm -it alpine nc -l -p 8080
$ echo hello | podman run --name foo --rm \
    -it --network container:foo alpine nc localhost 8080
```
Closes: https://github.com/containers/libpod/issues/1453