### PR TITLE
create: fix writing cidfile when using rootless

### DIFF
--- a/libpod/util.go
+++ b/libpod/util.go
@@ -24,22 +24,15 @@ const (
 	DefaultTransport = "docker://"
 )
 
-// WriteFile writes a provided string to a provided path
-func WriteFile(content string, path string) error {
+// OpenExclusiveFile opens a file for writing and ensure it doesn't already exist
+func OpenExclusiveFile(path string) (*os.File, error) {
 	baseDir := filepath.Dir(path)
 	if baseDir != "" {
 		if _, err := os.Stat(baseDir); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	f.WriteString(content)
-	f.Sync()
-	return nil
+	return os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 }
 
 // FuncTimer helps measure the execution time of a function


### PR DESCRIPTION
prevent opening the same file twice, since we re-exec podman in
rootless mode.  While at it, also solve a possible race between the
check for the file and writing to it.  Another process could have
created the file in the meanwhile and we would just end up overwriting
it.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>