### PR TITLE
honor RUNC_BINARY environment variable for integration tests

### DIFF
--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -17,7 +17,7 @@ case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
     ubuntu-18)
         make install PREFIX=/usr ETCDIR=/etc "BUILDTAGS=$BUILDTAGS"
         make test-binaries "BUILDTAGS=$BUILDTAGS"
-        SKIP_USERNS=1 make localintegration "BUILDTAGS=$BUILDTAGS"
+        RUNC_BINARY=/usr/lib/cri-o-runc/sbin/runc SKIP_USERNS=1 make localintegration "BUILDTAGS=$BUILDTAGS"
         ;;
     fedora-28) ;&  # Continue to the next item
     centos-7) ;&

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -99,7 +99,10 @@ var _ = BeforeSuite(func() {
 
 // PodmanTestCreate creates a PodmanTestIntegration instance for the tests
 func PodmanTestCreate(tempDir string) *PodmanTestIntegration {
-
+	var (
+		runCBinary string
+		err        error
+	)
 	host := GetHostDistributionInfo()
 	cwd, _ := os.Getwd()
 
@@ -129,12 +132,16 @@ func PodmanTestCreate(tempDir string) *PodmanTestIntegration {
 		cgroupManager = "cgroupfs"
 	}
 
-	runCBinary, err := exec.LookPath("runc")
-	// If we cannot find the runc binary, setting to something static as we have no way
-	// to return an error.  The tests will fail and point out that the runc binary could
-	// not be found nicely.
-	if err != nil {
-		runCBinary = "/usr/bin/runc"
+	if os.Getenv("RUNC_BINARY") != "" {
+		runCBinary = os.Getenv("RUNC_BINARY")
+	} else {
+		runCBinary, err = exec.LookPath("runc")
+		// If we cannot find the runc binary, setting to something static as we have no way
+		// to return an error.  The tests will fail and point out that the runc binary could
+		// not be found nicely.
+		if err != nil {
+			runCBinary = "/usr/bin/runc"
+		}
 	}
 
 	CNIConfigDir := "/etc/cni/net.d"


### PR DESCRIPTION
when running the integration tests on ubuntu, the test suite does not
pick up the unusual location of the runc binary.  simplest fix is to
honor an environment variable (which we do for most other components)
so that it can pass tests. This also protects us on ubuntu where
/usr/bin/runc can be installed by a different, out-dated package.

Signed-off-by: baude <bbaude@redhat.com>