### PR TITLE
rootless: fix create with images not in the storage

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -61,6 +61,10 @@ func createCmd(c *cli.Context) error {
 		return err
 	}
 
+	if os.Geteuid() != 0 {
+		rootless.SetSkipStorageSetup(true)
+	}
+
 	runtime, err := libpodruntime.GetContainerRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -38,6 +39,9 @@ var runCommand = cli.Command{
 func runCmd(c *cli.Context) error {
 	if err := createInit(c); err != nil {
 		return err
+	}
+	if os.Geteuid() != 0 {
+		rootless.SetSkipStorageSetup(true)
 	}
 
 	runtime, err := libpodruntime.GetContainerRuntime(c)


### PR DESCRIPTION
This chunk was mistakenly removed with ecec1a5430885baf96d2e3d6153c7454c41a4617

Introduce it back as it solves the pull of an image that is not yet in
the storage when using create/run.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>