### PR TITLE
Generate a passwd file for users not in container

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -642,6 +642,11 @@ func (c *Container) Hostname() string {
 	return c.ID()[:12]
 }
 
+// WorkingDir returns the containers working dir
+func (c *Container) WorkingDir() string {
+	return c.config.Spec.Process.Cwd
+}
+
 // State Accessors
 // Require locking
 

--- a/pkg/chrootuser/user.go
+++ b/pkg/chrootuser/user.go
@@ -99,3 +99,10 @@ func GetAdditionalGroupsForUser(rootdir string, userid uint64) ([]uint32, error)
 	}
 	return gids, nil
 }
+
+// LookupUIDInContainer returns username and gid associated with a UID in a container
+// it will use the /etc/passwd files inside of the rootdir
+// to return this information.
+func LookupUIDInContainer(rootdir string, uid uint64) (user string, gid uint64, err error) {
+	return lookupUIDInContainer(rootdir, uid)
+}

--- a/pkg/chrootuser/user_basic.go
+++ b/pkg/chrootuser/user_basic.go
@@ -21,3 +21,7 @@ func lookupGroupForUIDInContainer(rootdir string, userid uint64) (string, uint64
 func lookupAdditionalGroupsForUIDInContainer(rootdir string, userid uint64) (gid []uint32, err error) {
 	return nil, errors.New("supplemental groups list lookup by uid not supported")
 }
+
+func lookupUIDInContainer(rootdir string, uid uint64) (string, uint64, error) {
+	return "", 0, errors.New("UID lookup not supported")
+}

--- a/test/e2e/run_passwd_test.go
+++ b/test/e2e/run_passwd_test.go
@@ -1,0 +1,60 @@
+package integration
+
+import (
+	"os"
+
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman run passwd", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest PodmanTest
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanCreate(tempdir)
+		podmanTest.RestoreAllArtifacts()
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+		f := CurrentGinkgoTestDescription()
+		timedResult := fmt.Sprintf("Test: %s completed in %f seconds", f.TestText, f.Duration.Seconds())
+		GinkgoWriter.Write([]byte(timedResult))
+	})
+
+	It("podman run no user specified ", func() {
+		session := podmanTest.Podman([]string{"run", ALPINE, "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOutputContains("passwd")).To(BeFalse())
+	})
+	It("podman run user specified in container", func() {
+		session := podmanTest.Podman([]string{"run", "-u", "bin", ALPINE, "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOutputContains("passwd")).To(BeFalse())
+	})
+
+	It("podman run UID specified in container", func() {
+		session := podmanTest.Podman([]string{"run", "-u", "2:1", ALPINE, "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOutputContains("passwd")).To(BeFalse())
+	})
+
+	It("podman run UID not specified in container", func() {
+		session := podmanTest.Podman([]string{"run", "-u", "20001:1", ALPINE, "mount"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOutputContains("passwd")).To(BeTrue())
+	})
+})

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -401,7 +401,7 @@ var _ = Describe("Podman run", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "--user=1234", ALPINE, "id"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(Equal("uid=1234 gid=0(root)"))
+		Expect(session.OutputToString()).To(Equal("uid=1234(1234) gid=0(root)"))
 	})
 
 	It("podman run with user (integer, in /etc/passwd)", func() {


### PR DESCRIPTION
If someone runs podman as a user (uid) that is not defined in the container
we want generate a passwd file so that getpwuid() will work inside of container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>