### PR TITLE
Cirrus: Add master branch testing status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 ### Latest Version: 0.10.1.3
 ### Status: Active Development
 
+### Continuous Integration: [![Build Status](https://api.cirrus-ci.com/github/containers/libpod.svg)](https://cirrus-ci.com/github/containers/libpod)
+
 ## What is the scope of this project?
 
 libpod provides a library for applications looking to use the Container Pod concept popularized by Kubernetes.


### PR DESCRIPTION
Engineers get testing status via their PR's but another round of testing
happens post-merge, without any direct feedback.  Fix this in a small
way, by adding a dynamic status badge on the front-page.  If this
turns red, it means Cirrus-CI testing of the master branch failed
for some reason.

Nearly always it's something harmless, but once and a while, this
catches really nasty problems caused by merge-sequence issues.
Having that feedback on the front page ensures the right people will
eventually get called into action.

Signed-off-by: Chris Evich <cevich@redhat.com>