### PR TITLE
Bind Mounts should be mounted read-only when in read-only mode

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -970,3 +970,8 @@ func (c *Container) RootGID() int {
 func (c *Container) IsInfra() bool {
 	return c.config.IsInfra
 }
+
+// IsReadOnly returns whether the container is running in read only mode
+func (c *Container) IsReadOnly() bool {
+	return c.config.Spec.Root.Readonly
+}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -107,7 +107,10 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 			Type:        "bind",
 			Source:      srcPath,
 			Destination: dstPath,
-			Options:     []string{"rw", "bind", "private"},
+			Options:     []string{"bind", "private"},
+		}
+		if c.IsReadOnly() {
+			newMount.Options = append(newMount.Options, "ro")
 		}
 		if !MountExists(g.Mounts(), dstPath) {
 			g.AddMount(newMount)


### PR DESCRIPTION
We don't want to allow users to write to /etc/resolv.conf or /etc/hosts if in read
only mode.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>