### PR TITLE
disable checkpoint tests on f29

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -28,6 +28,10 @@ var _ = Describe("Podman checkpoint", func() {
 		if !criu.CheckForCriu() {
 			Skip("CRIU is missing or too old.")
 		}
+		hostInfo := podmanTest.Host
+		if hostInfo.Distribution == "fedora" && hostInfo.Version == "29" {
+			Skip("Checkpoint tests appear to fail on F29.")
+		}
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
temporarily disabling checkpoint tests on f29 as they don't currently pass.

Signed-off-by: baude <bbaude@redhat.com>