### PR TITLE
Cirrus: Use packaged-based dependencies

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,9 +29,9 @@ env:
     ####
     #### Cache-image names to test with
     ###
-    FEDORA_CACHE_IMAGE_NAME: "fedora-30-libpod-5699414987898880"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-29-libpod-5699414987898880"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-18-libpod-5699414987898880"
+    FEDORA_CACHE_IMAGE_NAME: "fedora-30-libpod-5081463649730560"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-29-libpod-5081463649730560"
+    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-18-libpod-5081463649730560"
 
     ####
     #### Variables for composing new cache-images (used in PR testing) from

--- a/contrib/cirrus/build_vm_images.sh
+++ b/contrib/cirrus/build_vm_images.sh
@@ -3,12 +3,10 @@
 set -e
 source $(dirname $0)/lib.sh
 
-ENV_VARS='CNI_COMMIT CONMON_COMMIT PACKER_BUILDS BUILT_IMAGE_SUFFIX UBUNTU_BASE_IMAGE FEDORA_BASE_IMAGE PRIOR_FEDORA_BASE_IMAGE SERVICE_ACCOUNT GCE_SSH_USERNAME GCP_PROJECT_ID PACKER_VER SCRIPT_BASE PACKER_BASE'
+ENV_VARS='PACKER_BUILDS BUILT_IMAGE_SUFFIX UBUNTU_BASE_IMAGE FEDORA_BASE_IMAGE PRIOR_FEDORA_BASE_IMAGE SERVICE_ACCOUNT GCE_SSH_USERNAME GCP_PROJECT_ID PACKER_VER SCRIPT_BASE PACKER_BASE'
 req_env_var $ENV_VARS
 # Must also be made available through make, into packer process
 export $ENV_VARS
-
-show_env_vars
 
 # Everything here is running on the 'image-builder-image' GCE image
 # Assume basic dependencies are all met, but there could be a newer version
@@ -27,21 +25,12 @@ fi
 
 cd "$GOSRC/$PACKER_BASE"
 
-# Separate PR-produced images from those produced on master.
-if [[ "${CIRRUS_BRANCH:-}" == "master" ]]
-then
-    POST_MERGE_BUCKET_SUFFIX="-master"
-else
-    POST_MERGE_BUCKET_SUFFIX=""
-fi
-
 make libpod_images \
     PACKER_BUILDS=$PACKER_BUILDS \
     PACKER_VER=$PACKER_VER \
     GOSRC=$GOSRC \
     SCRIPT_BASE=$SCRIPT_BASE \
     PACKER_BASE=$PACKER_BASE \
-    POST_MERGE_BUCKET_SUFFIX=$POST_MERGE_BUCKET_SUFFIX \
     BUILT_IMAGE_SUFFIX=$BUILT_IMAGE_SUFFIX
 
 # When successful, upload manifest of produced images using a filename unique

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+
 source $(dirname $0)/lib.sh
 
 req_env_var GOSRC SCRIPT_BASE OS_RELEASE_ID OS_RELEASE_VER CONTAINER_RUNTIME

--- a/contrib/cirrus/packer/fedora_setup.sh
+++ b/contrib/cirrus/packer/fedora_setup.sh
@@ -8,7 +8,7 @@ set -e
 # Load in library (copied by packer, before this script was run)
 source /tmp/libpod/$SCRIPT_BASE/lib.sh
 
-req_env_var SCRIPT_BASE FEDORA_CNI_COMMIT CNI_COMMIT CONMON_COMMIT CRIU_COMMIT
+req_env_var SCRIPT_BASE
 
 install_ooe
 
@@ -17,11 +17,16 @@ trap "sudo rm -rf $GOPATH" EXIT
 
 ooe.sh sudo dnf update -y
 
+echo "Installing general build/test dependencies"
 ooe.sh sudo dnf install -y \
     atomic-registries \
     bats \
+    bridge-utils \
     btrfs-progs-devel \
     bzip2 \
+    container-selinux \
+    containernetworking-plugins \
+    containers-common \
     criu \
     device-mapper-devel \
     emacs-nox \
@@ -32,22 +37,24 @@ ooe.sh sudo dnf install -y \
     gnupg \
     golang \
     golang-github-cpuguy83-go-md2man \
-    golang-github-cpuguy83-go-md2man \
     gpgme-devel \
-    iptables \
     iproute \
+    iptables \
     jq \
     libassuan-devel \
     libcap-devel \
     libnet \
     libnet-devel \
     libnl3-devel \
+    libseccomp \
     libseccomp-devel \
     libselinux-devel \
     lsof \
     make \
     nmap-ncat \
+    ostree \
     ostree-devel \
+    podman \
     procps-ng \
     protobuf \
     protobuf-c \
@@ -61,7 +68,7 @@ ooe.sh sudo dnf install -y \
     python3-psutil \
     python3-pytoml \
     runc \
-    skopeo-containers \
+    selinux-policy-devel \
     slirp4netns \
     unzip \
     vim \
@@ -69,15 +76,8 @@ ooe.sh sudo dnf install -y \
     xz \
     zip
 
-install_varlink
-
-install_conmon
-
-CNI_COMMIT=$FEDORA_CNI_COMMIT
-install_cni_plugins
-
 sudo /tmp/libpod/hack/install_catatonit.sh
 
-rh_finalize # N/B: Halts system!
+rh_finalize
 
 echo "SUCCESS!"

--- a/contrib/cirrus/packer/libpod_images.yml
+++ b/contrib/cirrus/packer/libpod_images.yml
@@ -7,13 +7,6 @@ variables:
     FEDORA_BASE_IMAGE: '{{env `FEDORA_BASE_IMAGE`}}'
     PRIOR_FEDORA_BASE_IMAGE: '{{env `PRIOR_FEDORA_BASE_IMAGE`}}'
 
-    # libpod dependencies to build and install into images
-    FEDORA_CNI_COMMIT: "{{env `FEDORA_CNI_COMMIT`}}"
-    CNI_COMMIT: "{{env `CNI_COMMIT`}}"
-    CONMON_COMMIT: "{{env `CONMON_COMMIT`}}"
-    CRIU_COMMIT: "{{env `CRIU_COMMIT`}}"
-    RUNC_COMMIT: "{{env `RUNC_COMMIT`}}"
-
     BUILT_IMAGE_SUFFIX: '{{env `BUILT_IMAGE_SUFFIX`}}'
     GOSRC: '{{env `GOSRC`}}'
     PACKER_BASE: '{{env `PACKER_BASE`}}'
@@ -24,10 +17,6 @@ variables:
     GCP_PROJECT_ID: '{{env `GCP_PROJECT_ID`}}'
     SERVICE_ACCOUNT: '{{env `SERVICE_ACCOUNT`}}'
     GOOGLE_APPLICATION_CREDENTIALS: '{{env `GOOGLE_APPLICATION_CREDENTIALS`}}'
-
-    # Used to separate images produced during PR testing from those
-    # produced from post-merge testing.  Must be empty for PR testing.
-    POST_MERGE_BUCKET_SUFFIX: ''
 
 # Don't leak sensitive values in error messages / output
 sensitive-variables:
@@ -72,12 +61,7 @@ provisioners:
       script: '{{user `GOSRC`}}/{{user `PACKER_BASE`}}/{{split build_name "-" 0}}_setup.sh'
       environment_vars:
           - 'GOSRC=/tmp/libpod'
-          - 'CNI_COMMIT={{user `CNI_COMMIT`}}'
-          - 'FEDORA_CNI_COMMIT={{user `FEDORA_CNI_COMMIT`}}'
-          - 'CONMON_COMMIT={{user `CONMON_COMMIT`}}'
-          - 'CRIU_COMMIT={{user `CRIU_COMMIT`}}'
-          - 'RUNC_COMMIT={{user `RUNC_COMMIT`}}'
           - 'SCRIPT_BASE={{user `SCRIPT_BASE`}}'
 
 post-processors:
-    - - type: 'manifest'  # writes packer-manifest.json
+    - type: 'manifest'  # writes packer-manifest.json

--- a/contrib/cirrus/unit_test.sh
+++ b/contrib/cirrus/unit_test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 set -e
+
 source $(dirname $0)/lib.sh
 
 req_env_var GOSRC
 
-set -x
 cd "$GOSRC"
 make install.tools
 make localunit


### PR DESCRIPTION
Building/installing dependencies from fixed source-version ensures
testing is reliable, but introduces a maintenance burden and
risks testing far outside of a real-world environment.  The
sensible alternative is to install dependencies from distro-packaging
systems.

Install all development and testing dependencies at cache-image build
time, to help ensure testing remains stable.  The existing cache-image
build workflow can be utilized at any future time to build/test
with updated packages.