### PR TITLE
create pod on the fly

### DIFF
--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -455,7 +455,8 @@ Tune the container's pids limit. Set `-1` to have unlimited pids for the contain
 
 **--pod**=""
 
-Run container in an existing pod
+Run container in an existing pod. If you want podman to make the pod for you, preference the pod name with `new:`.
+To make a pod with more granular options, use the `podman pod create` command before creating a container.
 
 **--privileged**=*true*|*false*
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -439,7 +439,8 @@ Tune the container's pids limit. Set `-1` to have unlimited pids for the contain
 
 **--pod**=""
 
-Run container in an existing pod
+Run container in an existing pod. If you want podman to make the pod for you, preference the pod name with `new:`.
+To make a pod with more granular options, use the `podman pod create` command before creating a container.
 
 **--privileged**=*true*|*false*
 

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -496,8 +496,13 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime) ([]lib
 
 // CreatePortBindings iterates ports mappings and exposed ports into a format CNI understands
 func (c *CreateConfig) CreatePortBindings() ([]ocicni.PortMapping, error) {
+	return NatToOCIPortBindings(c.PortBindings)
+}
+
+// NatToOCIPortBindings iterates a nat.portmap slice and creates []ocicni portmapping slice
+func NatToOCIPortBindings(ports nat.PortMap) ([]ocicni.PortMapping, error) {
 	var portBindings []ocicni.PortMapping
-	for containerPb, hostPb := range c.PortBindings {
+	for containerPb, hostPb := range ports {
 		var pm ocicni.PortMapping
 		pm.ContainerPort = int32(containerPb.Int())
 		for _, i := range hostPb {

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -189,4 +189,15 @@ var _ = Describe("Podman create", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("/create/test rw,nosuid,nodev,noexec,relatime - tmpfs"))
 	})
+
+	It("podman create --pod automatically", func() {
+		session := podmanTest.Podman([]string{"create", "--pod", "new:foobar", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		check := podmanTest.Podman([]string{"pod", "ps", "--no-trunc"})
+		check.WaitWithDefaultTimeout()
+		match, _ := check.GrepString("foobar")
+		Expect(match).To(BeTrue())
+	})
 })

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -628,4 +628,15 @@ USER mail`
 		isSharedOnly := !strings.Contains(shared[0], "shared,")
 		Expect(isSharedOnly).Should(BeTrue())
 	})
+
+	It("podman run --pod automatically", func() {
+		session := podmanTest.Podman([]string{"run", "--pod", "new:foobar", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		check := podmanTest.Podman([]string{"pod", "ps", "--no-trunc"})
+		check.WaitWithDefaultTimeout()
+		match, _ := check.GrepString("foobar")
+		Expect(match).To(BeTrue())
+	})
 })


### PR DESCRIPTION
when a user specifies --pod to podman create|run, we should create that pod
automatically.  the port bindings from the container are then inherited by
the infra container.  this signicantly improves the workflow of running
containers inside pods with podman.  the user is still encouraged to use
podman pod create to have more granular control of the pod create options.

Signed-off-by: baude <bbaude@redhat.com>