### PR TITLE
Stop containers in parallel fashion

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -75,6 +75,7 @@ golang.org/x/net c427ad74c6d7a814201695e9ffde0c5d400a7674
 golang.org/x/sys master
 golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756
 golang.org/x/time f51c12702a4d776e4c1fa9b0fabab841babae631
+golang.org/x/sync master
 google.golang.org/grpc v1.0.4 https://github.com/grpc/grpc-go
 gopkg.in/cheggaaa/pb.v1 v1.0.7
 gopkg.in/inf.v0 v0.9.0


### PR DESCRIPTION
Prior, we were stopping containers serially.  So if a container had a default
timeout of 10 seconds and there were five containers being stopped, the operation
would take roughly 50 seconds.  If we stop these containers in parallel, the operation
should be roughly 10 seconds and change which is a significant speed up at scale.

Signed-off-by: baude <bbaude@redhat.com>