### PR TITLE
Add --max-workers and heuristics for parallel operations

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -211,6 +211,11 @@ func main() {
 			Value:  hooks.DefaultDir,
 			Hidden: true,
 		},
+		cli.IntFlag{
+			Name:   "max-workers",
+			Usage:  "the maximum number of workers for parallel operations",
+			Hidden: true,
+		},
 		cli.StringFlag{
 			Name:  "log-level",
 			Usage: "log messages above specified level: debug, info, warn, error (default), fatal or panic",

--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -226,10 +226,10 @@ func NewBatchContainer(ctr *libpod.Container, opts PsOptions) (PsContainerOutput
 	return pso, nil
 }
 
-type pFunc func() (PsContainerOutput, error)
+type batchFunc func() (PsContainerOutput, error)
 
 type workerInput struct {
-	parallelFunc pFunc
+	parallelFunc batchFunc
 	opts         PsOptions
 	cid          string
 	job          int

--- a/cmd/podman/shared/parallel.go
+++ b/cmd/podman/shared/parallel.go
@@ -1,0 +1,91 @@
+package shared
+
+import (
+	"runtime"
+	"sync"
+)
+
+type pFunc func() error
+
+// ParallelWorkerInput is a struct used to pass in a slice of parallel funcs to be
+// performed on a container ID
+type ParallelWorkerInput struct {
+	ContainerID  string
+	ParallelFunc pFunc
+}
+
+type containerError struct {
+	ContainerID string
+	Err         error
+}
+
+// ParallelWorker is a "threaded" worker that takes jobs from the channel "queue"
+func ParallelWorker(wg *sync.WaitGroup, jobs <-chan ParallelWorkerInput, results chan<- containerError) {
+	for j := range jobs {
+		err := j.ParallelFunc()
+		results <- containerError{ContainerID: j.ContainerID, Err: err}
+		wg.Done()
+	}
+}
+
+// ParallelExecuteWorkerPool takes container jobs and performs them in parallel.  The worker
+// int determines how many workers/threads should be premade.
+func ParallelExecuteWorkerPool(workers int, functions []ParallelWorkerInput) map[string]error {
+	var (
+		wg sync.WaitGroup
+	)
+
+	resultChan := make(chan containerError, len(functions))
+	results := make(map[string]error)
+	paraJobs := make(chan ParallelWorkerInput, len(functions))
+
+	// If we have more workers than functions, match up the number of workers and functions
+	if workers > len(functions) {
+		workers = len(functions)
+	}
+
+	// Create the workers
+	for w := 1; w <= workers; w++ {
+		go ParallelWorker(&wg, paraJobs, resultChan)
+	}
+
+	// Add jobs to the workers
+	for _, j := range functions {
+		j := j
+		wg.Add(1)
+		paraJobs <- j
+	}
+
+	close(paraJobs)
+	wg.Wait()
+
+	close(resultChan)
+	for ctrError := range resultChan {
+		results[ctrError.ContainerID] = ctrError.Err
+	}
+
+	return results
+}
+
+// Parallelize provides the maximum number of parallel workers (int) as calculated by a basic
+// heuristic. This can be overriden by the --max-workers primary switch to podman.
+func Parallelize(job string) int {
+	numCpus := runtime.NumCPU()
+	switch job {
+	case "stop":
+		if numCpus <= 2 {
+			return 4
+		} else {
+			return numCpus * 3
+		}
+	case "rm":
+		if numCpus <= 3 {
+			return numCpus * 3
+		} else {
+			return numCpus * 4
+		}
+	case "ps":
+		return 8
+	}
+	return 3
+}

--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -3,10 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	gosignal "os/signal"
-	"sync"
-
 	"github.com/containers/libpod/libpod"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/term"
@@ -15,6 +11,8 @@ import (
 	"github.com/urfave/cli"
 	"golang.org/x/crypto/ssh/terminal"
 	"k8s.io/client-go/tools/remotecommand"
+	"os"
+	gosignal "os/signal"
 )
 
 type RawTtyFormatter struct {
@@ -208,64 +206,4 @@ func getPodsFromContext(c *cli.Context, r *libpod.Runtime) ([]*libpod.Pod, error
 		pods = append(pods, pod)
 	}
 	return pods, lastError
-}
-
-type pFunc func() error
-
-type workerInput struct {
-	containerID  string
-	parallelFunc pFunc
-}
-
-type containerError struct {
-	containerID string
-	err         error
-}
-
-// worker is a "threaded" worker that takes jobs from the channel "queue"
-func worker(wg *sync.WaitGroup, jobs <-chan workerInput, results chan<- containerError) {
-	for j := range jobs {
-		err := j.parallelFunc()
-		results <- containerError{containerID: j.containerID, err: err}
-		wg.Done()
-	}
-}
-
-// parallelExecuteWorkerPool takes container jobs and performs them in parallel.  The worker
-// int is determines how many workers/threads should be premade.
-func parallelExecuteWorkerPool(workers int, functions []workerInput) map[string]error {
-	var (
-		wg sync.WaitGroup
-	)
-
-	resultChan := make(chan containerError, len(functions))
-	results := make(map[string]error)
-	paraJobs := make(chan workerInput, len(functions))
-
-	// If we have more workers than functions, match up the number of workers and functions
-	if workers > len(functions) {
-		workers = len(functions)
-	}
-
-	// Create the workers
-	for w := 1; w <= workers; w++ {
-		go worker(&wg, paraJobs, resultChan)
-	}
-
-	// Add jobs to the workers
-	for _, j := range functions {
-		j := j
-		wg.Add(1)
-		paraJobs <- j
-	}
-
-	close(paraJobs)
-	wg.Wait()
-
-	close(resultChan)
-	for ctrError := range resultChan {
-		results[ctrError.containerID] = ctrError.err
-	}
-
-	return results
 }


### PR DESCRIPTION
add a global flag for --max-workers so users can limit the number
of parallel operations for a given function.  also, when not limited
by max-workers, we implement a heuristic function that returns the
number of preferred parallel workers based on the number of CPUs and
the given operation.

Signed-off-by: baude <bbaude@redhat.com>