### PR TITLE
rootless: do not add an additional /run to runroot

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -256,7 +256,7 @@ func GetRootlessStorageOpts() (storage.StoreOptions, error) {
 	if err != nil {
 		return opts, err
 	}
-	opts.RunRoot = filepath.Join(rootlessRuntime, "run")
+	opts.RunRoot = rootlessRuntime
 
 	dataDir := os.Getenv("XDG_DATA_HOME")
 	if dataDir == "" {


### PR DESCRIPTION
we are currently using something like /run/user/UID/run as runroot, as
it is already done by Buildah.  This ends up with
/run/user/UID/run/runc for the runc directory.  Change to drop the
additional /run so that runc will use /run/user/UID/runc.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>