### PR TITLE
podman pod exists

### DIFF
--- a/cmd/podman/exists.go
+++ b/cmd/podman/exists.go
@@ -44,6 +44,23 @@ var (
 	}
 )
 
+var (
+	podExistsDescription = `
+	podman pod exists
+
+	Check if a pod exists in local storage
+`
+
+	podExistsCommand = cli.Command{
+		Name:         "exists",
+		Usage:        "Check if a pod exists in local storage",
+		Description:  podExistsDescription,
+		Action:       podExistsCmd,
+		ArgsUsage:    "POD-NAME",
+		OnUsageError: usageErrorHandler,
+	}
+)
+
 func imageExistsCmd(c *cli.Context) error {
 	args := c.Args()
 	if len(args) > 1 || len(args) < 1 {
@@ -75,6 +92,26 @@ func containerExistsCmd(c *cli.Context) error {
 	defer runtime.Shutdown(false)
 	if _, err := runtime.LookupContainer(args[0]); err != nil {
 		if errors.Cause(err) == libpod.ErrNoSuchCtr {
+			os.Exit(1)
+		}
+		return err
+	}
+	return nil
+}
+
+func podExistsCmd(c *cli.Context) error {
+	args := c.Args()
+	if len(args) > 1 || len(args) < 1 {
+		return errors.New("you may only check for the existence of one pod at a time")
+	}
+	runtime, err := libpodruntime.GetRuntime(c)
+	if err != nil {
+		return errors.Wrapf(err, "could not get runtime")
+	}
+	defer runtime.Shutdown(false)
+
+	if _, err := runtime.LookupPod(args[0]); err != nil {
+		if errors.Cause(err) == libpod.ErrNoSuchPod {
 			os.Exit(1)
 		}
 		return err

--- a/cmd/podman/pod.go
+++ b/cmd/podman/pod.go
@@ -11,6 +11,7 @@ Pods are a group of one or more containers sharing the same network, pid and ipc
 `
 	podSubCommands = []cli.Command{
 		podCreateCommand,
+		podExistsCommand,
 		podInspectCommand,
 		podKillCommand,
 		podPauseCommand,

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2235,6 +2235,14 @@ _podman_container_exists() {
   "
 }
 
+_podman_pod_exists() {
+    local options_with_args="
+    "
+
+    local boolean_options="
+  "
+}
+
 _podman_image_exists() {
     local options_with_args="
     "

--- a/docs/podman-pod-exists.1.md
+++ b/docs/podman-pod-exists.1.md
@@ -1,0 +1,40 @@
+% podman-pod-exits(1) Podman Man Pages
+% Brent Baude
+% December 2018
+# NAME
+podman-pod-exists- Check if a pod exists in local storage
+
+# SYNOPSIS
+**podman pod exists**
+[**-h**|**--help**]
+POD
+
+# DESCRIPTION
+**podman pod exists** checks if a pod exists in local storage. The **ID** or **Name**
+of the pod may be used as input.  Podman will return an exit code
+of `0` when the pod is found.  A `1` will be returned otherwise. An exit code of `125` indicates there
+was an issue accessing the local storage.
+
+## Examples ##
+
+Check if a pod called `web` exists in local storage (the pod does actually exist).
+```
+$ sudo podman pod exists web
+$ echo $?
+0
+$
+```
+
+Check if a pod called `backend` exists in local storage (the pod does not actually exist).
+```
+$ sudo podman pod exists backend
+$ echo $?
+1
+$
+```
+
+## SEE ALSO
+podman-pod(1), podman(1)
+
+# HISTORY
+December 2018, Originally compiled by Brent Baude (bbaude at redhat dot com)

--- a/test/e2e/exists_test.go
+++ b/test/e2e/exists_test.go
@@ -82,4 +82,36 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session.ExitCode()).To(Equal(1))
 	})
 
+	It("podman pod exists in local storage by name", func() {
+		setup, rc, _ := podmanTest.CreatePod("foobar")
+		setup.WaitWithDefaultTimeout()
+		Expect(rc).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"pod", "exists", "foobar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+	It("podman pod exists in local storage by container ID", func() {
+		setup, rc, podID := podmanTest.CreatePod("")
+		setup.WaitWithDefaultTimeout()
+		Expect(rc).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"pod", "exists", podID})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+	It("podman pod exists in local storage by short container ID", func() {
+		setup, rc, podID := podmanTest.CreatePod("")
+		setup.WaitWithDefaultTimeout()
+		Expect(rc).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"pod", "exists", podID[0:12]})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+	It("podman pod does not exist in local storage", func() {
+		session := podmanTest.Podman([]string{"pod", "exists", "foobar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(1))
+	})
 })


### PR DESCRIPTION
like containers and images, users would benefit from being able to check
if a pod exists in local storage.  if the pod exists, the return code is 0.
if the pod does not exists, the return code is 1.  Any other return code
indicates a real errors, such as permissions or runtime.

Signed-off-by: baude <bbaude@redhat.com>