### PR TITLE
replace quay.io/baude to quay.io/libpod

### DIFF
--- a/test/e2e/config_amd64.go
+++ b/test/e2e/config_amd64.go
@@ -4,8 +4,8 @@ var (
 	STORAGE_OPTIONS          = "--storage-driver vfs"
 	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"
 	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, registry, infra, labels}
-	nginx                    = "quay.io/baude/alpine_nginx:latest"
+	nginx                    = "quay.io/libpod/alpine_nginx:latest"
 	BB_GLIBC                 = "docker.io/library/busybox:glibc"
 	registry                 = "docker.io/library/registry:2"
-	labels                   = "quay.io/baude/alpine_labels:latest"
+	labels                   = "quay.io/libpod/alpine_labels:latest"
 )

--- a/test/e2e/config_ppc64le.go
+++ b/test/e2e/config_ppc64le.go
@@ -4,8 +4,8 @@ var (
 	STORAGE_OPTIONS          = "--storage-driver overlay"
 	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"
 	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, infra, labels}
-	nginx                    = "quay.io/baude/alpine_nginx-ppc64le:latest"
+	nginx                    = "quay.io/libpod/alpine_nginx-ppc64le:latest"
 	BB_GLIBC                 = "docker.io/ppc64le/busybox:glibc"
-	labels                   = "quay.io/baude/alpine_labels-ppc64le:latest"
+	labels                   = "quay.io/libpod/alpine_labels-ppc64le:latest"
 	registry                 string
 )

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -63,11 +63,11 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull from alternate registry without tag", func() {
-		session := podmanTest.Podman([]string{"pull", "quay.io/baude/alpine_nginx"})
+		session := podmanTest.Podman([]string{"pull", "quay.io/libpod/alpine_nginx"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", "quay.io/baude/alpine_nginx"})
+		session = podmanTest.Podman([]string{"rmi", "quay.io/libpod/alpine_nginx"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -52,13 +52,13 @@ var _ = Describe("Podman run", func() {
 
 	It("podman run a container based on on a short name with localhost", func() {
 		podmanTest.RestoreArtifact(nginx)
-		tag := podmanTest.Podman([]string{"tag", nginx, "localhost/baude/alpine_nginx:latest"})
+		tag := podmanTest.Podman([]string{"tag", nginx, "localhost/libpod/alpine_nginx:latest"})
 		tag.WaitWithDefaultTimeout()
 
 		rmi := podmanTest.Podman([]string{"rmi", nginx})
 		rmi.WaitWithDefaultTimeout()
 
-		session := podmanTest.Podman([]string{"run", "baude/alpine_nginx:latest", "ls"})
+		session := podmanTest.Podman([]string{"run", "libpod/alpine_nginx:latest", "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ErrorToString()).ToNot(ContainSubstring("Trying to pull"))
 		Expect(session.ExitCode()).To(Equal(0))


### PR DESCRIPTION
images used for our integration suite have moved from my work account
to a group organization called libpod.

Signed-off-by: baude <bbaude@redhat.com>