### PR TITLE
Set --force-rm for podman build to true by default

### DIFF
--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/imagebuildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
@@ -10,14 +15,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 var (
 	layerFlags = []cli.Flag{
+		cli.BoolTFlag{
+			Name:  "force-rm",
+			Usage: "Always remove intermediate containers after a build, even if the build is unsuccessful. (default true)",
+		},
 		cli.BoolTFlag{
 			Name:  "layers",
 			Usage: "cache intermediate layers during build. Use BUILDAH_LAYERS environment variable to override. ",
@@ -230,7 +235,7 @@ func buildCmd(c *cli.Context) error {
 		Layers:                  layers,
 		NoCache:                 c.Bool("no-cache"),
 		RemoveIntermediateCtrs:  c.BoolT("rm"),
-		ForceRmIntermediateCtrs: c.Bool("force-rm"),
+		ForceRmIntermediateCtrs: c.BoolT("force-rm"),
 	}
 
 	if c.Bool("quiet") {

--- a/vendor.conf
+++ b/vendor.conf
@@ -92,7 +92,7 @@ k8s.io/kube-openapi 275e2ce91dec4c05a4094a7b1daee5560b555ac9 https://github.com/
 k8s.io/utils 258e2a2fa64568210fbd6267cf1d8fd87c3cb86e https://github.com/kubernetes/utils
 github.com/mrunalp/fileutils master
 github.com/varlink/go master
-github.com/containers/buildah 46c577c87d5a7ab30ef40cfa695cd2b96b32b117
+github.com/containers/buildah 795d43e60e5a1ab283981b79eeda1dd14a65a0bd
 github.com/Nvveen/Gotty master
 github.com/fsouza/go-dockerclient master
 github.com/openshift/imagebuilder master

--- a/vendor/github.com/containers/buildah/README.md
+++ b/vendor/github.com/containers/buildah/README.md
@@ -107,6 +107,7 @@ $ sudo ./lighttpd.sh
 | [buildah-images(1)](/docs/buildah-images.md)         | List images in local storage.                                                                        |
 | [buildah-inspect(1)](/docs/buildah-inspect.md)       | Inspects the configuration of a container or image.                                                  |
 | [buildah-mount(1)](/docs/buildah-mount.md)           | Mount the working container's root filesystem.                                                       |
+| [buildah-pull(1)](/docs/buildah-pull.md)             | Pull an image from the specified location.                                                           |
 | [buildah-push(1)](/docs/buildah-push.md)             | Push an image from local storage to elsewhere.                                                       |
 | [buildah-rename(1)](/docs/buildah-rename.md)         | Rename a local container.                                                                            |
 | [buildah-rm(1)](/docs/buildah-rm.md)                 | Removes one or more working containers.                                                              |

--- a/vendor/github.com/containers/buildah/buildah.go
+++ b/vendor/github.com/containers/buildah/buildah.go
@@ -224,6 +224,7 @@ func GetBuildInfo(b *Builder) BuilderInfo {
 		ContainerID:           b.ContainerID,
 		MountPoint:            b.MountPoint,
 		ProcessLabel:          b.ProcessLabel,
+		MountLabel:            b.MountLabel,
 		ImageAnnotations:      b.ImageAnnotations,
 		ImageCreatedBy:        b.ImageCreatedBy,
 		OCIv1:                 b.OCIv1,

--- a/vendor/github.com/containers/buildah/chroot/run.go
+++ b/vendor/github.com/containers/buildah/chroot/run.go
@@ -1147,7 +1147,7 @@ func setupChrootBindMounts(spec *specs.Spec, bundlePath string) (undoBinds func(
 		}
 		if uintptr(fs.Flags)&expectedFlags != expectedFlags {
 			if err := unix.Mount(target, target, "bind", requestFlags|unix.MS_REMOUNT, ""); err != nil {
-				return undoBinds, errors.Wrapf(err, "error remounting %q in mount namespace with expected flags")
+				return undoBinds, errors.Wrapf(err, "error remounting %q in mount namespace with expected flags", target)
 			}
 		}
 	}

--- a/vendor/github.com/containers/buildah/delete.go
+++ b/vendor/github.com/containers/buildah/delete.go
@@ -1,7 +1,6 @@
 package buildah
 
 import (
-	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 )
 
@@ -14,5 +13,5 @@ func (b *Builder) Delete() error {
 	b.MountPoint = ""
 	b.Container = ""
 	b.ContainerID = ""
-	return label.ReleaseLabel(b.ProcessLabel)
+	return nil
 }

--- a/vendor/github.com/containers/buildah/image.go
+++ b/vendor/github.com/containers/buildah/image.go
@@ -107,7 +107,6 @@ func expectedDockerDiffIDs(image docker.V2Image) int {
 // compression that we'll be applying.
 func (i *containerImageRef) computeLayerMIMEType(what string) (omediaType, dmediaType string, err error) {
 	omediaType = v1.MediaTypeImageLayer
-	//TODO: Convert to manifest.DockerV2Schema2LayerUncompressedMediaType once available
 	dmediaType = docker.V2S2MediaTypeUncompressedLayer
 	if i.compression != archive.Uncompressed {
 		switch i.compression {

--- a/vendor/github.com/containers/buildah/imagebuildah/build.go
+++ b/vendor/github.com/containers/buildah/imagebuildah/build.go
@@ -563,39 +563,39 @@ func NewExecutor(store storage.Store, options BuildOptions) (*Executor, error) {
 		registry:                       options.Registry,
 		transport:                      options.Transport,
 		ignoreUnrecognizedInstructions: options.IgnoreUnrecognizedInstructions,
-		quiet:                   options.Quiet,
-		runtime:                 options.Runtime,
-		runtimeArgs:             options.RuntimeArgs,
-		transientMounts:         options.TransientMounts,
-		compression:             options.Compression,
-		output:                  options.Output,
-		outputFormat:            options.OutputFormat,
-		additionalTags:          options.AdditionalTags,
-		signaturePolicyPath:     options.SignaturePolicyPath,
-		systemContext:           options.SystemContext,
-		volumeCache:             make(map[string]string),
-		volumeCacheInfo:         make(map[string]os.FileInfo),
-		log:                     options.Log,
-		in:                      options.In,
-		out:                     options.Out,
-		err:                     options.Err,
-		reportWriter:            options.ReportWriter,
-		isolation:               options.Isolation,
-		namespaceOptions:        options.NamespaceOptions,
-		configureNetwork:        options.ConfigureNetwork,
-		cniPluginPath:           options.CNIPluginPath,
-		cniConfigDir:            options.CNIConfigDir,
-		idmappingOptions:        options.IDMappingOptions,
-		commonBuildOptions:      options.CommonBuildOpts,
-		defaultMountsFilePath:   options.DefaultMountsFilePath,
-		iidfile:                 options.IIDFile,
-		squash:                  options.Squash,
-		labels:                  append([]string{}, options.Labels...),
-		annotations:             append([]string{}, options.Annotations...),
-		layers:                  options.Layers,
-		noCache:                 options.NoCache,
-		removeIntermediateCtrs:  options.RemoveIntermediateCtrs,
-		forceRmIntermediateCtrs: options.ForceRmIntermediateCtrs,
+		quiet:                          options.Quiet,
+		runtime:                        options.Runtime,
+		runtimeArgs:                    options.RuntimeArgs,
+		transientMounts:                options.TransientMounts,
+		compression:                    options.Compression,
+		output:                         options.Output,
+		outputFormat:                   options.OutputFormat,
+		additionalTags:                 options.AdditionalTags,
+		signaturePolicyPath:            options.SignaturePolicyPath,
+		systemContext:                  options.SystemContext,
+		volumeCache:                    make(map[string]string),
+		volumeCacheInfo:                make(map[string]os.FileInfo),
+		log:                            options.Log,
+		in:                             options.In,
+		out:                            options.Out,
+		err:                            options.Err,
+		reportWriter:                   options.ReportWriter,
+		isolation:                      options.Isolation,
+		namespaceOptions:               options.NamespaceOptions,
+		configureNetwork:               options.ConfigureNetwork,
+		cniPluginPath:                  options.CNIPluginPath,
+		cniConfigDir:                   options.CNIConfigDir,
+		idmappingOptions:               options.IDMappingOptions,
+		commonBuildOptions:             options.CommonBuildOpts,
+		defaultMountsFilePath:          options.DefaultMountsFilePath,
+		iidfile:                        options.IIDFile,
+		squash:                         options.Squash,
+		labels:                         append([]string{}, options.Labels...),
+		annotations:                    append([]string{}, options.Annotations...),
+		layers:                         options.Layers,
+		noCache:                        options.NoCache,
+		removeIntermediateCtrs:         options.RemoveIntermediateCtrs,
+		forceRmIntermediateCtrs:        options.ForceRmIntermediateCtrs,
 	}
 	if exec.err == nil {
 		exec.err = os.Stderr
@@ -764,7 +764,7 @@ func (b *Executor) resolveNameToImageRef() (types.ImageReference, error) {
 		if err != nil {
 			candidates, _, err := util.ResolveName(b.output, "", b.systemContext, b.store)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error parsing target image name %q: %v", b.output)
+				return nil, errors.Wrapf(err, "error parsing target image name %q", b.output)
 			}
 			if len(candidates) == 0 {
 				return nil, errors.Errorf("error parsing target image name %q", b.output)
@@ -1044,17 +1044,14 @@ func (b *Executor) copiedFilesMatch(node *parser.Node, historyTime *time.Time) (
 			}
 			continue
 		}
-		// For local files, walk the file tree and check the time stamps.
-		timeIsGreater := false
-		err := filepath.Walk(item, func(path string, info os.FileInfo, err error) error {
-			if info.ModTime().After(*historyTime) {
-				timeIsGreater = true
-				return nil
-			}
-			return nil
-		})
+		// Walks the file tree for local files and uses chroot to ensure we don't escape out of the allowed path
+		// when resolving any symlinks.
+		// Change the time format to ensure we don't run into a parsing error when converting again from string
+		// to time.Time. It is a known Go issue that the conversions cause errors sometimes, so specifying a particular
+		// time format here when converting to a string.
+		timeIsGreater, err := resolveModifiedTime(b.contextDir, item, historyTime.Format(time.RFC3339Nano))
 		if err != nil {
-			return false, errors.Wrapf(err, "error walking file tree %q", item)
+			return false, errors.Wrapf(err, "error resolving symlinks and comparing modified times: %q", item)
 		}
 		if timeIsGreater {
 			return false, nil
@@ -1289,15 +1286,24 @@ func BuildDockerfiles(ctx context.Context, store storage.Store, options BuildOpt
 		} else {
 			// If the Dockerfile isn't found try prepending the
 			// context directory to it.
-			if _, err := os.Stat(dfile); os.IsNotExist(err) {
+			dinfo, err := os.Stat(dfile)
+			if os.IsNotExist(err) {
 				dfile = filepath.Join(options.ContextDirectory, dfile)
+			}
+			dinfo, err = os.Stat(dfile)
+			if err != nil {
+				return "", nil, errors.Wrapf(err, "error reading info about %q", dfile)
+			}
+			// If given a directory, add '/Dockerfile' to it.
+			if dinfo.Mode().IsDir() {
+				dfile = filepath.Join(dfile, "Dockerfile")
 			}
 			logrus.Debugf("reading local Dockerfile %q", dfile)
 			contents, err := os.Open(dfile)
 			if err != nil {
 				return "", nil, errors.Wrapf(err, "error reading %q", dfile)
 			}
-			dinfo, err := contents.Stat()
+			dinfo, err = contents.Stat()
 			if err != nil {
 				contents.Close()
 				return "", nil, errors.Wrapf(err, "error reading info about %q", dfile)

--- a/vendor/github.com/containers/buildah/pkg/cli/common.go
+++ b/vendor/github.com/containers/buildah/pkg/cli/common.go
@@ -71,6 +71,10 @@ var (
 
 	LayerFlags = []cli.Flag{
 		cli.BoolFlag{
+			Name:  "force-rm",
+			Usage: "Always remove intermediate containers after a build, even if the build is unsuccessful.",
+		},
+		cli.BoolFlag{
 			Name:  "layers",
 			Usage: fmt.Sprintf("cache intermediate layers during build. Use BUILDAH_LAYERS environment variable to override. (default %t)", UseLayers()),
 		},
@@ -114,10 +118,6 @@ var (
 		cli.StringSliceFlag{
 			Name:  "file, f",
 			Usage: "`pathname or URL` of a Dockerfile",
-		},
-		cli.BoolFlag{
-			Name:  "force-rm",
-			Usage: "Always remove intermediate containers after a build, even if the build is unsuccessful.",
 		},
 		cli.StringFlag{
 			Name:  "format",

--- a/vendor/github.com/containers/buildah/pull.go
+++ b/vendor/github.com/containers/buildah/pull.go
@@ -146,11 +146,11 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 	srcRef, err := alltransports.ParseImageName(spec)
 	if err != nil {
 		if options.Transport == "" {
-			options.Transport = DefaultTransport
+			options.Transport = util.DefaultTransport
 		}
 		logrus.Debugf("error parsing image name %q, trying with transport %q: %v", spec, options.Transport, err)
 		transport := options.Transport
-		if transport != DefaultTransport {
+		if transport != util.DefaultTransport {
 			transport = transport + ":"
 		}
 		spec = transport + spec
@@ -201,6 +201,7 @@ func pullImage(ctx context.Context, store storage.Store, imageName string, optio
 
 	logrus.Debugf("copying %q to %q", spec, destName)
 	if _, err := cp.Image(ctx, policyContext, destRef, srcRef, getCopyOptions(options.ReportWriter, srcRef, sc, destRef, nil, "")); err != nil {
+		logrus.Debugf("error copying src image [%q] to dest image [%q] err: %v", spec, destName, err)
 		return nil, err
 	}
 	return destRef, nil

--- a/vendor/github.com/containers/buildah/run.go
+++ b/vendor/github.com/containers/buildah/run.go
@@ -451,7 +451,7 @@ func (b *Builder) setupMounts(mountPoint string, spec *specs.Spec, bundlePath st
 	// Add temporary copies of the contents of volume locations at the
 	// volume locations, unless we already have something there.
 	copyWithTar := b.copyWithTar(nil, nil)
-	builtins, err := runSetupBuiltinVolumes(b.MountLabel, mountPoint, cdir, copyWithTar, builtinVolumes)
+	builtins, err := runSetupBuiltinVolumes(b.MountLabel, mountPoint, cdir, copyWithTar, builtinVolumes, int(rootUID), int(rootGID))
 	if err != nil {
 		return err
 	}
@@ -493,15 +493,21 @@ func runSetupBoundFiles(bundlePath string, bindFiles map[string]string) (mounts 
 	return mounts, nil
 }
 
-func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, copyWithTar func(srcPath, dstPath string) error, builtinVolumes []string) ([]specs.Mount, error) {
+func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, copyWithTar func(srcPath, dstPath string) error, builtinVolumes []string, rootUID, rootGID int) ([]specs.Mount, error) {
 	var mounts []specs.Mount
+	hostOwner := idtools.IDPair{UID: rootUID, GID: rootGID}
 	// Add temporary copies of the contents of volume locations at the
 	// volume locations, unless we already have something there.
 	for _, volume := range builtinVolumes {
 		subdir := digest.Canonical.FromString(volume).Hex()
 		volumePath := filepath.Join(containerDir, "buildah-volumes", subdir)
+		srcPath := filepath.Join(mountPoint, volume)
+		initializeVolume := false
 		// If we need to, initialize the volume path's initial contents.
-		if _, err := os.Stat(volumePath); err != nil && os.IsNotExist(err) {
+		if _, err := os.Stat(volumePath); err != nil {
+			if !os.IsNotExist(err) {
+				return nil, errors.Wrapf(err, "failed to stat %q for volume %q", volumePath, volume)
+			}
 			logrus.Debugf("setting up built-in volume at %q", volumePath)
 			if err = os.MkdirAll(volumePath, 0755); err != nil {
 				return nil, errors.Wrapf(err, "error creating directory %q for volume %q", volumePath, volume)
@@ -509,11 +515,21 @@ func runSetupBuiltinVolumes(mountLabel, mountPoint, containerDir string, copyWit
 			if err = label.Relabel(volumePath, mountLabel, false); err != nil {
 				return nil, errors.Wrapf(err, "error relabeling directory %q for volume %q", volumePath, volume)
 			}
-			srcPath := filepath.Join(mountPoint, volume)
-			stat, err := os.Stat(srcPath)
-			if err != nil {
+			initializeVolume = true
+		}
+		stat, err := os.Stat(srcPath)
+		if err != nil {
+			if !os.IsNotExist(err) {
 				return nil, errors.Wrapf(err, "failed to stat %q for volume %q", srcPath, volume)
 			}
+			if err = idtools.MkdirAllAndChownNew(srcPath, 0755, hostOwner); err != nil {
+				return nil, errors.Wrapf(err, "error creating directory %q for volume %q", srcPath, volume)
+			}
+			if stat, err = os.Stat(srcPath); err != nil {
+				return nil, errors.Wrapf(err, "failed to stat %q for volume %q", srcPath, volume)
+			}
+		}
+		if initializeVolume {
 			if err = os.Chmod(volumePath, stat.Mode().Perm()); err != nil {
 				return nil, errors.Wrapf(err, "failed to chmod %q for volume %q", volumePath, volume)
 			}
@@ -1044,24 +1060,31 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 	}
 	rootIDPair := &idtools.IDPair{UID: int(rootUID), GID: int(rootGID)}
 
-	hostFile, err := b.addNetworkConfig(path, "/etc/hosts", rootIDPair)
-	if err != nil {
-		return err
-	}
-	resolvFile, err := b.addNetworkConfig(path, "/etc/resolv.conf", rootIDPair)
-	if err != nil {
-		return err
+	bindFiles := make(map[string]string)
+	namespaceOptions := append(b.NamespaceOptions, options.NamespaceOptions...)
+	volumes := b.Volumes()
+
+	if !contains(volumes, "/etc/hosts") {
+		hostFile, err := b.addNetworkConfig(path, "/etc/hosts", rootIDPair)
+		if err != nil {
+			return err
+		}
+		bindFiles["/etc/hosts"] = hostFile
+
+		if err := addHostsToFile(b.CommonBuildOpts.AddHost, hostFile); err != nil {
+			return err
+		}
 	}
 
-	if err := addHostsToFile(b.CommonBuildOpts.AddHost, hostFile); err != nil {
-		return err
+	if !contains(volumes, "/etc/resolv.conf") {
+		resolvFile, err := b.addNetworkConfig(path, "/etc/resolv.conf", rootIDPair)
+		if err != nil {
+			return err
+		}
+		bindFiles["/etc/resolv.conf"] = resolvFile
 	}
 
-	bindFiles := map[string]string{
-		"/etc/hosts":       hostFile,
-		"/etc/resolv.conf": resolvFile,
-	}
-	err = b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, b.Volumes(), b.CommonBuildOpts.Volumes, b.CommonBuildOpts.ShmSize, append(b.NamespaceOptions, options.NamespaceOptions...))
+	err = b.setupMounts(mountPoint, spec, path, options.Mounts, bindFiles, volumes, b.CommonBuildOpts.Volumes, b.CommonBuildOpts.ShmSize, namespaceOptions)
 	if err != nil {
 		return errors.Wrapf(err, "error resolving mountpoints for container %q", b.ContainerID)
 	}
@@ -1095,7 +1118,7 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 		} else {
 			moreCreateArgs = nil
 		}
-		err = b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, moreCreateArgs, spec, mountPoint, path, Package+"-"+filepath.Base(path))
+		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, configureNetworks, moreCreateArgs, spec, mountPoint, path, Package+"-"+filepath.Base(path))
 	case IsolationChroot:
 		err = chroot.RunUsingChroot(spec, path, options.Stdin, options.Stdout, options.Stderr)
 	case IsolationOCIRootless:
@@ -1109,11 +1132,20 @@ func (b *Builder) Run(command []string, options RunOptions) error {
 			}
 		}
 		options.Args = append(options.Args, rootlessFlag...)
-		err = b.runUsingRuntimeSubproc(options, configureNetwork, configureNetworks, []string{"--no-new-keyring"}, spec, mountPoint, path, Package+"-"+filepath.Base(path))
+		err = b.runUsingRuntimeSubproc(isolation, options, configureNetwork, configureNetworks, []string{"--no-new-keyring"}, spec, mountPoint, path, Package+"-"+filepath.Base(path))
 	default:
 		err = errors.Errorf("don't know how to run this command")
 	}
 	return err
+}
+
+func contains(volumes []string, v string) bool {
+	for _, i := range volumes {
+		if i == v {
+			return true
+		}
+	}
+	return false
 }
 
 func checkAndOverrideIsolationOptions(isolation Isolation, options *RunOptions) error {
@@ -1123,10 +1155,22 @@ func checkAndOverrideIsolationOptions(isolation Isolation, options *RunOptions) 
 			logrus.Debugf("Forcing use of an IPC namespace.")
 		}
 		options.NamespaceOptions.AddOrReplace(NamespaceOption{Name: string(specs.IPCNamespace)})
-		if ns := options.NamespaceOptions.Find(string(specs.NetworkNamespace)); ns != nil && !ns.Host {
-			logrus.Debugf("Disabling network namespace.")
+		_, err := exec.LookPath("slirp4netns")
+		hostNetworking := err != nil
+		networkNamespacePath := ""
+		if ns := options.NamespaceOptions.Find(string(specs.NetworkNamespace)); ns != nil {
+			hostNetworking = ns.Host
+			networkNamespacePath = ns.Path
+			if !hostNetworking && networkNamespacePath != "" && !filepath.IsAbs(networkNamespacePath) {
+				logrus.Debugf("Disabling network namespace configuration.")
+				networkNamespacePath = ""
+			}
 		}
-		options.NamespaceOptions.AddOrReplace(NamespaceOption{Name: string(specs.NetworkNamespace), Host: true})
+		options.NamespaceOptions.AddOrReplace(NamespaceOption{
+			Name: string(specs.NetworkNamespace),
+			Host: hostNetworking,
+			Path: networkNamespacePath,
+		})
 		if ns := options.NamespaceOptions.Find(string(specs.PIDNamespace)); ns == nil || ns.Host {
 			logrus.Debugf("Forcing use of a PID namespace.")
 		}
@@ -1227,9 +1271,10 @@ type runUsingRuntimeSubprocOptions struct {
 	ConfigureNetworks []string
 	MoreCreateArgs    []string
 	ContainerName     string
+	Isolation         Isolation
 }
 
-func (b *Builder) runUsingRuntimeSubproc(options RunOptions, configureNetwork bool, configureNetworks, moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName string) (err error) {
+func (b *Builder) runUsingRuntimeSubproc(isolation Isolation, options RunOptions, configureNetwork bool, configureNetworks, moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName string) (err error) {
 	var confwg sync.WaitGroup
 	config, conferr := json.Marshal(runUsingRuntimeSubprocOptions{
 		Options:           options,
@@ -1240,6 +1285,7 @@ func (b *Builder) runUsingRuntimeSubproc(options RunOptions, configureNetwork bo
 		ConfigureNetworks: configureNetworks,
 		MoreCreateArgs:    moreCreateArgs,
 		ContainerName:     containerName,
+		Isolation:         isolation,
 	})
 	if conferr != nil {
 		return errors.Wrapf(conferr, "error encoding configuration for %q", runUsingRuntimeCommand)
@@ -1318,7 +1364,7 @@ func runUsingRuntimeMain() {
 		os.Exit(1)
 	}
 	// Run the container, start to finish.
-	status, err := runUsingRuntime(options.Options, options.ConfigureNetwork, options.ConfigureNetworks, options.MoreCreateArgs, options.Spec, options.RootPath, options.BundlePath, options.ContainerName)
+	status, err := runUsingRuntime(options.Isolation, options.Options, options.ConfigureNetwork, options.ConfigureNetworks, options.MoreCreateArgs, options.Spec, options.RootPath, options.BundlePath, options.ContainerName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error running container: %v\n", err)
 		os.Exit(1)
@@ -1333,7 +1379,7 @@ func runUsingRuntimeMain() {
 	os.Exit(1)
 }
 
-func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetworks, moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName string) (wstatus unix.WaitStatus, err error) {
+func runUsingRuntime(isolation Isolation, options RunOptions, configureNetwork bool, configureNetworks, moreCreateArgs []string, spec *specs.Spec, rootPath, bundlePath, containerName string) (wstatus unix.WaitStatus, err error) {
 	// Lock the caller to a single OS-level thread.
 	runtime.LockOSThread()
 
@@ -1490,7 +1536,7 @@ func runUsingRuntime(options RunOptions, configureNetwork bool, configureNetwork
 	}()
 
 	if configureNetwork {
-		teardown, err := runConfigureNetwork(options, configureNetworks, pid, containerName, spec.Process.Args)
+		teardown, err := runConfigureNetwork(isolation, options, configureNetworks, pid, containerName, spec.Process.Args)
 		if teardown != nil {
 			defer teardown()
 		}
@@ -1623,9 +1669,81 @@ func runCollectOutput(fds, closeBeforeReadingFds []int) string {
 	}
 	return b.String()
 }
+func setupRootlessNetwork(pid int) (teardown func(), err error) {
+	slirp4netns, err := exec.LookPath("slirp4netns")
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot find slirp4netns")
+	}
 
-func runConfigureNetwork(options RunOptions, configureNetworks []string, pid int, containerName string, command []string) (teardown func(), err error) {
+	rootlessSlirpSyncR, rootlessSlirpSyncW, err := os.Pipe()
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot create slirp4netns sync pipe")
+	}
+	defer rootlessSlirpSyncR.Close()
+
+	// Be sure there are no fds inherited to slirp4netns except the sync pipe
+	files, err := ioutil.ReadDir("/proc/self/fd")
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot list open fds")
+	}
+	for _, f := range files {
+		fd, err := strconv.Atoi(f.Name())
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot parse fd")
+		}
+		if fd == int(rootlessSlirpSyncW.Fd()) {
+			continue
+		}
+		unix.CloseOnExec(fd)
+	}
+
+	cmd := exec.Command(slirp4netns, "-r", "3", "-c", fmt.Sprintf("%d", pid), "tap0")
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
+	cmd.ExtraFiles = []*os.File{rootlessSlirpSyncW}
+
+	err = cmd.Start()
+	rootlessSlirpSyncW.Close()
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot start slirp4netns")
+	}
+
+	b := make([]byte, 1)
+	for {
+		if err := rootlessSlirpSyncR.SetDeadline(time.Now().Add(1 * time.Second)); err != nil {
+			return nil, errors.Wrapf(err, "error setting slirp4netns pipe timeout")
+		}
+		if _, err := rootlessSlirpSyncR.Read(b); err == nil {
+			break
+		} else {
+			if os.IsTimeout(err) {
+				// Check if the process is still running.
+				var status syscall.WaitStatus
+				_, err := syscall.Wait4(cmd.Process.Pid, &status, syscall.WNOHANG, nil)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to read slirp4netns process status")
+				}
+				if status.Exited() || status.Signaled() {
+					return nil, errors.New("slirp4netns failed")
+				}
+
+				continue
+			}
+			return nil, errors.Wrapf(err, "failed to read from slirp4netns sync pipe")
+		}
+	}
+
+	return func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}, nil
+}
+
+func runConfigureNetwork(isolation Isolation, options RunOptions, configureNetworks []string, pid int, containerName string, command []string) (teardown func(), err error) {
 	var netconf, undo []*libcni.NetworkConfigList
+
+	if isolation == IsolationOCIRootless {
+		return setupRootlessNetwork(pid)
+	}
 	// Scan for CNI configuration files.
 	confdir := options.CNIConfigDir
 	files, err := libcni.ConfFiles(confdir, []string{".conf"})
@@ -1956,7 +2074,7 @@ func runAcceptTerminal(consoleListener *net.UnixListener, terminalSize *specs.Bo
 	for i := range scm {
 		fds, err := unix.ParseUnixRights(&scm[i])
 		if err != nil {
-			return -1, errors.Wrapf(err, "error parsing unix rights control message: %v")
+			return -1, errors.Wrapf(err, "error parsing unix rights control message: %v", &scm[i])
 		}
 		logrus.Debugf("fds: %v", fds)
 		if len(fds) == 0 {

--- a/vendor/github.com/containers/buildah/unshare/unshare.go
+++ b/vendor/github.com/containers/buildah/unshare/unshare.go
@@ -55,6 +55,10 @@ func (c *Cmd) Start() error {
 	}
 	c.Env = append(c.Env, fmt.Sprintf("_Buildah-unshare=%d", c.UnshareFlags))
 
+	// Please the libpod "rootless" package to find the expected env variables.
+	c.Env = append(c.Env, "_LIBPOD_USERNS_CONFIGURED=done")
+	c.Env = append(c.Env, fmt.Sprintf("_LIBPOD_ROOTLESS_UID=%d", os.Geteuid()))
+
 	// Create the pipe for reading the child's PID.
 	pidRead, pidWrite, err := os.Pipe()
 	if err != nil {

--- a/vendor/github.com/containers/buildah/vendor.conf
+++ b/vendor/github.com/containers/buildah/vendor.conf
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml master
 github.com/containerd/continuity master
 github.com/containernetworking/cni v0.7.0-alpha1
 github.com/containers/image 5e5b67d6b1cf43cc349128ec3ed7d5283a6cc0d1
-github.com/containers/libpod 2afadeec6696fefac468a49c8ba24b0bc275aa75
-github.com/containers/storage 41294c85d97bef688e18f710402895dbecde3308
+github.com/containers/libpod e75469ab99c48e9fbe2b36ade229d384bdea9144
+github.com/containers/storage 09abf3a26b8a3aa69e29fd7faeb260b98d675759
 github.com/docker/distribution 5f6282db7d65e6d72ad7c2cc66310724a57be716
 github.com/docker/docker 86f080cff0914e9694068ed78d503701667c4c00
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
@@ -36,7 +36,7 @@ github.com/opencontainers/image-spec v1.0.0
 github.com/opencontainers/runc master
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/opencontainers/runtime-tools master
-github.com/opencontainers/selinux b6fa367ed7f534f9ba25391cc2d467085dbb445a
+github.com/opencontainers/selinux master
 github.com/openshift/imagebuilder master
 github.com/ostreedev/ostree-go aeb02c6b6aa2889db3ef62f7855650755befd460
 github.com/pborman/uuid master


### PR DESCRIPTION
Since we use buildah containers for the build process, the
user will not know if we have any buildah containers lingering
due to a failed build. Setting this to true by default till
we figure out a better way to solve this.

Depends on https://github.com/containers/buildah/pull/1163
Fixes https://github.com/containers/libpod/issues/1586

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>