### PR TITLE
pypod run: ignore args intended for container command

### DIFF
--- a/contrib/python/pypodman/pypodman/lib/actions/create_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/create_action.py
@@ -21,7 +21,7 @@ class Create(AbstractActionBase):
         parser.add_argument('image', nargs=1, help='source image id')
         parser.add_argument(
             'command',
-            nargs='*',
+            nargs=parent.REMAINDER,
             help='command and args to run.',
         )
         parser.set_defaults(class_=cls, method='create')

--- a/contrib/python/pypodman/pypodman/lib/actions/run_action.py
+++ b/contrib/python/pypodman/pypodman/lib/actions/run_action.py
@@ -21,7 +21,7 @@ class Run(AbstractActionBase):
         parser.add_argument('image', nargs=1, help='source image id.')
         parser.add_argument(
             'command',
-            nargs='*',
+            nargs=parent.REMAINDER,
             help='command and args to run.',
         )
         parser.set_defaults(class_=cls, method='run')

--- a/contrib/python/pypodman/pypodman/lib/podman_parser.py
+++ b/contrib/python/pypodman/pypodman/lib/podman_parser.py
@@ -97,6 +97,8 @@ class PodmanArgumentParser(argparse.ArgumentParser):
 
         actions_parser = self.add_subparsers(
             dest='subparser_name', help='commands')
+        # For create/exec/run: don't process options intended for subcommand
+        actions_parser.REMAINDER = argparse.REMAINDER
 
         # import buried here to prevent import loops
         import pypodman.lib.actions  # pylint: disable=cyclic-import


### PR DESCRIPTION
Don't try to argparse command-line arguments on the right-hand
side of the image; those are intended for the container command:

   pypodman run fedora find / -name foo
   pypodman run fedora bash -c 'echo hi'
   pypodman run fedora ls -l

Signed-off-by: Ed Santiago <santiago@redhat.com>