### PR TITLE
Use paths written in DB instead if they differ from our defaults

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -66,7 +66,7 @@ func createCmd(c *cli.Context) error {
 		rootless.SetSkipStorageSetup(true)
 	}
 
-	runtime, err := libpodruntime.GetContainerRuntime(c)
+	runtime, err := libpodruntime.GetRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -11,31 +11,17 @@ import (
 
 // GetRuntime generates a new libpod runtime configured by command line options
 func GetRuntime(c *cli.Context) (*libpod.Runtime, error) {
-	storageOpts, err := util.GetDefaultStoreOptions()
-	if err != nil {
-		return nil, err
-	}
-	return GetRuntimeWithStorageOpts(c, &storageOpts)
-}
-
-// GetContainerRuntime generates a new libpod runtime configured by command line options for containers
-func GetContainerRuntime(c *cli.Context) (*libpod.Runtime, error) {
-	mappings, err := util.ParseIDMapping(c.StringSlice("uidmap"), c.StringSlice("gidmap"), c.String("subuidmap"), c.String("subgidmap"))
-	if err != nil {
-		return nil, err
-	}
-	storageOpts, err := util.GetDefaultStoreOptions()
-	if err != nil {
-		return nil, err
-	}
-	storageOpts.UIDMap = mappings.UIDMap
-	storageOpts.GIDMap = mappings.GIDMap
-	return GetRuntimeWithStorageOpts(c, &storageOpts)
-}
-
-// GetRuntime generates a new libpod runtime configured by command line options
-func GetRuntimeWithStorageOpts(c *cli.Context, storageOpts *storage.StoreOptions) (*libpod.Runtime, error) {
+	storageOpts := new(storage.StoreOptions)
 	options := []libpod.RuntimeOption{}
+
+	if c.IsSet("uidmap") || c.IsSet("gidmap") || c.IsSet("subuidmap") || c.IsSet("subgidmap") {
+		mappings, err := util.ParseIDMapping(c.StringSlice("uidmap"), c.StringSlice("gidmap"), c.String("subuidmap"), c.String("subgidmap"))
+		if err != nil {
+			return nil, err
+		}
+		storageOpts.UIDMap = mappings.UIDMap
+		storageOpts.GIDMap = mappings.GIDMap
+	}
 
 	if c.GlobalIsSet("root") {
 		storageOpts.GraphRoot = c.GlobalString("root")

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -44,7 +44,7 @@ func runCmd(c *cli.Context) error {
 		rootless.SetSkipStorageSetup(true)
 	}
 
-	runtime, err := libpodruntime.GetContainerRuntime(c)
+	runtime, err := libpodruntime.GetRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -18,7 +18,6 @@ type BoltState struct {
 	dbLock         sync.Mutex
 	namespace      string
 	namespaceBytes []byte
-	lockDir        string
 	runtime        *Runtime
 }
 
@@ -51,10 +50,9 @@ type BoltState struct {
 //   containers/storage do not occur.
 
 // NewBoltState creates a new bolt-backed state database
-func NewBoltState(path, lockDir string, runtime *Runtime) (State, error) {
+func NewBoltState(path string, runtime *Runtime) (State, error) {
 	state := new(BoltState)
 	state.dbPath = path
-	state.lockDir = lockDir
 	state.runtime = runtime
 	state.namespace = ""
 	state.namespaceBytes = nil

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -3,7 +3,6 @@ package libpod
 import (
 	"bytes"
 	"encoding/json"
-	"os"
 	"strings"
 	"sync"
 
@@ -61,15 +60,6 @@ func NewBoltState(path, lockDir string, runtime *Runtime) (State, error) {
 	state.namespaceBytes = nil
 
 	logrus.Debugf("Initializing boltdb state at %s", path)
-
-	// Make the directory that will hold container lockfiles
-	if err := os.MkdirAll(lockDir, 0750); err != nil {
-		// The directory is allowed to exist
-		if !os.IsExist(err) {
-			return nil, errors.Wrapf(err, "error creating lockfiles dir %s", lockDir)
-		}
-	}
-	state.lockDir = lockDir
 
 	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -266,7 +266,7 @@ func (s *BoltState) getContainerFromDB(id []byte, ctr *Container, ctrsBkt *bolt.
 	}
 
 	// Get the lock
-	lockPath := filepath.Join(s.lockDir, string(id))
+	lockPath := filepath.Join(s.runtime.lockDir, string(id))
 	lock, err := storage.GetLockfile(lockPath)
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving lockfile for container %s", string(id))
@@ -302,7 +302,7 @@ func (s *BoltState) getPodFromDB(id []byte, pod *Pod, podBkt *bolt.Bucket) error
 	}
 
 	// Get the lock
-	lockPath := filepath.Join(s.lockDir, string(id))
+	lockPath := filepath.Join(s.runtime.lockDir, string(id))
 	lock, err := storage.GetLockfile(lockPath)
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving lockfile for pod %s", string(id))

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -79,23 +79,23 @@ func checkRuntimeConfig(db *bolt.DB, rt *Runtime) error {
 			return err
 		}
 
-		if err := validateDBAgainstConfig(configBkt, "libpod root directory",
+		if err := validateDBAgainstConfig(configBkt, "libpod root directory (staticdir)",
 			rt.config.StaticDir, staticDirKey, ""); err != nil {
 			return err
 		}
 
-		if err := validateDBAgainstConfig(configBkt, "libpod temporary files directory",
+		if err := validateDBAgainstConfig(configBkt, "libpod temporary files directory (tmpdir)",
 			rt.config.TmpDir, tmpDirKey, ""); err != nil {
 			return err
 		}
 
-		if err := validateDBAgainstConfig(configBkt, "storage temporary directory",
+		if err := validateDBAgainstConfig(configBkt, "storage temporary directory (runroot)",
 			rt.config.StorageConfig.RunRoot, runRootKey,
 			storage.DefaultStoreOptions.RunRoot); err != nil {
 			return err
 		}
 
-		if err := validateDBAgainstConfig(configBkt, "storage graph root directory",
+		if err := validateDBAgainstConfig(configBkt, "storage graph root directory (graphroot)",
 			rt.config.StorageConfig.GraphRoot, graphRootKey,
 			storage.DefaultStoreOptions.GraphRoot); err != nil {
 			return err

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -30,6 +30,13 @@ const (
 	containersName   = "containers"
 	podIDName        = "pod-id"
 	namespaceName    = "namespace"
+
+	staticDirName   = "static-dir"
+	tmpDirName      = "tmp-dir"
+	runRootName     = "run-root"
+	graphRootName   = "graph-root"
+	graphDriverName = "graph-driver-name"
+	osName          = "os"
 )
 
 var (
@@ -49,21 +56,19 @@ var (
 	containersBkt   = []byte(containersName)
 	podIDKey        = []byte(podIDName)
 	namespaceKey    = []byte(namespaceName)
+
+	staticDirKey   = []byte(staticDirName)
+	tmpDirKey      = []byte(tmpDirName)
+	runRootKey     = []byte(runRootName)
+	graphRootKey   = []byte(graphRootName)
+	graphDriverKey = []byte(graphDriverName)
+	osKey          = []byte(osName)
 )
 
 // Check if the configuration of the database is compatible with the
 // configuration of the runtime opening it
 // If there is no runtime configuration loaded, load our own
 func checkRuntimeConfig(db *bolt.DB, rt *Runtime) error {
-	var (
-		staticDir       = []byte("static-dir")
-		tmpDir          = []byte("tmp-dir")
-		runRoot         = []byte("run-root")
-		graphRoot       = []byte("graph-root")
-		graphDriverName = []byte("graph-driver-name")
-		osKey           = []byte("os")
-	)
-
 	err := db.Update(func(tx *bolt.Tx) error {
 		configBkt, err := getRuntimeConfigBucket(tx)
 		if err != nil {
@@ -74,31 +79,31 @@ func checkRuntimeConfig(db *bolt.DB, rt *Runtime) error {
 			return err
 		}
 
-		if err := validateDBAgainstConfig(configBkt, "static dir",
-			rt.config.StaticDir, staticDir, ""); err != nil {
+		if err := validateDBAgainstConfig(configBkt, "libpod root directory",
+			rt.config.StaticDir, staticDirKey, ""); err != nil {
 			return err
 		}
 
-		if err := validateDBAgainstConfig(configBkt, "tmp dir",
-			rt.config.TmpDir, tmpDir, ""); err != nil {
+		if err := validateDBAgainstConfig(configBkt, "libpod temporary files directory",
+			rt.config.TmpDir, tmpDirKey, ""); err != nil {
 			return err
 		}
 
-		if err := validateDBAgainstConfig(configBkt, "run root",
-			rt.config.StorageConfig.RunRoot, runRoot,
+		if err := validateDBAgainstConfig(configBkt, "storage temporary directory",
+			rt.config.StorageConfig.RunRoot, runRootKey,
 			storage.DefaultStoreOptions.RunRoot); err != nil {
 			return err
 		}
 
-		if err := validateDBAgainstConfig(configBkt, "graph root",
-			rt.config.StorageConfig.GraphRoot, graphRoot,
+		if err := validateDBAgainstConfig(configBkt, "storage graph root directory",
+			rt.config.StorageConfig.GraphRoot, graphRootKey,
 			storage.DefaultStoreOptions.GraphRoot); err != nil {
 			return err
 		}
 
-		return validateDBAgainstConfig(configBkt, "graph driver name",
+		return validateDBAgainstConfig(configBkt, "storage graph driver",
 			rt.config.StorageConfig.GraphDriverName,
-			graphDriverName,
+			graphDriverKey,
 			storage.DefaultStoreOptions.GraphDriverName)
 	})
 

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -73,9 +73,10 @@ func (s *InMemoryState) Refresh() error {
 	return nil
 }
 
-// GetDBConfig is not implemented for the in-memory state
+// GetDBConfig is not implemented for in-memory state.
+// As we do not store a config, return an empty one.
 func (s *InMemoryState) GetDBConfig() (*DBConfig, error) {
-	return nil, ErrNotImplemented
+	return &DBConfig{}, nil
 }
 
 // ValidateDBConfig is not implemented for the in-memory state.

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -78,6 +78,12 @@ func (s *InMemoryState) GetDBConfig() (*DBConfig, error) {
 	return nil, ErrNotImplemented
 }
 
+// ValidateDBConfig is not implemented for the in-memory state.
+// Since we do nothing just return no error.
+func (s *InMemoryState) ValidateDBConfig(runtime *Runtime) error {
+	return nil
+}
+
 // SetNamespace sets the namespace for container and pod retrieval.
 func (s *InMemoryState) SetNamespace(ns string) error {
 	s.namespace = ns

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -73,6 +73,11 @@ func (s *InMemoryState) Refresh() error {
 	return nil
 }
 
+// GetDBConfig is not implemented for the in-memory state
+func (s *InMemoryState) GetDBConfig() (*DBConfig, error) {
+	return nil, ErrNotImplemented
+}
+
 // SetNamespace sets the namespace for container and pod retrieval.
 func (s *InMemoryState) SetNamespace(ns string) error {
 	s.namespace = ns

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -29,18 +29,18 @@ func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
 			return ErrRuntimeFinalized
 		}
 
-		rt.config.StorageConfig.RunRoot = config.RunRoot
 		if config.RunRoot != "" {
+			rt.config.StorageConfig.RunRoot = config.RunRoot
 			rt.configuredFrom.storageRunRootSet = true
 		}
 
-		rt.config.StorageConfig.GraphRoot = config.GraphRoot
 		if config.GraphRoot != "" {
+			rt.config.StorageConfig.GraphRoot = config.GraphRoot
 			rt.configuredFrom.storageGraphRootSet = true
 		}
 
-		rt.config.StorageConfig.GraphDriverName = config.GraphDriverName
 		if config.GraphDriverName != "" {
+			rt.config.StorageConfig.GraphDriverName = config.GraphDriverName
 			rt.configuredFrom.storageGraphDriverSet = true
 		}
 
@@ -51,14 +51,20 @@ func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
 			rt.configuredFrom.libpodStaticDirSet = true
 		}
 
-		rt.config.StorageConfig.GraphDriverOptions = make([]string, len(config.GraphDriverOptions))
-		copy(rt.config.StorageConfig.GraphDriverOptions, config.GraphDriverOptions)
+		if config.GraphDriverOptions != nil {
+			rt.config.StorageConfig.GraphDriverOptions = make([]string, len(config.GraphDriverOptions))
+			copy(rt.config.StorageConfig.GraphDriverOptions, config.GraphDriverOptions)
+		}
 
-		rt.config.StorageConfig.UIDMap = make([]idtools.IDMap, len(config.UIDMap))
-		copy(rt.config.StorageConfig.UIDMap, config.UIDMap)
+		if config.UIDMap != nil {
+			rt.config.StorageConfig.UIDMap = make([]idtools.IDMap, len(config.UIDMap))
+			copy(rt.config.StorageConfig.UIDMap, config.UIDMap)
+		}
 
-		rt.config.StorageConfig.GIDMap = make([]idtools.IDMap, len(config.GIDMap))
-		copy(rt.config.StorageConfig.GIDMap, config.GIDMap)
+		if config.GIDMap != nil {
+			rt.config.StorageConfig.GIDMap = make([]idtools.IDMap, len(config.GIDMap))
+			copy(rt.config.StorageConfig.GIDMap, config.GIDMap)
+		}
 
 		return nil
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -30,9 +30,26 @@ func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
 		}
 
 		rt.config.StorageConfig.RunRoot = config.RunRoot
+		if config.RunRoot != "" {
+			rt.configuredFrom.storageRunRootSet = true
+		}
+
 		rt.config.StorageConfig.GraphRoot = config.GraphRoot
+		if config.GraphRoot != "" {
+			rt.configuredFrom.storageGraphRootSet = true
+		}
+
 		rt.config.StorageConfig.GraphDriverName = config.GraphDriverName
-		rt.config.StaticDir = filepath.Join(config.GraphRoot, "libpod")
+		if config.GraphDriverName != "" {
+			rt.configuredFrom.storageGraphDriverSet = true
+		}
+
+		// Only set our static dir if it was not already explicitly
+		// overridden
+		if config.GraphRoot != "" && !rt.configuredFrom.libpodStaticDirSet {
+			rt.config.StaticDir = filepath.Join(config.GraphRoot, "libpod")
+			rt.configuredFrom.libpodStaticDirSet = true
+		}
 
 		rt.config.StorageConfig.GraphDriverOptions = make([]string, len(config.GraphDriverOptions))
 		copy(rt.config.StorageConfig.GraphDriverOptions, config.GraphDriverOptions)
@@ -174,6 +191,7 @@ func WithStaticDir(dir string) RuntimeOption {
 		}
 
 		rt.config.StaticDir = dir
+		rt.configuredFrom.libpodStaticDirSet = true
 
 		return nil
 	}
@@ -226,6 +244,7 @@ func WithTmpDir(dir string) RuntimeOption {
 		}
 
 		rt.config.TmpDir = dir
+		rt.configuredFrom.libpodTmpDirSet = true
 
 		return nil
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -37,18 +37,16 @@ func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
 		if config.GraphRoot != "" {
 			rt.config.StorageConfig.GraphRoot = config.GraphRoot
 			rt.configuredFrom.storageGraphRootSet = true
+
+			// Also set libpod static dir, so we are a subdirectory
+			// of the c/storage store by default
+			rt.config.StaticDir = filepath.Join(config.GraphRoot, "libpod")
+			rt.configuredFrom.libpodStaticDirSet = true
 		}
 
 		if config.GraphDriverName != "" {
 			rt.config.StorageConfig.GraphDriverName = config.GraphDriverName
 			rt.configuredFrom.storageGraphDriverSet = true
-		}
-
-		// Only set our static dir if it was not already explicitly
-		// overridden
-		if config.GraphRoot != "" && !rt.configuredFrom.libpodStaticDirSet {
-			rt.config.StaticDir = filepath.Join(config.GraphRoot, "libpod")
-			rt.configuredFrom.libpodStaticDirSet = true
 		}
 
 		if config.GraphDriverOptions != nil {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -448,6 +448,11 @@ func makeRuntime(runtime *Runtime) (err error) {
 		return errors.Wrapf(ErrInvalidArg, "unrecognized state type passed")
 	}
 
+	// Validate our config against the database
+	if err := runtime.state.ValidateDBConfig(runtime); err != nil {
+		return err
+	}
+
 	if err := runtime.state.SetNamespace(runtime.config.Namespace); err != nil {
 		return errors.Wrapf(err, "error setting libpod namespace in state")
 	}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -280,7 +280,7 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 
 	if rootless.IsRootless() {
 		// If we're rootless, override the default storage config
-		storageConf, err := util.GetDefaultRootlessStoreOptions()
+		storageConf, err := util.GetDefaultStoreOptions()
 		if err != nil {
 			return nil, errors.Wrapf(err, "error retrieving rootless storage config")
 		}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -278,6 +278,15 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 	deepcopier.Copy(defaultRuntimeConfig).To(runtime.config)
 	runtime.config.TmpDir = tmpDir
 
+	if rootless.IsRootless() {
+		// If we're rootless, override the default storage config
+		storageConf, err := util.GetDefaultRootlessStoreOptions()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error retrieving rootless storage config")
+		}
+		runtime.config.StorageConfig = storageConf
+	}
+
 	configPath := ConfigPath
 	foundConfig := true
 	rootlessConfigPath := ""

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -494,7 +494,7 @@ func makeRuntime(runtime *Runtime) (err error) {
 	case BoltDBStateStore:
 		dbPath := filepath.Join(runtime.config.StaticDir, "bolt_state.db")
 
-		state, err := NewBoltState(dbPath, runtime.lockDir, runtime)
+		state, err := NewBoltState(dbPath, runtime)
 		if err != nil {
 			return err
 		}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -472,6 +472,15 @@ func makeRuntime(runtime *Runtime) (err error) {
 			runtime.config.ConmonPath)
 	}
 
+	// Make the static files directory if it does not exist
+	if err := os.MkdirAll(runtime.config.StaticDir, 0700); err != nil {
+		// The directory is allowed to exist
+		if !os.IsExist(err) {
+			return errors.Wrapf(err, "error creating runtime static files directory %s",
+				runtime.config.StaticDir)
+		}
+	}
+
 	// Set up the state
 	switch runtime.config.StateType {
 	case InMemoryStateStore:
@@ -600,15 +609,6 @@ func makeRuntime(runtime *Runtime) (err error) {
 		return err
 	}
 	runtime.ociRuntime = ociRuntime
-
-	// Make the static files directory if it does not exist
-	if err := os.MkdirAll(runtime.config.StaticDir, 0755); err != nil {
-		// The directory is allowed to exist
-		if !os.IsExist(err) {
-			return errors.Wrapf(err, "error creating runtime static files directory %s",
-				runtime.config.StaticDir)
-		}
-	}
 
 	// Make a directory to hold container lockfiles
 	lockDir := filepath.Join(runtime.config.TmpDir, "lock")

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -285,6 +285,7 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 			return nil, errors.Wrapf(err, "error retrieving rootless storage config")
 		}
 		runtime.config.StorageConfig = storageConf
+		runtime.config.StaticDir = filepath.Join(storageConf.GraphRoot, "libpod")
 	}
 
 	configPath := ConfigPath
@@ -515,6 +516,12 @@ func makeRuntime(runtime *Runtime) (err error) {
 	if !runtime.configuredFrom.libpodTmpDirSet && dbConfig.LibpodTmp != "" {
 		runtime.config.TmpDir = dbConfig.LibpodTmp
 	}
+
+	logrus.Debugf("Using graph driver %s", runtime.config.StorageConfig.GraphDriverName)
+	logrus.Debugf("Using graph root %s", runtime.config.StorageConfig.GraphRoot)
+	logrus.Debugf("Using run root %s", runtime.config.StorageConfig.RunRoot)
+	logrus.Debugf("Using static dir %s", runtime.config.StaticDir)
+	logrus.Debugf("Using tmp dir %s", runtime.config.TmpDir)
 
 	// Validate our config against the database, now that we've set our
 	// final storage configuration

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -38,7 +38,7 @@ type State interface {
 	// validate runtime configuration.
 	GetDBConfig() (*DBConfig, error)
 
-	// ValidateDBConfig ralidates the config in the given Runtime struct
+	// ValidateDBConfig validates the config in the given Runtime struct
 	// against paths stored in the configured database.
 	// Libpod root and tmp dirs and c/storage root and tmp dirs and graph
 	// driver are validated.

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -3,10 +3,10 @@ package libpod
 // DBConfig is a set of Libpod runtime configuration settings that are saved
 // in a State when it is first created, and can subsequently be retrieved.
 type DBConfig struct {
-	LibpodRoot string
-	LibpodTmp string
+	LibpodRoot  string
+	LibpodTmp   string
 	StorageRoot string
-	StorageTmp string
+	StorageTmp  string
 	GraphDriver string
 }
 

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -1,5 +1,15 @@
 package libpod
 
+// DBConfig is a set of Libpod runtime configuration settings that are saved
+// in a State when it is first created, and can subsequently be retrieved.
+type DBConfig struct {
+	LibpodRoot string
+	LibpodTmp string
+	StorageRoot string
+	StorageTmp string
+	GraphDriver string
+}
+
 // State is a storage backend for libpod's current state.
 // A State is only initialized once per instance of libpod.
 // As such, initialization methods for State implementations may safely assume
@@ -20,6 +30,13 @@ type State interface {
 
 	// Refresh clears container and pod states after a reboot
 	Refresh() error
+
+	// GetDBConfig retrieves several paths configured within the database
+	// when it was created - namely, Libpod root and tmp dirs, c/storage
+	// root and tmp dirs, and c/storage graph driver.
+	// This is not implemented by the in-memory state, as it has no need to
+	// validate runtime configuration.
+	GetDBConfig() (*DBConfig, error)
 
 	// SetNamespace() sets the namespace for the store, and will determine
 	// what containers are retrieved with container and pod retrieval calls.

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -38,6 +38,15 @@ type State interface {
 	// validate runtime configuration.
 	GetDBConfig() (*DBConfig, error)
 
+	// ValidateDBConfig ralidates the config in the given Runtime struct
+	// against paths stored in the configured database.
+	// Libpod root and tmp dirs and c/storage root and tmp dirs and graph
+	// driver are validated.
+	// This is not implemented by the in-memory state, as it has no need to
+	// validate runtime configuration that may change over multiple runs of
+	// the program.
+	ValidateDBConfig(runtime *Runtime) error
+
 	// SetNamespace() sets the namespace for the store, and will determine
 	// what containers are retrieved with container and pod retrieval calls.
 	// A namespace of "", the empty string, acts as no namespace, and

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -52,8 +52,9 @@ func getEmptyBoltState() (s State, p string, p2 string, err error) {
 	runtime := new(Runtime)
 	runtime.config = new(RuntimeConfig)
 	runtime.config.StorageConfig = storage.StoreOptions{}
+	runtime.lockDir = lockDir
 
-	state, err := NewBoltState(dbPath, lockDir, runtime)
+	state, err := NewBoltState(dbPath, runtime)
 	if err != nil {
 		return nil, "", "", err
 	}

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -45,6 +45,10 @@ func getEmptyBoltState() (s State, p string, p2 string, err error) {
 	dbPath := filepath.Join(tmpDir, "db.sql")
 	lockDir := filepath.Join(tmpDir, "locks")
 
+	if err := os.Mkdir(lockDir, 0755); err != nil {
+		return nil, "", "", err
+	}
+
 	runtime := new(Runtime)
 	runtime.config = new(RuntimeConfig)
 	runtime.config.StorageConfig = storage.StoreOptions{}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -313,33 +313,31 @@ func getTomlStorage(storeOptions *storage.StoreOptions) *tomlConfig {
 	return config
 }
 
-// GetDefaultStoreOptions returns the storage ops for containers
-func GetDefaultStoreOptions() (storage.StoreOptions, error) {
-	storageOpts := storage.DefaultStoreOptions
-	if rootless.IsRootless() {
-		var err error
-		storageOpts, err = GetRootlessStorageOpts()
+// GetDefaultStoreOptions returns the storage ops for containers.
+func GetDefaultRootlessStoreOptions() (storage.StoreOptions, error) {
+	var err error
+	storageOpts, err := GetRootlessStorageOpts()
+	if err != nil {
+		return storageOpts, err
+	}
+
+	storageConf := filepath.Join(os.Getenv("HOME"), ".config/containers/storage.conf")
+	if _, err := os.Stat(storageConf); err == nil {
+		storage.ReloadConfigurationFile(storageConf, &storageOpts)
+	} else if os.IsNotExist(err) {
+		os.MkdirAll(filepath.Dir(storageConf), 0755)
+		file, err := os.OpenFile(storageConf, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 		if err != nil {
-			return storageOpts, err
+			return storageOpts, errors.Wrapf(err, "cannot open %s", storageConf)
 		}
 
-		storageConf := filepath.Join(os.Getenv("HOME"), ".config/containers/storage.conf")
-		if _, err := os.Stat(storageConf); err == nil {
-			storage.ReloadConfigurationFile(storageConf, &storageOpts)
-		} else if os.IsNotExist(err) {
-			os.MkdirAll(filepath.Dir(storageConf), 0755)
-			file, err := os.OpenFile(storageConf, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
-			if err != nil {
-				return storageOpts, errors.Wrapf(err, "cannot open %s", storageConf)
-			}
-
-			tomlConfiguration := getTomlStorage(&storageOpts)
-			defer file.Close()
-			enc := toml.NewEncoder(file)
-			if err := enc.Encode(tomlConfiguration); err != nil {
-				os.Remove(storageConf)
-			}
+		tomlConfiguration := getTomlStorage(&storageOpts)
+		defer file.Close()
+		enc := toml.NewEncoder(file)
+		if err := enc.Encode(tomlConfiguration); err != nil {
+			os.Remove(storageConf)
 		}
 	}
+
 	return storageOpts, nil
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -313,7 +313,8 @@ func getTomlStorage(storeOptions *storage.StoreOptions) *tomlConfig {
 	return config
 }
 
-// GetDefaultStoreOptions returns the storage ops for containers.
+// GetDefaultRootlessStoreOptions returns the storage opts for rootless
+// containers.
 func GetDefaultRootlessStoreOptions() (storage.StoreOptions, error) {
 	var err error
 	storageOpts, err := GetRootlessStorageOpts()


### PR DESCRIPTION
Finally have this in satisfying shape.

We encountered a regression a little over a week ago in Podman 0.11.x releases, where some directories' defaults changed for rootless. As we validate critical paths against the database, this caused a breaking change, requiring manual config file creation and editing (or deleting/recreating rootless container storage) to fix.

This resolves the breaking change by using the paths we validate against in the database if libpod would otherwise use default values (IE, the user has not explicitly overridden a setting). This ensures that changes to default paths will be respected for new installs, but existing installs will still continue working as expected. This also applies to the storage graph driver.

This cannot, however, fix situations where the libpod static directory's path changes - in which case we don't find the old DB, and cannot find the old paths. Libpod/Podman will function properly, but all containers/images from the old paths will be lost.