### PR TITLE
Add --all and --latest to checkpoint/restore

### DIFF
--- a/cmd/podman/cleanup.go
+++ b/cmd/podman/cleanup.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
-	"github.com/containers/libpod/libpod"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -48,31 +47,7 @@ func cleanupCmd(c *cli.Context) error {
 		return err
 	}
 
-	var lastError error
-	var cleanupContainers []*libpod.Container
-	if c.Bool("all") {
-		cleanupContainers, err = runtime.GetContainers()
-		if err != nil {
-			return errors.Wrapf(err, "unable to get container list")
-		}
-	} else if c.Bool("latest") {
-		lastCtr, err := runtime.GetLatestContainer()
-		if err != nil {
-			return errors.Wrapf(err, "unable to get latest container")
-		}
-		cleanupContainers = append(cleanupContainers, lastCtr)
-	} else {
-		args := c.Args()
-		for _, i := range args {
-			container, err := runtime.LookupContainer(i)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				lastError = errors.Wrapf(err, "unable to find container %s", i)
-				continue
-			}
-			cleanupContainers = append(cleanupContainers, container)
-		}
-	}
+	cleanupContainers, lastError := getAllOrLatestContainers(c, runtime, -1, "all")
 
 	ctx := getContext()
 

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -89,6 +89,21 @@ func validateFlags(c *cli.Context, flags []cli.Flag) error {
 	return nil
 }
 
+// checkAllAndLatest checks that --all and --latest are used correctly
+func checkAllAndLatest(c *cli.Context) error {
+	argLen := len(c.Args())
+	if (c.Bool("all") || c.Bool("latest")) && argLen > 0 {
+		return errors.Errorf("no arguments are needed with --all or --latest")
+	}
+	if c.Bool("all") && c.Bool("latest") {
+		return errors.Errorf("--all and --latest cannot be used together")
+	}
+	if argLen < 1 && !c.Bool("all") && !c.Bool("latest") {
+		return errors.Errorf("you must provide at least one pod name or id")
+	}
+	return nil
+}
+
 // getContext returns a non-nil, empty context
 func getContext() context.Context {
 	return context.TODO()

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -104,6 +104,58 @@ func checkAllAndLatest(c *cli.Context) error {
 	return nil
 }
 
+// getAllOrLatestContainers tries to return the correct list of containers
+// depending if --all, --latest or <container-id> is used.
+// It requires the Context (c) and the Runtime (runtime). As different
+// commands are using different container state for the --all option
+// the desired state has to be specified in filterState. If no filter
+// is desired a -1 can be used to get all containers. For a better
+// error message, if the filter fails, a corresponding verb can be
+// specified which will then appear in the error message.
+func getAllOrLatestContainers(c *cli.Context, runtime *libpod.Runtime, filterState libpod.ContainerStatus, verb string) ([]*libpod.Container, error) {
+	var containers []*libpod.Container
+	var lastError error
+	var err error
+	if c.Bool("all") {
+		if filterState != -1 {
+			var filterFuncs []libpod.ContainerFilter
+			filterFuncs = append(filterFuncs, func(c *libpod.Container) bool {
+				state, _ := c.State()
+				return state == filterState
+			})
+			containers, err = runtime.GetContainers(filterFuncs...)
+		} else {
+			containers, err = runtime.GetContainers()
+		}
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to get %s containers", verb)
+		}
+	} else if c.Bool("latest") {
+		lastCtr, err := runtime.GetLatestContainer()
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to get latest container")
+		}
+		containers = append(containers, lastCtr)
+	} else {
+		args := c.Args()
+		for _, i := range args {
+			container, err := runtime.LookupContainer(i)
+			if err != nil {
+				if lastError != nil {
+					fmt.Fprintln(os.Stderr, lastError)
+				}
+				lastError = errors.Wrapf(err, "unable to find container %s", i)
+			}
+			if container != nil {
+				// This is here to make sure this does not return [<nil>] but only nil
+				containers = append(containers, container)
+			}
+		}
+	}
+
+	return containers, lastError
+}
+
 // getContext returns a non-nil, empty context
 func getContext() context.Context {
 	return context.TODO()

--- a/cmd/podman/kill.go
+++ b/cmd/podman/kill.go
@@ -41,19 +41,10 @@ var (
 
 // killCmd kills one or more containers with a signal
 func killCmd(c *cli.Context) error {
-	args := c.Args()
-	if (!c.Bool("all") && !c.Bool("latest")) && len(args) == 0 {
-		return errors.Errorf("you must specify one or more containers to kill")
+	if err := checkAllAndLatest(c); err != nil {
+		return err
 	}
-	if (c.Bool("all") || c.Bool("latest")) && len(args) > 0 {
-		return errors.Errorf("you cannot specify any containers to kill with --latest or --all")
-	}
-	if c.Bool("all") && c.Bool("latest") {
-		return errors.Errorf("--all and --latest cannot be used together")
-	}
-	if len(args) < 1 && !c.Bool("all") && !c.Bool("latest") {
-		return errors.Errorf("you must provide at least one container name or id")
-	}
+
 	if err := validateFlags(c, killFlags); err != nil {
 		return err
 	}
@@ -96,6 +87,7 @@ func killCmd(c *cli.Context) error {
 		}
 		containers = append(containers, lastCtr)
 	} else {
+		args := c.Args()
 		for _, i := range args {
 			container, err := runtime.LookupContainer(i)
 			if err != nil {

--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -63,13 +63,8 @@ func rmCmd(c *cli.Context) error {
 	}
 	defer runtime.Shutdown(false)
 
-	args := c.Args()
-	if c.Bool("latest") && c.Bool("all") {
-		return errors.Errorf("--all and --latest cannot be used together")
-	}
-
-	if len(args) == 0 && !c.Bool("all") && !c.Bool("latest") {
-		return errors.Errorf("specify one or more containers to remove")
+	if err := checkAllAndLatest(c); err != nil {
+		return err
 	}
 
 	if c.Bool("all") {
@@ -84,6 +79,7 @@ func rmCmd(c *cli.Context) error {
 		}
 		delContainers = append(delContainers, lastCtr)
 	} else {
+		args := c.Args()
 		for _, i := range args {
 			container, err := runtime.LookupContainer(i)
 			if err != nil {

--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	rt "runtime"
 
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
@@ -67,29 +66,7 @@ func rmCmd(c *cli.Context) error {
 		return err
 	}
 
-	if c.Bool("all") {
-		delContainers, err = runtime.GetContainers()
-		if err != nil {
-			return errors.Wrapf(err, "unable to get container list")
-		}
-	} else if c.Bool("latest") {
-		lastCtr, err := runtime.GetLatestContainer()
-		if err != nil {
-			return errors.Wrapf(err, "unable to get latest container")
-		}
-		delContainers = append(delContainers, lastCtr)
-	} else {
-		args := c.Args()
-		for _, i := range args {
-			container, err := runtime.LookupContainer(i)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				lastError = errors.Wrapf(err, "unable to find container %s", i)
-				continue
-			}
-			delContainers = append(delContainers, container)
-		}
-	}
+	delContainers, lastError = getAllOrLatestContainers(c, runtime, -1, "all")
 
 	for _, container := range delContainers {
 		f := func() error {

--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -44,16 +44,11 @@ var (
 )
 
 func stopCmd(c *cli.Context) error {
-	args := c.Args()
-	if (c.Bool("all") || c.Bool("latest")) && len(args) > 0 {
-		return errors.Errorf("no arguments are needed with --all or --latest")
+
+	if err := checkAllAndLatest(c); err != nil {
+		return err
 	}
-	if c.Bool("all") && c.Bool("latest") {
-		return errors.Errorf("--all and --latest cannot be used together")
-	}
-	if len(args) < 1 && !c.Bool("all") && !c.Bool("latest") {
-		return errors.Errorf("you must provide at least one container name or id")
-	}
+
 	if err := validateFlags(c, stopFlags); err != nil {
 		return err
 	}
@@ -86,6 +81,7 @@ func stopCmd(c *cli.Context) error {
 		}
 		containers = append(containers, lastCtr)
 	} else {
+		args := c.Args()
 		for _, i := range args {
 			container, err := runtime.LookupContainer(i)
 			if err != nil {

--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	rt "runtime"
 
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
@@ -60,40 +59,7 @@ func stopCmd(c *cli.Context) error {
 	}
 	defer runtime.Shutdown(false)
 
-	var filterFuncs []libpod.ContainerFilter
-	var containers []*libpod.Container
-	var lastError error
-
-	if c.Bool("all") {
-		// only get running containers
-		filterFuncs = append(filterFuncs, func(c *libpod.Container) bool {
-			state, _ := c.State()
-			return state == libpod.ContainerStateRunning
-		})
-		containers, err = runtime.GetContainers(filterFuncs...)
-		if err != nil {
-			return errors.Wrapf(err, "unable to get running containers")
-		}
-	} else if c.Bool("latest") {
-		lastCtr, err := runtime.GetLatestContainer()
-		if err != nil {
-			return errors.Wrapf(err, "unable to get last created container")
-		}
-		containers = append(containers, lastCtr)
-	} else {
-		args := c.Args()
-		for _, i := range args {
-			container, err := runtime.LookupContainer(i)
-			if err != nil {
-				if lastError != nil {
-					fmt.Fprintln(os.Stderr, lastError)
-				}
-				lastError = errors.Wrapf(err, "unable to find container %s", i)
-				continue
-			}
-			containers = append(containers, container)
-		}
-	}
+	containers, lastError := getAllOrLatestContainers(c, runtime, libpod.ContainerStateRunning, "running")
 
 	var stopFuncs []workerInput
 	for _, ctr := range containers {

--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -160,15 +160,8 @@ func (f *RawTtyFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 }
 
 func checkMutuallyExclusiveFlags(c *cli.Context) error {
-	argLen := len(c.Args())
-	if (c.Bool("all") || c.Bool("latest")) && argLen > 0 {
-		return errors.Errorf("no arguments are needed with --all or --latest")
-	}
-	if c.Bool("all") && c.Bool("latest") {
-		return errors.Errorf("--all and --latest cannot be used together")
-	}
-	if argLen < 1 && !c.Bool("all") && !c.Bool("latest") {
-		return errors.Errorf("you must provide at least one pod name or id")
+	if err := checkAllAndLatest(c); err != nil {
+		return err
 	}
 	if err := validateFlags(c, startFlags); err != nil {
 		return err


### PR DESCRIPTION
This started as a simple change to add `--all` and `--latest` to the checkpoint and restore commands.

While adding these features I saw that the same code to handle `--all` and `--latest` can be found in multiple places. So I extended this PR to include common code for `--all` and `--latest` handling and replaced the code with the newly added common code at a few places. Overall this PR removes more lines of code than it adds.

I have run the test suite after each commit locally and the results looked good.

I initially included the changes also in `port.go` but as the port command allows a port to be listed after `-l` the newly added common logic cannot be used in `port.go`.