### PR TITLE
Add simple IRC messenger

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,6 +63,8 @@ full_vm_testing_task:
 
     integration_test_script: $SCRIPT_BASE/integration_test.sh
 
+    success_script: $SCRIPT_BASE/success.sh
+
 
 # This task build new images for future PR testing, but only after a PR merge.
 # These images save needing to install/setup the same environment to test every

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,6 +30,7 @@ env:
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
     PACKER_BASE: "./contrib/cirrus/packer"
+    IRCID: ENCRYPTED[e87bba62a8e924dc70bdb2b66b16f6ab4a60d2870e6e5534ae9e2b0076f483c71c84091c655ca239101e6816c5ec0883]
 
 # Every *_task runs in parallel in separate VMs. The name prefix only for reference
 # in WebUI, and will be followed by matrix details.  This task does all the

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,8 +19,6 @@ env:
     CNI_COMMIT: "7480240de9749f9a0a5c8614b17f1f03e0c06ab9"
     CRIO_COMMIT: "662dbb31b5d4f5ed54511a47cde7190c61c28677"
     RUNC_COMMIT: "ad0f5255060d36872be04de22f8731f38ef2d7b1"
-    # Enable debugging delay on test-failure if non-empty.
-    FLAKE_DEBUG_DELAY: 1
     # File to update in home-dir with task-specific env. var values
     ENVLIB: ".bash_profile"
     # Overrides default location (/tmp/cirrus) for repo clone

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -93,6 +93,19 @@ stub() {
     echo "STUB: Pretending to do $1"
 }
 
+ircmsg() {
+    req_env_var "
+        SCRIPT_BASE $SCRIPT_BASE
+        GOSRC $GOSRC
+        CIRRUS_TASK_ID $CIRRUS_TASK_ID
+        1 $1
+    "
+    SCRIPT="$GOSRC/$SCRIPT_BASE/podbot.py"
+    NICK="podbot_$CIRRUS_TASK_ID"
+    NICK="${NICK:0:15}"  # Any longer will break things
+    $SCRIPT $NICK $1
+}
+
 # Run sudo in directory with GOPATH set
 cdsudo() {
     DIR="$1"

--- a/contrib/cirrus/podbot.py
+++ b/contrib/cirrus/podbot.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# Simple and dumb script to send a message to the #podman IRC channel on frenode
+# Based on example from: https://pythonspot.com/building-an-irc-bot/
+
+import os
+import time
+import random
+import errno
+import socket
+import sys
+
+class IRC:
+
+    response_timeout = 10  # seconds
+    irc = socket.socket()
+
+    def __init__(self, server, nickname, channel):
+        self.server = server
+        self.nickname = nickname
+        self.channel = channel
+        self.irc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    def _send(self, cmdstr):
+        self.irc.send(bytes(cmdstr + '\r\n', 'utf-8'))
+
+    def message(self, msg):
+        data = 'PRIVMSG {0} :{1}\r\n'.format(self.channel, msg)
+        print(data)
+        self._send(data)
+
+    @staticmethod
+    def fix_newlines(bufr):
+        return bufr.replace('\\r\\n', '\n')
+
+    def _required_response(self, needle, haystack):
+        start = time.time()
+        end = start + self.response_timeout
+        while time.time() < end:
+            if haystack.find(needle) != -1:
+                return (False, haystack)
+            time.sleep(0.1)
+            try:
+                haystack += str(self.irc.recv(4096, socket.MSG_DONTWAIT))
+            except socket.error as serr:
+                if serr.errno == errno.EWOULDBLOCK:
+                    continue
+                raise  # can't handle this
+        return (True, haystack)  # Error
+
+    def connect(self, username, password):
+        # This is ugly as sin, but seems to be a working send/expect sequence
+
+        print("connecting to: {0}".format(self.server))
+        self.irc.connect((self.server, 6667))  #connects to the server
+        self._send("USER {0} {0} {0} :I am {0}".format(self.nickname))
+        self._send("NICK {0}".format(self.nickname))
+
+        err, haystack = self._required_response('End of /MOTD command.'
+                                                ''.format(self.nickname), "")
+        if err:
+            print(self.fix_newlines(haystack))
+            print("Error connecting to {0}".format(self.server))
+            return True
+
+        print("Logging in as {0}".format(username))
+        self._send("PRIVMSG NickServ :IDENTIFY {0} {1}".format(username, password))
+        err, _ = self._required_response("You are now identified for", "")
+        if err:
+            print("Error logging in to {0} as {1}".format(self.server, username))
+            return True
+
+        print("Joining {0}".format(self.channel))
+        self._send("JOIN {0}".format(self.channel))
+        err, haystack = self._required_response("{0} {1} :End of /NAMES list."
+                                                "".format(self.nickname, self.channel),
+                                                haystack)
+        print(self.fix_newlines(haystack))
+        if err:
+            print("Error joining {0}".format(self.channel))
+            return True
+        return False
+
+    def quit(self):
+        print("Quitting")
+        self._send("QUIT :my work is done here")
+        self.irc.close()
+
+
+if len(sys.argv) < 3:
+    print("Error: Must pass desired nick and message as parameters")
+else:
+    irc = IRC("irc.freenode.net", sys.argv[1], "#podman")
+    err = irc.connect(*os.environ.get('IRCID', 'Big Bug').split(" ", 2))
+    if not err:
+        irc.message(" ".join(sys.argv[2:]))
+        time.sleep(5.0)  # avoid join/quit spam
+        irc.quit()

--- a/contrib/cirrus/success.sh
+++ b/contrib/cirrus/success.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+source $(dirname $0)/lib.sh
+
+req_env_var "
+    CIRRUS_TASK_NAME $CIRRUS_TASK_NAME
+    CIRRUS_BRANCH $CIRRUS_BRANCH
+    OS_RELEASE_ID $OS_RELEASE_ID
+    OS_RELEASE_VER $OS_RELEASE_VER
+    CIRRUS_REPO_CLONE_URL $CIRRUS_REPO_CLONE_URL
+"
+
+REF_URL="$(echo $CIRRUS_REPO_CLONE_URL | sed 's/.git$//g')"
+if [[ "$CIRRUS_BRANCH" =~ "pull" ]]
+then
+    REF_URL="$REF_URL/$CIRRUS_BRANCH"  # pull request URL
+else
+    REF_URL="$REF_URL/commits/$CIRRUS_BRANCH"  # branch merge
+fi
+
+ircmsg "Cirrus-CI $CIRRUS_TASK_NAME on $OS_RELEASE_ID-$OS_RELEASE_VER successful for $REF_URL"

--- a/contrib/python/podman/test/test_runner.sh
+++ b/contrib/python/podman/test/test_runner.sh
@@ -143,18 +143,6 @@ else
   RETURNCODE=$?
 fi
 
-if [[ "$RETURNCODE" -ne 0 ]] && [[ -n "$FLAKE_DEBUG_DELAY" ]]
-then
-    cat << EOF > /dev/stderr
-*****
-***** WARNING: \$FLAKE_DEBUG_DELAY IS SET AND PYTHON-PODMAN TESTS EXITED: $RETURNCODE
-***** WARNING: Sleeping for 30 minutes for test-VM preservation oportunity.
-*****
-EOF
-    sleep 30m
-fi
-
-
 pkill -9 podman
 pkill -9 conmon
 


### PR DESCRIPTION
Add a naive python script that's able to connect to IRC and send a
single line of text to the #podman channel.  Call this script when
a flake is detected in `contrib/python/podman/test/test_runner.sh`
so somebody can access the VM and take a look.