### PR TITLE
Cirrus: Enable debugging delay on non-zero exit

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,6 +19,8 @@ env:
     CNI_COMMIT: "7480240de9749f9a0a5c8614b17f1f03e0c06ab9"
     CRIO_COMMIT: "662dbb31b5d4f5ed54511a47cde7190c61c28677"
     RUNC_COMMIT: "ad0f5255060d36872be04de22f8731f38ef2d7b1"
+    # Enable debugging delay on test-failure if non-empty.
+    FLAKE_DEBUG_DELAY: 1
     # File to update in home-dir with task-specific env. var values
     ENVLIB: ".bash_profile"
     # Overrides default location (/tmp/cirrus) for repo clone

--- a/contrib/python/podman/test/test_runner.sh
+++ b/contrib/python/podman/test/test_runner.sh
@@ -143,6 +143,18 @@ else
   RETURNCODE=$?
 fi
 
+if [[ "$RETURNCODE" -ne 0 ]] && [[ -n "$FLAKE_DEBUG_DELAY" ]]
+then
+    cat << EOF > /dev/stderr
+*****
+***** WARNING: \$FLAKE_DEBUG_DELAY IS SET AND PYTHON-PODMAN TESTS EXITED: $RETURNCODE
+***** WARNING: Sleeping for 30 minutes for test-VM preservation oportunity.
+*****
+EOF
+    sleep 30m
+fi
+
+
 pkill -9 podman
 pkill -9 conmon
 


### PR DESCRIPTION
There have been some python-podman flakes observed across multiple CI
systems.  Support capturing a VM for further investigation in the
event of a non-zero exit.  This is done by printing a warning message
and delaying script-exit for a long time.  Hopefully a human will notice
and have an opportunity to enable deletion-protection on the VM.

Signed-off-by: Chris Evich <cevich@redhat.com>