### PR TITLE
Use host's resolv.conf if no network namespace enabled

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -729,9 +729,10 @@ func (c *Container) generateResolvConf() (string, error) {
 		return "", errors.Wrapf(err, "unable to read %s", resolvPath)
 	}
 
-	// Process the file to remove localhost nameservers
+	// Ensure that the container's /etc/resolv.conf is compatible with its
+	// network configuration.
 	// TODO: set ipv6 enable bool more sanely
-	resolv, err := resolvconf.FilterResolvDNS(contents, true)
+	resolv, err := resolvconf.FilterResolvDNS(contents, true, c.config.CreateNetNS)
 	if err != nil {
 		return "", errors.Wrapf(err, "error parsing host resolv.conf")
 	}


### PR DESCRIPTION
My host system runs Fedora Silverblue 29 and I have NetworkManager's
`dns=dnsmasq` setting enabled, so my `/etc/resolv.conf` only has
`127.0.0.1`.

I also run my development podman containers with `--net=host`
for various reasons.

If we have a host network namespace, there's no reason not to just
use the host's nameserver configuration either.

I know this doesn't solve the bigger picture issue of localhost-DNS
conflicting with bridged networking, but that's far more involved,
probably requiring a DNS proxy in the container.  This patch
makes my workflow a lot nicer and was easy to write.