### PR TITLE
update seccomp.json

### DIFF
--- a/seccomp.json
+++ b/seccomp.json
@@ -322,13 +322,13 @@
 				"stat64",
 				"statfs",
 				"statfs64",
+				"statx",
 				"symlink",
 				"symlinkat",
 				"sync",
 				"sync_file_range",
 				"syncfs",
 				"sysinfo",
-				"syslog",
 				"tee",
 				"tgkill",
 				"time",
@@ -565,6 +565,7 @@
 				"setdomainname",
 				"sethostname",
 				"setns",
+				"syslog",
 				"umount",
 				"umount2",
 				"unshare"
@@ -747,6 +748,36 @@
 			"includes": {
 				"caps": [
 					"CAP_SYS_TTY_CONFIG"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"get_mempolicy",
+				"mbind",
+				"set_mempolicy"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_NICE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"syslog"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYSLOG"
 				]
 			},
 			"excludes": {}


### PR DESCRIPTION
Merge the following changes from the upstream Moby seccomp profile:

 * commit b2a907c8cab6 ("Whitelist statx syscall for libseccomp-2.3.3
                         onward")

 * commit 47dfff68e436 ("Whitelist syscalls linked to CAP_SYS_NICE in
                         default seccomp profile")

 * commit ccd22ffcc8b5 ("Move the syslog syscall to be gated by
                         CAP_SYS_ADMIN or CAP_SYSLOG")

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>