### PR TITLE
Update the OWNERS file so bot assigns sane reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,10 +4,10 @@ approvers:
   - mrunalp
   - rhatdan
 reviewers:
-  - mtrmac
-  - jwhonce
-  - runcom
-  - nalind
-  - wking
+  - mheon
+  - baude
+  - rhatdan
   - TomSweeneyRedHat
   - umohnani8
+  - giuseppe
+  - vrothberg


### PR DESCRIPTION
The Openshift bot assigns reviewers to each PR seemingly based on this file, which means right now it's picking runcom and jwhonce to review every PR, not our maintainers. Set said maintainers as reviewers instead.