### PR TITLE
pypodman: Don't use $HOST and $USER variables for remote

### DIFF
--- a/contrib/python/pypodman/docs/man1/pypodman.1
+++ b/contrib/python/pypodman/docs/man1/pypodman.1
@@ -85,7 +85,7 @@ overwriting earlier. Any missing items are ignored.
 .IP \[bu] 2
 From \f[C]\-\-config\-home\f[] command line option + \f[C]pypodman/pypodman.conf\f[]
 .IP \[bu] 2
-From environment variable, for example: RUN_DIR
+From environment variable prefixed with PODMAN_, for example: PODMAN_RUN_DIR
 .IP \[bu] 2
 From command line option, for example: \[en]run\-dir
 .PP

--- a/contrib/python/pypodman/pypodman/lib/podman_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/podman_parser.py
@@ -152,7 +152,7 @@ class PodmanArgumentParser(argparse.ArgumentParser):
         reqattr(
             'run_dir',
             getattr(args, 'run_dir')
-            or os.environ.get('RUN_DIR')
+            or os.environ.get('PODMAN_RUN_DIR')
             or config['default'].get('run_dir')
             or str(Path(args.xdg_runtime_dir, 'pypodman'))
         )   # yapf: disable
@@ -161,23 +161,24 @@ class PodmanArgumentParser(argparse.ArgumentParser):
             args,
             'host',
             getattr(args, 'host')
-            or os.environ.get('HOST')
+            or os.environ.get('PODMAN_HOST')
             or config['default'].get('host')
         )   # yapf:disable
 
         reqattr(
             'username',
             getattr(args, 'username')
+            or os.environ.get('PODMAN_USER')
+            or config['default'].get('username')
             or os.environ.get('USER')
             or os.environ.get('LOGNAME')
-            or config['default'].get('username')
             or getpass.getuser()
         )   # yapf:disable
 
         reqattr(
             'port',
             getattr(args, 'port')
-            or os.environ.get('PORT')
+            or os.environ.get('PODMAN_PORT')
             or config['default'].get('port', None)
             or 22
         )   # yapf:disable
@@ -185,7 +186,7 @@ class PodmanArgumentParser(argparse.ArgumentParser):
         reqattr(
             'remote_socket_path',
             getattr(args, 'remote_socket_path')
-            or os.environ.get('REMOTE_SOCKET_PATH')
+            or os.environ.get('PODMAN_REMOTE_SOCKET_PATH')
             or config['default'].get('remote_socket_path')
             or '/run/podman/io.podman'
         )   # yapf:disable
@@ -193,7 +194,7 @@ class PodmanArgumentParser(argparse.ArgumentParser):
         reqattr(
             'log_level',
             getattr(args, 'log_level')
-            or os.environ.get('LOG_LEVEL')
+            or os.environ.get('PODMAN_LOG_LEVEL')
             or config['default'].get('log_level')
             or logging.WARNING
         )  # yapf:disable
@@ -202,7 +203,7 @@ class PodmanArgumentParser(argparse.ArgumentParser):
             args,
             'identity_file',
             getattr(args, 'identity_file')
-            or os.environ.get('IDENTITY_FILE')
+            or os.environ.get('PODMAN_IDENTITY_FILE')
             or config['default'].get('identity_file')
             or os.path.expanduser('~{}/.ssh/id_dsa'.format(args.username))
         )   # yapf:disable


### PR DESCRIPTION
Also, don't use $PORT. These are too generic.

Make sure to read $LOGNAME after the config.

----

Makes it hard to configure "root" in pypodman.conf

It will always use $USER, for the ssh login name ?