### PR TITLE
Add history field to image inspect

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -869,6 +869,7 @@ func (i *Image) Inspect(ctx context.Context) (*inspect.ImageData, error) {
 		GraphDriver:  driver,
 		ManifestType: manifestType,
 		User:         ociv1Img.Config.User,
+		History:      ociv1Img.History,
 	}
 	return data, nil
 }

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -126,6 +126,7 @@ type ImageData struct {
 	Annotations     map[string]string `json:"Annotations"`
 	ManifestType    string            `json:"ManifestType"`
 	User            string            `json:"User"`
+	History         []v1.History      `json:"History"`
 }
 
 // RootFS holds the root fs information of an image


### PR DESCRIPTION
This fixes #860 
Only add ```history``` to image inspect since the rest field mentioned in this issue are buildah specific. There is no sense to add it here.
Signed-off-by: Qi Wang <qiwan@redhat.com>