### PR TITLE
implement --format for version command

### DIFF
--- a/cmd/podman/version.go
+++ b/cmd/podman/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containers/libpod/cmd/podman/formats"
 	"github.com/containers/libpod/libpod"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -14,6 +15,19 @@ func versionCmd(c *cli.Context) error {
 	output, err := libpod.GetVersion()
 	if err != nil {
 		errors.Wrapf(err, "unable to determine version")
+	}
+
+	versionOutputFormat := c.String("format")
+	if versionOutputFormat != "" {
+		var out formats.Writer
+		switch versionOutputFormat {
+		case formats.JSONString:
+			out = formats.JSONStruct{Output: output}
+		default:
+			out = formats.StdoutTemplate{Output: output, Template: versionOutputFormat}
+		}
+		formats.Writer(out).Out()
+		return nil
 	}
 	fmt.Println("Version:      ", output.Version)
 	fmt.Println("Go Version:   ", output.GoVersion)
@@ -30,8 +44,17 @@ func versionCmd(c *cli.Context) error {
 }
 
 // Cli command to print out the full version of podman
-var versionCommand = cli.Command{
-	Name:   "version",
-	Usage:  "Display the PODMAN Version Information",
-	Action: versionCmd,
-}
+var (
+	versionCommand = cli.Command{
+		Name:   "version",
+		Usage:  "Display the Podman Version Information",
+		Action: versionCmd,
+		Flags:  versionFlags,
+	}
+	versionFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "Change the output format to JSON or a Go template",
+		},
+	}
+)

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1906,11 +1906,16 @@ _podman_top() {
 }
 
 _podman_version() {
-     local options_with_args="
-     "
-     local boolean_options="
-     "
-     _complete_ "$options_with_args" "$boolean_options"
+    local boolean_options="
+     --help
+     -h
+    "
+    local options_with_args="
+     --format
+    "
+    local all_options="$options_with_args $boolean_options"
+
+    _complete_ "$options_with_args" "$boolean_options"
 }
 
 _podman_save() {

--- a/docs/podman-version.1.md
+++ b/docs/podman-version.1.md
@@ -16,8 +16,31 @@ OS, and Architecture.
 
 Print usage statement
 
+**--format**
+
+Change output format to "json" or a Go template.
+
+## Example
+
+A sample output of the `version` command:
+```
+$ podman version
+Version:       0.11.1
+Go Version:    go1.11
+Git Commit:    "8967a1d691ed44896b81ad48c863033f23c65eb0-dirty"
+Built:         Thu Nov  8 22:35:40 2018
+OS/Arch:       linux/amd64
+```
+
+Filtering out only the version:
+```
+$ podman version --format '{{.Version}}'
+0.11.2
+```
+
 ## SEE ALSO
 podman(1), crio(8)
 
 ## HISTORY
+November 2018, Added --format flag by Tomas Tomecek <ttomecek@redhat.com>
 July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>


### PR DESCRIPTION
Unfortunately `info` doesn't print podman's version, so I'm adding --format
option to version command.

```
$ ./bin/podman version --format '{{.}}'
{0.11.2-dev go1.11.2 "78604c3c397068f70ccb5e8b4be4b9229e2072fb-dirty" 1543008279 linux/amd64}

$ ./bin/podman version --format '{{.Version}}'
0.11.2-dev

$ ./bin/podman version --format '{}'
{}
```
