### PR TITLE
WIP - Add driver mismatch error to runtime check

### DIFF
--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -137,6 +137,9 @@ func validateDBAgainstConfig(bucket *bolt.Bucket, fieldName, runtimeValue string
 				return nil
 			}
 
+			if (strings.EqualFold(fieldName, "graph driver name")) {
+				return errors.New("Configuration specifies " + runtimeValue + " storage driver but detected " + string(keyBytes) + "\nPlease change the configuration or clean up storage.")
+			}
 			return errors.Wrapf(ErrDBBadConfig, "database %s %s does not match our %s %s",
 				fieldName, string(keyBytes), fieldName, runtimeValue)
 		}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

If we're checking graph driver and our drivers don't match, i.e. we have vfs and expect overlay or vise versa, throw up an error rather than the default error which isn't terribly helpful.

Addresses #1157