### PR TITLE
Don't initialize CNI when running as rootless

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -523,11 +523,13 @@ func makeRuntime(runtime *Runtime) (err error) {
 	}
 
 	// Set up the CNI net plugin
-	netPlugin, err := ocicni.InitCNI(runtime.config.CNIDefaultNetwork, runtime.config.CNIConfigDir, runtime.config.CNIPluginDir...)
-	if err != nil {
-		return errors.Wrapf(err, "error configuring CNI network plugin")
+	if !rootless.IsRootless() {
+		netPlugin, err := ocicni.InitCNI(runtime.config.CNIDefaultNetwork, runtime.config.CNIConfigDir, runtime.config.CNIPluginDir...)
+		if err != nil {
+			return errors.Wrapf(err, "error configuring CNI network plugin")
+		}
+		runtime.netPlugin = netPlugin
 	}
-	runtime.netPlugin = netPlugin
 
 	// Set up a firewall backend
 	backendType := ""


### PR DESCRIPTION
We don't use CNI to configure networks for rootless containers, so no need to set it up. It may also cause issues with inotify, so disabling it resolves some potential problems.