### PR TITLE
Load NAT modules to fix tests involving CRIU

### DIFF
--- a/.papr_prepare.sh
+++ b/.papr_prepare.sh
@@ -10,6 +10,13 @@ if [[ ${DIST} != "Fedora" ]]; then
     PYTHON=python
 fi
 
+# Since CRIU 3.11 has been pushed to Fedora 28 the checkpoint/restore
+# test cases are actually run. As CRIU uses iptables to lock and unlock
+# the network during checkpoint and restore it needs the following two
+# modules loaded.
+modprobe ip6table_nat || :
+modprobe iptable_nat || :
+
 # Build the test image
 ${CONTAINER_RUNTIME} build -t ${IMAGE} -f Dockerfile.${DIST} . 2>build.log
 


### PR DESCRIPTION
CRIU uses iptables to lock and unlock the network during checkpoint and
restore. If Podman is running in Podman the automatic loading of modules
does not work and thus this commit pre-loads the necessary modules to
make sure the checkpoint test cases are not failing.

Signed-off-by: Adrian Reber <areber@redhat.com>