### PR TITLE
Fix cleanup for "Pause a bunch of running containers"

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -139,6 +139,3 @@ if [ $integrationtest -eq 1 ]; then
     fi
     make ginkgo GOPATH=/go $INTEGRATION_TEST_ENVS
 fi
-
-
-exit 0

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -250,6 +250,10 @@ var _ = Describe("Podman pause", func() {
 		running.WaitWithDefaultTimeout()
 		Expect(running.ExitCode()).To(Equal(0))
 		Expect(len(running.OutputToStringArray())).To(Equal(0))
+
+		unpause := podmanTest.Podman([]string{"unpause", "--all"})
+		unpause.WaitWithDefaultTimeout()
+		Expect(unpause.ExitCode()).To(Equal(0))
 	})
 
 	It("Unpause a bunch of running containers", func() {


### PR DESCRIPTION
When running integration tests in our CI, we observe a problem where paused containers
are not able to be stopped; and therefore cannot be cleaned up.  This leaves dangling mounts
and sometimes zombied conmon processes.

Signed-off-by: baude <bbaude@redhat.com>