### PR TITLE
Add support for pod commands

### DIFF
--- a/contrib/python/podman/podman/libs/pods.py
+++ b/contrib/python/podman/podman/libs/pods.py
@@ -42,16 +42,15 @@ class Pod(collections.UserDict):
         default signal is signal.SIGTERM.
         wait n of seconds, 0 waits forever.
         """
-        running = FoldedString(self.status)
-
         with self._client() as podman:
             podman.KillPod(self._ident, signal_)
             timeout = time.time() + wait
             while True:
                 # pylint: disable=maybe-no-member
                 self._refresh(podman)
+                running = FoldedString(self.status)
                 if running != 'running':
-                    return self
+                    break
 
                 if wait and timeout < time.time():
                     raise TimeoutError()
@@ -131,7 +130,7 @@ class Pods():
         self._client = client
 
     def create(self,
-               ident,
+               ident=None,
                cgroupparent=None,
                labels=None,
                share=None,

--- a/contrib/python/podman/test/test_images.py
+++ b/contrib/python/podman/test/test_images.py
@@ -64,7 +64,7 @@ class TestImages(PodmanTestCase):
         self.assertEqual(actual.status, 'configured')
 
         ctnr = actual.start()
-        self.assertIn(ctnr.status, ['running', 'exited'])
+        self.assertIn(ctnr.status, ['running', 'stopped', 'exited'])
 
         ctnr_details = ctnr.inspect()
         for e in img_details.containerconfig['env']:

--- a/contrib/python/podman/test/test_runner.sh
+++ b/contrib/python/podman/test/test_runner.sh
@@ -119,15 +119,18 @@ if [[ -n $VERBOSE ]]; then
 fi
 PODMAN="podman $PODMAN_ARGS"
 
-cat >/tmp/test_podman.output <<-EOT
+cat <<-EOT |tee /tmp/test_podman.output
 $($PODMAN --version)
 $PODMAN varlink --timeout=0 ${PODMAN_HOST}
 ==========================================
 EOT
 
 # Run podman in background without systemd for test purposes
-set -x
 $PODMAN varlink --timeout=0 ${PODMAN_HOST} >>/tmp/test_podman.output 2>&1 &
+if [[ $? != 0 ]]; then
+  echo 1>&2 Failed to start podman
+  showlog /tmp/test_podman.output
+fi
 
 if [[ -z $1 ]]; then
   export PYTHONPATH=.
@@ -139,7 +142,6 @@ else
   RETURNCODE=$?
 fi
 
-set +x
 pkill -9 podman
 pkill -9 conmon
 

--- a/contrib/python/pypodman/.pylintrc
+++ b/contrib/python/pypodman/.pylintrc
@@ -1,4 +1,564 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+#argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+argument-rgx=[a-z_][a-z0-9_]{1,30}$
+argument-name-hint=[a-z_][a-z0-9_]{1,30}$
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=c,
+           e,
+           i,
+           j,
+           k,
+           r,
+           v,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+#variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
 [VARIABLES]
 
-# Enforce only pep8 variable names
-variable-rgx=[a-z0-9_]{1,30}$
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[DESIGN]
+
+# Support argparse.Action constructor API
+# Maximum number of arguments for function / method.
+max-args=12
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=10
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception".
+overgeneral-exceptions=Exception

--- a/contrib/python/pypodman/pypodman/lib/__init__.py
+++ b/contrib/python/pypodman/pypodman/lib/__init__.py
@@ -1,4 +1,7 @@
 """Remote podman client support library."""
+import sys
+
+import podman
 from pypodman.lib.action_base import AbstractActionBase
 from pypodman.lib.parser_actions import (BooleanAction, BooleanValidate,
                                          PathAction, PositiveIntAction,
@@ -19,3 +22,22 @@ __all__ = [
     'Report',
     'ReportColumn',
 ]
+
+
+def query_model(model, identifiers=None):
+    """Retrieve all (default) or given model(s)."""
+    objs = []
+    if identifiers is None:
+        objs.extend(model.list())
+    else:
+        try:
+            for ident in identifiers:
+                objs.append(model.get(ident))
+        except (
+                podman.PodNotFound,
+                podman.ImageNotFound,
+                podman.ContainerNotFound,
+        ) as ex:
+            print(
+                '"{}" not found'.format(ex.name), file=sys.stderr, flush=True)
+    return objs

--- a/contrib/python/pypodman/pypodman/lib/action_base.py
+++ b/contrib/python/pypodman/pypodman/lib/action_base.py
@@ -10,33 +10,33 @@ class AbstractActionBase(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def subparser(cls, parser):
+    def subparser(cls, parent):
         """Define parser for this action.  Subclasses must implement.
 
         API:
         Use set_defaults() to set attributes "class_" and "method". These will
         be invoked as class_(parsed_args).method()
         """
-        parser.add_argument(
+        parent.add_argument(
             '--all',
             action='store_true',
             help=('list all items.'
                   ' (default: no-op, included for compatibility.)'))
-        parser.add_argument(
+        parent.add_argument(
             '--no-trunc',
             '--notruncate',
             action='store_false',
             dest='truncate',
             default=True,
             help='Display extended information. (default: False)')
-        parser.add_argument(
+        parent.add_argument(
             '--noheading',
             action='store_false',
             dest='heading',
             default=True,
             help=('Omit the table headings from the output.'
                   ' (default: False)'))
-        parser.add_argument(
+        parent.add_argument(
             '--quiet',
             action='store_true',
             help='List only the IDs. (default: %(default)s)')

--- a/contrib/python/pypodman/pypodman/lib/actions/__init__.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/__init__.py
@@ -12,6 +12,7 @@ from pypodman.lib.actions.kill_action import Kill
 from pypodman.lib.actions.logs_action import Logs
 from pypodman.lib.actions.mount_action import Mount
 from pypodman.lib.actions.pause_action import Pause
+from pypodman.lib.actions.pod_action import Pod
 from pypodman.lib.actions.port_action import Port
 from pypodman.lib.actions.ps_action import Ps
 from pypodman.lib.actions.pull_action import Pull
@@ -36,6 +37,7 @@ __all__ = [
     'Logs',
     'Mount',
     'Pause',
+    'Pod',
     'Port',
     'Ps',
     'Pull',

--- a/contrib/python/pypodman/pypodman/lib/actions/create_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/create_action.py
@@ -1,6 +1,5 @@
 """Remote client command for creating container from image."""
 import sys
-from builtins import vars
 
 import podman
 from pypodman.lib import AbstractActionBase

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/__init__.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/__init__.py
@@ -1,0 +1,24 @@
+"""Provide subparsers for pod commands."""
+from pypodman.lib.actions.pod.create_parser import CreatePod
+from pypodman.lib.actions.pod.inspect_parser import InspectPod
+from pypodman.lib.actions.pod.kill_parser import KillPod
+from pypodman.lib.actions.pod.pause_parser import PausePod
+from pypodman.lib.actions.pod.processes_parser import ProcessesPod
+from pypodman.lib.actions.pod.remove_parser import RemovePod
+from pypodman.lib.actions.pod.start_parser import StartPod
+from pypodman.lib.actions.pod.stop_parser import StopPod
+from pypodman.lib.actions.pod.top_parser import TopPod
+from pypodman.lib.actions.pod.unpause_parser import UnpausePod
+
+__all__ = [
+    'CreatePod',
+    'InspectPod',
+    'KillPod',
+    'PausePod',
+    'ProcessesPod',
+    'RemovePod',
+    'StartPod',
+    'StopPod',
+    'TopPod',
+    'UnpausePod',
+]

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/create_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/create_parser.py
@@ -1,0 +1,79 @@
+"""Remote client command for creating pod."""
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase, BooleanAction
+
+
+class CreatePod(AbstractActionBase):
+    """Implement Create Pod command."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Pod Create command to parent parser."""
+        parser = parent.add_parser('create', help='create pod')
+        super().subparser(parser)
+
+        parser.add_argument(
+            '--cgroup-parent',
+            dest='cgroupparent',
+            type=str,
+            help='Path to cgroups under which the'
+            ' cgroup for the pod will be created.')
+        parser.add_argument(
+            '--infra',
+            action=BooleanAction,
+            default=True,
+            help='Create an infra container and associate it with the pod'
+            '(default: %(default)s)')
+        parser.add_argument(
+            '-l',
+            '--label',
+            dest='labels',
+            action='append',
+            type=str,
+            help='Add metadata to a pod (e.g., --label=com.example.key=value)')
+        parser.add_argument(
+            '-n',
+            '--name',
+            dest='ident',
+            type=str,
+            help='Assign name to the pod')
+        parser.add_argument(
+            '--share',
+            choices=('ipc', 'net', 'pid', 'user', 'uts'),
+            help='Comma deliminated list of kernel namespaces to share')
+
+        parser.set_defaults(class_=cls, method='create')
+
+        # TODO: Add golang CLI arguments not included in API.
+        # parser.add_argument(
+        #     '--infra-command',
+        #     default='/pause',
+        #     help='Command to run to start the infra container.'
+        #     '(default: %(default)s)')
+        # parser.add_argument(
+        #     '--infra-image',
+        #     default='k8s.gcr.io/pause:3.1',
+        #     help='Image to create for the infra container.'
+        #     '(default: %(default)s)')
+        # parser.add_argument(
+        #     '--podidfile',
+        #     help='Write the pod ID to given file name on remote host')
+
+    def create(self):
+        """Create Pod from given options."""
+        config = {}
+        for key in ('ident', 'cgroupparent', 'infra', 'labels', 'share'):
+            config[key] = self.opts.get(key)
+
+        try:
+            pod = self.client.pods.create(**config)
+        except podman.ErrorOccurred as ex:
+            sys.stdout.flush()
+            print(
+                '{}'.format(ex.reason).capitalize(),
+                file=sys.stderr,
+                flush=True)
+        else:
+            print(pod.id)

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/inspect_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/inspect_parser.py
@@ -1,0 +1,43 @@
+"""Remote client command for inspecting pods."""
+import json
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+
+
+class InspectPod(AbstractActionBase):
+    """Class for reporting on pods and their containers."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Pod Inspect command to parent parser."""
+        parser = parent.add_parser(
+            'inspect',
+            help='configuration and state information about a given pod')
+        parser.add_argument('pod', nargs='+', help='pod(s) to inspect')
+        parser.set_defaults(class_=cls, method='inspect')
+
+    def inspect(self):
+        """Report on provided pods."""
+        output = {}
+        try:
+            for ident in self._args.pod:
+                try:
+                    pod = self.client.pods.get(ident)
+                except podman.PodNotFound:
+                    print(
+                        'Pod "{}" not found.'.format(ident),
+                        file=sys.stdout,
+                        flush=True)
+                output.update(pod.inspect()._asdict())
+        except podman.ErrorOccurred as e:
+            sys.stdout.flush()
+            print(
+                '{}'.format(e.reason).capitalize(),
+                file=sys.stderr,
+                flush=True)
+            return 1
+        else:
+            print(json.dumps(output, indent=2))
+        return 0

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/kill_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/kill_parser.py
@@ -1,0 +1,59 @@
+"""Remote client command for signaling pods and their containers."""
+import signal
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+from pypodman.lib import query_model as query_pods
+
+
+class KillPod(AbstractActionBase):
+    """Class for sending signal to processes in pod."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Pod Kill command to parent parser."""
+        parser = parent.add_parser('kill', help='signal containers in pod')
+
+        parser.add_argument(
+            '-a',
+            '--all',
+            action='store_true',
+            help='Sends signal to all pods')
+        parser.add_argument(
+            '-s',
+            '--signal',
+            choices=range(1, signal.NSIG),
+            metavar='[1,{}]'.format(signal.NSIG),
+            default=9,
+            help='Signal to send to the pod. (default: 9)')
+        parser.add_argument('pod', nargs='*', help='pod(s) to signal')
+        parser.set_defaults(class_=cls, method='kill')
+
+    def __init__(self, args):
+        """Construct Pod Kill object."""
+        if args.all and args.pod:
+            raise ValueError('You may give a pod or use --all, but not both')
+        super().__init__(args)
+
+    def kill(self):
+        """Signal provided pods."""
+        idents = None if self._args.all else self._args.pod
+        pods = query_pods(self.client.pods, idents)
+
+        for pod in pods:
+            try:
+                pod.kill(self._args.signal)
+                print(pod.id)
+            except podman.PodNotFound as ex:
+                print(
+                    'Pod "{}" not found.'.format(ex.name),
+                    file=sys.stderr,
+                    flush=True)
+            except podman.ErrorOccurred as e:
+                print(
+                    '{}'.format(e.reason).capitalize(),
+                    file=sys.stderr,
+                    flush=True)
+                return 1
+        return 0

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/pause_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/pause_parser.py
@@ -1,0 +1,47 @@
+"""Remote client command for pausing processes in pod."""
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+from pypodman.lib import query_model as query_pods
+
+
+class PausePod(AbstractActionBase):
+    """Class for pausing containers in pod."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Pod Pause command to parent parser."""
+        parser = parent.add_parser('pause', help='pause containers in pod')
+        parser.add_argument(
+            '-a', '--all', action='store_true', help='Pause all pods')
+        parser.add_argument('pod', nargs='*', help='pod(s) to pause.')
+        parser.set_defaults(class_=cls, method='pause')
+
+    def __init__(self, args):
+        """Construct Pod Pause object."""
+        if args.all and args.pod:
+            raise ValueError('You may give a pod or use --all, but not both')
+        super().__init__(args)
+
+    def pause(self):
+        """Pause containers in provided Pod."""
+        idents = None if self._args.all else self._args.pod
+        pods = query_pods(self.client.pods, idents)
+
+        for pod in pods:
+            try:
+                pod.pause()
+                print(pod.id)
+            except podman.PodNotFound as ex:
+                print(
+                    'Pod "{}" not found'.format(ex.name),
+                    file=sys.stderr,
+                    flush=True)
+            except podman.ErrorOccurred as ex:
+                print(
+                    '{}'.format(ex.reason).capitalize(),
+                    file=sys.stderr,
+                    flush=True)
+                return 1
+        return 0

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/processes_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/processes_parser.py
@@ -1,0 +1,97 @@
+"""Report on pod's containers' processes."""
+import operator
+from collections import OrderedDict
+
+from pypodman.lib import AbstractActionBase, Report, ReportColumn
+
+
+class ProcessesPod(AbstractActionBase):
+    """Report on Pod's processes."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Images command to parent parser."""
+        parser = parent.add_parser('ps', help='list processes of pod')
+        super().subparser(parser)
+
+        parser.add_argument(
+            '--ctr-names',
+            action='store_true',
+            help='Include container name in the info field')
+        parser.add_argument(
+            '--ctr-ids',
+            action='store_true',
+            help='Include container ID in the info field')
+        parser.add_argument(
+            '--ctr-status',
+            action='store_true',
+            help='Include container status in the info field')
+        parser.add_argument(
+            '--format',
+            choices=('json'),
+            help='Pretty-print containers to JSON')
+        parser.add_argument(
+            '--sort',
+            choices=('created', 'id', 'name', 'status', 'count'),
+            default='created',
+            type=str.lower,
+            help='Sort on given field. (default: %(default)s)')
+        parser.add_argument('--filter', help='Not Implemented')
+        parser.set_defaults(class_=cls, method='processes')
+
+    def __init__(self, args):
+        """Contstruct ProcessesPod class."""
+        if args.sort == 'created':
+            args.sort = 'createdat'
+        elif args.sort == 'count':
+            args.sort = 'numberofcontainers'
+
+        super().__init__(args)
+
+        self.columns = OrderedDict({
+            'id':
+            ReportColumn('id', 'POD ID', 14),
+            'name':
+            ReportColumn('name', 'NAME', 30),
+            'status':
+            ReportColumn('status', 'STATUS', 8),
+            'numberofcontainers':
+            ReportColumn('numberofcontainers', 'NUMBER OF CONTAINERS', 0),
+            'info':
+            ReportColumn('info', 'CONTAINER INFO', 0),
+        })
+
+    def processes(self):
+        """List pods."""
+        pods = sorted(
+            self.client.pods.list(), key=operator.attrgetter(self._args.sort))
+        if not pods:
+            return
+
+        rows = list()
+        for pod in pods:
+            fields = dict(pod)
+            if self._args.ctr_ids \
+                    or self._args.ctr_names \
+                    or self._args.ctr_status:
+                keys = ('id', 'name', 'status', 'info')
+                info = []
+                for ctnr in pod.containersinfo:
+                    ctnr_info = []
+                    if self._args.ctr_ids:
+                        ctnr_info.append(ctnr['id'])
+                    if self._args.ctr_names:
+                        ctnr_info.append(ctnr['name'])
+                    if self._args.ctr_status:
+                        ctnr_info.append(ctnr['status'])
+                    info.append("[ {} ]".format(" ".join(ctnr_info)))
+                fields.update({'info': " ".join(info)})
+            else:
+                keys = ('id', 'name', 'status', 'numberofcontainers')
+
+            rows.append(fields)
+
+        with Report(self.columns, heading=self._args.heading) as report:
+            report.layout(rows, keys, truncate=self._args.truncate)
+            for row in rows:
+                report.row(**row)

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/remove_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/remove_parser.py
@@ -1,0 +1,53 @@
+"""Remote client command for deleting pod and containers."""
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+from pypodman.lib import query_model as query_pods
+
+
+class RemovePod(AbstractActionBase):
+    """Class for removing pod and containers from storage."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Pod Rm command to parent parser."""
+        parser = parent.add_parser('rm', help='Delete pod and container(s)')
+        parser.add_argument(
+            '-a', '--all', action='store_true', help='Remove all pods')
+        parser.add_argument(
+            '-f',
+            '--force',
+            action='store_true',
+            help='Stop and remove container(s) then delete pod')
+        parser.add_argument(
+            'pod', nargs='*', help='Pod to remove. Or, use --all')
+        parser.set_defaults(class_=cls, method='remove')
+
+    def __init__(self, args):
+        """Construct RemovePod object."""
+        if args.all and args.pod:
+            raise ValueError('You may give a pod or use --all, but not both')
+        super().__init__(args)
+
+    def remove(self):
+        """Remove pod and container(s)."""
+        idents = None if self._args.all else self._args.pod
+        pods = query_pods(self.client.pods, idents)
+
+        for pod in pods:
+            try:
+                pod.remove(self._args.force)
+                print(pod.id)
+            except podman.PodNotFound as ex:
+                print(
+                    'Pod "{}" not found.'.format(ex.name),
+                    file=sys.stderr,
+                    flush=True)
+            except podman.ErrorOccurred as ex:
+                print(
+                    '{}'.format(ex.reason).capitalize,
+                    file=sys.stderr,
+                    flush=True)
+                return 1
+        return 0

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/restart_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/restart_parser.py
@@ -1,0 +1,48 @@
+"""Remote client command for restarting pod and container(s)."""
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+from pypodman.lib import query_model as query_pods
+
+
+class RestartPod(AbstractActionBase):
+    """Class for restarting containers in Pod."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Pod Restart command to parent parser."""
+        parser = parent.add_parser('restart', help='restart containers in pod')
+        parser.add_argument(
+            '-a', '--all', action='store_true', help='Restart all pods')
+        parser.add_argument(
+            'pod', nargs='*', help='Pod to restart. Or, use --all')
+        parser.set_defaults(class_=cls, method='restart')
+
+    def __init__(self, args):
+        """Construct RestartPod object."""
+        if args.all and args.pod:
+            raise ValueError('You may give a pod or use --all, not both')
+        super().__init__(args)
+
+    def restart(self):
+        """Restart pod and container(s)."""
+        idents = None if self._args.all else self._args.pod
+        pods = query_pods(self.client.pods, idents)
+
+        for pod in pods:
+            try:
+                pod.restart()
+                print(pod.id)
+            except podman.PodNotFound as ex:
+                print(
+                    'Pod "{}" not found.'.format(ex.name),
+                    file=sys.stderr,
+                    flush=True)
+            except podman.ErrorOccurred as ex:
+                print(
+                    '{}'.format(ex.reason).capitalize(),
+                    file=sys.stderr,
+                    flush=True)
+                return 1
+        return 0

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/start_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/start_parser.py
@@ -1,0 +1,43 @@
+"""Remote client command for starting pod and container(s)."""
+
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+from pypodman.lib import query_model as query_pods
+
+
+class StartPod(AbstractActionBase):
+    """Class for starting pod and container(s)."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Pod Start command to parent parser."""
+        parser = parent.add_parser('start', help='start pod')
+        parser.add_argument(
+            '-a', '--all', action='store_true', help='Start all pods')
+        parser.add_argument(
+            'pod', nargs='*', help='Pod to start. Or, use --all')
+        parser.set_defaults(class_=cls, method='start')
+
+    def __init__(self, args):
+        """Construct StartPod object."""
+        if args.all and args.pod:
+            raise ValueError('You may give a pod or use --all, but not both')
+        super().__init__(args)
+
+    def start(self):
+        """Start pod and container(s)."""
+        idents = None if self._args.all else self._args.pod
+        pods = query_pods(self.client.pods, idents)
+
+        for pod in pods:
+            try:
+                pod.start()
+            except podman.ErrorOccurred as ex:
+                print(
+                    '{}'.format(ex.reason).capitalize(),
+                    file=sys.stderr,
+                    flush=True)
+                return 1
+        return 0

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/stop_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/stop_parser.py
@@ -1,0 +1,42 @@
+"""Remote client command for stopping pod and container(s)."""
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+from pypodman.lib import query_model as query_pods
+
+
+class StopPod(AbstractActionBase):
+    """Class for stopping pod and container(s)."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Pod Stop command to parent parser."""
+        parser = parent.add_parser('stop', help='stop pod')
+        parser.add_argument(
+            '-a', '--all', action='store_true', help='Stop all pods')
+        parser.add_argument(
+            'pod', nargs='*', help='Pod to stop. Or, use --all')
+        parser.set_defaults(class_=cls, method='stop')
+
+    def __init__(self, args):
+        """Contruct StopPod object."""
+        if args.all and args.pod:
+            raise ValueError('You may give a pod or use --all, not both')
+        super().__init__(args)
+
+    def stop(self):
+        """Stop pod and container(s)."""
+        idents = None if self._args.all else self._args.pod
+        pods = query_pods(self.client.pods, idents)
+
+        for pod in pods:
+            try:
+                pod.stop()
+            except podman.ErrorOccurred as ex:
+                print(
+                    '{}'.format(ex.reason).capitalize(),
+                    file=sys.stderr,
+                    flush=True)
+                return 1
+        return 0

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/top_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/top_parser.py
@@ -1,0 +1,35 @@
+"""Remote client command for reporting on pod and container(s)."""
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+
+
+class TopPod(AbstractActionBase):
+    """Report on containers in Pod."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Pod Top command to parent parser."""
+        parser = parent.add_parser('top', help='report on containers in pod')
+        parser.add_argument('pod', nargs=1, help='Pod to report on.')
+        parser.set_defaults(class_=cls, method='top')
+
+    def top(self):
+        """Report on pod and container(s)."""
+        try:
+            for ident in self._args.pod:
+                pod = self.client.pods.get(ident)
+                print(pod.top())
+        except podman.PodNotFound as ex:
+            print(
+                'Pod "{}" not found.'.format(ex.name),
+                file=sys.stderr,
+                flush=True)
+        except podman.ErrorOccurred as ex:
+            print(
+                '{}'.format(ex.reason).capitalize(),
+                file=sys.stderr,
+                flush=True)
+            return 1
+        return 0

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/unpause_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/unpause_parser.py
@@ -1,0 +1,48 @@
+"""Remote client command for unpausing processes in pod."""
+import sys
+
+import podman
+from pypodman.lib import AbstractActionBase
+from pypodman.lib import query_model as query_pods
+
+
+class UnpausePod(AbstractActionBase):
+    """Class for unpausing containers in pod."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Pod Unpause command to parent parser."""
+        parser = parent.add_parser('unpause', help='unpause pod')
+        parser.add_argument(
+            '-a', '--all', action='store_true', help='Unpause all pods')
+        parser.add_argument(
+            'pod', nargs='*', help='Pod to unpause. Or, use --all')
+        parser.set_defaults(class_=cls, method='unpause')
+
+    def __init__(self, args):
+        """Construct Pod Unpause class."""
+        if args.all and args.pod:
+            raise ValueError('You may give a pod or use --all, but not both')
+        super().__init__(args)
+
+    def unpause(self):
+        """Unpause containers in provided Pod."""
+        idents = None if self._args.all else self._args.pod
+        pods = query_pods(self.client.pods, idents)
+
+        for pod in pods:
+            try:
+                pod.unpause()
+                print(pod.id)
+            except podman.PodNotFound as ex:
+                print(
+                    'Pod "{}" not found'.format(ex.name),
+                    file=sys.stderr,
+                    flush=True)
+            except podman.ErrorOccurred as ex:
+                print(
+                    '{}'.format(ex.reason).capitalize(),
+                    file=sys.stderr,
+                    flush=True)
+                return 1
+        return 0

--- a/contrib/python/pypodman/pypodman/lib/actions/pod_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod_action.py
@@ -1,0 +1,34 @@
+"""Remote client command for pod subcommands."""
+import inspect
+import logging
+import sys
+
+from pypodman.lib import AbstractActionBase
+
+from .pod import *
+
+
+class Pod(AbstractActionBase):
+    """Class for creating a pod."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Pod Create command to parent parser."""
+        pod_parser = parent.add_parser(
+            'pod',
+            help='pod commands.'
+            ' For subcommands, see: %(prog)s pod --help')
+        subparser = pod_parser.add_subparsers()
+
+        # pull in plugin(s) code for each subcommand
+        for name, obj in inspect.getmembers(
+                sys.modules['pypodman.lib.actions.pod'],
+                predicate=inspect.isclass):
+            if hasattr(obj, 'subparser'):
+                try:
+                    obj.subparser(subparser)
+                except NameError as e:
+                    logging.critical(e)
+                    logging.warning(
+                        'See subparser configuration for Class "%s"', name)
+                    sys.exit(3)

--- a/contrib/python/pypodman/pypodman/lib/actions/port_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/port_action.py
@@ -12,7 +12,7 @@ class Port(AbstractActionBase):
     def subparser(cls, parent):
         """Add Port command to parent parser."""
         parser = parent.add_parser(
-            'port', help='retrieve ports from containers.')
+            'port', help='retrieve ports from containers')
         parser.add_argument(
             '--all',
             '-a',

--- a/docs/podman-pod-create.1.md
+++ b/docs/podman-pod-create.1.md
@@ -15,7 +15,7 @@ containers added to it. The pod id is printed to STDOUT. You can then use
 
 ## OPTIONS
 
-**--cgroup-parent**=*true*|*false*
+**--cgroup-parent**=""
 
 Path to cgroups under which the cgroup for the pod will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 


### PR DESCRIPTION
* Add support for pod -- create, inspect, kill, pause, ps, rm,
  restart, start, stop, top, unpause
* Update pylintrc to better reflect pep8 code standards
* Fix various pylint reported errors
* Refactor code that determines screen width to no longer
  require initializing curses.  Improved start up time and
  pushing data blob down ssh tunnel.
* Correct pod-create man page, cgroupparent not boolean
* Abort integration tests if podman service fails to start

Signed-off-by: Jhon Honce <jhonce@redhat.com>