### PR TITLE
Do not hide errors when creating container with UserNSRoot

### DIFF
--- a/libpod/oci_linux.go
+++ b/libpod/oci_linux.go
@@ -74,7 +74,8 @@ func (r *OCIRuntime) createContainer(ctr *Container, cgroupParent string, restor
 		defer wg.Done()
 		runtime.LockOSThread()
 
-		fd, err := os.Open(fmt.Sprintf("/proc/%d/task/%d/ns/mnt", os.Getpid(), unix.Gettid()))
+		var fd *os.File
+		fd, err = os.Open(fmt.Sprintf("/proc/%d/task/%d/ns/mnt", os.Getpid(), unix.Gettid()))
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
This one is tricky. By using `:=` operator we have made err variable to be local in the gorutine and different from `err` variable in the surrounding function. And thus `createContainer` function returned always nil, even in cases when some error occurred in the gorutine.

To reproduce this, you will need to run podman as root with  --uidmap or --guidmap and error has to occur in the given gorutine.

Signed-off-by: Šimon Lukašík <slukasik@redhat.com>

PS: I knew that fixing lint in libpod may be good way to learn go, but boy, would I ever tell that I can learn so much by fixing my first lint error? :books: 