### PR TITLE
Use restoreArtifacts to save time in integration tests

### DIFF
--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -111,6 +111,7 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec with user only in container", func() {
+		podmanTest.RestoreArtifact(fedoraMinimal)
 		testUser := "test123"
 		setup := podmanTest.Podman([]string{"run", "--name", "test1", "-d", fedoraMinimal, "sleep", "60"})
 		setup.WaitWithDefaultTimeout()

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -577,6 +577,7 @@ USER mail`
 	})
 
 	It("podman run findmnt nothing shared", func() {
+		podmanTest.RestoreArtifact(fedoraMinimal)
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
 		err := os.MkdirAll(vol1, 0755)
 		Expect(err).To(BeNil())
@@ -592,6 +593,7 @@ USER mail`
 	})
 
 	It("podman run findmnt shared", func() {
+		podmanTest.RestoreArtifact(fedoraMinimal)
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
 		err := os.MkdirAll(vol1, 0755)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
Signed-off-by: baude <bbaude@redhat.com>