### PR TITLE
Handle http/https in registry given to login/out

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -465,3 +465,11 @@ func getAuthFile(authfile string) string {
 	}
 	return os.Getenv("REGISTRY_AUTH_FILE")
 }
+
+// scrubServer removes 'http://' or 'https://' from the front of the
+// server/registry string if either is there.  This will be mostly used
+// for user input from 'podman login' and 'podman logout'.
+func scrubServer(server string) string {
+	server = strings.TrimPrefix(server, "https://")
+	return strings.TrimPrefix(server, "http://")
+}

--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -60,10 +60,7 @@ func loginCmd(c *cli.Context) error {
 	if len(args) == 0 {
 		return errors.Errorf("registry must be given")
 	}
-	var server string
-	if len(args) == 1 {
-		server = args[0]
-	}
+	server := scrubServer(args[0])
 	authfile := getAuthFile(c.String("authfile"))
 
 	sc := common.GetSystemContext("", authfile, false)
@@ -112,6 +109,10 @@ func getUserAndPass(username, password, userFromAuthFile string) (string, string
 		username, err = reader.ReadString('\n')
 		if err != nil {
 			return "", "", errors.Wrapf(err, "error reading username")
+		}
+		// If no username provided, use userFromAuthFile instead.
+		if strings.TrimSpace(username) == "" {
+			username = userFromAuthFile
 		}
 	}
 	if password == "" {

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -44,7 +44,7 @@ func logoutCmd(c *cli.Context) error {
 	}
 	var server string
 	if len(args) == 1 {
-		server = args[0]
+		server = scrubServer(args[0])
 	}
 	authfile := getAuthFile(c.String("authfile"))
 
@@ -54,14 +54,14 @@ func logoutCmd(c *cli.Context) error {
 		if err := config.RemoveAllAuthentication(sc); err != nil {
 			return err
 		}
-		fmt.Println("Remove login credentials for all registries")
+		fmt.Println("Removed login credentials for all registries")
 		return nil
 	}
 
 	err := config.RemoveAuthentication(sc, server)
 	switch err {
 	case nil:
-		fmt.Printf("Remove login credentials for %s\n", server)
+		fmt.Printf("Removed login credentials for %s\n", server)
 		return nil
 	case config.ErrNotLoggedIn:
 		return errors.Errorf("Not logged into %s\n", server)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

If 'http://' or 'https://' was specified as part of the registry name to podman login like:
```
podman login https://quay.io
```
The underlying authentication code would slap on an another 'https://' to it and try to resolve `https://https://quay.io` which failed.  This addresses: #1599.

I originally had the fix retaining the http:// or https:// in the authentication file, but when you did `podman logout` it would only remove the specific registry.  So you could end up with `quay.io` and `https://quay.io` in the auth.json and only the specific one you specified would be removed.  If you only removed one, you could still pull from the registry which might cause confusion.  I changed it to not include 'https://' or 'http://' in the auth.json and verified that's the same functionality as Docker-CE.

While testing I discovered that if you'd used login prior the prompt made it look as if you could just hit return to use the last username supplied to `podman login/logout`.  That was not working as the carriage return was captured and the user would always get an authentication failed message even with the right password.  Touched that up to drop the carriage return and to use the displayed/prior username if none is given.

Finally touched up a couple of typos in messages for logout.