### PR TITLE
Refactor Wait() to not require a timeout

### DIFF
--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -117,7 +117,7 @@ func runCmd(c *cli.Context) error {
 		return err
 	}
 
-	if ecode, err := ctr.Wait(libpod.WaitTimeout); err != nil {
+	if ecode, err := ctr.Wait(); err != nil {
 		if errors.Cause(err) == libpod.ErrNoSuchCtr {
 			// The container may have been removed
 			// Go looking for an exit file

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -115,7 +115,7 @@ func startCmd(c *cli.Context) error {
 				return errors.Wrapf(err, "unable to start container %s", ctr.ID())
 			}
 
-			if ecode, err := ctr.Wait(libpod.WaitTimeout); err != nil {
+			if ecode, err := ctr.Wait(); err != nil {
 				logrus.Errorf("unable to get exit code of container %s: %q", ctr.ID(), err)
 			} else {
 				exitCode = int(ecode)

--- a/cmd/podman/wait.go
+++ b/cmd/podman/wait.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
-	"github.com/containers/libpod/libpod"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -21,7 +20,7 @@ var (
 		cli.UintFlag{
 			Name:  "interval, i",
 			Usage: "Milliseconds to wait before polling for completion",
-			Value: uint(libpod.WaitTimeout),
+			Value: 250,
 		},
 		LatestFlag,
 	}
@@ -69,7 +68,7 @@ func waitCmd(c *cli.Context) error {
 		if c.Uint("interval") == 0 {
 			return errors.Errorf("interval must be greater then 0")
 		}
-		returnCode, err := ctr.Wait(time.Duration(c.Uint("interval")))
+		returnCode, err := ctr.WaitWithInterval(time.Duration(c.Uint("interval")) * time.Millisecond)
 		if err != nil {
 			if lastError != nil {
 				fmt.Fprintln(os.Stderr, lastError)

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -36,8 +36,6 @@ const (
 	ContainerStateStopped ContainerStatus = iota
 	// ContainerStatePaused indicates that the container has been paused
 	ContainerStatePaused ContainerStatus = iota
-	// WaitTimeout is the wait timeout before checking for container exit
-	WaitTimeout = time.Second / time.Millisecond
 )
 
 // CgroupfsDefaultCgroupParent is the cgroup parent for CGroupFS in libpod
@@ -46,6 +44,10 @@ const CgroupfsDefaultCgroupParent = "/libpod_parent"
 // SystemdDefaultCgroupParent is the cgroup parent for the systemd cgroup
 // manager in libpod
 const SystemdDefaultCgroupParent = "machine.slice"
+
+// DefaultWaitInterval is the default interval between container status checks
+// while waiting.
+const DefaultWaitInterval = 250 * time.Millisecond
 
 // LinuxNS represents a Linux namespace
 type LinuxNS int

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -593,13 +593,20 @@ func (c *Container) Inspect(size bool) (*inspect.ContainerInspectData, error) {
 	return c.getContainerInspectData(size, driverData)
 }
 
-// Wait blocks on a container to exit and returns its exit code
-func (c *Container) Wait(waitTimeout time.Duration) (int32, error) {
+// Wait blocks until the container exits and returns its exit code.
+func (c *Container) Wait() (int32, error) {
+	return c.WaitWithInterval(DefaultWaitInterval)
+}
+
+// WaitWithInterval blocks until the container to exit and returns its exit
+// code. The argument is the interval at which checks the container's status.
+func (c *Container) WaitWithInterval(waitTimeout time.Duration) (int32, error) {
 	if !c.valid {
 		return -1, ErrCtrRemoved
 	}
-	err := wait.PollImmediateInfinite(waitTimeout*time.Millisecond,
+	err := wait.PollImmediateInfinite(waitTimeout,
 		func() (bool, error) {
+			logrus.Debugf("Checking container %s status...", c.ID())
 			stopped, err := c.isStopped()
 			if err != nil {
 				return false, err

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -341,7 +341,7 @@ func (i *LibpodAPI) WaitContainer(call iopodman.VarlinkCall, name string) error 
 	if err != nil {
 		return call.ReplyContainerNotFound(name)
 	}
-	exitCode, err := ctr.Wait(libpod.WaitTimeout)
+	exitCode, err := ctr.Wait()
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}


### PR DESCRIPTION
We added a timeout for convenience, but most invocations don't care about it. Refactor it into WaitWithTimeout() and add a Wait() that doesn't require a timeout and uses the default.
