### PR TITLE
vendor: update selinux

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -51,7 +51,7 @@ github.com/opencontainers/image-spec v1.0.0
 github.com/opencontainers/runc b4e2ecb452d9ee4381137cc0a7e6715b96bed6de
 github.com/opencontainers/runtime-spec d810dbc60d8c5aeeb3d054bd1132fab2121968ce
 github.com/opencontainers/runtime-tools master
-github.com/opencontainers/selinux 36a9bc45a08c85f2c52bd9eb32e20267876773bd
+github.com/opencontainers/selinux 6ba084dd09db3dfe49a839bab0bbe97fd9274d80
 github.com/ostreedev/ostree-go master
 github.com/pkg/errors v0.8.0
 github.com/pmezard/go-difflib 792786c7400a136282c1664665ae0a8db921c6c2

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
@@ -687,7 +687,11 @@ func Chcon(fpath string, label string, recurse bool) error {
 		return err
 	}
 	callback := func(p string, info os.FileInfo, err error) error {
-		return SetFileLabel(p, label)
+		e := SetFileLabel(p, label)
+		if os.IsNotExist(e) {
+			return nil
+		}
+		return e
 	}
 
 	if recurse {


### PR DESCRIPTION
inherit a change for not failing a recursive relabelling if the file
is removed between the directory is read and the lsetxattr syscall.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>