### PR TITLE
Log an otherwise ignored error from joining a net ns

### DIFF
--- a/libpod/boltdb_state_linux.go
+++ b/libpod/boltdb_state_linux.go
@@ -25,7 +25,7 @@ func replaceNetNS(netNSPath string, ctr *Container, newState *containerState) er
 			if err == nil {
 				newState.NetNS = ns
 			} else {
-				logrus.Errorf("error joining network namespace for container %s", ctr.ID())
+				logrus.Errorf("error joining network namespace for container %s: %v", ctr.ID(), err)
 				ctr.valid = false
 			}
 		}


### PR DESCRIPTION
As the title says - make sure we actually print the error occurring