### PR TITLE
Fix run --hostname test that started failing post-merge

### DIFF
--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -83,23 +82,12 @@ var _ = Describe("Podman run dns", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Equal("foobar"))
+	})
 
-		session = podmanTest.Podman([]string{"run", "-d", "--hostname=foobar", ALPINE, "cat", "/etc/hosts"})
-		session.WaitWithDefaultTimeout()
-		cid := session.OutputToString()
-		session = podmanTest.Podman([]string{"start", "-ia", cid})
+	It("podman run add hostname sets /etc/hosts", func() {
+		session := podmanTest.Podman([]string{"run", "-t", "-i", "--hostname=foobar", ALPINE, "cat", "/etc/hosts"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session.LineInOutputContains("foobar")
-		line := strings.Split(session.OutputToStringArray()[len(session.OutputToStringArray())-1], "\t")
-		ip1 := line[0]
-
-		session = podmanTest.Podman([]string{"start", "-ia", cid})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		session.LineInOutputContains("foobar")
-		line = strings.Split(session.OutputToStringArray()[len(session.OutputToStringArray())-1], "\t")
-		ip2 := line[0]
-		Expect(ip2).To(Not(Equal(ip1)))
+		Expect(session.LineInOutputContains("foobar")).To(BeTrue())
 	})
 })


### PR DESCRIPTION
As the title says. Split the relevant code into a new test, so we can be sure this is the case if the test fails, and remove some logic that doesn't make sense (we cannot expect container IP to change across runs - that's expecting a lot out of CNI that we don't want to depend on)