### PR TITLE
selinux: drop superflous relabel

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -939,9 +939,6 @@ func (c *Container) makeBindMounts() error {
 	if err != nil {
 		return errors.Wrapf(err, "error creating resolv.conf for container %s", c.ID())
 	}
-	if err = label.Relabel(newResolv, c.config.MountLabel, false); err != nil {
-		return errors.Wrapf(err, "error relabeling %q for container %q", newResolv, c.ID())
-	}
 	c.state.BindMounts["/etc/resolv.conf"] = newResolv
 
 	// Make /etc/hosts
@@ -953,9 +950,6 @@ func (c *Container) makeBindMounts() error {
 	if err != nil {
 		return errors.Wrapf(err, "error creating hosts file for container %s", c.ID())
 	}
-	if err = label.Relabel(newHosts, c.config.MountLabel, false); err != nil {
-		return errors.Wrapf(err, "error relabeling %q for container %q", newHosts, c.ID())
-	}
 	c.state.BindMounts["/etc/hosts"] = newHosts
 
 	// Make /etc/hostname
@@ -964,9 +958,6 @@ func (c *Container) makeBindMounts() error {
 		hostnamePath, err := c.writeStringToRundir("hostname", c.Hostname())
 		if err != nil {
 			return errors.Wrapf(err, "error creating hostname file for container %s", c.ID())
-		}
-		if err = label.Relabel(hostnamePath, c.config.MountLabel, false); err != nil {
-			return errors.Wrapf(err, "error relabeling %q for container %q", hostnamePath, c.ID())
 		}
 		c.state.BindMounts["/etc/hostname"] = hostnamePath
 	}


### PR DESCRIPTION
The same relabel is already done in writeStringToRundir so we don't
need to do it twice.  The version in writeStringToRundir takes into
account the correct file path when using user namespaces.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>