### PR TITLE
Cirrus-CI: Add option to run system-tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,6 +62,8 @@ full_vm_testing_task:
 
     integration_test_script: $SCRIPT_BASE/integration_test.sh
 
+    optional_system_test_script: $SCRIPT_BASE/optional_system_test.sh
+
     success_script: $SCRIPT_BASE/success.sh
 
 

--- a/contrib/cirrus/optional_system_test.sh
+++ b/contrib/cirrus/optional_system_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+source $(dirname $0)/lib.sh
+
+MAGIC_RE='\*\*\*\s*CIRRUS:\s*SYSTEM\s*TEST\s*\*\*\*'
+if ! echo "$CIRRUS_CHANGE_MESSAGE" | egrep -q "$MAGIC_RE"
+then
+    echo "Skipping system-testing because PR title or description"
+    echo "does not match regular expression: $MAGIC_RE"
+    exit 0
+fi
+
+req_env_var "
+GOSRC $GOSRC
+OS_RELEASE_ID $OS_RELEASE_ID
+OS_RELEASE_VER $OS_RELEASE_VER
+"
+
+show_env_vars
+
+set -x
+cd "$GOSRC"
+make localsystem


### PR DESCRIPTION
Normally, we would not run system-tests as part of PR-level CI, they're
simply too heavy-weight and complex.  However, in some instances it may
be desirable to provide a quick feedback loop, prior to release packaging
and official testing.  Enable this by executing the system-tests when
a magic string is present in the PR description.