### PR TITLE
WIP: Cirrus: Enable parallel testing on Fedora 28

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,10 +43,11 @@ full_vm_testing_task:
         matrix:
             # Images are generated separetly, from build_images_task (below)
             image_name: "ubuntu-1804-bionic-v20180911-libpod-63a86a18"
+            image_name: "fedora-cloud-base-28-1-1-7-libpod-fce09afe"
             # TODO: Make these work (also build_images_task below)
             #image_name: "rhel-server-ec2-7-5-165-1-libpod-fce09afe"
             #image_name: "centos-7-v20180911-libpod-fce09afe"
-            #image_name: "fedora-cloud-base-28-1-1-7-libpod-fce09afe"
+
     timeout_in: 120m
 
     # Every *_script runs in sequence, for each task. The name prefix is for
@@ -81,7 +82,7 @@ build_vm_images_task:
 
     env:
         # CSV of packer builder names to enable (see $PACKER_BASE/libpod_images.json)
-        PACKER_BUILDS: "ubuntu-18"
+        PACKER_BUILDS: "ubuntu-18,fedora-28"
         # TODO: Make these work (also full_vm_testing_task above)
         # PACKER_BUILDS: "rhel-7,centos-7,fedora-28,ubuntu-18"
         CENTOS_BASE_IMAGE: "centos-7-v20180911"

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -22,7 +22,9 @@ case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
     fedora-28) ;&  # Continue to the next item
     centos-7) ;&
     rhel-7)
-        stub 'integration testing not working on $OS_RELEASE_ID'
+        make install PREFIX=/usr ETCDIR=/etc
+        make test-binaries
+        make localintegration
         ;;
     *) bad_os_id_ver ;;
 esac

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -4,8 +4,8 @@
 # to be sourced by other scripts, not called directly.
 
 # Under some contexts these values are not set, make sure they are.
-USER="$(whoami)"
-HOME="$(getent passwd $USER | cut -d : -f 6)"
+export USER="$(whoami)"
+export HOME="$(getent passwd $USER | cut -d : -f 6)"
 if ! [[ "$PATH" =~ "/usr/local/bin" ]]
 then
     export PATH="$PATH:/usr/local/bin"

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -55,8 +55,12 @@ then
         ubuntu-18)
             envstr='export BUILDTAGS="seccomp $($GOSRC/hack/btrfs_tag.sh) $($GOSRC/hack/btrfs_installed_tag.sh) $($GOSRC/hack/ostree_tag.sh) varlink exclude_graphdriver_devicemapper"'
             ;;
-        fedora-28) ;&  # Continue to the next item
-        centos-7) ;&
+        fedora-28)
+            # Because papr does it this way
+            sed 's/^expand-check.*/expand-check=0/g' -i /etc/selinux/semanage.conf
+            yum -y reinstall container-selinux
+            ;;
+        centos-7) ;&  # Continue to the next item
         rhel-7)
             envstr='unset BUILDTAGS'  # Use default from Makefile
             ;;

--- a/contrib/cirrus/unit_test.sh
+++ b/contrib/cirrus/unit_test.sh
@@ -18,13 +18,11 @@ case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
         make localunit "BUILDTAGS=$BUILDTAGS"
         make "BUILDTAGS=$BUILDTAGS"
         ;;
-    fedora-28)
-        make localunit
-        make
-        ;;
-    centos-7) ;&  # Continue to the next item
+    fedora-28) ;&  # Continue to the next item
+    centos-7) ;&
     rhel-7)
-        stub 'unit testing not working on $OS_RELEASE_ID'
+        make localunit
+        make GOPATH=$GOPATH
         ;;
     *) bad_os_id_ver ;;
 esac


### PR DESCRIPTION
Run verify, unit, int. tests on a Fedora VM, but tolerate any/all failures.  This gives it runtime and visibility but prevents it from blocking merges (for now).

Signed-off-by: Chris Evich <cevich@redhat.com>