### PR TITLE
Fix setting of version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ PACKAGES ?= $(shell $(GO) list -tags "${BUILDTAGS}" ./... | grep -v github.com/c
 COMMIT_NO ?= $(shell git rev-parse HEAD 2> /dev/null || true)
 GIT_COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 BUILD_INFO ?= $(shell date +%s)
-LDFLAGS_PODMAN ?= $(LDFLAGS) -X main.gitCommit=$(GIT_COMMIT) -X main.buildInfo=$(BUILD_INFO)
+LIBPOD := ${PROJECT}/libpod
+LDFLAGS_PODMAN ?= $(LDFLAGS) -X $(LIBPOD).gitCommit=$(GIT_COMMIT) -X $(LIBPOD).buildInfo=$(BUILD_INFO)
 ISODATE ?= $(shell date --iso-8601)
 LIBSECCOMP_COMMIT := release-2.3
 

--- a/cmd/podman/info.go
+++ b/cmd/podman/info.go
@@ -81,6 +81,7 @@ func debugInfo(c *cli.Context) map[string]interface{} {
 	info["compiler"] = runtime.Compiler
 	info["go version"] = runtime.Version()
 	info["podman version"] = c.App.Version
-	info["git commit"] = libpod.GitCommit
+	version, _ := libpod.GetVersion()
+	info["git commit"] = version.GitCommit
 	return info
 }

--- a/cmd/podman/version.go
+++ b/cmd/podman/version.go
@@ -21,7 +21,7 @@ func versionCmd(c *cli.Context) error {
 		fmt.Println("Git Commit:   ", output.GitCommit)
 	}
 	// Prints out the build time in readable format
-	if libpod.BuildInfo != "" {
+	if output.Built != 0 {
 		fmt.Println("Built:        ", time.Unix(output.Built, 0).Format(time.ANSIC))
 	}
 

--- a/libpod/version.go
+++ b/libpod/version.go
@@ -11,10 +11,10 @@ import (
 var (
 	// GitCommit is the commit that the binary is being built from.
 	// It will be populated by the Makefile.
-	GitCommit string
+	gitCommit string
 	// BuildInfo is the time at which the binary was built
 	// It will be populated by the Makefile.
-	BuildInfo string
+	buildInfo string
 )
 
 //Version is an output struct for varlink
@@ -30,9 +30,9 @@ type Version struct {
 func GetVersion() (Version, error) {
 	var err error
 	var buildTime int64
-	if BuildInfo != "" {
+	if buildInfo != "" {
 		// Converts unix time from string to int64
-		buildTime, err = strconv.ParseInt(BuildInfo, 10, 64)
+		buildTime, err = strconv.ParseInt(buildInfo, 10, 64)
 
 		if err != nil {
 			return Version{}, err
@@ -41,7 +41,7 @@ func GetVersion() (Version, error) {
 	return Version{
 		Version:   podmanVersion.Version,
 		GoVersion: runtime.Version(),
-		GitCommit: GitCommit,
+		GitCommit: gitCommit,
 		Built:     buildTime,
 		OsArch:    runtime.GOOS + "/" + runtime.GOARCH,
 	}, nil

--- a/pkg/varlinkapi/system.go
+++ b/pkg/varlinkapi/system.go
@@ -34,6 +34,10 @@ func (i *LibpodAPI) Ping(call iopodman.VarlinkCall) error {
 
 // GetInfo returns details about the podman host and its stores
 func (i *LibpodAPI) GetInfo(call iopodman.VarlinkCall) error {
+	versionInfo, err := libpod.GetVersion()
+	if err != nil {
+		return err
+	}
 	var (
 		registries, insecureRegistries []string
 	)
@@ -64,11 +68,10 @@ func (i *LibpodAPI) GetInfo(call iopodman.VarlinkCall) error {
 	podmanInfo.Host = infoHost
 	store := info[1].Data
 	pmaninfo := iopodman.InfoPodmanBinary{
-		Compiler:   goruntime.Compiler,
-		Go_version: goruntime.Version(),
-		// TODO : How are we going to get this here?
-		//Podman_version:
-		Git_commit: libpod.GitCommit,
+		Compiler:       goruntime.Compiler,
+		Go_version:     goruntime.Version(),
+		Podman_version: versionInfo.Version,
+		Git_commit:     versionInfo.GitCommit,
 	}
 
 	graphStatus := iopodman.InfoGraphStatus{


### PR DESCRIPTION
It was setting the wrong variable (CamelCase)
in the wrong module ("main", not "libpod")...

Thus the version information was always missing,
from `podman version` and friends (e.g varlink)