### PR TITLE
rootless: default to fuse-overlayfs when available

### DIFF
--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -56,7 +56,7 @@ Path to the OCI compatible binary used to run containers
 
 **--storage-driver, -s**=**value**
 
-Storage driver.  The default storage driver for UID 0 is configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode), and is *vfs* for other users.  The `STORAGE_DRIVER` environment variable overrides the default.  The --storage-driver specified driver overrides all.
+Storage driver.  The default storage driver for UID 0 is configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode), and is *vfs* for non-root users when *fuse-overlayfs* is not available.  The `STORAGE_DRIVER` environment variable overrides the default.  The --storage-driver specified driver overrides all.
 
 Overriding this option will cause the *storage-opt* settings in /etc/containers/storage.conf to be ignored.  The user must
 specify additional options via the `--storage-opt` flag.

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -273,7 +274,12 @@ func GetRootlessStorageOpts() (storage.StoreOptions, error) {
 		dataDir = filepath.Join(resolvedHome, ".local", "share")
 	}
 	opts.GraphRoot = filepath.Join(dataDir, "containers", "storage")
-	opts.GraphDriverName = "vfs"
+	if path, err := exec.LookPath("fuse-overlayfs"); err == nil {
+		opts.GraphDriverName = "overlay"
+		opts.GraphDriverOptions = []string{fmt.Sprintf("overlay.mount_program=%s", path)}
+	} else {
+		opts.GraphDriverName = "vfs"
+	}
 	return opts, nil
 }
 


### PR DESCRIPTION
If fuse-overlayfs is present, rootless containers default to use it.
This can still be overriden either via the command line with
--storage-driver or in the ~/.config/containers/storage.conf
configuration file.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>