### PR TITLE
bind mount /etc/resolv.conf|hosts in pods

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -601,7 +601,11 @@ func (c *Container) checkDependenciesRunningLocked(depCtrs map[string]*Container
 }
 
 func (c *Container) completeNetworkSetup() error {
-	if !c.config.PostConfigureNetNS || c.NetworkDisabled() {
+	netDisabled, err := c.NetworkDisabled()
+	if err != nil {
+		return err
+	}
+	if !c.config.PostConfigureNetNS || netDisabled {
 		return nil
 	}
 	if err := c.syncContainer(); err != nil {


### PR DESCRIPTION
containers inside pods need to make sure they get /etc/resolv.conf
and /etc/hosts bind mounted when network is expected

Signed-off-by: baude <bbaude@redhat.com>