### PR TITLE
run complex image names with short names

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -42,6 +42,28 @@ var _ = Describe("Podman run", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman run a container based on a complex local image name", func() {
+		podmanTest.RestoreArtifact(nginx)
+		session := podmanTest.Podman([]string{"run", "baude/alpine_nginx:latest", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ErrorToString()).ToNot(ContainSubstring("Trying to pull"))
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
+	It("podman run a container based on on a short name with localhost", func() {
+		podmanTest.RestoreArtifact(nginx)
+		tag := podmanTest.Podman([]string{"tag", nginx, "localhost/baude/alpine_nginx:latest"})
+		tag.WaitWithDefaultTimeout()
+
+		rmi := podmanTest.Podman([]string{"rmi", nginx})
+		rmi.WaitWithDefaultTimeout()
+
+		session := podmanTest.Podman([]string{"run", "baude/alpine_nginx:latest", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ErrorToString()).ToNot(ContainSubstring("Trying to pull"))
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman run a container based on local image with short options", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
In cases where the image name is more complex like:

quay/baude/alpine_nginx:latest  and is not from the docker
registry, we need to be able to run the image by its shortname
such as baude/alpine_nginx.  The same goes when the image is
not from a registry but instead has the localhost repository.

This resolves buildah issue #1034

Signed-off-by: baude <bbaude@redhat.com>