### PR TITLE
fix environment variable parsing

### DIFF
--- a/cmd/podman/create_cli_test.go
+++ b/cmd/podman/create_cli_test.go
@@ -47,7 +47,7 @@ func TestGetAllLabels(t *testing.T) {
 }
 
 func TestGetAllLabelsBadKeyValue(t *testing.T) {
-	inLabels := []string{"ONE1", "TWO=2"}
+	inLabels := []string{"=badValue", "="}
 	fileLabels := []string{}
 	_, err := getAllLabels(fileLabels, inLabels)
 	assert.Error(t, err, assert.AnError)

--- a/cmd/podman/parse.go
+++ b/cmd/podman/parse.go
@@ -198,6 +198,11 @@ func readKVStrings(env map[string]string, files []string, override []string) err
 func parseEnv(env map[string]string, line string) error {
 	data := strings.SplitN(line, "=", 2)
 
+	// catch invalid variables such as "=" or "=A"
+	if data[0] == "" {
+		return errors.Errorf("invalid environment variable: %q", line)
+	}
+
 	// trim the front of a variable, but nothing else
 	name := strings.TrimLeft(data[0], whiteSpaces)
 	if strings.ContainsAny(name, whiteSpaces) {
@@ -208,10 +213,7 @@ func parseEnv(env map[string]string, line string) error {
 		env[name] = data[1]
 	} else {
 		// if only a pass-through variable is given, clean it up.
-		val, exists := os.LookupEnv(name)
-		if !exists {
-			return errors.Errorf("environment variable %q does not exist", name)
-		}
+		val, _ := os.LookupEnv(name)
 		env[name] = val
 	}
 	return nil


### PR DESCRIPTION
Fix the parsing of environment variables to catch invalid ones, such as
`-e = ` or `-e =A`, early in the stack to return meaningful error
messages.  Also, instead of erroring out, set unspecified env variables
as empty (e.g., `-e FOO`) to remain compatible with Docker.

Fixes: #1663
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>