### PR TITLE
Improve podman run --mount test

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -226,7 +226,6 @@ var _ = Describe("Podman run", func() {
 		found, matches := session.GrepString("/run/test")
 		Expect(found).Should(BeTrue())
 		Expect(matches[0]).To(ContainSubstring("rw"))
-		Expect(matches[0]).To(ContainSubstring("relatime"))
 		Expect(matches[0]).To(ContainSubstring("shared"))
 
 		mountPath = filepath.Join(podmanTest.TempDir, "scratchpad")

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Podman run", func() {
 		Expect(session.OutputToString()).To(ContainSubstring("/run/test rw,relatime, shared"))
 	})
 
-	It("podman run with mount flag", func() {
+	It("podman run with --mount flag", func() {
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("skip failing test on ppc64le")
 		}


### PR DESCRIPTION
1. Update the test case name to make it easier to filter the test cases
2. Remove one options check for shared mode mount test to fit more OS.