### PR TITLE
Implement more subcommands

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,11 +7,13 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func BuildImage(build: BuildInfo) BuildResponse](#BuildImage)
 
-[func Commit(name: string, image_name: string, changes: []string, author: string, message: string, pause: bool) string](#Commit)
+[func Commit(name: string, image_name: string, changes: []string, author: string, message: string, pause: bool, manifestType: string) string](#Commit)
 
 [func CreateContainer(create: Create) string](#CreateContainer)
 
 [func CreateImage() NotImplemented](#CreateImage)
+
+[func CreatePod(create: PodCreate) string](#CreatePod)
 
 [func DeleteStoppedContainers() []string](#DeleteStoppedContainers)
 
@@ -33,6 +35,10 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func GetInfo() PodmanInfo](#GetInfo)
 
+[func GetPod(name: string) ListPodData](#GetPod)
+
+[func GetPodStats(name: string) string, ContainerStats](#GetPodStats)
+
 [func GetVersion() Version](#GetVersion)
 
 [func HistoryImage(name: string) ImageHistory](#HistoryImage)
@@ -43,7 +49,11 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func InspectImage(name: string) string](#InspectImage)
 
+[func InspectPod(name: string) string](#InspectPod)
+
 [func KillContainer(name: string, signal: int) string](#KillContainer)
+
+[func KillPod(name: string, signal: int) string](#KillPod)
 
 [func ListContainerChanges(name: string) ContainerChanges](#ListContainerChanges)
 
@@ -53,7 +63,11 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func ListImages() ImageInList](#ListImages)
 
+[func ListPods() ListPodData](#ListPods)
+
 [func PauseContainer(name: string) string](#PauseContainer)
+
+[func PausePod(name: string) string](#PausePod)
 
 [func Ping() StringResponse](#Ping)
 
@@ -65,25 +79,39 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func RemoveImage(name: string, force: bool) string](#RemoveImage)
 
+[func RemovePod(name: string, force: bool) string](#RemovePod)
+
 [func RenameContainer() NotImplemented](#RenameContainer)
 
 [func ResizeContainerTty() NotImplemented](#ResizeContainerTty)
 
 [func RestartContainer(name: string, timeout: int) string](#RestartContainer)
 
+[func RestartPod(name: string) string](#RestartPod)
+
 [func SearchImage(name: string, limit: int) ImageSearch](#SearchImage)
 
 [func StartContainer(name: string) string](#StartContainer)
 
+[func StartPod(name: string) string](#StartPod)
+
 [func StopContainer(name: string, timeout: int) string](#StopContainer)
+
+[func StopPod(name: string) string](#StopPod)
 
 [func TagImage(name: string, tagged: string) string](#TagImage)
 
+[func TopPod() NotImplemented](#TopPod)
+
 [func UnpauseContainer(name: string) string](#UnpauseContainer)
+
+[func UnpausePod(name: string) string](#UnpausePod)
 
 [func UpdateContainer() NotImplemented](#UpdateContainer)
 
 [func WaitContainer(name: string) int](#WaitContainer)
+
+[func WaitPod() NotImplemented](#WaitPod)
 
 [type BuildInfo](#BuildInfo)
 
@@ -123,7 +151,15 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [type ListContainerData](#ListContainerData)
 
+[type ListPodContainerInfo](#ListPodContainerInfo)
+
+[type ListPodData](#ListPodData)
+
 [type NotImplemented](#NotImplemented)
+
+[type PodContainerErrorData](#PodContainerErrorData)
+
+[type PodCreate](#PodCreate)
 
 [type PodmanInfo](#PodmanInfo)
 
@@ -138,6 +174,12 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 [error ErrorOccurred](#ErrorOccurred)
 
 [error ImageNotFound](#ImageNotFound)
+
+[error NoContainerRunning](#NoContainerRunning)
+
+[error PodContainerError](#PodContainerError)
+
+[error PodNotFound](#PodNotFound)
 
 [error RuntimeError](#RuntimeError)
 
@@ -157,7 +199,7 @@ that contains the build logs and resulting image ID.
 ### <a name="Commit"></a>func Commit
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
-method Commit(name: [string](https://godoc.org/builtin#string), image_name: [string](https://godoc.org/builtin#string), changes: [[]string](#[]string), author: [string](https://godoc.org/builtin#string), message: [string](https://godoc.org/builtin#string), pause: [bool](https://godoc.org/builtin#bool)) [string](https://godoc.org/builtin#string)</div>
+method Commit(name: [string](https://godoc.org/builtin#string), image_name: [string](https://godoc.org/builtin#string), changes: [[]string](#[]string), author: [string](https://godoc.org/builtin#string), message: [string](https://godoc.org/builtin#string), pause: [bool](https://godoc.org/builtin#bool), manifestType: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
 Commit, creates an image from an existing container. It requires the name or
 ID of the container as well as the resulting image name.  Optionally, you can define an author and message
 to be added to the resulting image.  You can also define changes to the resulting image for the following
@@ -184,6 +226,23 @@ $ varlink call unix:/run/podman/io.podman/io.podman.CreateContainer '{"create": 
 
 method CreateImage() [NotImplemented](#NotImplemented)</div>
 This function is not implemented yet.
+### <a name="CreatePod"></a>func CreatePod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method CreatePod(create: [PodCreate](#PodCreate)) [string](https://godoc.org/builtin#string)</div>
+CreatePod creates a new empty pod.  It uses a [PodCreate](#PodCreate) type for input.
+On success, the ID of the newly created pod will be returned.
+#### Example
+~~~
+$ varlink call unix:/run/podman/io.podman/io.podman.CreatePod '{"create": {"name": "test"}}'
+{
+  "pod": "b05dee7bd4ccfee688099fe1588a7a898d6ddd6897de9251d4671c9b0feacb2a"
+}
+# $ varlink call unix:/run/podman/io.podman/io.podman.CreatePod '{"create": {"infra": true, "share": ["ipc", "net", "uts"]}}'
+{
+  "pod": "d7697449a8035f613c1a8891286502aca68fff7d5d49a85279b3bda229af3b28"
+}
+~~~
 ### <a name="DeleteStoppedContainers"></a>func DeleteStoppedContainers
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -253,7 +312,8 @@ capability of varlink if the client invokes it.
 method GetContainerStats(name: [string](https://godoc.org/builtin#string)) [ContainerStats](#ContainerStats)</div>
 GetContainerStats takes the name or ID of a container and returns a single ContainerStats structure which
 contains attributes like memory and cpu usage.  If the container cannot be found, a
-[ContainerNotFound](#ContainerNotFound)  error will be returned.
+[ContainerNotFound](#ContainerNotFound) error will be returned. If the container is not running, a [NoContainerRunning](#NoContainerRunning)
+error will be returned
 #### Example
 ~~~
 $ varlink call -m unix:/run/podman/io.podman/io.podman.GetContainerStats '{"name": "c33e4164f384"}'
@@ -287,6 +347,45 @@ If the image cannot be found, an [ImageNotFound](#ImageNotFound) error will be r
 method GetInfo() [PodmanInfo](#PodmanInfo)</div>
 GetInfo returns a [PodmanInfo](#PodmanInfo) struct that describes podman and its host such as storage stats,
 build information of Podman, and system-wide registries.
+### <a name="GetPod"></a>func GetPod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method GetPod(name: [string](https://godoc.org/builtin#string)) [ListPodData](#ListPodData)</div>
+GetPod takes a name or ID of a pod and returns single [ListPodData](#ListPodData)
+structure.  A [PodNotFound](#PodNotFound) error will be returned if the pod cannot be found.
+See also [ListPods](ListPods).
+### <a name="GetPodStats"></a>func GetPodStats
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method GetPodStats(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string), [ContainerStats](#ContainerStats)</div>
+GetPodStats takes the name or ID of a pod and returns a pod name and slice of ContainerStats structure which
+contains attributes like memory and cpu usage.  If the pod cannot be found, a [PodNotFound](#PodNotFound)
+error will be returned.  If the pod has no running containers associated with it, a [NoContainerRunning](#NoContainerRunning)
+error will be returned.
+#### Example
+~~~
+$ varlink call unix:/run/podman/io.podman/io.podman.GetPodStats '{"name": "7f62b508b6f12b11d8fe02e"}'
+{
+  "containers": [
+    {
+      "block_input": 0,
+      "block_output": 0,
+      "cpu": 2.833470544016107524276e-08,
+      "cpu_nano": 54363072,
+      "id": "a64b51f805121fe2c5a3dc5112eb61d6ed139e3d1c99110360d08b58d48e4a93",
+      "mem_limit": 12276146176,
+      "mem_perc": 7.974359265237864966003e-03,
+      "mem_usage": 978944,
+      "name": "quirky_heisenberg",
+      "net_input": 866,
+      "net_output": 7388,
+      "pids": 1,
+      "system_nano": 20000000
+    }
+  ],
+  "pod": "7f62b508b6f12b11d8fe02e0db4de6b9e43a7d7699b33a4fc0d574f6e82b4ebd"
+}
+~~~
 ### <a name="GetVersion"></a>func GetVersion
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -320,6 +419,13 @@ method InspectImage(name: [string](https://godoc.org/builtin#string)) [string](h
 InspectImage takes the name or ID of an image and returns a string respresentation of data associated with the
 mage.  You must serialize the string into JSON to use it further.  An [ImageNotFound](#ImageNotFound) error will
 be returned if the image cannot be found.
+### <a name="InspectPod"></a>func InspectPod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method InspectPod(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+InspectPod takes the name or ID of an image and returns a string respresentation of data associated with the
+pod.  You must serialize the string into JSON to use it further.  A [PodNotFound](#PodNotFound) error will
+be returned if the pod cannot be found.
 ### <a name="KillContainer"></a>func KillContainer
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -327,13 +433,22 @@ method KillContainer(name: [string](https://godoc.org/builtin#string), signal: [
 KillContainer takes the name or ID of a container as well as a signal to be applied to the container.  Once the
 container has been killed, the container's ID is returned.  If the container cannot be found, a
 [ContainerNotFound](#ContainerNotFound) error is returned. See also [StopContainer](StopContainer).
+### <a name="KillPod"></a>func KillPod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method KillPod(name: [string](https://godoc.org/builtin#string), signal: [int](https://godoc.org/builtin#int)) [string](https://godoc.org/builtin#string)</div>
+KillPod takes the name or ID of a pod as well as a signal to be applied to the pod.  If the pod cannot be found, a
+[PodNotFound](#PodNotFound) error is returned.
+Containers in a pod are killed independently. If there is an error killing one container, the ID of those containers
+will be returned in a list, along with the ID of the pod in a [PodContainerError](#PodContainerError).
+If the pod was killed with no errors, the pod ID is returned.
+See also [StopPod](StopPod).
 ### <a name="ListContainerChanges"></a>func ListContainerChanges
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
 method ListContainerChanges(name: [string](https://godoc.org/builtin#string)) [ContainerChanges](#ContainerChanges)</div>
 ListContainerChanges takes a name or ID of a container and returns changes between the container and
-its base image. It returns a struct of changed, deleted, and added path names. If the
-container cannot be found, a [ContainerNotFound](#ContainerNotFound) error will be returned.
+its base image. It returns a struct of changed, deleted, and added path names.
 ### <a name="ListContainerProcesses"></a>func ListContainerProcesses
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -366,6 +481,12 @@ returned as an array of ListContainerData structs.  See also [GetContainer](#Get
 method ListImages() [ImageInList](#ImageInList)</div>
 ListImages returns an array of ImageInList structures which provide basic information about
 an image currently in storage.  See also [InspectImage](InspectImage).
+### <a name="ListPods"></a>func ListPods
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method ListPods() [ListPodData](#ListPodData)</div>
+ListPods returns a list of pods in no particular order.  They are
+returned as an array of ListPodData structs.  See also [GetPod](#GetPod).
 ### <a name="PauseContainer"></a>func PauseContainer
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -373,6 +494,16 @@ method PauseContainer(name: [string](https://godoc.org/builtin#string)) [string]
 PauseContainer takes the name or ID of container and pauses it.  If the container cannot be found,
 a [ContainerNotFound](#ContainerNotFound) error will be returned; otherwise the ID of the container is returned.
 See also [UnpauseContainer](#UnpauseContainer).
+### <a name="PausePod"></a>func PausePod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method PausePod(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+PausePod takes the name or ID of a pod and pauses the running containers associated with it.  If the pod cannot be found,
+a [PodNotFound](#PodNotFound) error will be returned.
+Containers in a pod are paused independently. If there is an error pausing one container, the ID of those containers
+will be returned in a list, along with the ID of the pod in a [PodContainerError](#PodContainerError).
+If the pod was paused with no errors, the pod ID is returned.
+See also [UnpausePod](#UnpausePod).
 ### <a name="Ping"></a>func Ping
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -435,6 +566,24 @@ varlink call -m unix:/run/podman/io.podman/io.podman.RemoveImage '{"name": "regi
   "image": "426866d6fa419873f97e5cbd320eeb22778244c1dfffa01c944db3114f55772e"
 }
 ~~~
+### <a name="RemovePod"></a>func RemovePod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method RemovePod(name: [string](https://godoc.org/builtin#string), force: [bool](https://godoc.org/builtin#bool)) [string](https://godoc.org/builtin#string)</div>
+RemovePod takes the name or ID of a pod as well a boolean representing whether a running
+container in the pod can be stopped and removed.  If a pod has containers associated with it, and force is not true,
+an error will occur.
+If the pod cannot be found by name or ID, a [PodNotFound](#PodNotFound) error will be returned.
+Containers in a pod are removed independently. If there is an error removing any container, the ID of those containers
+will be returned in a list, along with the ID of the pod in a [PodContainerError](#PodContainerError).
+If the pod was removed with no errors, the pod ID is returned.
+#### Example
+~~~
+$ varlink call -m unix:/run/podman/io.podman/io.podman.RemovePod '{"name": "62f4fd98cb57", "force": "true"}'
+{
+  "pod": "62f4fd98cb57f529831e8f90610e54bba74bd6f02920ffb485e15376ed365c20"
+}
+~~~
 ### <a name="RenameContainer"></a>func RenameContainer
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -453,6 +602,23 @@ RestartContainer will restart a running container given a container name or ID a
 value is the time before a forcible stop is used to stop the container.  If the container cannot be found by
 name or ID, a [ContainerNotFound](#ContainerNotFound)  error will be returned; otherwise, the ID of the
 container will be returned.
+### <a name="RestartPod"></a>func RestartPod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method RestartPod(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+RestartPod will restart containers in a pod given a pod name or ID. Containers in
+the pod that are running will be stopped, then all stopped containers will be run.
+If the pod cannot be found by name or ID, a [PodNotFound](#PodNotFound) error will be returned.
+Containers in a pod are restarted independently. If there is an error restarting one container, the ID of those containers
+will be returned in a list, along with the ID of the pod in a [PodContainerError](#PodContainerError).
+If the pod was restarted with no errors, the pod ID is returned.
+#### Example
+~~~
+$ varlink call -m unix:/run/podman/io.podman/io.podman.RestartPod '{"name": "135d71b9495f"}'
+{
+  "pod": "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6"
+}
+~~~
 ### <a name="SearchImage"></a>func SearchImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -467,6 +633,22 @@ method StartContainer(name: [string](https://godoc.org/builtin#string)) [string]
 StartContainer starts a created or stopped container. It takes the name or ID of container.  It returns
 the container ID once started.  If the container cannot be found, a [ContainerNotFound](#ContainerNotFound)
 error will be returned.  See also [CreateContainer](#CreateContainer).
+### <a name="StartPod"></a>func StartPod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method StartPod(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+StartPod starts containers in a pod.  It takes the name or ID of pod.  If the pod cannot be found, a [PodNotFound](#PodNotFound)
+error will be returned.  Containers in a pod are started independently. If there is an error starting one container, the ID of those containers
+will be returned in a list, along with the ID of the pod in a [PodContainerError](#PodContainerError).
+If the pod was started with no errors, the pod ID is returned.
+See also [CreatePod](#CreatePod).
+#### Example
+~~~
+$ varlink call -m unix:/run/podman/io.podman/io.podman.StartPod '{"name": "135d71b9495f"}'
+{
+  "pod": "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6",
+}
+~~~
 ### <a name="StopContainer"></a>func StopContainer
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -482,12 +664,34 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.StopContainer '{"name": "
   "container": "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6"
 }
 ~~~
+### <a name="StopPod"></a>func StopPod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method StopPod(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+StopPod stops containers in a pod.  It takes the name or ID of a pod.
+If the pod cannot be found, a [PodNotFound](#PodNotFound) error will be returned instead.
+Containers in a pod are stopped independently. If there is an error stopping one container, the ID of those containers
+will be returned in a list, along with the ID of the pod in a [PodContainerError](#PodContainerError).
+If the pod was stopped with no errors, the pod ID is returned.
+See also [KillPod](KillPod).
+#### Example
+~~~
+$ varlink call -m unix:/run/podman/io.podman/io.podman.StopPod '{"name": "135d71b9495f"}'
+{
+  "pod": "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6"
+}
+~~~
 ### <a name="TagImage"></a>func TagImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
 method TagImage(name: [string](https://godoc.org/builtin#string), tagged: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
 TagImage takes the name or ID of an image in local storage as well as the desired tag name.  If the image cannot
 be found, an [ImageNotFound](#ImageNotFound) error will be returned; otherwise, the ID of the image is returned on success.
+### <a name="TopPod"></a>func TopPod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method TopPod() [NotImplemented](#NotImplemented)</div>
+This method has not been implemented yet.
 ### <a name="UnpauseContainer"></a>func UnpauseContainer
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -495,6 +699,16 @@ method UnpauseContainer(name: [string](https://godoc.org/builtin#string)) [strin
 UnpauseContainer takes the name or ID of container and unpauses a paused container.  If the container cannot be
 found, a [ContainerNotFound](#ContainerNotFound) error will be returned; otherwise the ID of the container is returned.
 See also [PauseContainer](#PauseContainer).
+### <a name="UnpausePod"></a>func UnpausePod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method UnpausePod(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+UnpausePod takes the name or ID of a pod and unpauses the paused containers associated with it.  If the pod cannot be
+found, a [PodNotFound](#PodNotFound) error will be returned.
+Containers in a pod are unpaused independently. If there is an error unpausing one container, the ID of those containers
+will be returned in a list, along with the ID of the pod in a [PodContainerError](#PodContainerError).
+If the pod was unpaused with no errors, the pod ID is returned.
+See also [PausePod](#PausePod).
 ### <a name="UpdateContainer"></a>func UpdateContainer
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -507,6 +721,11 @@ method WaitContainer(name: [string](https://godoc.org/builtin#string)) [int](htt
 WaitContainer takes the name or ID of a container and waits until the container stops.  Upon stopping, the return
 code of the container is returned. If the container container cannot be found by ID or name,
 a [ContainerNotFound](#ContainerNotFound) error is returned.
+### <a name="WaitPod"></a>func WaitPod
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method WaitPod() [NotImplemented](#NotImplemented)</div>
+This method has not be implemented yet.
 ## Types
 ### <a name="BuildInfo"></a>type BuildInfo
 
@@ -989,11 +1208,63 @@ mounts [ContainerMount](#ContainerMount)
 containerrunning [bool](https://godoc.org/builtin#bool)
 
 namespaces [ContainerNameSpace](#ContainerNameSpace)
+### <a name="ListPodContainerInfo"></a>type ListPodContainerInfo
+
+ListPodContainerInfo is a returned struct for describing containers
+in a pod.
+
+name [string](https://godoc.org/builtin#string)
+
+id [string](https://godoc.org/builtin#string)
+
+status [string](https://godoc.org/builtin#string)
+### <a name="ListPodData"></a>type ListPodData
+
+ListPodData is the returned struct for an individual pod
+
+id [string](https://godoc.org/builtin#string)
+
+name [string](https://godoc.org/builtin#string)
+
+createdat [string](https://godoc.org/builtin#string)
+
+cgroup [string](https://godoc.org/builtin#string)
+
+status [string](https://godoc.org/builtin#string)
+
+labels [map[string]](#map[string])
+
+numberofcontainers [string](https://godoc.org/builtin#string)
+
+containersinfo [ListPodContainerInfo](#ListPodContainerInfo)
 ### <a name="NotImplemented"></a>type NotImplemented
 
 
 
 comment [string](https://godoc.org/builtin#string)
+### <a name="PodContainerErrorData"></a>type PodContainerErrorData
+
+
+
+containerid [string](https://godoc.org/builtin#string)
+
+reason [string](https://godoc.org/builtin#string)
+### <a name="PodCreate"></a>type PodCreate
+
+PodCreate is an input structure for creating pods.
+It emulates options to podman pod create, however
+changing pause image name and pause container
+is not currently supported
+
+name [string](https://godoc.org/builtin#string)
+
+cgroupParent [string](https://godoc.org/builtin#string)
+
+labels [map[string]](#map[string])
+
+share [[]string](#[]string)
+
+infra [bool](https://godoc.org/builtin#bool)
 ### <a name="PodmanInfo"></a>type PodmanInfo
 
 PodmanInfo describes the Podman host and build
@@ -1045,6 +1316,16 @@ is includes as part of the error's text.
 ### <a name="ImageNotFound"></a>type ImageNotFound
 
 ImageNotFound means the image could not be found by the provided name or ID in local storage.
+### <a name="NoContainerRunning"></a>type NoContainerRunning
+
+NoContainerRunning means none of the containers requested are running in a command that requires a running container.
+### <a name="PodContainerError"></a>type PodContainerError
+
+PodContainerError means a container associated with a pod failed to preform an operation. It contains
+a container ID of the container that failed.
+### <a name="PodNotFound"></a>type PodNotFound
+
+PodNotFound means the pod could not be found by the provided name or ID in local storage.
 ### <a name="RuntimeError"></a>type RuntimeError
 
 RuntimeErrors generally means a runtime could not be found or gotten.

--- a/contrib/python/podman/Makefile
+++ b/contrib/python/podman/Makefile
@@ -1,5 +1,6 @@
 PYTHON ?= /usr/bin/python3
 DESTDIR ?= /
+PODMAN_VERSION ?= '0.0.4'
 
 .PHONY: python-podman
 python-podman:
@@ -16,6 +17,11 @@ integration:
 .PHONY: install
 install:
 	$(PYTHON) setup.py install --root ${DESTDIR}
+
+.PHONY: upload
+upload:
+	$(PODMAN_VERSION) $(PYTHON) setup.py sdist bdist_wheel
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 .PHONY: clobber
 clobber: uninstall clean

--- a/contrib/python/podman/podman/libs/_containers_start.py
+++ b/contrib/python/podman/podman/libs/_containers_start.py
@@ -20,6 +20,7 @@ class Mixin:
         Will block if container has been detached.
         """
         with self._client() as podman:
+            logging.debug('Starting Container "%s"', self._id)
             results = podman.StartContainer(self._id)
             logging.debug('Started Container "%s"', results['container'])
 

--- a/contrib/python/podman/test/test_runner.sh
+++ b/contrib/python/podman/test/test_runner.sh
@@ -97,11 +97,12 @@ EOT
 
 cat >$TMPDIR/ctnr/hello.sh <<-EOT
 echo 'Hello, World'
+exit 0
 EOT
 
 cat >$TMPDIR/ctnr/Dockerfile <<-EOT
 FROM alpine:latest
-COPY ./hello.sh /tmp/hello.sh
+COPY ./hello.sh /tmp/
 RUN chmod 755 /tmp/hello.sh
 ENTRYPOINT ["/tmp/hello.sh"]
 EOT

--- a/contrib/python/pypodman/.pylintrc
+++ b/contrib/python/pypodman/.pylintrc
@@ -1,0 +1,4 @@
+[VARIABLES]
+
+# Enforce only pep8 variable names
+variable-rgx=[a-z0-9_]{1,30}$

--- a/contrib/python/pypodman/Makefile
+++ b/contrib/python/pypodman/Makefile
@@ -1,5 +1,6 @@
 PYTHON ?= /usr/bin/python3
 DESTDIR := /
+PODMAN_VERSION ?= '0.0.4'
 
 .PHONY: python-pypodman
 python-pypodman:
@@ -16,6 +17,11 @@ integration:
 .PHONY: install
 install:
 	$(PYTHON) setup.py install --root ${DESTDIR}
+
+.PHONY: upload
+upload:
+	$(PODMAN_VERSION) $(PYTHON) setup.py sdist bdist_wheel
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 .PHONY: clobber
 clobber: uninstall clean

--- a/contrib/python/pypodman/pypodman/lib/__init__.py
+++ b/contrib/python/pypodman/pypodman/lib/__init__.py
@@ -1,7 +1,17 @@
 """Remote podman client support library."""
 from pypodman.lib.action_base import AbstractActionBase
-from pypodman.lib.config import PodmanArgumentParser
+from pypodman.lib.parser_actions import (BooleanAction, BooleanValidate,
+                                         PathAction, PositiveIntAction,
+                                         UnitAction)
+from pypodman.lib.podman_parser import PodmanArgumentParser
 from pypodman.lib.report import Report, ReportColumn
+
+# Silence pylint overlording...
+assert BooleanAction
+assert BooleanValidate
+assert PathAction
+assert PositiveIntAction
+assert UnitAction
 
 __all__ = [
     'AbstractActionBase',

--- a/contrib/python/pypodman/pypodman/lib/action_base.py
+++ b/contrib/python/pypodman/pypodman/lib/action_base.py
@@ -43,7 +43,12 @@ class AbstractActionBase(abc.ABC):
 
     def __init__(self, args):
         """Construct class."""
+        # Dump all unset arguments before transmitting to service
         self._args = args
+        self.opts = {
+            k: v
+            for k, v in vars(self._args).items() if v is not None
+        }
 
     @property
     def remote_uri(self):

--- a/contrib/python/pypodman/pypodman/lib/actions/__init__.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/__init__.py
@@ -3,7 +3,10 @@ from pypodman.lib.actions.attach_action import Attach
 from pypodman.lib.actions.commit_action import Commit
 from pypodman.lib.actions.create_action import Create
 from pypodman.lib.actions.export_action import Export
+from pypodman.lib.actions.history_action import History
 from pypodman.lib.actions.images_action import Images
+from pypodman.lib.actions.import_action import Import
+from pypodman.lib.actions.info_action import Info
 from pypodman.lib.actions.inspect_action import Inspect
 from pypodman.lib.actions.kill_action import Kill
 from pypodman.lib.actions.logs_action import Logs
@@ -12,15 +15,22 @@ from pypodman.lib.actions.pause_action import Pause
 from pypodman.lib.actions.port_action import Port
 from pypodman.lib.actions.ps_action import Ps
 from pypodman.lib.actions.pull_action import Pull
+from pypodman.lib.actions.push_action import Push
+from pypodman.lib.actions.restart_action import Restart
 from pypodman.lib.actions.rm_action import Rm
 from pypodman.lib.actions.rmi_action import Rmi
+from pypodman.lib.actions.run_action import Run
+from pypodman.lib.actions.search_action import Search
 
 __all__ = [
     'Attach',
     'Commit',
     'Create',
     'Export',
+    'History',
     'Images',
+    'Import',
+    'Info',
     'Inspect',
     'Kill',
     'Logs',
@@ -29,6 +39,10 @@ __all__ = [
     'Port',
     'Ps',
     'Pull',
+    'Push',
+    'Restart',
     'Rm',
     'Rmi',
+    'Run',
+    'Search',
 ]

--- a/contrib/python/pypodman/pypodman/lib/actions/_create_args.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/_create_args.py
@@ -1,0 +1,394 @@
+"""Implement common create container arguments together."""
+from pypodman.lib import BooleanAction, UnitAction
+
+
+class CreateArguments():
+    """Helper to add all the create flags to a command."""
+
+    @classmethod
+    def add_arguments(cls, parser):
+        """Add CreateArguments to parser."""
+        parser.add_argument(
+            '--add-host',
+            action='append',
+            metavar='HOST',
+            help='Add a line to /etc/hosts.'
+            ' The option can be set multiple times.'
+            ' (Format: hostname:ip)')
+        parser.add_argument(
+            '--annotation',
+            action='append',
+            help='Add an annotation to the container.'
+            'The option can be set multiple times.'
+            '(Format: key=value)')
+        parser.add_argument(
+            '--attach',
+            '-a',
+            action='append',
+            metavar='FD',
+            help=('Attach to STDIN, STDOUT or STDERR. The option can be set'
+                  ' for each of stdin, stdout, and stderr.'))
+
+        parser.add_argument(
+            '--blkio-weight',
+            choices=range(10, 1000),
+            metavar='[10-1000]',
+            help=('Block IO weight (relative weight) accepts a'
+                  ' weight value between 10 and 1000.'))
+        parser.add_argument(
+            '--blkio-weight-device',
+            action='append',
+            metavar='WEIGHT',
+            help='Block IO weight, relative device weight.'
+            ' (Format: DEVICE_NAME:WEIGHT)')
+        parser.add_argument(
+            '--cap-add',
+            action='append',
+            metavar='CAP',
+            help=('Add Linux capabilities'
+                  'The option can be set multiple times.'))
+        parser.add_argument(
+            '--cap-drop',
+            action='append',
+            metavar='CAP',
+            help=('Drop Linux capabilities'
+                  'The option can be set multiple times.'))
+        parser.add_argument(
+            '--cgroup-parent',
+            metavar='PATH',
+            help='Path to cgroups under which the cgroup for the'
+            ' container will be created. If the path is not'
+            ' absolute, the path is considered to be relative'
+            ' to the cgroups path of the init process. Cgroups'
+            ' will be created if they do not already exist.')
+        parser.add_argument(
+            '--cidfile',
+            metavar='PATH',
+            help='Write the container ID to the file, on the remote host.')
+        parser.add_argument(
+            '--conmon-pidfile',
+            metavar='PATH',
+            help=('Write the pid of the conmon process to a file,'
+                  ' on the remote host.'))
+        parser.add_argument(
+            '--cpu-period',
+            type=int,
+            metavar='PERIOD',
+            help=('Limit the CPU CFS (Completely Fair Scheduler) period.'))
+        parser.add_argument(
+            '--cpu-quota',
+            type=int,
+            metavar='QUOTA',
+            help=('Limit the CPU CFS (Completely Fair Scheduler) quota.'))
+        parser.add_argument(
+            '--cpu-rt-period',
+            type=int,
+            metavar='PERIOD',
+            help=('Limit the CPU real-time period in microseconds.'))
+        parser.add_argument(
+            '--cpu-rt-runtime',
+            type=int,
+            metavar='LIMIT',
+            help=('Limit the CPU real-time runtime in microseconds.'))
+        parser.add_argument(
+            '--cpu-shares',
+            type=int,
+            metavar='SHARES',
+            help=('CPU shares (relative weight)'))
+        parser.add_argument(
+            '--cpus',
+            type=float,
+            help=('Number of CPUs. The default is 0.0 which means no limit'))
+        parser.add_argument(
+            '--cpuset-cpus',
+            metavar='LIST',
+            help=('CPUs in which to allow execution (0-3, 0,1)'))
+        parser.add_argument(
+            '--cpuset-mems',
+            metavar='NODES',
+            help=('Memory nodes (MEMs) in which to allow execution (0-3, 0,1).'
+                  ' Only effective on NUMA systems'))
+        parser.add_argument(
+            '--detach',
+            '-d',
+            action=BooleanAction,
+            default=False,
+            help='Detached mode: run the container in the background and'
+            ' print the new container ID. (Default: False)')
+        parser.add_argument(
+            '--detach-keys',
+            metavar='KEY(s)',
+            default=4,
+            help='Override the key sequence for detaching a container.'
+            ' (Format: a single character [a-Z] or ctrl-<value> where'
+            ' <value> is one of: a-z, @, ^, [, , or _)')
+        parser.add_argument(
+            '--device',
+            action='append',
+            help=('Add a host device to the container'
+                  'The option can be set multiple times.'),
+        )
+        parser.add_argument(
+            '--device-read-bps',
+            action='append',
+            metavar='LIMIT',
+            help=('Limit read rate (bytes per second) from a device'
+                  ' (e.g. --device-read-bps=/dev/sda:1mb)'
+                  'The option can be set multiple times.'),
+        )
+        parser.add_argument(
+            '--device-read-iops',
+            action='append',
+            metavar='LIMIT',
+            help=('Limit read rate (IO per second) from a device'
+                  ' (e.g. --device-read-iops=/dev/sda:1000)'
+                  'The option can be set multiple times.'),
+        )
+        parser.add_argument(
+            '--device-write-bps',
+            action='append',
+            metavar='LIMIT',
+            help=('Limit write rate (bytes per second) to a device'
+                  ' (e.g. --device-write-bps=/dev/sda:1mb)'
+                  'The option can be set multiple times.'),
+        )
+        parser.add_argument(
+            '--device-write-iops',
+            action='append',
+            metavar='LIMIT',
+            help=('Limit write rate (IO per second) to a device'
+                  ' (e.g. --device-write-iops=/dev/sda:1000)'
+                  'The option can be set multiple times.'),
+        )
+        parser.add_argument(
+            '--dns',
+            action='append',
+            metavar='SERVER',
+            help=('Set custom DNS servers.'
+                  'The option can be set multiple times.'),
+        )
+        parser.add_argument(
+            '--dns-option',
+            action='append',
+            metavar='OPT',
+            help=('Set custom DNS options.'
+                  'The option can be set multiple times.'),
+        )
+        parser.add_argument(
+            '--dns-search',
+            action='append',
+            metavar='DOMAIN',
+            help=('Set custom DNS search domains.'
+                  'The option can be set multiple times.'),
+        )
+        parser.add_argument(
+            '--entrypoint',
+            help=('Overwrite the default ENTRYPOINT of the image.'),
+        )
+        parser.add_argument(
+            '--env',
+            '-e',
+            action='append',
+            help=('Set environment variables.'),
+        )
+        parser.add_argument(
+            '--env-file',
+            help=('Read in a line delimited file of environment variables,'
+                  ' on the remote host.'),
+        )
+        parser.add_argument(
+            '--expose',
+            metavar='RANGE',
+            help=('Expose a port, or a range of ports'
+                  ' (e.g. --expose=3300-3310) to set up port redirection.'),
+        )
+        parser.add_argument(
+            '--gidmap',
+            metavar='MAP',
+            help=('GID map for the user namespace'),
+        )
+        parser.add_argument(
+            '--group-add',
+            action='append',
+            metavar='GROUP',
+            help=('Add additional groups to run as'))
+        parser.add_argument('--hostname', help='Container host name')
+
+        volume_group = parser.add_mutually_exclusive_group()
+        volume_group.add_argument(
+            '--image-volume',
+            choices=['bind', 'tmpfs', 'ignore'],
+            metavar='MODE',
+            help='Tells podman how to handle the builtin image volumes')
+        volume_group.add_argument(
+            '--builtin-volume',
+            choices=['bind', 'tmpfs', 'ignore'],
+            metavar='MODE',
+            help='Tells podman how to handle the builtin image volumes')
+
+        parser.add_argument(
+            '--interactive',
+            '-i',
+            action=BooleanAction,
+            default=False,
+            help='Keep STDIN open even if not attached. (Default: False)')
+        parser.add_argument('--ipc', help='Create namespace')
+        parser.add_argument(
+            '--kernel-memory', action=UnitAction, help='Kernel memory limit')
+        parser.add_argument(
+            '--label',
+            '-l',
+            help=('Add metadata to a container'
+                  ' (e.g., --label com.example.key=value)'))
+        parser.add_argument(
+            '--label-file', help='Read in a line delimited file of labels')
+        parser.add_argument(
+            '--log-driver',
+            choices=['json-file', 'journald'],
+            help='Logging driver for the container.')
+        parser.add_argument(
+            '--log-opt',
+            action='append',
+            help='Logging driver specific options')
+        parser.add_argument(
+            '--memory', '-m', action=UnitAction, help='Memory limit')
+        parser.add_argument(
+            '--memory-reservation',
+            action=UnitAction,
+            help='Memory soft limit')
+        parser.add_argument(
+            '--memory-swap',
+            action=UnitAction,
+            help=('A limit value equal to memory plus swap.'
+                  'Must be used with the --memory flag'))
+        parser.add_argument(
+            '--memory-swappiness',
+            choices=range(0, 100),
+            metavar='[0-100]',
+            help="Tune a container's memory swappiness behavior")
+        parser.add_argument('--name', help='Assign a name to the container')
+        parser.add_argument(
+            '--network',
+            metavar='BRIDGE',
+            help=('Set the Network mode for the container.'))
+        parser.add_argument(
+            '--oom-kill-disable',
+            action=BooleanAction,
+            help='Whether to disable OOM Killer for the container or not')
+        parser.add_argument(
+            '--oom-score-adj',
+            choices=range(-1000, 1000),
+            metavar='[-1000-1000]',
+            help="Tune the host's OOM preferences for containers")
+        parser.add_argument('--pid', help='Set the PID mode for the container')
+        parser.add_argument(
+            '--pids-limit',
+            type=int,
+            metavar='LIMIT',
+            help=("Tune the container's pids limit."
+                  " Set -1 to have unlimited pids for the container."))
+        parser.add_argument('--pod', help='Run container in an existing pod')
+        parser.add_argument(
+            '--privileged',
+            action=BooleanAction,
+            help='Give extended privileges to this container.')
+        parser.add_argument(
+            '--publish',
+            '-p',
+            metavar='RANGE',
+            help="Publish a container's port, or range of ports, to the host")
+        parser.add_argument(
+            '--publish-all',
+            '-P',
+            action=BooleanAction,
+            help='Publish all exposed ports to random'
+            ' ports on the host interfaces'
+            '(Default: False)')
+        parser.add_argument(
+            '--quiet',
+            '-q',
+            action='store_true',
+            help='Suppress output information when pulling images')
+        parser.add_argument(
+            '--read-only',
+            action=BooleanAction,
+            help="Mount the container's root filesystem as read only.")
+        parser.add_argument(
+            '--rm',
+            action=BooleanAction,
+            default=False,
+            help='Automatically remove the container when it exits.')
+        parser.add_argument(
+            '--rootfs',
+            action='store_true',
+            help=('If specified, the first argument refers to an'
+                  ' exploded container on the file system of remote host.'))
+        parser.add_argument(
+            '--security-opt',
+            action='append',
+            metavar='OPT',
+            help='Set security options.')
+        parser.add_argument(
+            '--shm-size', action=UnitAction, help='Size of /dev/shm')
+        parser.add_argument(
+            '--sig-proxy',
+            action=BooleanAction,
+            default=True,
+            help='Proxy signals sent to the podman run'
+            ' command to the container process')
+        parser.add_argument(
+            '--stop-signal',
+            metavar='SIGTERM',
+            help='Signal to stop a container')
+        parser.add_argument(
+            '--stop-timeout',
+            metavar='TIMEOUT',
+            type=int,
+            default=10,
+            help='Seconds to wait on stopping container.')
+        parser.add_argument(
+            '--subgidname',
+            metavar='MAP',
+            help='Name for GID map from the /etc/subgid file')
+        parser.add_argument(
+            '--subuidname',
+            metavar='MAP',
+            help='Name for UID map from the /etc/subuid file')
+        parser.add_argument(
+            '--sysctl',
+            action='append',
+            help='Configure namespaced kernel parameters at runtime')
+        parser.add_argument(
+            '--tmpfs', metavar='MOUNT', help='Create a tmpfs mount')
+        parser.add_argument(
+            '--tty',
+            '-t',
+            action=BooleanAction,
+            default=False,
+            help='Allocate a pseudo-TTY for standard input of container.')
+        parser.add_argument(
+            '--uidmap', metavar='MAP', help='UID map for the user namespace')
+        parser.add_argument('--ulimit', metavar='OPT', help='Ulimit options')
+        parser.add_argument(
+            '--user',
+            '-u',
+            help=('Sets the username or UID used and optionally'
+                  ' the groupname or GID for the specified command.'))
+        parser.add_argument(
+            '--userns',
+            choices=['host', 'ns'],
+            help='Set the usernamespace mode for the container')
+        parser.add_argument(
+            '--uts',
+            choices=['host', 'ns'],
+            help='Set the UTS mode for the container')
+        parser.add_argument('--volume', '-v', help='Create a bind mount.')
+        parser.add_argument(
+            '--volumes-from',
+            action='append',
+            help='Mount volumes from the specified container(s).')
+        parser.add_argument(
+            '--workdir',
+            '-w',
+            metavar='PATH',
+            help='Working directory inside the container')

--- a/contrib/python/pypodman/pypodman/lib/actions/commit_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/commit_action.py
@@ -2,7 +2,7 @@
 import sys
 
 import podman
-from pypodman.lib import AbstractActionBase
+from pypodman.lib import AbstractActionBase, BooleanAction
 
 
 class Commit(AbstractActionBase):
@@ -47,14 +47,14 @@ class Commit(AbstractActionBase):
         parser.add_argument(
             '--pause',
             '-p',
-            choices=('True', 'False'),
+            action=BooleanAction,
             default=True,
-            type=bool,
             help='Pause the container when creating an image',
         )
         parser.add_argument(
             '--quiet',
             '-q',
+            action='store_true',
             help='Suppress output',
         )
         parser.add_argument(
@@ -71,20 +71,24 @@ class Commit(AbstractActionBase):
 
     def __init__(self, args):
         """Construct Commit class."""
-        super().__init__(args)
         if not args.container:
             raise ValueError('You must supply one container id'
                              ' or name to be used as source.')
         if not args.image:
             raise ValueError('You must supply one image id'
                              ' or name to be created.')
+        super().__init__(args)
+
+        # used only on client
+        del self.opts['image']
+        del self.opts['container']
 
     def commit(self):
         """Create image from container."""
         try:
             try:
                 ctnr = self.client.containers.get(self._args.container[0])
-                ident = ctnr.commit(**self._args)
+                ident = ctnr.commit(**self.opts)
                 print(ident)
             except podman.ContainerNotFound as e:
                 sys.stdout.flush()

--- a/contrib/python/pypodman/pypodman/lib/actions/create_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/create_action.py
@@ -1,413 +1,11 @@
 """Remote client command for creating container from image."""
-import argparse
 import sys
 from builtins import vars
 
 import podman
 from pypodman.lib import AbstractActionBase
 
-
-class UnitAction(argparse.Action):
-    """Validate number given is positive integer, with optional suffix."""
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        """Validate input."""
-        if isinstance(values, str):
-            if not values[:-1].isdigit():
-                msg = 'unit must be a positive integer, with optional suffix'
-                raise argparse.ArgumentError(self, msg)
-            if not values[-1] in ('b', 'k', 'm', 'g'):
-                msg = 'unit only supports suffices of: b, k, m, g'
-                raise argparse.ArgumentError(self, msg)
-        elif values <= 0:
-            msg = 'number must be a positive integer.'
-            raise argparse.ArgumentError(self, msg)
-
-        setattr(namespace, self.dest, values)
-
-
-def add_options(parser):
-    """Add options for Create command."""
-    parser.add_argument(
-        '--add-host',
-        action='append',
-        metavar='HOST',
-        help=('Add a line to /etc/hosts. The format is hostname:ip.'
-              ' The option can be set multiple times.'),
-    )
-    parser.add_argument(
-        '--attach',
-        '-a',
-        action='append',
-        metavar='FD',
-        help=('Attach to STDIN, STDOUT or STDERR. The option can be set'
-              ' for each of stdin, stdout, and stderr.'))
-    parser.add_argument(
-        '--annotation',
-        action='append',
-        help=('Add an annotation to the container. The format is'
-              ' key=value. The option can be set multiple times.'))
-    parser.add_argument(
-        '--blkio-weight',
-        choices=range(10, 1000),
-        metavar='[10-1000]',
-        help=('Block IO weight (relative weight) accepts a'
-              ' weight value between 10 and 1000.'))
-    parser.add_argument(
-        '--blkio-weight-device',
-        action='append',
-        metavar='WEIGHT',
-        help=('Block IO weight (relative device weight,'
-              ' format: DEVICE_NAME:WEIGHT).'))
-    parser.add_argument(
-        '--cap-add',
-        action='append',
-        metavar='CAP',
-        help=('Add Linux capabilities'
-              'The option can be set multiple times.'))
-    parser.add_argument(
-        '--cap-drop',
-        action='append',
-        metavar='CAP',
-        help=('Drop Linux capabilities'
-              'The option can be set multiple times.'))
-    parser.add_argument(
-        '--cgroup-parent',
-        metavar='PATH',
-        help=('Path to cgroups under which the cgroup for the'
-              ' container will be created. If the path is not'
-              ' absolute, the path is considered to be relative'
-              ' to the cgroups path of the init process. Cgroups'
-              ' will be created if they do not already exist.'))
-    parser.add_argument(
-        '--cidfile',
-        metavar='PATH',
-        help='Write the container ID to the file, on the remote host.')
-    parser.add_argument(
-        '--conmon-pidfile',
-        metavar='PATH',
-        help=('Write the pid of the conmon process to a file,'
-              ' on the remote host.'))
-    parser.add_argument(
-        '--cpu-count',
-        type=int,
-        metavar='COUNT',
-        help=('Limit the number of CPUs available'
-              ' for execution by the container.'))
-    parser.add_argument(
-        '--cpu-period',
-        type=int,
-        metavar='PERIOD',
-        help=('Limit the CPU CFS (Completely Fair Scheduler) period.'))
-    parser.add_argument(
-        '--cpu-quota',
-        type=int,
-        metavar='QUOTA',
-        help=('Limit the CPU CFS (Completely Fair Scheduler) quota.'))
-    parser.add_argument(
-        '--cpu-rt-period',
-        type=int,
-        metavar='PERIOD',
-        help=('Limit the CPU real-time period in microseconds.'))
-    parser.add_argument(
-        '--cpu-rt-runtime',
-        type=int,
-        metavar='LIMIT',
-        help=('Limit the CPU real-time runtime in microseconds.'))
-    parser.add_argument(
-        '--cpu-shares',
-        type=int,
-        metavar='SHARES',
-        help=('CPU shares (relative weight)'))
-    parser.add_argument(
-        '--cpus',
-        type=int,
-        help=('Number of CPUs. The default is 0 which means no limit'))
-    parser.add_argument(
-        '--cpuset-cpus',
-        metavar='LIST',
-        help=('CPUs in which to allow execution (0-3, 0,1)'))
-    parser.add_argument(
-        '--cpuset-mems',
-        metavar='NODES',
-        help=('Memory nodes (MEMs) in which to allow execution (0-3, 0,1).'
-              ' Only effective on NUMA systems'))
-    parser.add_argument(
-        '--detach',
-        '-d',
-        choices=['True', 'False'],
-        help=('Detached mode: run the container in the background and'
-              ' print the new container ID. The default is false.'))
-    parser.add_argument(
-        '--detach-keys',
-        metavar='KEY(s)',
-        help=('Override the key sequence for detaching a container.'
-              ' Format is a single character [a-Z] or ctrl-<value> where'
-              ' <value> is one of: a-z, @, ^, [, , or _.'))
-    parser.add_argument(
-        '--device',
-        action='append',
-        help=('Add a host device to the container'
-              'The option can be set multiple times.'),
-    )
-    parser.add_argument(
-        '--device-read-bps',
-        action='append',
-        metavar='LIMIT',
-        help=('Limit read rate (bytes per second) from a device'
-              ' (e.g. --device-read-bps=/dev/sda:1mb)'
-              'The option can be set multiple times.'),
-    )
-    parser.add_argument(
-        '--device-read-iops',
-        action='append',
-        metavar='LIMIT',
-        help=('Limit read rate (IO per second) from a device'
-              ' (e.g. --device-read-iops=/dev/sda:1000)'
-              'The option can be set multiple times.'),
-    )
-    parser.add_argument(
-        '--device-write-bps',
-        action='append',
-        metavar='LIMIT',
-        help=('Limit write rate (bytes per second) to a device'
-              ' (e.g. --device-write-bps=/dev/sda:1mb)'
-              'The option can be set multiple times.'),
-    )
-    parser.add_argument(
-        '--device-write-iops',
-        action='append',
-        metavar='LIMIT',
-        help=('Limit write rate (IO per second) to a device'
-              ' (e.g. --device-write-iops=/dev/sda:1000)'
-              'The option can be set multiple times.'),
-    )
-    parser.add_argument(
-        '--dns',
-        action='append',
-        metavar='SERVER',
-        help=('Set custom DNS servers.'
-              'The option can be set multiple times.'),
-    )
-    parser.add_argument(
-        '--dns-option',
-        action='append',
-        metavar='OPT',
-        help=('Set custom DNS options.'
-              'The option can be set multiple times.'),
-    )
-    parser.add_argument(
-        '--dns-search',
-        action='append',
-        metavar='DOMAIN',
-        help=('Set custom DNS search domains.'
-              'The option can be set multiple times.'),
-    )
-    parser.add_argument(
-        '--entrypoint',
-        help=('Overwrite the default ENTRYPOINT of the image.'),
-    )
-    parser.add_argument(
-        '--env',
-        '-e',
-        action='append',
-        help=('Set environment variables.'),
-    )
-    parser.add_argument(
-        '--env-file',
-        help=('Read in a line delimited file of environment variables,'
-              ' on the remote host.'),
-    )
-    parser.add_argument(
-        '--expose',
-        metavar='PORT(s)',
-        help=('Expose a port, or a range of ports'
-              ' (e.g. --expose=3300-3310) to set up port redirection.'),
-    )
-    parser.add_argument(
-        '--gidmap',
-        metavar='MAP',
-        help=('GID map for the user namespace'),
-    )
-    parser.add_argument(
-        '--group-add',
-        action='append',
-        metavar='GROUP',
-        help=('Add additional groups to run as'))
-    parser.add_argument('--hostname', help='Container host name')
-
-    volume_group = parser.add_mutually_exclusive_group()
-    volume_group.add_argument(
-        '--image-volume',
-        choices=['bind', 'tmpfs', 'ignore'],
-        metavar='MODE',
-        help='Tells podman how to handle the builtin image volumes')
-    volume_group.add_argument(
-        '--builtin-volume',
-        choices=['bind', 'tmpfs', 'ignore'],
-        metavar='MODE',
-        help='Tells podman how to handle the builtin image volumes')
-    parser.add_argument(
-        '--interactive',
-        '-i',
-        choices=['True', 'False'],
-        help='Keep STDIN open even if not attached. The default is false')
-    parser.add_argument('--ipc', help='Create namespace')
-    parser.add_argument(
-        '--kernel-memory',
-        action=UnitAction,
-        metavar='UNIT',
-        help=('Kernel memory limit (format: <number>[<unit>],'
-              ' where unit = b, k, m or g)'))
-    parser.add_argument(
-        '--label',
-        '-l',
-        help=('Add metadata to a container'
-              ' (e.g., --label com.example.key=value)'))
-    parser.add_argument(
-        '--label-file', help='Read in a line delimited file of labels')
-    parser.add_argument(
-        '--log-driver',
-        choices=['json-file', 'journald'],
-        help='Logging driver for the container.')
-    parser.add_argument(
-        '--log-opt', action='append', help='Logging driver specific options')
-    parser.add_argument(
-        '--mac-address', help='Container MAC address (e.g. 92:d0:c6:0a:29:33)')
-    parser.add_argument(
-        '--memory',
-        '-m',
-        action=UnitAction,
-        metavar='UNIT',
-        help='Memory limit (format: [], where unit = b, k, m or g)')
-    parser.add_argument(
-        '--memory-reservation',
-        action=UnitAction,
-        metavar='UNIT',
-        help='Memory soft limit (format: [], where unit = b, k, m or g)')
-    parser.add_argument(
-        '--memory-swap',
-        action=UnitAction,
-        metavar='UNIT',
-        help=('A limit value equal to memory plus swap.'
-              'Must be used with the --memory flag'))
-    parser.add_argument(
-        '--memory-swappiness',
-        choices=range(0, 100),
-        metavar='[0-100]',
-        help="Tune a container's memory swappiness behavior")
-    parser.add_argument('--name', help='Assign a name to the container')
-    parser.add_argument(
-        '--network',
-        metavar='BRIDGE',
-        help=('Set the Network mode for the container.'))
-    parser.add_argument(
-        '--oom-kill-disable',
-        choices=['True', 'False'],
-        help='Whether to disable OOM Killer for the container or not')
-    parser.add_argument(
-        '--oom-score-adj',
-        choices=range(-1000, 1000),
-        metavar='[-1000-1000]',
-        help="Tune the host's OOM preferences for containers")
-    parser.add_argument('--pid', help='Set the PID mode for the container')
-    parser.add_argument(
-        '--pids-limit',
-        type=int,
-        metavar='LIMIT',
-        help=("Tune the container's pids limit."
-              " Set -1 to have unlimited pids for the container."))
-    parser.add_argument('--pod', help='Run container in an existing pod')
-    parser.add_argument(
-        '--privileged',
-        choices=['True', 'False'],
-        help='Give extended privileges to this container.')
-    parser.add_argument(
-        '--publish',
-        '-p',
-        metavar='PORT(s)',
-        help="Publish a container's port, or range of ports, to the host")
-    parser.add_argument(
-        '--publish-all',
-        '-P',
-        action='store_true',
-        help=("Publish all exposed ports to random"
-              " ports on the host interfaces"))
-    parser.add_argument(
-        '--quiet',
-        '-q',
-        action='store_true',
-        help='Suppress output information when pulling images')
-    parser.add_argument(
-        '--read-only',
-        choices=['True', 'False'],
-        help="Mount the container's root filesystem as read only.")
-    parser.add_argument(
-        '--rm',
-        choices=['True', 'False'],
-        help='Automatically remove the container when it exits.')
-    parser.add_argument(
-        '--rootfs',
-        action='store_true',
-        help=('If specified, the first argument refers to an'
-              ' exploded container on the file system of remote host.'))
-    parser.add_argument(
-        '--security-opt',
-        action='append',
-        metavar='OPT',
-        help='Set security options.')
-    parser.add_argument(
-        '--shm-size',
-        action=UnitAction,
-        metavar='UNIT',
-        help='Size of /dev/shm')
-    parser.add_argument(
-        '--stop-signal', metavar='SIGTERM', help='Signal to stop a container')
-    parser.add_argument(
-        '--stop-timeout',
-        metavar='TIMEOUT',
-        help='Seconds to wait on stopping container.')
-    parser.add_argument(
-        '--subgidname',
-        metavar='MAP',
-        help='Name for GID map from the /etc/subgid file')
-    parser.add_argument(
-        '--subuidname',
-        metavar='MAP',
-        help='Name for UID map from the /etc/subuid file')
-    parser.add_argument(
-        '--sysctl',
-        action='append',
-        help='Configure namespaced kernel parameters at runtime')
-    parser.add_argument('--tmpfs', help='Create a tmpfs mount')
-    parser.add_argument(
-        '--tty',
-        '-t',
-        choices=['True', 'False'],
-        help='Allocate a pseudo-TTY for standard input of container.')
-    parser.add_argument(
-        '--uidmap', metavar='MAP', help='UID map for the user namespace')
-    parser.add_argument('--ulimit', metavar='OPT', help='Ulimit options')
-    parser.add_argument(
-        '--user',
-        '-u',
-        help=('Sets the username or UID used and optionally'
-              ' the groupname or GID for the specified command.'))
-    parser.add_argument(
-        '--userns',
-        choices=['host', 'ns'],
-        help='Set the usernamespace mode for the container')
-    parser.add_argument(
-        '--uts',
-        choices=['host', 'ns'],
-        help='Set the UTS mode for the container')
-    parser.add_argument('--volume', '-v', help='Create a bind mount.')
-    parser.add_argument(
-        '--volumes-from',
-        action='append',
-        help='Mount volumes from the specified container(s).')
-    parser.add_argument(
-        '--workdir', '-w', help='Working directory inside the container')
+from ._create_args import CreateArguments
 
 
 class Create(AbstractActionBase):
@@ -419,40 +17,40 @@ class Create(AbstractActionBase):
         parser = parent.add_parser(
             'create', help='create container from image')
 
-        add_options(parser)
+        CreateArguments.add_arguments(parser)
 
-        parser.add_argument('image', nargs='*', help='source image id.')
+        parser.add_argument('image', nargs=1, help='source image id')
+        parser.add_argument(
+            'command',
+            nargs='*',
+            help='command and args to run.',
+        )
         parser.set_defaults(class_=cls, method='create')
 
     def __init__(self, args):
         """Construct Create class."""
         super().__init__(args)
-        if not args.image:
-            raise ValueError('You must supply at least one image id'
-                             ' or name to be retrieved.')
+
+        # image id used only on client
+        del self.opts['image']
 
     def create(self):
         """Create container."""
-        # Dump all unset arguments before transmitting to service
-        opts = {k: v for k, v in vars(self._args).items() if v is not None}
-
-        # image id(s) used only on client
-        del opts['image']
-
-        for ident in self._args.image:
-            try:
-                img = self.client.images.get(ident)
-                img.container(**opts)
-                print(ident)
-            except podman.ImageNotFound as e:
-                sys.stdout.flush()
-                print(
-                    'Image {} not found.'.format(e.name),
-                    file=sys.stderr,
-                    flush=True)
-            except podman.ErrorOccurred as e:
-                sys.stdout.flush()
-                print(
-                    '{}'.format(e.reason).capitalize(),
-                    file=sys.stderr,
-                    flush=True)
+        try:
+            for ident in self._args.image:
+                try:
+                    img = self.client.images.get(ident)
+                    img.container(**self.opts)
+                    print(ident)
+                except podman.ImageNotFound as e:
+                    sys.stdout.flush()
+                    print(
+                        'Image {} not found.'.format(e.name),
+                        file=sys.stderr,
+                        flush=True)
+        except podman.ErrorOccurred as e:
+            sys.stdout.flush()
+            print(
+                '{}'.format(e.reason).capitalize(),
+                file=sys.stderr,
+                flush=True)

--- a/contrib/python/pypodman/pypodman/lib/actions/export_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/export_action.py
@@ -29,7 +29,6 @@ class Export(AbstractActionBase):
 
     def __init__(self, args):
         """Construct Export class."""
-        super().__init__(args)
         if not args.container:
             raise ValueError('You must supply one container id'
                              ' or name to be used as source.')
@@ -37,6 +36,7 @@ class Export(AbstractActionBase):
         if not args.output:
             raise ValueError('You must supply one filename'
                              ' to be created as tarball using --output.')
+        super().__init__(args)
 
     def export(self):
         """Create tarball from container filesystem."""

--- a/contrib/python/pypodman/pypodman/lib/actions/history_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/history_action.py
@@ -1,0 +1,83 @@
+"""Remote client for reporting image history."""
+import json
+from collections import OrderedDict
+
+import humanize
+
+import podman
+from pypodman.lib import (AbstractActionBase, BooleanAction, Report,
+                          ReportColumn)
+
+
+class History(AbstractActionBase):
+    """Class for reporting Image History."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add History command to parent parser."""
+        parser = parent.add_parser('history', help='report image history')
+        super().subparser(parser)
+        parser.add_argument(
+            '--human',
+            '-H',
+            action=BooleanAction,
+            default='True',
+            help='Display sizes and dates in human readable format.'
+            ' (default: %(default)s)')
+        parser.add_argument(
+            '--format',
+            choices=('json', 'table'),
+            help="Alter the output for a format like 'json' or 'table'."
+            " (default: table)")
+        parser.add_argument(
+            'image', nargs='+', help='image for history report')
+        parser.set_defaults(class_=cls, method='history')
+
+    def __init__(self, args):
+        """Construct History class."""
+        super().__init__(args)
+
+        self.columns = OrderedDict({
+            'id':
+            ReportColumn('id', 'ID', 12),
+            'created':
+            ReportColumn('created', 'CREATED', 11),
+            'createdBy':
+            ReportColumn('createdBy', 'CREATED BY', 45),
+            'size':
+            ReportColumn('size', 'SIZE', 8),
+            'comment':
+            ReportColumn('comment', 'COMMENT', 0)
+        })
+
+    def history(self):
+        """Report image history."""
+        rows = list()
+        for ident in self._args.image:
+            for details in self.client.images.get(ident).history():
+                fields = dict(details._asdict())
+
+                if self._args.human:
+                    fields.update({
+                        'size':
+                        humanize.naturalsize(details.size, binary=True),
+                        'created':
+                        humanize.naturaldate(
+                            podman.datetime_parse(details.created)),
+                    })
+                del fields['tags']
+
+                rows.append(fields)
+
+        if self._args.quiet:
+            for row in rows:
+                ident = row['id'][:12] if self._args.truncate else row['id']
+                print(ident)
+        elif self._args.format == 'json':
+            print(json.dumps(rows, indent=2), flush=True)
+        else:
+            with Report(self.columns, heading=self._args.heading) as report:
+                report.layout(
+                    rows, self.columns.keys(), truncate=self._args.truncate)
+                for row in rows:
+                    report.row(**row)

--- a/contrib/python/pypodman/pypodman/lib/actions/images_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/images_action.py
@@ -65,7 +65,7 @@ class Images(AbstractActionBase):
                 'created':
                 humanize.naturaldate(podman.datetime_parse(image.created)),
                 'size':
-                humanize.naturalsize(int(image.size)),
+                humanize.naturalsize(int(image.size), binary=True),
                 'repoDigests':
                 ' '.join(image.repoDigests),
             })

--- a/contrib/python/pypodman/pypodman/lib/actions/import_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/import_action.py
@@ -1,0 +1,60 @@
+"""Remote client command to import tarball as image filesystem."""
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+
+
+class Import(AbstractActionBase):
+    """Class for importing tarball as image filesystem."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Import command to parent parser."""
+        parser = parent.add_parser(
+            'import', help='import tarball as image filesystem')
+        parser.add_argument(
+            '--change',
+            '-c',
+            action='append',
+            choices=('CMD', 'ENTRYPOINT', 'ENV', 'EXPOSE', 'LABEL',
+                     'STOPSIGNAL', 'USER', 'VOLUME', 'WORKDIR'),
+            type=str.upper,
+            help='Apply the following possible instructions',
+        )
+        parser.add_argument(
+            '--message', '-m', help='Set commit message for imported image.')
+        parser.add_argument(
+            'source',
+            metavar='PATH',
+            nargs=1,
+            help='tarball to use as source on remote system',
+        )
+        parser.add_argument(
+            'reference',
+            metavar='TAG',
+            nargs='*',
+            help='Optional tag for image. (default: None)',
+        )
+        parser.set_defaults(class_=cls, method='import_')
+
+    def __init__(self, args):
+        """Construct Import class."""
+        super().__init__(args)
+
+    def import_(self):
+        """Import tarball as image filesystem."""
+        try:
+            ident = self.client.images.import_image(
+                self.opts.source,
+                self.opts.reference,
+                message=self.opts.message,
+                changes=self.opts.change)
+            print(ident)
+        except podman.ErrorOccurred as e:
+            sys.stdout.flush()
+            print(
+                '{}'.format(e.reason).capitalize(),
+                file=sys.stderr,
+                flush=True)
+            return 1

--- a/contrib/python/pypodman/pypodman/lib/actions/info_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/info_action.py
@@ -1,0 +1,49 @@
+"""Remote client command for reporting on Podman service."""
+import json
+import sys
+
+import podman
+import yaml
+from pypodman.lib import AbstractActionBase
+
+
+class Info(AbstractActionBase):
+    """Class for reporting on Podman Service."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Info command to parent parser."""
+        parser = parent.add_parser(
+            'info', help='report info on podman service')
+        parser.add_argument(
+            '--format',
+            choices=('json', 'yaml'),
+            help="Alter the output for a format like 'json' or 'yaml'."
+            " (default: yaml)")
+        parser.set_defaults(class_=cls, method='info')
+
+    def __init__(self, args):
+        """Construct Info class."""
+        super().__init__(args)
+
+    def info(self):
+        """Report on Podman Service."""
+        try:
+            info = self.client.system.info()
+        except podman.ErrorOccurred as e:
+            sys.stdout.flush()
+            print(
+                '{}'.format(e.reason).capitalize(),
+                file=sys.stderr,
+                flush=True)
+            return 1
+        else:
+            if self._args.format == 'json':
+                print(json.dumps(info._asdict(), indent=2), flush=True)
+            else:
+                print(
+                    yaml.dump(
+                        dict(info._asdict()),
+                        canonical=False,
+                        default_flow_style=False),
+                    flush=True)

--- a/contrib/python/pypodman/pypodman/lib/actions/inspect_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/inspect_action.py
@@ -41,7 +41,7 @@ class Inspect(AbstractActionBase):
 
     def _get_container(self, ident):
         try:
-            logging.debug("Get container %s", ident)
+            logging.debug("Getting container %s", ident)
             ctnr = self.client.containers.get(ident)
         except podman.ContainerNotFound:
             pass
@@ -50,7 +50,7 @@ class Inspect(AbstractActionBase):
 
     def _get_image(self, ident):
         try:
-            logging.debug("Get image %s", ident)
+            logging.debug("Getting image %s", ident)
             img = self.client.images.get(ident)
         except podman.ImageNotFound:
             pass

--- a/contrib/python/pypodman/pypodman/lib/actions/kill_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/kill_action.py
@@ -19,7 +19,7 @@ class Kill(AbstractActionBase):
             choices=range(1, signal.NSIG),
             metavar='[1,{}]'.format(signal.NSIG),
             default=9,
-            help='Signal to send to the container. (Default: 9)')
+            help='Signal to send to the container. (default: 9)')
         parser.add_argument(
             'containers',
             nargs='+',

--- a/contrib/python/pypodman/pypodman/lib/actions/logs_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/logs_action.py
@@ -5,20 +5,7 @@ import sys
 from collections import deque
 
 import podman
-from pypodman.lib import AbstractActionBase
-
-
-class PositiveIntAction(argparse.Action):
-    """Validate number given is positive integer."""
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        """Validate input."""
-        if values > 0:
-            setattr(namespace, self.dest, values)
-            return
-
-        msg = 'Must be a positive integer.'
-        raise argparse.ArgumentError(self, msg)
+from pypodman.lib import AbstractActionBase, PositiveIntAction
 
 
 class Logs(AbstractActionBase):
@@ -32,7 +19,6 @@ class Logs(AbstractActionBase):
             '--tail',
             metavar='LINES',
             action=PositiveIntAction,
-            type=int,
             help='Output the specified number of LINES at the end of the logs')
         parser.add_argument(
             'container',

--- a/contrib/python/pypodman/pypodman/lib/actions/port_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/port_action.py
@@ -29,10 +29,10 @@ class Port(AbstractActionBase):
 
     def __init__(self, args):
         """Construct Port class."""
-        super().__init__(args)
         if not args.all and not args.containers:
             ValueError('You must supply at least one'
                        ' container id or name, or --all.')
+        super().__init__(args)
 
     def port(self):
         """Retrieve ports from containers."""

--- a/contrib/python/pypodman/pypodman/lib/actions/port_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/port_action.py
@@ -30,8 +30,8 @@ class Port(AbstractActionBase):
     def __init__(self, args):
         """Construct Port class."""
         if not args.all and not args.containers:
-            ValueError('You must supply at least one'
-                       ' container id or name, or --all.')
+            raise ValueError('You must supply at least one'
+                             ' container id or name, or --all.')
         super().__init__(args)
 
     def port(self):

--- a/contrib/python/pypodman/pypodman/lib/actions/ps_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/ps_action.py
@@ -18,10 +18,8 @@ class Ps(AbstractActionBase):
         super().subparser(parser)
         parser.add_argument(
             '--sort',
-            choices=[
-                'createdat', 'id', 'image', 'names', 'runningfor', 'size',
-                'status'
-            ],
+            choices=('createdat', 'id', 'image', 'names', 'runningfor', 'size',
+                     'status'),
             default='createdat',
             type=str.lower,
             help=('Change sort ordered of displayed containers.'

--- a/contrib/python/pypodman/pypodman/lib/actions/pull_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pull_action.py
@@ -17,7 +17,7 @@ class Pull(AbstractActionBase):
         )
         parser.add_argument(
             'targets',
-            nargs='*',
+            nargs='+',
             help='image id(s) to retrieve.',
         )
         parser.set_defaults(class_=cls, method='pull')
@@ -25,9 +25,6 @@ class Pull(AbstractActionBase):
     def __init__(self, args):
         """Construct Pull class."""
         super().__init__(args)
-        if not args.targets:
-            raise ValueError('You must supply at least one container id'
-                             ' or name to be retrieved.')
 
     def pull(self):
         """Retrieve image."""

--- a/contrib/python/pypodman/pypodman/lib/actions/push_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/push_action.py
@@ -1,0 +1,56 @@
+"""Remote client command for pushing image elsewhere."""
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+
+
+class Push(AbstractActionBase):
+    """Class for pushing images to repository."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Push command to parent parser."""
+        parser = parent.add_parser(
+            'push',
+            help='push image elsewhere',
+        )
+        parser.add_argument(
+            '--tlsverify',
+            action='store_true',
+            default=True,
+            help='Require HTTPS and verify certificates when'
+            ' contacting registries (default: %(default)s)')
+        parser.add_argument(
+            'image', nargs=1, help='name or id of image to push')
+        parser.add_argument(
+            'tag',
+            nargs=1,
+            help='destination image id',
+        )
+        parser.set_defaults(class_=cls, method='push')
+
+    def __init__(self, args):
+        """Construct Push class."""
+        super().__init__(args)
+
+    def pull(self):
+        """Store image elsewhere."""
+        try:
+            try:
+                img = self.client.images.get(self._args.image[0])
+            except podman.ImageNotFound as e:
+                sys.stdout.flush()
+                print(
+                    'Image {} not found.'.format(e.name),
+                    file=sys.stderr,
+                    flush=True)
+            else:
+                img.push(self._args.tag[0], tlsverify=self._args.tlsverify)
+                print(self._args.image[0])
+        except podman.ErrorOccurred as e:
+            sys.stdout.flush()
+            print(
+                '{}'.format(e.reason).capitalize(),
+                file=sys.stderr,
+                flush=True)

--- a/contrib/python/pypodman/pypodman/lib/actions/restart_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/restart_action.py
@@ -1,0 +1,50 @@
+"""Remote client command for restarting containers."""
+import logging
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase, PositiveIntAction
+
+
+class Restart(AbstractActionBase):
+    """Class for Restarting containers."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Restart command to parent parser."""
+        parser = parent.add_parser('restart', help='restart container(s)')
+        parser.add_argument(
+            '--timeout',
+            action=PositiveIntAction,
+            default=10,
+            help='Timeout to wait before forcibly stopping the container'
+            ' (default: %(default)s seconds)')
+        parser.add_argument(
+            'targets', nargs='+', help='container id(s) to restart')
+        parser.set_defaults(class_=cls, method='restart')
+
+    def __init__(self, args):
+        """Construct Restart class."""
+        super().__init__(args)
+
+    def restart(self):
+        """Restart container(s)."""
+        try:
+            for ident in self._args.targets:
+                try:
+                    ctnr = self.client.containers.get(ident)
+                    logging.debug('Restarting Container %s', ctnr.id)
+                    ctnr.restart(timeout=self._args.timeout)
+                    print(ident)
+                except podman.ContainerNotFound as e:
+                    sys.stdout.flush()
+                    print(
+                        'Container {} not found.'.format(e.name),
+                        file=sys.stderr,
+                        flush=True)
+        except podman.ErrorOccurred as e:
+            sys.stdout.flush()
+            print(
+                '{}'.format(e.reason).capitalize(),
+                file=sys.stderr,
+                flush=True)

--- a/contrib/python/pypodman/pypodman/lib/actions/rm_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/rm_action.py
@@ -19,15 +19,12 @@ class Rm(AbstractActionBase):
             help=('force delete of running container(s).'
                   ' (default: %(default)s)'))
         parser.add_argument(
-            'targets', nargs='*', help='container id(s) to delete')
+            'targets', nargs='+', help='container id(s) to delete')
         parser.set_defaults(class_=cls, method='remove')
 
     def __init__(self, args):
         """Construct Rm class."""
         super().__init__(args)
-        if not args.targets:
-            raise ValueError('You must supply at least one container id'
-                             ' or name to be deleted.')
 
     def remove(self):
         """Remove container(s)."""

--- a/contrib/python/pypodman/pypodman/lib/actions/rmi_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/rmi_action.py
@@ -18,15 +18,12 @@ class Rmi(AbstractActionBase):
             action='store_true',
             help=('force delete of image(s) and associated containers.'
                   ' (default: %(default)s)'))
-        parser.add_argument('targets', nargs='*', help='image id(s) to delete')
+        parser.add_argument('targets', nargs='+', help='image id(s) to delete')
         parser.set_defaults(class_=cls, method='remove')
 
     def __init__(self, args):
         """Construct Rmi class."""
         super().__init__(args)
-        if not args.targets:
-            raise ValueError('You must supply at least one image id'
-                             ' or name to be deleted.')
 
     def remove(self):
         """Remove image(s)."""

--- a/contrib/python/pypodman/pypodman/lib/actions/run_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/run_action.py
@@ -1,0 +1,73 @@
+"""Remote client command for run a command in a new container."""
+import logging
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+
+from ._create_args import CreateArguments
+
+
+class Run(AbstractActionBase):
+    """Class for running a command in a container."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Run command to parent parser."""
+        parser = parent.add_parser('run', help='Run container from image')
+
+        CreateArguments.add_arguments(parser)
+
+        parser.add_argument('image', nargs=1, help='source image id.')
+        parser.add_argument(
+            'command',
+            nargs='*',
+            help='command and args to run.',
+        )
+        parser.set_defaults(class_=cls, method='run')
+
+    def __init__(self, args):
+        """Construct Run class."""
+        super().__init__(args)
+        if args.detach and args.rm:
+            raise ValueError('Incompatible options: --detach and --rm')
+
+        # image id used only on client
+        del self.opts['image']
+
+    def run(self):
+        """Run container."""
+        for ident in self._args.image:
+            try:
+                try:
+                    img = self.client.images.get(ident)
+                    ctnr = img.container(**self.opts)
+                except podman.ImageNotFound as e:
+                    sys.stdout.flush()
+                    print(
+                        'Image {} not found.'.format(e.name),
+                        file=sys.stderr,
+                        flush=True)
+                    continue
+                else:
+                    logging.debug('New container created "{}"'.format(ctnr.id))
+
+                if self._args.detach:
+                    ctnr.start()
+                    print(ctnr.id)
+                else:
+                    ctnr.attach(eot=4)
+                    ctnr.start()
+                    print(ctnr.id)
+
+                    if self._args.rm:
+                        ctnr.remove(force=True)
+            except (BrokenPipeError, KeyboardInterrupt):
+                print('\nContainer "{}" disconnected.'.format(ctnr.id))
+            except podman.ErrorOccurred as e:
+                sys.stdout.flush()
+                print(
+                    'Run for container "{}" failed: {} {}'.format(
+                        ctnr.id, repr(e), e.reason.capitalize()),
+                    file=sys.stderr,
+                    flush=True)

--- a/contrib/python/pypodman/pypodman/lib/actions/search_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/search_action.py
@@ -1,0 +1,160 @@
+"""Remote client command for searching registries for an image."""
+import argparse
+import sys
+from collections import OrderedDict
+
+import podman
+from pypodman.lib import (AbstractActionBase, BooleanValidate,
+                          PositiveIntAction, Report, ReportColumn)
+
+
+class FilterAction(argparse.Action):
+    """Parse filter argument components."""
+
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 nargs=None,
+                 const=None,
+                 default=None,
+                 type=None,
+                 choices=None,
+                 required=False,
+                 help=None,
+                 metavar='FILTER'):
+        """Create FilterAction object."""
+        help = (help or '') + (' (format: stars=##'
+                               ' or is-automated=[True|False]'
+                               ' or is-official=[True|False])')
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=nargs,
+            const=const,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """
+        Convert and Validate input.
+
+        Note: side effects
+        1) self.dest value is set to subargument dest
+        2) new attribute self.dest + '_value' is created with 2nd value.
+        """
+        opt, val = values.split('=', 1)
+        if opt == 'stars':
+            msg = ('{} option "stars" requires'
+                   ' a positive integer').format(self.dest)
+            try:
+                val = int(val)
+            except ValueError:
+                parser.error(msg)
+
+            if val < 0:
+                parser.error(msg)
+        elif opt == 'is-automated':
+            try:
+                val = BooleanValidate()(val)
+            except ValueError:
+                msg = ('{} option "is-automated"'
+                       ' must be True or False.'.format(self.dest))
+                parser.error(msg)
+        elif opt == 'is-official':
+            try:
+                val = BooleanValidate()(val)
+            except ValueError:
+                msg = ('{} option "is-official"'
+                       ' must be True or False.'.format(self.dest))
+                parser.error(msg)
+        else:
+            msg = ('{} only supports one of the following options:\n'
+                   '  stars, is-automated, or is-official').format(self.dest)
+            parser.error(msg)
+        setattr(namespace, self.dest, opt)
+        setattr(namespace, self.dest + '_value', val)
+
+
+class Search(AbstractActionBase):
+    """Class for searching registries for an image."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Search command to parent parser."""
+        parser = parent.add_parser('search', help='search for images')
+        super().subparser(parser)
+        parser.add_argument(
+            '--filter',
+            '-f',
+            action=FilterAction,
+            help='Filter output based on conditions provided.')
+        parser.add_argument(
+            '--limit',
+            action=PositiveIntAction,
+            default=25,
+            help='Limit the number of results.'
+            ' (default: %(default)s)')
+        parser.add_argument('term', nargs=1, help='search term for image')
+        parser.set_defaults(class_=cls, method='search')
+
+    def __init__(self, args):
+        """Construct Search class."""
+        super().__init__(args)
+
+        self.columns = OrderedDict({
+            'name':
+            ReportColumn('name', 'NAME', 44),
+            'description':
+            ReportColumn('description', 'DESCRIPTION', 44),
+            'star_count':
+            ReportColumn('star_count', 'STARS', 5),
+            'is_official':
+            ReportColumn('is_official', 'OFFICIAL', 8),
+            'is_automated':
+            ReportColumn('is_automated', 'AUTOMATED', 9),
+        })
+
+    def search(self):
+        """Search registries for image."""
+        try:
+            rows = list()
+            for entry in self.client.images.search(
+                    self._args.term[0], limit=self._args.limit):
+
+                if self._args.filter == 'is-official':
+                    if self._args.filter_value != entry.is_official:
+                        continue
+                elif self._args.filter == 'is-automated':
+                    if self._args.filter_value != entry.is_automated:
+                        continue
+                elif self._args.filter == 'stars':
+                    if self._args.filter_value > entry.star_count:
+                        continue
+
+                fields = dict(entry._asdict())
+
+                status = '[OK]' if entry.is_official else ''
+                fields['is_official'] = status
+
+                status = '[OK]' if entry.is_automated else ''
+                fields['is_automated'] = status
+
+                if self._args.truncate:
+                    fields.update({'name': entry.name[-44:]})
+                rows.append(fields)
+
+            with Report(self.columns, heading=self._args.heading) as report:
+                report.layout(
+                    rows, self.columns.keys(), truncate=self._args.truncate)
+                for row in rows:
+                    report.row(**row)
+        except podman.ErrorOccurred as e:
+            sys.stdout.flush()
+            print(
+                '{}'.format(e.reason).capitalize(),
+                file=sys.stderr,
+                flush=True)

--- a/contrib/python/pypodman/pypodman/lib/parser_actions.py
+++ b/contrib/python/pypodman/pypodman/lib/parser_actions.py
@@ -1,0 +1,185 @@
+"""
+Supplimental argparse.Action converters and validaters.
+
+The constructors are very verbose but remain for IDE support.
+"""
+import argparse
+import os
+
+# API defined by argparse.Action shut up pylint
+# pragma pylint: disable=redefined-builtin
+# pragma pylint: disable=too-few-public-methods
+# pragma pylint: disable=too-many-arguments
+
+
+class BooleanValidate():
+    """Validate value is boolean string."""
+
+    def __call__(self, value):
+        """Return True, False or raise ValueError."""
+        val = value.capitalize()
+        if val == 'False':
+            return False
+        elif val == 'True':
+            return True
+        else:
+            raise ValueError('"{}" is not True or False'.format(value))
+
+
+class BooleanAction(argparse.Action):
+    """Convert and validate bool argument."""
+
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 nargs=None,
+                 const=None,
+                 default=None,
+                 type=None,
+                 choices=('True', 'False'),
+                 required=False,
+                 help=None,
+                 metavar='{True,False}'):
+        """Create BooleanAction object."""
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=nargs,
+            const=const,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """Convert and Validate input."""
+        try:
+            val = BooleanValidate()(values)
+        except ValueError:
+            parser.error('{} must be True or False.'.format(self.dest))
+        else:
+            setattr(namespace, self.dest, val)
+
+
+class UnitAction(argparse.Action):
+    """Validate number given is positive integer, with optional suffix."""
+
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 nargs=None,
+                 const=None,
+                 default=None,
+                 type=None,
+                 choices=None,
+                 required=False,
+                 help=None,
+                 metavar='UNIT'):
+        """Create UnitAction object."""
+        help = (help or metavar or dest
+                ) + ' (format: <number>[<unit>], where unit = b, k, m or g)'
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=nargs,
+            const=const,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """Validate input as a UNIT."""
+        try:
+            val = int(values)
+        except ValueError:
+            if not values[:-1].isdigit():
+                msg = ('{} must be a positive integer,'
+                       ' with optional suffix').format(self.dest)
+                parser.error(msg)
+            if not values[-1] in ('b', 'k', 'm', 'g'):
+                msg = '{} only supports suffices of: b, k, m, g'.format(
+                    self.dest)
+                parser.error(msg)
+        else:
+            if val <= 0:
+                msg = '{} must be a positive integer'.format(self.dest)
+                parser.error(msg)
+
+        setattr(namespace, self.dest, values)
+
+
+class PositiveIntAction(argparse.Action):
+    """Validate number given is positive integer."""
+
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 nargs=None,
+                 const=None,
+                 default=None,
+                 type=int,
+                 choices=None,
+                 required=False,
+                 help=None,
+                 metavar=None):
+        """Create PositiveIntAction object."""
+        self.message = '{} must be a positive integer'.format(dest)
+        help = help or self.message
+
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=nargs,
+            const=const,
+            default=default,
+            type=int,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """Validate input."""
+        if values > 0:
+            setattr(namespace, self.dest, values)
+            return
+
+        parser.error(self.message)
+
+
+class PathAction(argparse.Action):
+    """Expand user- and relative-paths."""
+
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 nargs=None,
+                 const=None,
+                 default=None,
+                 type=None,
+                 choices=None,
+                 required=False,
+                 help=None,
+                 metavar='PATH'):
+        """Create PathAction object."""
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=nargs,
+            const=const,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """Resolve full path value on local filesystem."""
+        setattr(namespace, self.dest,
+                os.path.abspath(os.path.expanduser(values)))

--- a/contrib/python/pypodman/pypodman/lib/report.py
+++ b/contrib/python/pypodman/pypodman/lib/report.py
@@ -53,7 +53,7 @@ class Report():
         fmt = []
 
         for key in keys:
-            slice_ = [i.get(key, '') for i in iterable]
+            slice_ = [str(i.get(key, '')) for i in iterable]
             data_len = len(max(slice_, key=len))
 
             info = self._columns.get(key,

--- a/contrib/python/pypodman/requirements.txt
+++ b/contrib/python/pypodman/requirements.txt
@@ -1,4 +1,5 @@
 humanize
 podman
 pytoml
+PyYAML
 setuptools>=39


### PR DESCRIPTION
* Refactor create subparser to share arguments with run subparser
* Add argparse.*Action subclasses to reduce duplicate code in parsers
* Using BooleanAction now accept True/False value as expected
* .pylintrc added to loosen variable name policing
* Update AbstractBaseAction to remove unset arguments before
  transmitting to podman service
* Align logging messages to podman output
* Renamed global argument from --user to --username, to avoid conflict
  with create/run podman commands
* Add new subcommands: run, create, history, import, info, push,
  restart and search
* Add makefile support for Uploads to PyPi.org
* Add retries to container._refresh()

Signed-off-by: Jhon Honce <jhonce@redhat.com>