### PR TITLE
Fix podman port -l

### DIFF
--- a/cmd/podman/port.go
+++ b/cmd/podman/port.go
@@ -104,6 +104,9 @@ func portCmd(c *cli.Context) error {
 		containers = append(containers, container)
 	} else if c.Bool("latest") {
 		container, err = runtime.GetLatestContainer()
+		if err != nil {
+			return errors.Wrapf(err, "unable to get last created container")
+		}
 		containers = append(containers, container)
 	} else {
 		containers, err = runtime.GetRunningContainers()


### PR DESCRIPTION
Running 'podman port -l' on a system without any containers created
gives:

 $ podman port -l
 panic: runtime error: invalid memory address or nil pointer dereference
 [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xf3cef1]

 goroutine 1 [running]:
 github.com/containers/libpod/libpod.(*Container).State(0x0, 0x0, 0x0, 0x0)
 	/share/go/src/github.com/containers/libpod/libpod/container.go:658 +0x41
 main.portCmd(0xc420094580, 0x0, 0x0)
 	/share/go/src/github.com/containers/libpod/cmd/podman/port.go:118 +0x406

This fixes it by making sure the variable 'containers' is nil and not [<nil>].

Signed-off-by: Adrian Reber <areber@redhat.com>