### PR TITLE
test: update runc again

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ env:
     CNI_COMMIT: "7480240de9749f9a0a5c8614b17f1f03e0c06ab9"
     CRIO_COMMIT: "7a283c391abb7bd25086a8ff91dbb36ebdd24466"
     CRIU_COMMIT: "c74b83cd49c00589c0c0468ba5fe685b67fdbd0a"
-    RUNC_COMMIT: "869add33186caff4a22e3e11a7472a2d48d77889"
+    RUNC_COMMIT: "96ec2177ae841256168fcf76954f7177af9446eb"
     # File to update in home-dir with task-specific env. var values
     ENVLIB: ".bash_profile"
     # Overrides default location (/tmp/cirrus) for repo clone

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ADD . /go/src/github.com/containers/libpod
 RUN set -x && cd /go/src/github.com/containers/libpod && make install.libseccomp.sudo
 
 # Install runc
-ENV RUNC_COMMIT 869add33186caff4a22e3e11a7472a2d48d77889
+ENV RUNC_COMMIT 96ec2177ae841256168fcf76954f7177af9446eb
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \


### PR DESCRIPTION
the regression we noticed in runc was fixed upstream:

https://github.com/opencontainers/runc/pull/1943

so we can use again runc from master.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>