### PR TITLE
Stopping a stopped container is not an error for Podman

### DIFF
--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/libpod"
@@ -77,7 +78,11 @@ func stopCmd(c *cli.Context) error {
 			stopTimeout = ctr.StopTimeout()
 		}
 		f := func() error {
-			return con.StopWithTimeout(stopTimeout)
+			if err := con.StopWithTimeout(stopTimeout); err != nil && errors.Cause(err) != libpod.ErrCtrStopped {
+				return err
+			}
+			return nil
+
 		}
 		stopFuncs = append(stopFuncs, shared.ParallelWorkerInput{
 			ContainerID:  con.ID(),

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -57,6 +57,20 @@ var _ = Describe("Podman stop", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman stop stopped container", func() {
+		session := podmanTest.RunTopContainer("test1")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session2 := podmanTest.Podman([]string{"stop", "test1"})
+		session2.WaitWithDefaultTimeout()
+		Expect(session2.ExitCode()).To(Equal(0))
+
+		session3 := podmanTest.Podman([]string{"stop", "test1"})
+		session3.WaitWithDefaultTimeout()
+		Expect(session3.ExitCode()).To(Equal(0))
+	})
+
 	It("podman stop all containers", func() {
 		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
As the title says. We originally fixed this a long while back, and regressed after we parallelized stop.