### PR TITLE
Use two spaces to pad PS fields

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -329,7 +329,7 @@ func psCmd(c *cli.Context) error {
 	}
 
 	// Define a tab writer with stdout as the output
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	defer w.Flush()
 
 	// Output standard PS headers


### PR DESCRIPTION
Ed has asked that we revert to using two spaces for padding between PS fields.  I assume
this is for docker autotests.

Signed-off-by: baude <bbaude@redhat.com>