### PR TITLE
Fix errors where OCI hooks directory does not exist

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1228,6 +1228,10 @@ func (c *Container) setupOCIHooks(ctx context.Context, config *spec.Spec) (exten
 
 	manager, err := hooks.New(ctx, c.runtime.config.HooksDir, []string{"poststop"}, lang)
 	if err != nil {
+		if os.IsNotExist(err) {
+			logrus.Warnf("Requested OCI hooks directory %q does not exist", c.runtime.config.HooksDir)
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Hopefully fixes https://bugzilla.redhat.com/show_bug.cgi?id=1657263