### PR TITLE
Standardized container image for gofmt and lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,27 @@ Use your real name (sorry, no pseudonyms or anonymous contributions.)
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.
 
+### Go Format and lint
+
+All code changes must pass ``make validate`` and ``make lint``, as
+executed in a standard container.  The container image for this
+purpose is provided at: ``quay.io/libpod/gate:latest``.  However,
+for changes to the image itself, it may also be built locally
+from the repository root, with the command:
+
+```
+sudo podman build -t quay.io/libpod/gate:latest -f contrib/gate/Dockerfile .
+```
+
+The container executes 'make' by default, on a copy of the repository.
+This avoids changing or leaving build artifacts in your working directory.
+Execution does not require any special permissions from the host. However,
+the repository root must be bind-mounted into the container at
+'/usr/src/libpod'. For example, running `make lint` is done (from
+the repository root) with the command:
+
+``sudo podman run -it --rm -v $PWD:/usr/src/libpod:z quay.io/libpod/gate:latest lint``
+
 ### Integration Tests
 
 Our primary means of performing integration testing for libpod is with the

--- a/contrib/gate/Dockerfile
+++ b/contrib/gate/Dockerfile
@@ -1,0 +1,69 @@
+FROM fedora:28
+RUN dnf -y install \
+      atomic-registries \
+      btrfs-progs-devel \
+      buildah \
+      bzip2 \
+      conmon \
+      container-selinux \
+      containernetworking-cni \
+      containernetworking-cni-devel \
+      device-mapper-devel \
+      findutils \
+      git \
+      glib2-devel \
+      glibc-static \
+      gnupg \
+      golang \
+      gpgme-devel \
+      iptables \
+      libassuan-devel \
+      libseccomp-devel \
+      libselinux-devel \
+      lsof \
+      make \
+      nmap-ncat \
+      ostree-devel \
+      procps-ng \
+      python \
+      python3-dateutil \
+      python3-psutil \
+      python3-pytoml \
+      python3-varlink \
+      skopeo-containers \
+      slirp4netns \
+      rsync \
+      which \
+      xz \
+      && dnf clean all
+
+ENV GOPATH="/go" \
+    PATH="/go/bin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin" \
+    SRCPATH="/usr/src/libpod" \
+    GOSRC="/go/src/github.com/containers/libpod"
+
+# Only needed for installing build-time dependencies
+COPY / $GOSRC
+
+WORKDIR $GOSRC
+
+# Install dependencies
+RUN set -x && \
+    go get -u github.com/mailru/easyjson/... && \
+    install -D -m 755 "$GOPATH"/bin/easyjson /usr/bin/ && \
+    make install.tools && \
+    install -D -m 755 $GOSRC/contrib/gate/entrypoint.sh /usr/local/bin/ && \
+    rm -rf "$GOSRC"
+
+# Install cni config
+#RUN make install.cni
+RUN mkdir -p /etc/cni/net.d/
+COPY cni/87-podman-bridge.conflist /etc/cni/net.d/87-podman-bridge.conflist
+
+# Make sure we have some policy for pulling images
+RUN mkdir -p /etc/containers
+COPY test/policy.json /etc/containers/policy.json
+COPY test/redhat_sigstore.yaml /etc/containers/registries.d/registry.access.redhat.com.yaml
+
+VOLUME ["/usr/src/libpod"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/contrib/gate/README.md
+++ b/contrib/gate/README.md
@@ -1,0 +1,4 @@
+![PODMAN logo](../../logo/podman-logo-source.svg)
+
+A standard container image for `gofmt` and lint-checking the libpod
+repository.  The [contributors guide contains the documentation for usage.](https://github.com/containers/libpod/blob/master/CONTRIBUTING.md#go-format-and-lint)

--- a/contrib/gate/entrypoint.sh
+++ b/contrib/gate/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+[[ -n "$SRCPATH" ]] || \
+    ( echo "ERROR: \$SRCPATH must be non-empty" && exit 1 )
+[[ -n "$GOSRC" ]] || \
+    ( echo "ERROR: \$GOSRC must be non-empty" && exit 2 )
+[[ -r "${SRCPATH}/contrib/gate/Dockerfile" ]] || \
+    ( echo "ERROR: Expecting libpod repository root at $SRCPATH" && exit 3 )
+
+# Working from a copy avoids needing to perturb the actual source files
+mkdir -p "$GOSRC"
+/usr/bin/rsync --recursive --links --quiet --safe-links \
+               --perms --times "${SRCPATH}/" "${GOSRC}/"
+cd "$GOSRC"
+make "$@"


### PR DESCRIPTION
Having a standardized image allows uniform application of format and
lint checking across multiple host platforms.  This ensures all
contributors and disparate CI systems to play by a common set of basic
rules.  It also makes it easier to maintain the common rules over-time.

Signed-off-by: Chris Evich <cevich@redhat.com>