### PR TITLE
add timeout to pod stop

### DIFF
--- a/API.md
+++ b/API.md
@@ -113,7 +113,7 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func StopContainer(name: string, timeout: int) string](#StopContainer)
 
-[func StopPod(name: string) string](#StopPod)
+[func StopPod(name: string, timeout: int) string](#StopPod)
 
 [func TagImage(name: string, tagged: string) string](#TagImage)
 
@@ -741,8 +741,8 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.StopContainer '{"name": "
 ### <a name="StopPod"></a>func StopPod
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
-method StopPod(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
-StopPod stops containers in a pod.  It takes the name or ID of a pod.
+method StopPod(name: [string](https://godoc.org/builtin#string), timeout: [int](https://godoc.org/builtin#int)) [string](https://godoc.org/builtin#string)</div>
+StopPod stops containers in a pod.  It takes the name or ID of a pod and a timeout.
 If the pod cannot be found, a [PodNotFound](#PodNotFound) error will be returned instead.
 Containers in a pod are stopped independently. If there is an error stopping one container, the ID of those containers
 will be returned in a list, along with the ID of the pod in a [PodContainerError](#PodContainerError).

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -715,7 +715,7 @@ method InspectPod(name: string) -> (pod: string)
 # ~~~
 method StartPod(name: string) -> (pod: string)
 
-# StopPod stops containers in a pod.  It takes the name or ID of a pod.
+# StopPod stops containers in a pod.  It takes the name or ID of a pod and a timeout.
 # If the pod cannot be found, a [PodNotFound](#PodNotFound) error will be returned instead.
 # Containers in a pod are stopped independently. If there is an error stopping one container, the ID of those containers
 # will be returned in a list, along with the ID of the pod in a [PodContainerError](#PodContainerError).
@@ -728,7 +728,7 @@ method StartPod(name: string) -> (pod: string)
 #   "pod": "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6"
 # }
 # ~~~
-method StopPod(name: string) -> (pod: string)
+method StopPod(name: string, timeout: int) -> (pod: string)
 
 # RestartPod will restart containers in a pod given a pod name or ID. Containers in
 # the pod that are running will be stopped, then all stopped containers will be run.

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2451,6 +2451,8 @@ _podman_pod_start() {
 
 _podman_pod_stop() {
   local options_with_args="
+      -t
+      --timeout
   "
 
   local boolean_options="

--- a/docs/podman-pod-stop.1.md
+++ b/docs/podman-pod-stop.1.md
@@ -19,26 +19,48 @@ Stops all pods
 
 Instead of providing the pod name or ID, stop the last created pod.
 
+**--timeout, --time, t**
+
+Timeout to wait before forcibly stopping the containers in the pod.
+
 ## EXAMPLE
 
-podman pod stop mywebserverpod
+Stop a pod called *mywebserverpod*
+```
+$ podman pod stop mywebserverpod
 cc8f0bea67b1a1a11aec1ecd38102a1be4b145577f21fc843c7c83b77fc28907
+```
 
-podman pod stop 490eb 3557fb
+Stop two pods by their short IDs.
+```
+$ podman pod stop 490eb 3557fb
 490eb241aaf704d4dd2629904410fe4aa31965d9310a735f8755267f4ded1de5
 3557fbea6ad61569de0506fe037479bd9896603c31d3069a6677f23833916fab
+```
 
+Stop the most recent pod
+```
+$ podman pod stop --latest
 3557fbea6ad61569de0506fe037479bd9896603c31d3069a6677f23833916fab
+```
 
-podman pod stop --latest
-3557fbea6ad61569de0506fe037479bd9896603c31d3069a6677f23833916fab
-
-podman pod stop --all
+Stop all pods
+```
+$ podman pod stop --all
 19456b4cd557eaf9629825113a552681a6013f8c8cad258e36ab825ef536e818
 3557fbea6ad61569de0506fe037479bd9896603c31d3069a6677f23833916fab
 490eb241aaf704d4dd2629904410fe4aa31965d9310a735f8755267f4ded1de5
 70c358daecf71ef9be8f62404f926080ca0133277ef7ce4f6aa2d5af6bb2d3e9
 cc8f0bea67b1a1a11aec1ecd38102a1be4b145577f21fc843c7c83b77fc28907
+```
+
+Stop all pods with a timeout of 1 second.
+```
+$ podman pod stop -a -t 1
+3557fbea6ad61569de0506fe037479bd9896603c31d3069a6677f23833916fab
+490eb241aaf704d4dd2629904410fe4aa31965d9310a735f8755267f4ded1de5
+70c358daecf71ef9be8f62404f926080ca0133277ef7ce4f6aa2d5af6bb2d3e9
+```
 
 ## SEE ALSO
 podman-pod(1), podman-pod-start(1), podman-stop(1)

--- a/pkg/varlinkapi/pods.go
+++ b/pkg/varlinkapi/pods.go
@@ -120,12 +120,12 @@ func (i *LibpodAPI) StartPod(call iopodman.VarlinkCall, name string) error {
 }
 
 // StopPod ...
-func (i *LibpodAPI) StopPod(call iopodman.VarlinkCall, name string) error {
+func (i *LibpodAPI) StopPod(call iopodman.VarlinkCall, name string, timeout int64) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
 		return call.ReplyPodNotFound(name)
 	}
-	ctrErrs, err := pod.Stop(getContext(), true)
+	ctrErrs, err := pod.StopWithTimeout(getContext(), true, int(timeout))
 	callErr := handlePodCall(call, pod, ctrErrs, err)
 	if callErr != nil {
 		return err


### PR DESCRIPTION
like podman stop of containers, we should allow the user to specify
a timeout override when stopping pods; otherwise they have to wait
the full timeout time specified during the pod/container creation.