### PR TITLE
Allow users to expose ports from the pod to the host

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2178,12 +2178,14 @@ _podman_pod_create() {
       --cgroup-parent
       --infra-command
       --infra-image
-      --share
-      --podidfile
       --label-file
       --label
       -l
       --name
+      --podidfile
+      --publish
+      -p
+      --share
   "
 
   local boolean_options="

--- a/docs/podman-pod-create.1.md
+++ b/docs/podman-pod-create.1.md
@@ -51,6 +51,15 @@ Assign a name to the pod
 
 Write the pod ID to the file
 
+**-p**, **--publish**=[]
+
+Publish a port or range of ports from the pod to the host
+
+Format: `ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort`
+Both hostPort and containerPort can be specified as a range of ports.
+When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range.
+Use `podman port` to see the actual mapping: `podman port CONTAINER $CONTAINERPORT`
+
 **--share**=""
 
 A comma deliminated list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared. The namespaces to choose from are ipc, net, pid, user, uts.

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1295,3 +1295,14 @@ func WithInfraContainer() PodCreateOption {
 		return nil
 	}
 }
+
+// WithInfraContainerPorts tells the pod to add port bindings to the pause container
+func WithInfraContainerPorts(bindings []ocicni.PortMapping) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return ErrPodFinalized
+		}
+		pod.config.InfraContainer.PortBindings = bindings
+		return nil
+	}
+}

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/containers/storage"
+	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/pkg/errors"
 )
 
@@ -96,7 +97,8 @@ type PodContainerInfo struct {
 
 // InfraContainerConfig is the configuration for the pod's infra container
 type InfraContainerConfig struct {
-	HasInfraContainer bool `json:"makeInfraContainer"`
+	HasInfraContainer bool                 `json:"makeInfraContainer"`
+	PortBindings      []ocicni.PortMapping `json:"infraPortBindings"`
 }
 
 // ID retrieves the pod's ID

--- a/libpod/pod_easyjson.go
+++ b/libpod/pod_easyjson.go
@@ -6,6 +6,7 @@ package libpod
 
 import (
 	json "encoding/json"
+	ocicni "github.com/cri-o/ocicni/pkg/ocicni"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
@@ -721,6 +722,29 @@ func easyjsonBe091417DecodeGithubComContainersLibpodLibpod5(in *jlexer.Lexer, ou
 		switch key {
 		case "makeInfraContainer":
 			out.HasInfraContainer = bool(in.Bool())
+		case "infraPortBindings":
+			if in.IsNull() {
+				in.Skip()
+				out.PortBindings = nil
+			} else {
+				in.Delim('[')
+				if out.PortBindings == nil {
+					if !in.IsDelim(']') {
+						out.PortBindings = make([]ocicni.PortMapping, 0, 1)
+					} else {
+						out.PortBindings = []ocicni.PortMapping{}
+					}
+				} else {
+					out.PortBindings = (out.PortBindings)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v6 ocicni.PortMapping
+					easyjsonBe091417DecodeGithubComContainersLibpodVendorGithubComCriOOcicniPkgOcicni(in, &v6)
+					out.PortBindings = append(out.PortBindings, v6)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -744,6 +768,110 @@ func easyjsonBe091417EncodeGithubComContainersLibpodLibpod5(out *jwriter.Writer,
 			out.RawString(prefix)
 		}
 		out.Bool(bool(in.HasInfraContainer))
+	}
+	{
+		const prefix string = ",\"infraPortBindings\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		if in.PortBindings == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v7, v8 := range in.PortBindings {
+				if v7 > 0 {
+					out.RawByte(',')
+				}
+				easyjsonBe091417EncodeGithubComContainersLibpodVendorGithubComCriOOcicniPkgOcicni(out, v8)
+			}
+			out.RawByte(']')
+		}
+	}
+	out.RawByte('}')
+}
+func easyjsonBe091417DecodeGithubComContainersLibpodVendorGithubComCriOOcicniPkgOcicni(in *jlexer.Lexer, out *ocicni.PortMapping) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeString()
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "hostPort":
+			out.HostPort = int32(in.Int32())
+		case "containerPort":
+			out.ContainerPort = int32(in.Int32())
+		case "protocol":
+			out.Protocol = string(in.String())
+		case "hostIP":
+			out.HostIP = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonBe091417EncodeGithubComContainersLibpodVendorGithubComCriOOcicniPkgOcicni(out *jwriter.Writer, in ocicni.PortMapping) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"hostPort\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int32(int32(in.HostPort))
+	}
+	{
+		const prefix string = ",\"containerPort\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Int32(int32(in.ContainerPort))
+	}
+	{
+		const prefix string = ",\"protocol\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Protocol))
+	}
+	{
+		const prefix string = ",\"hostIP\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.HostIP))
 	}
 	out.RawByte('}')
 }

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/rootless"
-	"github.com/cri-o/ocicni/pkg/ocicni"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 )
@@ -50,9 +49,8 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, imgID
 	options = append(options, withIsInfra())
 
 	// Since user namespace sharing is not implemented, we only need to check if it's rootless
-	portMappings := make([]ocicni.PortMapping, 0)
 	networks := make([]string, 0)
-	options = append(options, WithNetNS(portMappings, isRootless, networks))
+	options = append(options, WithNetNS(p.config.InfraContainer.PortBindings, isRootless, networks))
 
 	return r.newContainer(ctx, g.Config, options...)
 }

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -335,7 +335,6 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime) ([]lib
 		}
 		options = append(options, runtime.WithPod(pod))
 	}
-
 	if len(c.PortBindings) > 0 {
 		portBindings, err = c.CreatePortBindings()
 		if err != nil {


### PR DESCRIPTION
we need to allow users to expose ports to the host for the purposes
of networking, like a webserver.  the port exposure must be done at
the time the pod is created.

strictly speaking, the port exposure occurs on the infra container.

Signed-off-by: baude <bbaude@redhat.com>