### PR TITLE
_split_token(): handle None

### DIFF
--- a/contrib/python/podman/podman/libs/images.py
+++ b/contrib/python/podman/podman/libs/images.py
@@ -27,9 +27,10 @@ class Image(collections.UserDict):
 
     @staticmethod
     def _split_token(values=None, sep='='):
+        if not values:
+            return {}
         return {
-            k: v1
-            for k, v1 in (v0.split(sep, 1) for v0 in values if values)
+            k: v1 for k, v1 in (v0.split(sep, 1) for v0 in values)
         }
 
     def create(self, *args, **kwargs):


### PR DESCRIPTION
The conditional + list comprehension in images.py:_split_token()
wasn't quite working as intended; in particular, when fed None,
it chokes with

    TypeError: 'NoneType' object is not iterable

This is the correct behavior: comprehensions iterate first,
then apply the conditional.

Solution: special-case None, and remove the now-unnecessary
conditional.

Context: seen when trying 'pypodman run' against
docker.io/stackbrew/centos:7, which has no .ContainerConfig.Env

Signed-off-by: Ed Santiago <santiago@redhat.com>