### PR TITLE
Run stop in parallel

### DIFF
--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/containers/libpod/cmd/podman/formats"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
@@ -16,6 +14,7 @@ import (
 	"github.com/docker/go-units"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 


### PR DESCRIPTION
Currently when stopping a container we can take 10 seconds per container to stop
but we do this synchronously.

Running the containers stops in parrallel can speed up the stop by N times,
where N is the number of containers we are stopping.

Tested starting and stopping 3 sleep containers, time went from 30 seconds
to 10 seconds.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>