### PR TITLE
hooks: Add pre-create hooks for runtime-config manipulation

### DIFF
--- a/docs/libpod.conf.5.md
+++ b/docs/libpod.conf.5.md
@@ -37,7 +37,9 @@ libpod to manage containers.
 
   For the bind-mount conditions, only mounts explicitly requested by the caller via `--volume` are considered.  Bind mounts that libpod inserts by default (e.g. `/dev/shm`) are not considered.
 
-  If `hooks_dir` is unset for root callers, Podman and libpod will currently default to `/usr/share/containers/oci/hooks.d` and `/etc/containers/oci/hooks.d` in order of increasing precedence.  Using these defaults is deprecated, and callers should migrate to explicitly setting `hooks_dir`.
+  Podman and libpod currently support an additional `precreate` state which is called before the runtime's `create` operation.  Unlike the other stages, which receive the container state on their standard input, `precreate` hooks receive the proposed runtime configuration on their standard input.  They may alter that configuration as they see fit, and write the altered form to their standard output.
+
+  **WARNING**: the `precreate` hook lets you do powerful things, such as adding additional mounts to the runtime configuration.  That power also makes it easy to break things.  Before reporting libpod errors, try running your container with `precreate` hooks disabled to see if the problem is due to one of your hooks.
 
 **static_dir**=""
   Directory for persistent libpod files (database, etc)

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -43,6 +43,10 @@ For the bind-mount conditions, only mounts explicitly requested by the caller vi
 
 If `--hooks-dir` is unset for root callers, Podman and libpod will currently default to `/usr/share/containers/oci/hooks.d` and `/etc/containers/oci/hooks.d` in order of increasing precedence.  Using these defaults is deprecated, and callers should migrate to explicitly setting `--hooks-dir`.
 
+Podman and libpod currently support an additional `precreate` state which is called before the runtime's `create` operation.  Unlike the other stages, which receive the container state on their standard input, `precreate` hooks receive the proposed runtime configuration on their standard input.  They may alter that configuration as they see fit, and write the altered form to their standard output.
+
+**WARNING**: the `precreate` hook lets you do powerful things, such as adding additional mounts to the runtime configuration.  That power also makes it easy to break things.  Before reporting libpod errors, try running your container with `precreate` hooks disabled to see if the problem is due to one of your hooks.
+
 **--log-level**
 
 Log messages above specified level: debug, info, warn, error (default), fatal or panic

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -228,10 +228,6 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 		}
 	}
 
-	if c.state.ExtensionStageHooks, err = c.setupOCIHooks(ctx, g.Config); err != nil {
-		return nil, errors.Wrapf(err, "error setting up OCI Hooks")
-	}
-
 	// Bind builtin image volumes
 	if c.config.Rootfs == "" && c.config.ImageVolumes {
 		if err := c.addLocalVolumes(ctx, &g, execUser); err != nil {
@@ -384,6 +380,12 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 		logrus.Debugf("set root propagation to %q", rootPropagation)
 		g.SetLinuxRootPropagation(rootPropagation)
 	}
+
+	// Warning: precreate hooks may alter g.Config in place.
+	if c.state.ExtensionStageHooks, err = c.setupOCIHooks(ctx, g.Config); err != nil {
+		return nil, errors.Wrapf(err, "error setting up OCI Hooks")
+	}
+
 	return g.Config, nil
 }
 

--- a/pkg/hooks/exec/exec.go
+++ b/pkg/hooks/exec/exec.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 // DefaultPostKillTimeout is the recommended default post-kill timeout.
@@ -42,7 +43,11 @@ func Run(ctx context.Context, hook *rspec.Hook, state []byte, stdout io.Writer, 
 	}
 	exit := make(chan error, 1)
 	go func() {
-		exit <- cmd.Wait()
+		err := cmd.Wait()
+		if err != nil {
+			err = errors.Wrapf(err, "executing %v", cmd.Args)
+		}
+		exit <- err
 	}()
 
 	select {

--- a/pkg/hooks/exec/exec_test.go
+++ b/pkg/hooks/exec/exec_test.go
@@ -163,14 +163,14 @@ func TestRunCancel(t *testing.T) {
 			name:              "context timeout",
 			contextTimeout:    time.Duration(1) * time.Second,
 			expectedStdout:    "waiting\n",
-			expectedHookError: "^signal: killed$",
+			expectedHookError: "^executing \\[sh -c echo waiting; sleep 2; echo done]: signal: killed$",
 			expectedRunError:  context.DeadlineExceeded,
 		},
 		{
 			name:              "hook timeout",
 			hookTimeout:       &one,
 			expectedStdout:    "waiting\n",
-			expectedHookError: "^signal: killed$",
+			expectedHookError: "^executing \\[sh -c echo waiting; sleep 2; echo done]: signal: killed$",
 			expectedRunError:  context.DeadlineExceeded,
 		},
 	} {
@@ -207,7 +207,7 @@ func TestRunKillTimeout(t *testing.T) {
 	}
 	hookErr, err := Run(ctx, hook, []byte("{}"), nil, nil, time.Duration(0))
 	assert.Equal(t, context.DeadlineExceeded, err)
-	assert.Regexp(t, "^(failed to reap process within 0s of the kill signal|signal: killed)$", hookErr)
+	assert.Regexp(t, "^(failed to reap process within 0s of the kill signal|executing \\[sh -c sleep 1]: signal: killed)$", hookErr)
 }
 
 func init() {

--- a/pkg/hooks/exec/runtimeconfigfilter.go
+++ b/pkg/hooks/exec/runtimeconfigfilter.go
@@ -1,0 +1,36 @@
+package exec
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"time"
+
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// RuntimeConfigFilter calls a series of hooks.  But instead of
+// passing container state on their standard input,
+// RuntimeConfigFilter passes the proposed runtime configuration (and
+// reads back a possibly-altered form from their standard output).
+func RuntimeConfigFilter(ctx context.Context, hooks []spec.Hook, config *spec.Spec, postKillTimeout time.Duration) (hookErr, err error) {
+	data, err := json.Marshal(config)
+	for _, hook := range hooks {
+		var stdout bytes.Buffer
+		hookErr, err = Run(ctx, &hook, data, &stdout, nil, postKillTimeout)
+		if err != nil {
+			return hookErr, err
+		}
+
+		data = stdout.Bytes()
+	}
+	err = json.Unmarshal(data, config)
+	if err != nil {
+		logrus.Debugf("invalid JSON from config-filter hooks:\n%s", string(data))
+		return nil, errors.Wrap(err, "unmarshal output from config-filter hooks")
+	}
+
+	return nil, nil
+}

--- a/pkg/hooks/exec/runtimeconfigfilter_test.go
+++ b/pkg/hooks/exec/runtimeconfigfilter_test.go
@@ -1,0 +1,266 @@
+package exec
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func pointerInt(value int) *int {
+	return &value
+}
+
+func pointerUInt32(value uint32) *uint32 {
+	return &value
+}
+
+func pointerFileMode(value os.FileMode) *os.FileMode {
+	return &value
+}
+
+func TestRuntimeConfigFilter(t *testing.T) {
+	unexpectedEndOfJSONInput := json.Unmarshal([]byte("{\n"), nil)
+
+	for _, test := range []struct {
+		name              string
+		contextTimeout    time.Duration
+		hooks             []spec.Hook
+		input             *spec.Spec
+		expected          *spec.Spec
+		expectedHookError string
+		expectedRunError  error
+	}{
+		{
+			name: "no-op",
+			hooks: []spec.Hook{
+				{
+					Path: path,
+					Args: []string{"sh", "-c", "cat"},
+				},
+			},
+			input: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+			},
+			expected: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+			},
+		},
+		{
+			name: "device injection",
+			hooks: []spec.Hook{
+				{
+					Path: path,
+					Args: []string{"sh", "-c", `sed 's|\("gid":0}\)|\1,{"path": "/dev/sda","type":"b","major":8,"minor":0,"fileMode":384,"uid":0,"gid":0}|'`},
+				},
+			},
+			input: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+				Linux: &spec.Linux{
+					Devices: []spec.LinuxDevice{
+						{
+							Path:     "/dev/fuse",
+							Type:     "c",
+							Major:    10,
+							Minor:    229,
+							FileMode: pointerFileMode(0600),
+							UID:      pointerUInt32(0),
+							GID:      pointerUInt32(0),
+						},
+					},
+				},
+			},
+			expected: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+				Linux: &spec.Linux{
+					Devices: []spec.LinuxDevice{
+						{
+							Path:     "/dev/fuse",
+							Type:     "c",
+							Major:    10,
+							Minor:    229,
+							FileMode: pointerFileMode(0600),
+							UID:      pointerUInt32(0),
+							GID:      pointerUInt32(0),
+						},
+						{
+							Path:     "/dev/sda",
+							Type:     "b",
+							Major:    8,
+							Minor:    0,
+							FileMode: pointerFileMode(0600),
+							UID:      pointerUInt32(0),
+							GID:      pointerUInt32(0),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "chaining",
+			hooks: []spec.Hook{
+				{
+					Path: path,
+					Args: []string{"sh", "-c", `sed 's|\("gid":0}\)|\1,{"path": "/dev/sda","type":"b","major":8,"minor":0,"fileMode":384,"uid":0,"gid":0}|'`},
+				},
+				{
+					Path: path,
+					Args: []string{"sh", "-c", `sed 's|/dev/sda|/dev/sdb|'`},
+				},
+			},
+			input: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+				Linux: &spec.Linux{
+					Devices: []spec.LinuxDevice{
+						{
+							Path:     "/dev/fuse",
+							Type:     "c",
+							Major:    10,
+							Minor:    229,
+							FileMode: pointerFileMode(0600),
+							UID:      pointerUInt32(0),
+							GID:      pointerUInt32(0),
+						},
+					},
+				},
+			},
+			expected: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+				Linux: &spec.Linux{
+					Devices: []spec.LinuxDevice{
+						{
+							Path:     "/dev/fuse",
+							Type:     "c",
+							Major:    10,
+							Minor:    229,
+							FileMode: pointerFileMode(0600),
+							UID:      pointerUInt32(0),
+							GID:      pointerUInt32(0),
+						},
+						{
+							Path:     "/dev/sdb",
+							Type:     "b",
+							Major:    8,
+							Minor:    0,
+							FileMode: pointerFileMode(0600),
+							UID:      pointerUInt32(0),
+							GID:      pointerUInt32(0),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "context timeout",
+			contextTimeout: time.Duration(1) * time.Second,
+			hooks: []spec.Hook{
+				{
+					Path: path,
+					Args: []string{"sh", "-c", "sleep 2"},
+				},
+			},
+			input: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+			},
+			expected: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+			},
+			expectedHookError: "^signal: killed$",
+			expectedRunError:  context.DeadlineExceeded,
+		},
+		{
+			name: "hook timeout",
+			hooks: []spec.Hook{
+				{
+					Path:    path,
+					Args:    []string{"sh", "-c", "sleep 2"},
+					Timeout: pointerInt(1),
+				},
+			},
+			input: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+			},
+			expected: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+			},
+			expectedHookError: "^signal: killed$",
+			expectedRunError:  context.DeadlineExceeded,
+		},
+		{
+			name: "invalid JSON",
+			hooks: []spec.Hook{
+				{
+					Path: path,
+					Args: []string{"sh", "-c", "echo '{'"},
+				},
+			},
+			input: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+			},
+			expected: &spec.Spec{
+				Version: "1.0.0",
+				Root: &spec.Root{
+					Path: "rootfs",
+				},
+			},
+			expectedRunError: unexpectedEndOfJSONInput,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			if test.contextTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, test.contextTimeout)
+				defer cancel()
+			}
+			hookErr, err := RuntimeConfigFilter(ctx, test.hooks, test.input, DefaultPostKillTimeout)
+			assert.Equal(t, test.expectedRunError, errors.Cause(err))
+			if test.expectedHookError == "" {
+				if hookErr != nil {
+					t.Fatal(hookErr)
+				}
+			} else {
+				assert.Regexp(t, test.expectedHookError, hookErr.Error())
+			}
+			assert.Equal(t, test.expected, test.input)
+		})
+	}
+}

--- a/pkg/hooks/exec/runtimeconfigfilter_test.go
+++ b/pkg/hooks/exec/runtimeconfigfilter_test.go
@@ -194,7 +194,7 @@ func TestRuntimeConfigFilter(t *testing.T) {
 					Path: "rootfs",
 				},
 			},
-			expectedHookError: "^signal: killed$",
+			expectedHookError: "^executing \\[sh -c sleep 2]: signal: killed$",
 			expectedRunError:  context.DeadlineExceeded,
 		},
 		{
@@ -218,7 +218,7 @@ func TestRuntimeConfigFilter(t *testing.T) {
 					Path: "rootfs",
 				},
 			},
-			expectedHookError: "^signal: killed$",
+			expectedHookError: "^executing \\[sh -c sleep 2]: signal: killed$",
 			expectedRunError:  context.DeadlineExceeded,
 		},
 		{


### PR DESCRIPTION
There's been a lot of discussion over in opencontainers/runc#1811 about how to support the NVIDIA folks and others who want to be able to create devices (possibly after having loaded kernel modules) and bind userspace libraries into the container.  Currently that's happening in the middle of `runc`'s create-time mount handling before the container pivots to its new root directory with `runc`'s incorrectly-timed `prestart` hook trigger (opencontainers/runc#1710).  With this pull request, I extend hooks with a `precreate` stage to allow trusted parties to manipulate the config JSON before calling the runtime's `create`.

I'm recycling the existing `Hook` schema from `pkg/hooks` for this, because we'll want `Timeout` for reliability and `When` to [avoid the expense of fork/exec when a given hook does not need to make config changes][3].

Fixes #1828.

[3]: https://github.com/containers/libpod/issues/1828#issuecomment-439888059