### PR TITLE
Update metalinter dependency

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -41,6 +41,7 @@ ${LINTER} \
 	--exclude='duplicate of.*_test.go.*\(dupl\)$'\
 	--exclude='cmd\/client\/.*\.go.*\(dupl\)$'\
 	--exclude='libpod\/.*_easyjson.go:.*'\
+	--exclude='.* other occurrence\(s\) of "(container|host|tmpfs|unknown)" found in: .*\(goconst\)$'\
 	--exclude='vendor\/.*'\
 	--exclude='podman\/.*'\
 	--exclude='server\/seccomp\/.*\.go.*$'\

--- a/.tool/lint
+++ b/.tool/lint
@@ -40,6 +40,7 @@ ${LINTER} \
 	--exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$'\
 	--exclude='duplicate of.*_test.go.*\(dupl\)$'\
 	--exclude='cmd\/client\/.*\.go.*\(dupl\)$'\
+	--exclude='libpod\/.*_easyjson.go:.*'\
 	--exclude='vendor\/.*'\
 	--exclude='podman\/.*'\
 	--exclude='server\/seccomp\/.*\.go.*$'\

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ install.tools: .install.gitvalidation .install.gometalinter .install.md2man .ins
 	if [ ! -x "$(GOBIN)/gometalinter" ]; then \
 		$(GO) get -u github.com/alecthomas/gometalinter; \
 		cd $(FIRST_GOPATH)/src/github.com/alecthomas/gometalinter; \
-		git checkout 23261fa046586808612c61da7a81d75a658e0814; \
+		git checkout e8d801238da6f0dfd14078d68f9b53fa50a7eeb5; \
 		$(GO) install github.com/alecthomas/gometalinter; \
 		$(GOBIN)/gometalinter --install; \
 	fi

--- a/libpod/container_graph_test.go
+++ b/libpod/container_graph_test.go
@@ -205,6 +205,7 @@ func TestBuildContainerGraphFourContainersNoEdges(t *testing.T) {
 	ctr3, err := getTestCtrN("3", tmpDir)
 	assert.NoError(t, err)
 	ctr4, err := getTestCtrN("4", tmpDir)
+	assert.NoError(t, err)
 
 	graph, err := buildContainerGraph([]*Container{ctr1, ctr2, ctr3, ctr4})
 	assert.NoError(t, err)
@@ -241,6 +242,7 @@ func TestBuildContainerGraphFourContainersTwoInCycle(t *testing.T) {
 	ctr3, err := getTestCtrN("3", tmpDir)
 	assert.NoError(t, err)
 	ctr4, err := getTestCtrN("4", tmpDir)
+	assert.NoError(t, err)
 	ctr1.config.IPCNsCtr = ctr2.config.ID
 	ctr2.config.UserNsCtr = ctr1.config.ID
 
@@ -260,6 +262,7 @@ func TestBuildContainerGraphFourContainersAllInCycle(t *testing.T) {
 	ctr3, err := getTestCtrN("3", tmpDir)
 	assert.NoError(t, err)
 	ctr4, err := getTestCtrN("4", tmpDir)
+	assert.NoError(t, err)
 	ctr1.config.IPCNsCtr = ctr2.config.ID
 	ctr2.config.UserNsCtr = ctr3.config.ID
 	ctr3.config.NetNsCtr = ctr4.config.ID
@@ -281,6 +284,7 @@ func TestBuildContainerGraphFourContainersNoneInCycle(t *testing.T) {
 	ctr3, err := getTestCtrN("3", tmpDir)
 	assert.NoError(t, err)
 	ctr4, err := getTestCtrN("4", tmpDir)
+	assert.NoError(t, err)
 	ctr1.config.IPCNsCtr = ctr2.config.ID
 	ctr1.config.NetNsCtr = ctr3.config.ID
 	ctr2.config.UserNsCtr = ctr3.config.ID

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -350,7 +350,8 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 		// Set the label of the conmon process to be level :s0
 		// This will allow the container processes to talk to fifo-files
 		// passed into the container by conmon
-		plabel, err := selinux.CurrentLabel()
+		var plabel string
+		plabel, err = selinux.CurrentLabel()
 		if err != nil {
 			childPipe.Close()
 			return errors.Wrapf(err, "Failed to get current SELinux label")
@@ -360,7 +361,7 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 		runtime.LockOSThread()
 		if c["level"] != "s0" && c["level"] != "" {
 			c["level"] = "s0"
-			if err := label.SetProcessLabel(c.Get()); err != nil {
+			if err = label.SetProcessLabel(c.Get()); err != nil {
 				runtime.UnlockOSThread()
 				return err
 			}

--- a/libpod/oci_linux.go
+++ b/libpod/oci_linux.go
@@ -19,6 +19,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const unknownPackage = "Unknown"
+
 func (r *OCIRuntime) moveConmonToCgroup(ctr *Container, cgroupParent string, cmd *exec.Cmd) error {
 	if os.Geteuid() == 0 {
 		if r.cgroupManager == SystemdCgroupsManager {
@@ -112,7 +114,7 @@ func (r *OCIRuntime) createContainer(ctr *Container, cgroupParent string, restor
 }
 
 func rpmVersion(path string) string {
-	output := "Unknown"
+	output := unknownPackage
 	cmd := exec.Command("/usr/bin/rpm", "-q", "-f", path)
 	if outp, err := cmd.Output(); err == nil {
 		output = string(outp)
@@ -121,7 +123,7 @@ func rpmVersion(path string) string {
 }
 
 func dpkgVersion(path string) string {
-	output := "Unknown"
+	output := unknownPackage
 	cmd := exec.Command("/usr/bin/dpkg", "-S", path)
 	if outp, err := cmd.Output(); err == nil {
 		output = string(outp)
@@ -130,14 +132,14 @@ func dpkgVersion(path string) string {
 }
 
 func (r *OCIRuntime) pathPackage() string {
-	if out := rpmVersion(r.path); out != "Unknown" {
+	if out := rpmVersion(r.path); out != unknownPackage {
 		return out
 	}
 	return dpkgVersion(r.path)
 }
 
 func (r *OCIRuntime) conmonPackage() string {
-	if out := rpmVersion(r.conmonPath); out != "Unknown" {
+	if out := rpmVersion(r.conmonPath); out != unknownPackage {
 		return out
 	}
 	return dpkgVersion(r.conmonPath)

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -271,6 +271,9 @@ func (i *LibpodAPI) InspectImage(call iopodman.VarlinkCall, name string) error {
 		return call.ReplyImageNotFound(name)
 	}
 	inspectInfo, err := newImage.Inspect(getContext())
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
 	b, err := json.Marshal(inspectInfo)
 	if err != nil {
 		return call.ReplyErrorOccurred(fmt.Sprintf("unable to serialize"))


### PR DESCRIPTION
We fixated on old metalinter dependency in past based on experience of
metalinter being oftentimes broke and hence broking our build. See
[762f508d9ca... in cri-o](https://github.com/kubernetes-sigs/cri-o/commit/762f508d9ca97cdbaee6053b663e98aee9cae081) for more details.

Now, dated metalinter is messing up with my environment (like it is
panicing on containters/storage) so let's see if we can move to more
current version of metalinter.