### PR TITLE
libpod/container_internal_linux: Allow gids that aren't in the group file

### DIFF
--- a/pkg/lookup/lookup.go
+++ b/pkg/lookup/lookup.go
@@ -99,9 +99,11 @@ func GetContainerGroups(groups []string, containerMount string, override *Overri
 	return uintgids, nil
 }
 
-// GetUser takes a containermount path and user name or id and returns
+// GetUser takes a containermount path and user name or ID and returns
 // a matching User structure from /etc/passwd.  If it cannot locate a user
 // with the provided information, an ErrNoPasswdEntries is returned.
+// When the provided user name was an ID, a User structure with Uid
+// set is returned along with ErrNoPasswdEntries.
 func GetUser(containerMount, userIDorName string) (*user.User, error) {
 	var inputIsName bool
 	uid, err := strconv.Atoi(userIDorName)
@@ -124,12 +126,17 @@ func GetUser(containerMount, userIDorName string) (*user.User, error) {
 	if len(users) > 0 {
 		return &users[0], nil
 	}
+	if !inputIsName {
+		return &user.User{Uid: uid}, user.ErrNoPasswdEntries
+	}
 	return nil, user.ErrNoPasswdEntries
 }
 
-// GetGroup takes ac ontainermount path and a group name or id and returns
-// a match Group struct from /etc/group.  if it cannot locate a group,
-// an ErrNoGroupEntries error is returned.
+// GetGroup takes a containermount path and a group name or ID and returns
+// a match Group struct from /etc/group.  If it cannot locate a group,
+// an ErrNoGroupEntries error is returned.  When the provided group name
+// was an ID, a Group structure with Gid set is returned along with
+// ErrNoGroupEntries.
 func GetGroup(containerMount, groupIDorName string) (*user.Group, error) {
 	var inputIsName bool
 	gid, err := strconv.Atoi(groupIDorName)
@@ -153,6 +160,9 @@ func GetGroup(containerMount, groupIDorName string) (*user.Group, error) {
 	}
 	if len(groups) > 0 {
 		return &groups[0], nil
+	}
+	if !inputIsName {
+		return &user.Group{Gid: gid}, user.ErrNoGroupEntries
 	}
 	return nil, user.ErrNoGroupEntries
 }


### PR DESCRIPTION
When an image config sets [`config.User`][1] to a numeric group (like `1000:1000`), but those values do not exist in the container's `/etc/group`, libpod is currently breaking:

```console
$ podman run --rm registry.svc.ci.openshift.org/ci-op-zvml7cd6/pipeline:installer --help
error creating temporary passwd file for container 228f6e9943d6f18b93c19644e9b619ec4d459a3e0eb31680e064eeedf6473678: unable to get gid 1000 from group file: no matching entries in group file
```

However, the OCI spec [requires converters to copy numeric `uid` and `gid` to the runtime config verbatim][2].

With this commit, I'm frontloading the "is groupspec an integer?" check and only bothering with `lookup.GetGroup` when it was not.

I've also removed a few `.Mounted` checks, which are originally from 00d38cb3 (#110).  We don't need a mounted container filesystem to translate integers.  And when the lookup code needs to fall back to the mounted root to translate names, it can handle erroring out internally (and looking it over, it seems to do that already).

Fixes #1937

[1]: https://github.com/opencontainers/image-spec/blame/v1.0.1/config.md#L118-L123
[2]: https://github.com/opencontainers/image-spec/blame/v1.0.1/conversion.md#L70