### PR TITLE
exec: always make explicit the tty value

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -741,6 +741,8 @@ func (r *OCIRuntime) execContainer(c *Container, cmd, capAdd, env []string, tty 
 
 	if tty {
 		args = append(args, "--tty")
+	} else {
+		args = append(args, "--tty=false")
 	}
 
 	if user != "" {


### PR DESCRIPTION
otherwise runc will take by default the value used for creating the
container.  Setting it explicit overrides its default value and we
won't end up trying to use a terminal when not available.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1625876

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>