### PR TITLE
Pass along syslog variable to podman cleanup processes

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -782,6 +782,7 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 		WorkDir:     workDir,
 		Rootfs:      rootfs,
 		VolumesFrom: c.StringSlice("volumes-from"),
+		Syslog:      c.GlobalBool("syslog"),
 	}
 
 	if config.Privileged {


### PR DESCRIPTION
As of now, there is no way to debug podman clean up processes. They are started by conmon with no stdout/stderr and log nowhere. This allows us to actually figure out what is going on when a
cleanup process runs.