### PR TITLE
info: add rootless field

### DIFF
--- a/libpod/info.go
+++ b/libpod/info.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/utils"
 	"github.com/containers/storage/pkg/system"
 	"github.com/pkg/errors"
@@ -30,6 +31,7 @@ func (r *Runtime) hostInfo() (map[string]interface{}, error) {
 	info["os"] = runtime.GOOS
 	info["arch"] = runtime.GOARCH
 	info["cpus"] = runtime.NumCPU()
+	info["rootless"] = rootless.IsRootless()
 	mi, err := system.ReadMemInfo()
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading memory info")


### PR DESCRIPTION
Add a rootless field to the info data (e.g., `podman info`) to indicate
if the executing user is root or not.  In most cases, this can be
guessed but now it is clear and may aid in debugging, reporting and
understanding certain issues.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>