### PR TITLE
run performance improvements

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -750,30 +750,31 @@ func (c *Container) restartWithTimeout(ctx context.Context, timeout uint) (err e
 // TODO: Add ability to override mount label so we can use this for Mount() too
 // TODO: Can we use this for export? Copying SHM into the export might not be
 // good
-func (c *Container) mountStorage() (err error) {
+func (c *Container) mountStorage() (string, error) {
+	var err error
 	// Container already mounted, nothing to do
 	if c.state.Mounted {
-		return nil
+		return c.state.Mountpoint, nil
 	}
 
 	if !rootless.IsRootless() {
 		// TODO: generalize this mount code so it will mount every mount in ctr.config.Mounts
 		mounted, err := mount.Mounted(c.config.ShmDir)
 		if err != nil {
-			return errors.Wrapf(err, "unable to determine if %q is mounted", c.config.ShmDir)
+			return "", errors.Wrapf(err, "unable to determine if %q is mounted", c.config.ShmDir)
 		}
 
 		if err := os.Chown(c.config.ShmDir, c.RootUID(), c.RootGID()); err != nil {
-			return errors.Wrapf(err, "failed to chown %s", c.config.ShmDir)
+			return "", errors.Wrapf(err, "failed to chown %s", c.config.ShmDir)
 		}
 
 		if !mounted {
 			shmOptions := fmt.Sprintf("mode=1777,size=%d", c.config.ShmSize)
 			if err := c.mountSHM(shmOptions); err != nil {
-				return err
+				return "", err
 			}
 			if err := os.Chown(c.config.ShmDir, c.RootUID(), c.RootGID()); err != nil {
-				return errors.Wrapf(err, "failed to chown %s", c.config.ShmDir)
+				return "", errors.Wrapf(err, "failed to chown %s", c.config.ShmDir)
 			}
 		}
 	}
@@ -782,28 +783,11 @@ func (c *Container) mountStorage() (err error) {
 	if mountPoint == "" {
 		mountPoint, err = c.mount()
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
-	c.state.Mounted = true
-	c.state.Mountpoint = mountPoint
-	if c.state.UserNSRoot == "" {
-		c.state.RealMountpoint = c.state.Mountpoint
-	} else {
-		c.state.RealMountpoint = filepath.Join(c.state.UserNSRoot, "mountpoint")
-	}
 
-	logrus.Debugf("Created root filesystem for container %s at %s", c.ID(), c.state.Mountpoint)
-
-	defer func() {
-		if err != nil {
-			if err2 := c.cleanupStorage(); err2 != nil {
-				logrus.Errorf("Error unmounting storage for container %s: %v", c.ID(), err)
-			}
-		}
-	}()
-
-	return c.save()
+	return mountPoint, nil
 }
 
 // cleanupStorage unmounts and cleans up the container's root filesystem


### PR DESCRIPTION
run prepare() -- which consists of creating a network namespace and mounting the container image is now run in parallel.   This saves 25-40ms.

Signed-off-by: baude <bbaude@redhat.com>