### PR TITLE
Fix golang formatting issues

### DIFF
--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -95,7 +95,7 @@ func commitCmd(c *cli.Context) error {
 		for _, change := range c.StringSlice("change") {
 			splitChange := strings.Split(strings.ToUpper(change), "=")
 			if !util.StringInSlice(splitChange[0], libpod.ChangeCmds) {
-				return errors.Errorf("invalid syntax for --change ", change)
+				return errors.Errorf("invalid syntax for --change: %s", change)
 			}
 		}
 	}

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -376,13 +376,13 @@ func CreateFilterFuncs(ctx context.Context, r *libpod.Runtime, c *cli.Context, i
 		case "before":
 			before, err := r.ImageRuntime().NewFromLocal(splitFilter[1])
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to find image % in local stores", splitFilter[1])
+				return nil, errors.Wrapf(err, "unable to find image %s in local stores", splitFilter[1])
 			}
 			filterFuncs = append(filterFuncs, image.CreatedBeforeFilter(before.Created()))
 		case "after":
 			after, err := r.ImageRuntime().NewFromLocal(splitFilter[1])
 			if err != nil {
-				return nil, errors.Wrapf(err, "unable to find image % in local stores", splitFilter[1])
+				return nil, errors.Wrapf(err, "unable to find image %s in local stores", splitFilter[1])
 			}
 			filterFuncs = append(filterFuncs, image.CreatedAfterFilter(after.Created()))
 		case "dangling":

--- a/cmd/podman/import.go
+++ b/cmd/podman/import.go
@@ -139,7 +139,7 @@ func downloadFromURL(source string) (string, error) {
 
 	_, err = io.Copy(outFile, response.Body)
 	if err != nil {
-		return "", errors.Wrapf(err, "error saving %q to %q", source, outFile)
+		return "", errors.Wrapf(err, "error saving %s to %s", source, outFile.Name())
 	}
 
 	return outFile.Name(), nil

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -119,7 +119,7 @@ func iterateInput(ctx context.Context, c *cli.Context, args []string, runtime *l
 			}
 			libpodInspectData, err := ctr.Inspect(c.Bool("size"))
 			if err != nil {
-				inspectError = errors.Wrapf(err, "error getting libpod container inspect data %q", ctr.ID)
+				inspectError = errors.Wrapf(err, "error getting libpod container inspect data %s", ctr.ID())
 				break
 			}
 			data, err = shared.GetCtrInspectInfo(ctr, libpodInspectData)
@@ -154,12 +154,12 @@ func iterateInput(ctx context.Context, c *cli.Context, args []string, runtime *l
 			} else {
 				libpodInspectData, err := ctr.Inspect(c.Bool("size"))
 				if err != nil {
-					inspectError = errors.Wrapf(err, "error getting libpod container inspect data %q", ctr.ID)
+					inspectError = errors.Wrapf(err, "error getting libpod container inspect data %s", ctr.ID())
 					break
 				}
 				data, err = shared.GetCtrInspectInfo(ctr, libpodInspectData)
 				if err != nil {
-					inspectError = errors.Wrapf(err, "error parsing container data %q", ctr.ID)
+					inspectError = errors.Wrapf(err, "error parsing container data %s", ctr.ID())
 					break
 				}
 			}

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -829,7 +829,7 @@ func (c *Container) IPs() ([]net.IPNet, error) {
 	}
 
 	if !c.config.CreateNetNS {
-		return nil, errors.Wrapf(ErrInvalidArg, "container %s network namespace is not managed by libpod")
+		return nil, errors.Wrapf(ErrInvalidArg, "container %s network namespace is not managed by libpod", c.ID())
 	}
 
 	ips := make([]net.IPNet, 0)
@@ -857,7 +857,7 @@ func (c *Container) Routes() ([]types.Route, error) {
 	}
 
 	if !c.config.CreateNetNS {
-		return nil, errors.Wrapf(ErrInvalidArg, "container %s network namespace is not managed by libpod")
+		return nil, errors.Wrapf(ErrInvalidArg, "container %s network namespace is not managed by libpod", c.ID())
 	}
 
 	routes := make([]types.Route, 0)

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -39,7 +39,7 @@ func (c *Container) Init(ctx context.Context) (err error) {
 
 	notRunning, err := c.checkDependenciesRunning()
 	if err != nil {
-		return errors.Wrapf(err, "error checking dependencies for container %s")
+		return errors.Wrapf(err, "error checking dependencies for container %s", c.ID())
 	}
 	if len(notRunning) > 0 {
 		depString := strings.Join(notRunning, ",")
@@ -93,7 +93,7 @@ func (c *Container) Start(ctx context.Context) (err error) {
 
 	notRunning, err := c.checkDependenciesRunning()
 	if err != nil {
-		return errors.Wrapf(err, "error checking dependencies for container %s")
+		return errors.Wrapf(err, "error checking dependencies for container %s", c.ID())
 	}
 	if len(notRunning) > 0 {
 		depString := strings.Join(notRunning, ",")
@@ -159,7 +159,7 @@ func (c *Container) StartAndAttach(ctx context.Context, streams *AttachStreams, 
 
 	notRunning, err := c.checkDependenciesRunning()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error checking dependencies for container %s")
+		return nil, errors.Wrapf(err, "error checking dependencies for container %s", c.ID())
 	}
 	if len(notRunning) > 0 {
 		depString := strings.Join(notRunning, ",")
@@ -718,7 +718,7 @@ func (c *Container) RestartWithTimeout(ctx context.Context, timeout uint) (err e
 
 	notRunning, err := c.checkDependenciesRunning()
 	if err != nil {
-		return errors.Wrapf(err, "error checking dependencies for container %s")
+		return errors.Wrapf(err, "error checking dependencies for container %s", c.ID())
 	}
 	if len(notRunning) > 0 {
 		depString := strings.Join(notRunning, ",")
@@ -803,7 +803,7 @@ func (c *Container) Refresh(ctx context.Context) error {
 		return err
 	}
 
-	logrus.Debugf("Successfully refresh container %s state")
+	logrus.Debugf("Successfully refresh container %s state", c.ID())
 
 	// Initialize the container if it was created in runc
 	if wasCreated || wasRunning || wasPaused {
@@ -847,7 +847,7 @@ type ContainerCheckpointOptions struct {
 
 // Checkpoint checkpoints a container
 func (c *Container) Checkpoint(ctx context.Context, options ContainerCheckpointOptions) error {
-	logrus.Debugf("Trying to checkpoint container %s", c)
+	logrus.Debugf("Trying to checkpoint container %s", c.ID())
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()
@@ -862,7 +862,7 @@ func (c *Container) Checkpoint(ctx context.Context, options ContainerCheckpointO
 
 // Restore restores a container
 func (c *Container) Restore(ctx context.Context, options ContainerCheckpointOptions) (err error) {
-	logrus.Debugf("Trying to restore container %s", c)
+	logrus.Debugf("Trying to restore container %s", c.ID())
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1191,7 +1191,7 @@ func (c *Container) setupOCIHooks(ctx context.Context, config *spec.Spec) (exten
 			if c.runtime.config.HooksDirNotExistFatal || !os.IsNotExist(err) {
 				return nil, err
 			}
-			logrus.Warnf("failed to load hooks: {}", err)
+			logrus.Warnf("failed to load hooks: %q", err)
 			return nil, nil
 		}
 		hooks, err := manager.Hooks(config, c.Spec().Annotations, len(c.config.UserVolumes) > 0)

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -764,7 +764,7 @@ func (c *Container) generateResolvConf() (string, error) {
 
 	// Build resolv.conf
 	if _, err = resolvconf.Build(destPath, nameservers, search, options); err != nil {
-		return "", errors.Wrapf(err, "error building resolv.conf for container %s")
+		return "", errors.Wrapf(err, "error building resolv.conf for container %s", c.ID())
 	}
 
 	// Relabel resolv.conf for the container

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -240,7 +240,7 @@ func generateKubeSecurityContext(c *Container) (*v1.SecurityContext, error) {
 
 	if c.User() != "" {
 		// It is *possible* that
-		logrus.Debug("Looking in container for user: %s", c.User())
+		logrus.Debugf("Looking in container for user: %s", c.User())
 		u, err := lookup.GetUser(c.state.Mountpoint, c.User())
 		if err != nil {
 			return nil, err

--- a/libpod/pod_internal.go
+++ b/libpod/pod_internal.go
@@ -48,7 +48,7 @@ func (p *Pod) updatePod() error {
 // Save pod state to database
 func (p *Pod) save() error {
 	if err := p.runtime.state.SavePod(p); err != nil {
-		return errors.Wrapf(err, "error saving pod %s state")
+		return errors.Wrapf(err, "error saving pod %s state", p.ID())
 	}
 
 	return nil


### PR DESCRIPTION
Whe running unittests on newer golang versions, we observe failures with some
formatting types when no declared correctly.

Signed-off-by: baude <bbaude@redhat.com>