### PR TITLE
Use more reliable check for rootless for firewall init

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -508,7 +508,7 @@ func makeRuntime(runtime *Runtime) (err error) {
 
 	// Set up a firewall backend
 	backendType := ""
-	if os.Geteuid() != 0 {
+	if rootless.IsRootless() {
 		backendType = "none"
 	}
 	fwBackend, err := firewall.GetBackend(backendType)


### PR DESCRIPTION
We probably won't be able to initialize a firewall plugin when we are not running as root, so we shouldn't even try. Replace the less-effect EUID check with the rootless package's better check to make sure we don't accidentally set up the firewall in these cases.

Fixes #1685 