### PR TITLE
Vendor in latest opencontainers/runtime-tools

### DIFF
--- a/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
@@ -162,7 +162,7 @@ func New(os string) (generator Generator, err error) {
 				Destination: "/proc",
 				Type:        "proc",
 				Source:      "proc",
-				Options:     nil,
+				Options:     []string{"nosuid", "noexec", "nodev"},
 			},
 			{
 				Destination: "/dev",


### PR DESCRIPTION
This will cause /proc inside of the container to match the mount options
of the host.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>