### PR TITLE
Do not call out to runc for sync

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -685,7 +685,7 @@ func (c *Container) Sync() error {
 		(c.state.State != ContainerStateConfigured) {
 		oldState := c.state.State
 		// TODO: optionally replace this with a stat for the exit file
-		if err := c.runtime.ociRuntime.updateContainerStatus(c); err != nil {
+		if err := c.runtime.ociRuntime.updateContainerStatus(c, true); err != nil {
 			return err
 		}
 		// Only save back to DB if state changed

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -734,6 +734,8 @@ func (c *Container) start() error {
 	}
 	logrus.Debugf("Started container %s", c.ID())
 
+	c.state.State = ContainerStateRunning
+
 	return c.save()
 }
 

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -679,7 +679,7 @@ func (c *Container) stop(timeout uint) error {
 	}
 
 	// Container should clean itself up
-	return nil
+	return c.save()
 }
 
 // Internal, non-locking function to pause a container

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -734,11 +734,6 @@ func (c *Container) start() error {
 	}
 	logrus.Debugf("Started container %s", c.ID())
 
-	// We need to pick up full container state, including PID.
-	if err := c.runtime.ociRuntime.updateContainerStatus(c, true); err != nil {
-		return err
-	}
-
 	return c.save()
 }
 

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -13,8 +13,10 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/containers/buildah/imagebuildah"
+	"github.com/containers/libpod/pkg/ctime"
 	"github.com/containers/libpod/pkg/hooks"
 	"github.com/containers/libpod/pkg/hooks/exec"
 	"github.com/containers/libpod/pkg/lookup"
@@ -31,6 +33,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/text/language"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -147,6 +150,77 @@ func (c *Container) execPidPath(sessionID string) string {
 	return filepath.Join(c.state.RunDir, "exec_pid_"+sessionID)
 }
 
+// exitFilePath gets the path to the container's exit file
+func (c *Container) exitFilePath() string {
+	return filepath.Join(c.runtime.ociRuntime.exitsDir, c.ID())
+}
+
+// Wait for the container's exit file to appear.
+// When it does, update our state based on it.
+func (c *Container) waitForExitFileAndSync() error {
+	exitFile := c.exitFilePath()
+
+	err := kwait.ExponentialBackoff(
+		kwait.Backoff{
+			Duration: 500 * time.Millisecond,
+			Factor:   1.2,
+			Steps:    6,
+		},
+		func() (bool, error) {
+			_, err := os.Stat(exitFile)
+			if err != nil {
+				// wait longer
+				return false, nil
+			}
+			return true, nil
+		})
+	if err != nil {
+		// Exit file did not appear
+		// Reset our state
+		c.state.ExitCode = -1
+		c.state.FinishedTime = time.Now()
+		c.state.State = ContainerStateStopped
+
+		if err2 := c.save(); err2 != nil {
+			logrus.Errorf("Error saving container %s state: %v", c.ID(), err2)
+		}
+
+		return err
+	}
+
+	if err := c.runtime.ociRuntime.updateContainerStatus(c, false); err != nil {
+		return err
+	}
+
+	return c.save()
+}
+
+// Handle the container exit file.
+// The exit file is used to supply container exit time and exit code.
+// This assumes the exit file already exists.
+func (c *Container) handleExitFile(exitFile string, fi os.FileInfo) error {
+	c.state.FinishedTime = ctime.Created(fi)
+	statusCodeStr, err := ioutil.ReadFile(exitFile)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read exit file for container %s", c.ID())
+	}
+	statusCode, err := strconv.Atoi(string(statusCodeStr))
+	if err != nil {
+		return errors.Wrapf(err, "error converting exit status code for container %s to int",
+			c.ID())
+	}
+	c.state.ExitCode = int32(statusCode)
+
+	oomFilePath := filepath.Join(c.bundlePath(), "oom")
+	if _, err = os.Stat(oomFilePath); err == nil {
+		c.state.OOMKilled = true
+	}
+
+	c.state.Exited = true
+
+	return nil
+}
+
 // Sync this container with on-disk state and runtime status
 // Should only be called with container lock held
 // This function should suffice to ensure a container's state is accurate and
@@ -162,7 +236,7 @@ func (c *Container) syncContainer() error {
 		(c.state.State != ContainerStateExited) {
 		oldState := c.state.State
 		// TODO: optionally replace this with a stat for the exit file
-		if err := c.runtime.ociRuntime.updateContainerStatus(c); err != nil {
+		if err := c.runtime.ociRuntime.updateContainerStatus(c, false); err != nil {
 			return err
 		}
 		// Only save back to DB if state changed
@@ -660,7 +734,10 @@ func (c *Container) start() error {
 	}
 	logrus.Debugf("Started container %s", c.ID())
 
-	c.state.State = ContainerStateRunning
+	// We need to pick up full container state, including PID.
+	if err := c.runtime.ociRuntime.updateContainerStatus(c, true); err != nil {
+		return err
+	}
 
 	return c.save()
 }
@@ -673,13 +750,8 @@ func (c *Container) stop(timeout uint) error {
 		return err
 	}
 
-	// Sync the container's state to pick up return code
-	if err := c.runtime.ociRuntime.updateContainerStatus(c); err != nil {
-		return err
-	}
-
-	// Container should clean itself up
-	return c.save()
+	// Wait until we have an exit file, and sync once we do
+	return c.waitForExitFileAndSync()
 }
 
 // Internal, non-locking function to pause a container

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -206,8 +206,8 @@ func (c *Container) handleExitFile(exitFile string, fi os.FileInfo) error {
 	}
 	statusCode, err := strconv.Atoi(string(statusCodeStr))
 	if err != nil {
-		return errors.Wrapf(err, "error converting exit status code for container %s to int",
-			c.ID())
+		return errors.Wrapf(err, "error converting exit status code (%q) for container %s to int",
+			c.ID(), statusCodeStr)
 	}
 	c.state.ExitCode = int32(statusCode)
 

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -451,7 +451,7 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 // updateContainerStatus retrieves the current status of the container from the
 // runtime. It updates the container's state but does not save it.
 // If useRunc is false, we will not directly hit runc to see the container's
-// status, but will instead only check for the existance of the conmon exit file
+// status, but will instead only check for the existence of the conmon exit file
 // and update state to stopped if it exists.
 func (r *OCIRuntime) updateContainerStatus(ctr *Container, useRunc bool) error {
 	exitFile := ctr.exitFilePath()

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -441,6 +441,7 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 			}
 			return errors.Wrapf(ErrInternal, "container create failed")
 		}
+		ctr.state.PID = ss.si.Pid
 	case <-time.After(ContainerCreateTimeout):
 		return errors.Wrapf(ErrInternal, "container creation timeout")
 	}

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -508,6 +508,8 @@ func (r *OCIRuntime) updateContainerStatus(ctr *Container, useRunc bool) error {
 		}
 		if strings.Contains(string(out), "does not exist") {
 			ctr.removeConmonFiles()
+			ctr.state.ExitCode = -1
+			ctr.state.FinishedTime = time.Now()
 			ctr.state.State = ContainerStateExited
 			return nil
 		}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -256,7 +256,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool)
 		}
 
 		// Need to update container state to make sure we know it's stopped
-		if err := c.syncContainer(); err != nil {
+		if err := c.waitForExitFileAndSync(); err != nil {
 			return err
 		}
 	} else if !(c.state.State == ContainerStateConfigured ||


### PR DESCRIPTION
An initial attempt to solve #1574 

Presently, for almost all API operations, we update the container's state using runc. This is very expensive (a full fork/exec for every container involved in an API operation like `ps` adds up very quickly). Also, we're seeing issues when running large quantities of runc processes (as in #1574).

This attempts to resolve this by replacing the expensive call to runc with a much faster `stat()` call to check for the existence of the container exit file created by Conmon when the container exits (and even this can be avoided in most container states).

I'd like to also introduce a --force-sync flag (or something similar) to force a full sync against runc to prevent desync from occurring, but that will come later.