### PR TITLE
Papr: Use updates-testing repo for packages

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -101,6 +101,10 @@ host:
     specs:
         ram: 8192
         cpus: 4
+extra-repos:
+    - name: updates-testing
+      metalink: https://mirrors.fedoraproject.org/metalink?repo=updates-testing-f$releasever&arch=$basearch
+
 packages:
     - btrfs-progs-devel
     - glib2-devel


### PR DESCRIPTION
This supports podman-in-podman testing on Fedora with a newer version of
podman on the host-side.  This is needed to validate changes/fixes
before they are released generally.

Signed-off-by: Chris Evich <cevich@redhat.com>