### PR TITLE
Added option to keep container running after checkpointing

### DIFF
--- a/cmd/podman/checkpoint.go
+++ b/cmd/podman/checkpoint.go
@@ -24,6 +24,10 @@ var (
 			Usage: "keep all temporary checkpoint files",
 		},
 		cli.BoolFlag{
+			Name:  "leave-running, R",
+			Usage: "leave the container running after writing checkpoint to disk",
+		},
+		cli.BoolFlag{
 			Name:  "all, a",
 			Usage: "checkpoint all running containers",
 		},
@@ -51,7 +55,8 @@ func checkpointCmd(c *cli.Context) error {
 	defer runtime.Shutdown(false)
 
 	options := libpod.ContainerCheckpointOptions{
-		Keep: c.Bool("keep"),
+		Keep:        c.Bool("keep"),
+		KeepRunning: c.Bool("leave-running"),
 	}
 
 	if err := checkAllAndLatest(c); err != nil {

--- a/cmd/podman/checkpoint.go
+++ b/cmd/podman/checkpoint.go
@@ -50,7 +50,9 @@ func checkpointCmd(c *cli.Context) error {
 	}
 	defer runtime.Shutdown(false)
 
-	keep := c.Bool("keep")
+	options := libpod.ContainerCheckpointOptions{
+		Keep: c.Bool("keep"),
+	}
 
 	if err := checkAllAndLatest(c); err != nil {
 		return err
@@ -59,7 +61,7 @@ func checkpointCmd(c *cli.Context) error {
 	containers, lastError := getAllOrLatestContainers(c, runtime, libpod.ContainerStateRunning, "running")
 
 	for _, ctr := range containers {
-		if err = ctr.Checkpoint(context.TODO(), keep); err != nil {
+		if err = ctr.Checkpoint(context.TODO(), options); err != nil {
 			if lastError != nil {
 				fmt.Fprintln(os.Stderr, lastError)
 			}

--- a/docs/podman-container-checkpoint.1.md
+++ b/docs/podman-container-checkpoint.1.md
@@ -17,6 +17,18 @@ are not deleted if checkpointing fails for further debugging. If checkpointing s
 files are theoretically not needed, but if these files are needed Podman can keep the files
 for further analysis.
 
+**--all, -a**
+
+Checkpoint all running containers.
+
+**--latest, -l**
+
+Instead of providing the container name or ID, checkpoint the last created container.
+
+**--leave-running, -R**
+
+Leave the container running after checkpointing instead of stopping it.
+
 ## EXAMPLE
 
 podman container checkpoint mywebserver

--- a/docs/podman-container-restore.1.md
+++ b/docs/podman-container-restore.1.md
@@ -24,6 +24,14 @@ processes in the checkpointed container.
 Without the **-k**, **--keep** option the checkpoint will be consumed and cannot be used
 again.
 
+**--all, -a**
+
+Restore all checkpointed containers.
+
+**--latest, -l**
+
+Instead of providing the container name or ID, restore the last created container.
+
 ## EXAMPLE
 
 podman container restore mywebserver

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -830,8 +830,14 @@ func (c *Container) Refresh(ctx context.Context) error {
 	return nil
 }
 
+// ContainerCheckpointOptions is a struct used to pass the parameters
+// for checkpointing to corresponding functions
+type ContainerCheckpointOptions struct {
+	Keep bool
+}
+
 // Checkpoint checkpoints a container
-func (c *Container) Checkpoint(ctx context.Context, keep bool) error {
+func (c *Container) Checkpoint(ctx context.Context, options ContainerCheckpointOptions) error {
 	logrus.Debugf("Trying to checkpoint container %s", c)
 	if !c.batched {
 		c.lock.Lock()
@@ -842,7 +848,7 @@ func (c *Container) Checkpoint(ctx context.Context, keep bool) error {
 		}
 	}
 
-	return c.checkpoint(ctx, keep)
+	return c.checkpoint(ctx, options)
 }
 
 // Restore restores a container

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -833,7 +833,8 @@ func (c *Container) Refresh(ctx context.Context) error {
 // ContainerCheckpointOptions is a struct used to pass the parameters
 // for checkpointing to corresponding functions
 type ContainerCheckpointOptions struct {
-	Keep bool
+	Keep        bool
+	KeepRunning bool
 }
 
 // Checkpoint checkpoints a container

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -431,7 +431,7 @@ func (c *Container) addNamespaceContainer(g *generate.Generator, ns LinuxNS, ctr
 	return nil
 }
 
-func (c *Container) checkpoint(ctx context.Context, keep bool) (err error) {
+func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointOptions) (err error) {
 
 	if !criu.CheckForCriu() {
 		return errors.Errorf("checkpointing a container requires at least CRIU %d", criu.MinCriuVersion)
@@ -464,7 +464,7 @@ func (c *Container) checkpoint(ctx context.Context, keep bool) (err error) {
 		return err
 	}
 
-	if !keep {
+	if !options.Keep {
 		// Remove log file
 		os.Remove(filepath.Join(c.bundlePath(), "dump.log"))
 		// Remove statistic file

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -844,13 +844,22 @@ func (r *OCIRuntime) execStopContainer(ctr *Container, timeout uint) error {
 }
 
 // checkpointContainer checkpoints the given container
-func (r *OCIRuntime) checkpointContainer(ctr *Container) error {
+func (r *OCIRuntime) checkpointContainer(ctr *Container, options ContainerCheckpointOptions) error {
 	// imagePath is used by CRIU to store the actual checkpoint files
 	imagePath := ctr.CheckpointPath()
 	// workPath will be used to store dump.log and stats-dump
 	workPath := ctr.bundlePath()
 	logrus.Debugf("Writing checkpoint to %s", imagePath)
 	logrus.Debugf("Writing checkpoint logs to %s", workPath)
-	return utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, nil, r.path, "checkpoint",
-		"--image-path", imagePath, "--work-path", workPath, ctr.ID())
+	args := []string{}
+	args = append(args, "checkpoint")
+	args = append(args, "--image-path")
+	args = append(args, imagePath)
+	args = append(args, "--work-path")
+	args = append(args, workPath)
+	if options.KeepRunning {
+		args = append(args, "--leave-running")
+	}
+	args = append(args, ctr.ID())
+	return utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, nil, r.path, args...)
 }


### PR DESCRIPTION
CRIU supports to leave processes running after checkpointing:

  `-R|--leave-running    leave tasks in running state after checkpoint`

runc also support to leave containers running after checkpointing:

   `--leave-running      leave the process running after checkpointing`

With this commit the support to leave a container running after checkpointing is brought to Podman:

   `--leave-running, -R  leave the container running after writing checkpoint to disk`

Now it is possible to checkpoint a container at some point in time without stopping the container. This can be used to rollback the container to an early state:
```
$ podman run --tmpfs /tmp --name podman-criu-test -d docker://docker.io/yovfiatbeb/podman-criu-test
$ curl 10.88.64.253:8080/examples/servlets/servlet/HelloWorldExample
3
$ podman container checkpoint -R -l
$ curl 10.88.64.253:8080/examples/servlets/servlet/HelloWorldExample
4
$ curl 10.88.64.253:8080/examples/servlets/servlet/HelloWorldExample
5
$ podman stop -l
$ podman container restore -l
$ curl 10.88.64.253:8080/examples/servlets/servlet/HelloWorldExample
4
```
So after checkpointing the container kept running and was stopped after some time. Restoring this container will restore the state right at the checkpoint.