### PR TITLE
Downgrade code to support python3.4

### DIFF
--- a/contrib/python/podman/MANIFEST.in
+++ b/contrib/python/podman/MANIFEST.in
@@ -1,2 +1,3 @@
 prune test/
 include README.md
+include requirements.txt

--- a/contrib/python/podman/tox.ini
+++ b/contrib/python/podman/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py34,py35,py36
+skipdist = True
+
+[testenv]
+deps=-rrequirements.txt
+whitelist_externals = bash
+commands=bash test/test_runner.sh

--- a/contrib/python/pypodman/pypodman/lib/actions/pod/processes_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/pod/processes_parser.py
@@ -10,7 +10,7 @@ class ProcessesPod(AbstractActionBase):
 
     @classmethod
     def subparser(cls, parent):
-        """Add Images command to parent parser."""
+        """Add Pod Ps command to parent parser."""
         parser = parent.add_parser('ps', help='list processes of pod')
         super().subparser(parser)
 
@@ -40,7 +40,7 @@ class ProcessesPod(AbstractActionBase):
         parser.set_defaults(class_=cls, method='processes')
 
     def __init__(self, args):
-        """Contstruct ProcessesPod class."""
+        """Construct ProcessesPod class."""
         if args.sort == 'created':
             args.sort = 'createdat'
         elif args.sort == 'count':

--- a/contrib/python/pypodman/pypodman/lib/podman_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/podman_parser.py
@@ -154,7 +154,7 @@ class PodmanArgumentParser(argparse.ArgumentParser):
             getattr(args, 'run_dir')
             or os.environ.get('RUN_DIR')
             or config['default'].get('run_dir')
-            or Path(args.xdg_runtime_dir, 'pypodman')
+            or str(Path(args.xdg_runtime_dir, 'pypodman'))
         )   # yapf: disable
 
         setattr(
@@ -211,7 +211,7 @@ class PodmanArgumentParser(argparse.ArgumentParser):
             args.identity_file = None
 
         if args.host:
-            args.local_socket_path = Path(args.run_dir, 'podman.socket')
+            args.local_socket_path = str(Path(args.run_dir, 'podman.socket'))
         else:
             args.local_socket_path = args.remote_socket_path
 


### PR DESCRIPTION
* Added tox configuration to test python 3.4, 3.5 and 3.6.
  Tox testing not enabled on every PR
* Updated MANIFEST.ini to support tox
* Correct comments

Fixes #1641

Signed-off-by: Jhon Honce <jhonce@redhat.com>