### PR TITLE
`--interactive` shall keep STDIN attached even when not explicitly set

### DIFF
--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -96,8 +96,6 @@ func runCmd(c *cli.Context) error {
 			inputStream = nil
 		}
 
-		inputStream = nil
-
 		attachTo := c.StringSlice("attach")
 		for _, stream := range attachTo {
 			switch strings.ToLower(stream) {


### PR DESCRIPTION
Addressing:

    podman run -it -a STDERR --rm alpine /bin/ash

hanging. As we droped stdin as soon as -a was used. Notice this is contrary to
what D-tool does and contrary to what podman help implies:

    podman run --help | grep interact
    --interactive, -i                  Keep STDIN open even if not attached

Signed-off-by: Šimon Lukašík <slukasik@redhat.com>