### PR TITLE
Add version command to pypodman

### DIFF
--- a/contrib/python/pypodman/pypodman/lib/actions/__init__.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/__init__.py
@@ -22,6 +22,7 @@ from pypodman.lib.actions.rm_action import Rm
 from pypodman.lib.actions.rmi_action import Rmi
 from pypodman.lib.actions.run_action import Run
 from pypodman.lib.actions.search_action import Search
+from pypodman.lib.actions.version_action import Version
 
 __all__ = [
     'Attach',
@@ -47,4 +48,5 @@ __all__ = [
     'Rmi',
     'Run',
     'Search',
+    'Version',
 ]

--- a/contrib/python/pypodman/pypodman/lib/actions/version_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/version_action.py
@@ -1,0 +1,41 @@
+"""Remote client command for reporting on Podman service."""
+import json
+import sys
+
+import podman
+import yaml
+from pypodman.lib import AbstractActionBase
+
+
+class Version(AbstractActionBase):
+    """Class for reporting on Podman Service."""
+
+    @classmethod
+    def subparser(cls, parent):
+        """Add Version command to parent parser."""
+        parser = parent.add_parser(
+            'version', help='report version on podman service')
+        parser.set_defaults(class_=cls, method='version')
+
+    def __init__(self, args):
+        """Construct Version class."""
+        super().__init__(args)
+
+    def version(self):
+        """Report on Podman Service."""
+        try:
+            info = self.client.system.info()
+        except podman.ErrorOccurred as e:
+            sys.stdout.flush()
+            print(
+                '{}'.format(e.reason).capitalize(),
+                file=sys.stderr,
+                flush=True)
+            return 1
+        else:
+            version = info._asdict()['podman']
+            host = info._asdict()['host']
+            print("Version        {}".format(version['podman_version']))
+            print("Go Version     {}".format(version['go_version']))
+            print("Git Commit     {}".format(version['git_commit']))
+            print("OS/Arch        {}/{}".format(host["os"], host["arch"]))


### PR DESCRIPTION
pypodman does not currently support the version command.  We want to
have as close to the same functionality between podman and pypodman,
so adding this command.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>