### PR TITLE
Cleanup podman spec to not show git checkout is dirty

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -378,10 +378,6 @@ providing packages with %{import_path} prefix.
 
 %prep
 %autosetup -Sgit -n %{repo}-%{shortcommit0}
-sed -i '/\/bin\/env/d' completions/bash/%{name}
-sed -i 's/0.0.0/%{version}/' contrib/python/%{name}/setup.py
-sed -i 's/0.0.0/%{version}/' contrib/python/py%{name}/setup.py
-mv pkg/hooks/README.md pkg/hooks/README-hooks.md
 
 # untar cri-o
 tar zxf %{SOURCE1}
@@ -416,15 +412,17 @@ popd
 
 %install
 install -dp %{buildroot}%{_unitdir}
-%{__make} PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir} \
+PODMAN_VERSION=%{version} %{__make} PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir} \
         install.bin \
         install.man \
         install.cni \
         install.systemd \
         install.completions
 
+mv pkg/hooks/README.md pkg/hooks/README-hooks.md
+
 %if %{with varlink}
-%{__make} DESTDIR=%{buildroot} install.python
+PODMAN_VERSION=%{version} %{__make} DESTDIR=%{buildroot} install.python
 %endif # varlink
 
 # install libpod.conf


### PR DESCRIPTION
Currently we modify the git checkout which ends up showing that the checkout is dirty.  This patch sets the PYTHON_VERSION so that python code will handle
it correctly without having to modify the actual code.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>