### PR TITLE
rootless: create user conf files when they don't exist

### DIFF
--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -38,8 +38,10 @@ func GetRegistries() ([]string, error) {
 func GetInsecureRegistries() ([]string, error) {
 	registryConfigPath := ""
 
-	if _, err := os.Stat(userRegistriesFile); err == nil {
-		registryConfigPath = userRegistriesFile
+	if rootless.IsRootless() {
+		if _, err := os.Stat(userRegistriesFile); err == nil {
+			registryConfigPath = userRegistriesFile
+		}
 	}
 
 	envOverride := os.Getenv("REGISTRIES_CONFIG_PATH")

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -149,6 +149,15 @@ func SecretMountsWithUIDGID(mountLabel, containerWorkingDir, mountFile, mountPre
 		mountFiles = append(mountFiles, []string{OverrideMountsFile, DefaultMountsFile}...)
 		if rootless.IsRootless() {
 			mountFiles = append([]string{UserOverrideMountsFile}, mountFiles...)
+			_, err := os.Stat(UserOverrideMountsFile)
+			if err != nil && os.IsNotExist(err) {
+				os.MkdirAll(filepath.Dir(UserOverrideMountsFile), 0755)
+				if f, err := os.Create(UserOverrideMountsFile); err != nil {
+					logrus.Warnf("could not create file %s: %v", UserOverrideMountsFile, err)
+				} else {
+					f.Close()
+				}
+			}
 		}
 	} else {
 		mountFiles = append(mountFiles, mountFile)


### PR DESCRIPTION
If the configuration files for the user don't exist, create them automatically.

Different policies are used for the creation of these files:

- `storage.conf`: use the default configuration known to libpod at the time these files are created.  This will prevent that users will keep using their configuration if we decide to change any default value in future.
- `libpod.conf`: same policy as `storage.conf`.
- `registries.conf`: when the file is not found, the global configuration is used.
- `policy.json`: same policy as `registries.conf`.
- `mounts.conf`: it is created as an empty file.
