### PR TITLE
Actually set version for podman module / pypodman

### DIFF
--- a/contrib/python/podman/Makefile
+++ b/contrib/python/podman/Makefile
@@ -4,6 +4,7 @@ PODMAN_VERSION ?= '0.0.4'
 
 .PHONY: python-podman
 python-podman:
+	PODMAN_VERSION=$(PODMAN_VERSION) \
 	$(PYTHON) setup.py sdist bdist
 
 .PHONY: lint
@@ -16,6 +17,7 @@ integration:
 
 .PHONY: install
 install:
+	PODMAN_VERSION=$(PODMAN_VERSION) \
 	$(PYTHON) setup.py install --root ${DESTDIR}
 
 .PHONY: upload

--- a/contrib/python/pypodman/Makefile
+++ b/contrib/python/pypodman/Makefile
@@ -4,6 +4,7 @@ PODMAN_VERSION ?= '0.0.4'
 
 .PHONY: python-pypodman
 python-pypodman:
+	PODMAN_VERSION=$(PODMAN_VERSION) \
 	$(PYTHON) setup.py sdist bdist
 
 .PHONY: lint
@@ -16,6 +17,7 @@ integration:
 
 .PHONY: install
 install:
+	PODMAN_VERSION=$(PODMAN_VERSION) \
 	$(PYTHON) setup.py install --root ${DESTDIR}
 
 .PHONY: upload


### PR DESCRIPTION
The environment variable wasn't set, giving 0.0.0

It is a still a problem if you use python3 to build,
rather than make. You *need* to set $PODMAN_VERSION,
or your module and packages won't have the version.
