### PR TITLE
Don't output inodes created to run a container

### DIFF
--- a/contrib/python/podman/test/test_containers.py
+++ b/contrib/python/podman/test/test_containers.py
@@ -111,8 +111,8 @@ class TestContainers(PodmanTestCase):
                 list(actual.keys())))
 
         # TODO: brittle, depends on knowing history of ctnr
-        self.assertGreaterEqual(len(actual['changed']), 2)
-        self.assertGreaterEqual(len(actual['added']), 2)
+        self.assertGreaterEqual(len(actual['changed']), 0)
+        self.assertGreaterEqual(len(actual['added']), 0)
         self.assertEqual(len(actual['deleted']), 0)
 
     def test_kill(self):


### PR DESCRIPTION
There is a group of inodes that get created when running a container
if they do not exist.

```
containerMounts = map[string]bool{
	"/dev":               true,
	"/etc/hostname":      true,
	"/etc/hosts":         true,
	"/etc/resolv.conf":   true,
	"/proc":              true,
	"/run":               true,
	"/run/.containerenv": true,
	"/run/secrets":       true,
	"/sys":               true,
}
```
If the destination inode does not exist, libpod/runc will create the inode.
This can cause programs like podman diff to see the image as having changed,
when actually it has not.  This patch ignores changes in these inodes.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>