### PR TITLE
runlabel: execute /proc/self/exe and avoid recursion

### DIFF
--- a/cmd/podman/shared/funcs.go
+++ b/cmd/podman/shared/funcs.go
@@ -15,9 +15,8 @@ func GenerateCommand(command, imageName, name string) []string {
 		name = imageName
 	}
 	cmd := strings.Split(command, " ")
-	// Replace the first position of cmd with podman whether
-	// it is docker, /usr/bin/docker, or podman
-	newCommand = append(newCommand, "podman")
+	// Replace the first element of cmd with "/proc/self/exe"
+	newCommand = append(newCommand, "/proc/self/exe")
 	for _, arg := range cmd[1:] {
 		var newArg string
 		switch arg {

--- a/cmd/podman/shared/funcs_test.go
+++ b/cmd/podman/shared/funcs_test.go
@@ -15,35 +15,35 @@ var (
 
 func TestGenerateCommand(t *testing.T) {
 	inputCommand := "docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
-	correctCommand := "podman run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
+	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
 	newCommand := GenerateCommand(inputCommand, "foo", "bar")
 	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
 }
 
 func TestGenerateCommandPath(t *testing.T) {
 	inputCommand := "/usr/bin/docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
-	correctCommand := "podman run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
+	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
 	newCommand := GenerateCommand(inputCommand, "foo", "bar")
 	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
 }
 
 func TestGenerateCommandNoSetName(t *testing.T) {
 	inputCommand := "docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
-	correctCommand := "podman run -it --name foo -e NAME=foo -e IMAGE=foo foo echo install"
+	correctCommand := "/proc/self/exe run -it --name foo -e NAME=foo -e IMAGE=foo foo echo install"
 	newCommand := GenerateCommand(inputCommand, "foo", "")
 	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
 }
 
 func TestGenerateCommandNoName(t *testing.T) {
 	inputCommand := "docker run -it  -e IMAGE=IMAGE IMAGE echo install"
-	correctCommand := "podman run -it  -e IMAGE=foo foo echo install"
+	correctCommand := "/proc/self/exe run -it  -e IMAGE=foo foo echo install"
 	newCommand := GenerateCommand(inputCommand, "foo", "")
 	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
 }
 
 func TestGenerateCommandAlreadyPodman(t *testing.T) {
 	inputCommand := "podman run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
-	correctCommand := "podman run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
+	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
 	newCommand := GenerateCommand(inputCommand, "foo", "bar")
 	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
 }


### PR DESCRIPTION
Execute /proc/self/exe instead of podman.  This makes the runlabel
command more portable as it works for binaries outside the path as
well as for local builds.

Also, avoid redundantly executing the runlabel command by setting
the PODMAN_RUNLABEL_NESTED environment variable to "1".  Podman
now checks for this variable before executing the runlabel command
and will throw an error in case the variable is set.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>