### PR TITLE
report when rootless

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -147,6 +147,8 @@ func main() {
 			if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, rlimits); err != nil {
 				return errors.Wrapf(err, "error setting new rlimits")
 			}
+		} else {
+			logrus.Info("running as rootless")
 		}
 
 		if logLevel == "debug" {


### PR DESCRIPTION
when running as rootless, report as such.

resolves: #1509
Signed-off-by: baude <bbaude@redhat.com>