### PR TITLE
Cirrus: Migrate PAPR testing of F28 to Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,14 +34,15 @@ env:
     CRIU_COMMIT: "c74b83cd49c00589c0c0468ba5fe685b67fdbd0a"
     RUNC_COMMIT: "25f3f893c86d07426df93b7aa172f33fdf093fbd"
     # CSV of cache-image names to build (see $PACKER_BASE/libpod_images.json)
-    PACKER_BUILDS: "ubuntu-18,fedora-29"  # TODO: fah-29,rhel-7,centos-7
+    PACKER_BUILDS: "ubuntu-18,fedora-29,fedora-28"  # TODO: fah-29,rhel-7,centos-7
     # Version of packer to use
     PACKER_VER: "1.3.1"
     # Google-maintained base-image names
     UBUNTU_BASE_IMAGE: "ubuntu-1804-bionic-v20181203a"
     CENTOS_BASE_IMAGE: "centos-7-v20181113"
     # Manually produced base-image names (see $SCRIPT_BASE/README.md)
-    FEDORA_BASE_IMAGE:  "fedora-cloud-base-29-1-2-1541789245"
+    FEDORA_BASE_IMAGE: "fedora-cloud-base-29-1-2-1541789245"
+    PRIOR_FEDORA_BASE_IMAGE: "fedora-cloud-base-28-1-1-1544474897"
     FAH_BASE_IMAGE:  "fedora-atomichost-29-20181025-1-1541787861"
     # RHEL image must be imported, google bills extra for their native image.
     RHEL_BASE_IMAGE: "rhel-guest-image-7-6-210-x86-64-qcow2-1541783972"
@@ -111,8 +112,10 @@ testing_task:
         # 'matrix' combinations.
         matrix:
             # Images are generated separately, from build_images_task (below)
-            image_name: "ubuntu-18-libpod-0c954a67"
-            image_name: "fedora-29-libpod-0c954a67"
+            image_name: "ubuntu-18-libpod-86d821ea"
+            image_name: "fedora-28-libpod-86d821ea"
+            image_name: "fedora-29-libpod-86d821ea"
+
             # TODO: tests fail
             # image_name: "rhel-7-something-something"
             # image_name: "centos-7-something-something"
@@ -148,8 +151,9 @@ optional_testing_task:
     gce_instance:
         image_project: "libpod-218412"
         matrix:
-            image_name: "ubuntu-18-libpod-0c954a67"
-            image_name: "fedora-29-libpod-0c954a67"
+            image_name: "ubuntu-18-libpod-86d821ea"
+            image_name: "fedora-28-libpod-86d821ea"
+            image_name: "fedora-29-libpod-86d821ea"
             # TODO: Make these work (also build_images_task below)
             #image_name: "rhel-server-ec2-7-5-165-1-libpod-fce09afe"
             #image_name: "centos-7-v20180911-libpod-fce09afe"

--- a/.papr.yml
+++ b/.papr.yml
@@ -22,33 +22,33 @@ context: "FAH28 - Containerized (Podman in Podman)"
 
 ---
 
- host:
-   distro: centos/7/atomic/smoketested
-   specs:
-      ram: 8192
-      cpus: 4
- extra-repos:
-     - name: epel
-       metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
-       gpgcheck: 0
-     - name: cri-o
-       baseurl: https://cbs.centos.org/repos/virt7-container-common-candidate/$basearch/os
-       gpgcheck: 0
+host:
+  distro: centos/7/atomic/smoketested
+  specs:
+     ram: 8192
+     cpus: 4
+extra-repos:
+    - name: epel
+      metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+      gpgcheck: 0
+    - name: cri-o
+      baseurl: https://cbs.centos.org/repos/virt7-container-common-candidate/$basearch/os
+      gpgcheck: 0
 
- required: true
+required: true
 
- timeout: 90m
+timeout: 90m
 
- tests:
-   - CONTAINER_RUNTIME="docker" sh .papr_prepare.sh
+tests:
+  - CONTAINER_RUNTIME="docker" sh .papr_prepare.sh
 
- artifacts:
-   - build.log
+artifacts:
+  - build.log
 
- context: "CAH 7-smoketested - Containerized (Podman in Docker)"
+context: "CAH 7-smoketested - Containerized (Podman in Docker)"
 
----
-
+#---
+#
 #host:
 #  distro: centos/7/cloud
 #  specs:
@@ -95,41 +95,3 @@ context: "FAH28 - Containerized (Podman in Podman)"
 #context: "CentOS 7 Cloud"
 #
 #---
-
-host:
-    distro: fedora/28/cloud
-    specs:
-        ram: 8192
-        cpus: 4
-packages:
-    - btrfs-progs-devel
-    - glib2-devel
-    - glibc-devel
-    - glibc-static
-    - git
-    - go-md2man
-    - gpgme-devel
-    - libassuan-devel
-    - libgpg-error-devel
-    - libseccomp-devel
-    - libselinux-devel
-    - ostree-devel
-    - pkgconfig
-    - make
-    - nc
-    - go-compilers-golang-compiler
-    - podman
-    - python3-varlink
-    - python3-dateutil
-    - python3-psutil
-    - https://kojipkgs.fedoraproject.org//packages/runc/1.0.0/54.dev.git00dc700.fc28/x86_64/runc-1.0.0-54.dev.git00dc700.fc28.x86_64.rpm
-
-tests:
-    - sed 's/^expand-check.*/expand-check=0/g' -i /etc/selinux/semanage.conf
-    - yum -y reinstall container-selinux
-    - sh .papr.sh -b -i -t -p
-
-required: false
-
-timeout: 90m
-context: "Fedora 28 Cloud"

--- a/contrib/cirrus/packer/fedora_setup.sh
+++ b/contrib/cirrus/packer/fedora_setup.sh
@@ -28,7 +28,6 @@ ooe.sh sudo dnf install -y \
     atomic-registries \
     btrfs-progs-devel \
     bzip2 \
-    conmon \
     device-mapper-devel \
     findutils \
     git \

--- a/contrib/cirrus/packer/libpod_base_images.yml
+++ b/contrib/cirrus/packer/libpod_base_images.yml
@@ -18,10 +18,14 @@ variables:
     # RHEL requires a subscription to install/update packages
     RHSM_COMMAND:
 
-    # Fedora images are obtainable by direct download
+    # Latest Fedora release
     FEDORA_IMAGE_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/29/Cloud/x86_64/images/Fedora-Cloud-Base-29-1.2.x86_64.qcow2"
     FEDORA_CSUM_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/29/Cloud/x86_64/images/Fedora-Cloud-29-1.2-x86_64-CHECKSUM"
     FEDORA_BASE_IMAGE_NAME: 'fedora-cloud-base-29-1-2'  # Name to use in GCE
+    # Prior Fedora release
+    PRIOR_FEDORA_IMAGE_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2"
+    PRIOR_FEDORA_CSUM_URL: "https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-28-1.1-x86_64-CHECKSUM"
+    PRIOR_FEDORA_BASE_IMAGE_NAME: 'fedora-cloud-base-28-1-1'  # Name to use in GCE
     FAH_IMAGE_URL: "https://dl.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-29-20181025.1/AtomicHost/x86_64/images/Fedora-AtomicHost-29-20181025.1.x86_64.qcow2"
     FAH_CSUM_URL: "https://dl.fedoraproject.org/pub/alt/atomic/stable/Fedora-Atomic-29-20181025.1/AtomicHost/x86_64/images/Fedora-AtomicHost-29-20181025.1-x86_64-CHECKSUM"
     FAH_BASE_IMAGE_NAME: 'fedora-atomichost-29-20181025-1'  # Name to use in GCE
@@ -101,6 +105,11 @@ builders:
       ssh_username: 'root'
 
     - <<: *nested_virt
+      name: 'prior_fedora'
+      iso_url: '{{user `PRIOR_FEDORA_IMAGE_URL`}}'
+      iso_checksum_url: '{{user `PRIOR_FEDORA_CSUM_URL`}}'
+
+    - <<: *nested_virt
       name: 'fah'
       iso_url: '{{user `FAH_IMAGE_URL`}}'
       iso_checksum_url: '{{user `FAH_CSUM_URL`}}'
@@ -152,7 +161,7 @@ provisioners:
 
 post-processors:
     - - type: "compress"
-        only: ['fedora', 'fah', 'rhel']
+        only: ['fedora', 'prior_fedora', 'fah', 'rhel']
         output: '/tmp/{{build_name}}/disk.raw.tar.gz'
         format: '.tar.gz'
         compression_level: 9
@@ -166,6 +175,11 @@ post-processors:
         image_name: "{{user `FEDORA_BASE_IMAGE_NAME`}}-{{user `TIMESTAMP`}}"
         image_description: 'Based on {{user `FEDORA_IMAGE_URL`}}'
         image_family: '{{user `FEDORA_BASE_IMAGE_NAME`}}'
+      - <<: *gcp_import
+        only: ['prior_fedora']
+        image_name: "{{user `PRIOR_FEDORA_BASE_IMAGE_NAME`}}-{{user `TIMESTAMP`}}"
+        image_description: 'Based on {{user `PRIOR_FEDORA_IMAGE_URL`}}'
+        image_family: '{{user `PRIOR_FEDORA_BASE_IMAGE_NAME`}}'
       - <<: *gcp_import
         only: ['fah']
         image_name: "{{user `FAH_BASE_IMAGE_NAME`}}-{{user `TIMESTAMP`}}"

--- a/contrib/cirrus/packer/libpod_images.yml
+++ b/contrib/cirrus/packer/libpod_images.yml
@@ -7,6 +7,7 @@ variables:
     CENTOS_BASE_IMAGE: '{{env `CENTOS_BASE_IMAGE`}}'
     UBUNTU_BASE_IMAGE: '{{env `UBUNTU_BASE_IMAGE`}}'
     FEDORA_BASE_IMAGE: '{{env `FEDORA_BASE_IMAGE`}}'
+    PRIOR_FEDORA_BASE_IMAGE: '{{env `PRIOR_FEDORA_BASE_IMAGE`}}'
     FAH_BASE_IMAGE: '{{env `FAH_BASE_IMAGE`}}'
 
     # libpod dependencies to build and install into images
@@ -65,6 +66,10 @@ builders:
     - <<: *gce_hosted_image
       name: 'fedora-29'
       source_image: '{{user `FEDORA_BASE_IMAGE`}}'
+
+    - <<: *gce_hosted_image
+      name: 'fedora-28'
+      source_image: '{{user `PRIOR_FEDORA_BASE_IMAGE`}}'
 
     - <<: *gce_hosted_image
       name: 'fah-29'

--- a/contrib/cirrus/packer/prior_fedora_base-setup.sh
+++ b/contrib/cirrus/packer/prior_fedora_base-setup.sh
@@ -1,0 +1,1 @@
+fedora_base-setup.sh

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -58,7 +58,11 @@ then
             envstr='export BUILDTAGS="seccomp $($GOSRC/hack/btrfs_tag.sh) $($GOSRC/hack/btrfs_installed_tag.sh) $($GOSRC/hack/ostree_tag.sh) varlink exclude_graphdriver_devicemapper"'
             ;;
         fedora-29) ;&  # Continue to the next item
-        fedora-28) ;&
+        fedora-28)
+            RUNC="https://kojipkgs.fedoraproject.org/packages/runc/1.0.0/55.dev.git578fe65.fc${OS_RELEASE_VER}/x86_64/runc-1.0.0-55.dev.git578fe65.fc${OS_RELEASE_VER}.x86_64.rpm"
+            echo ">>>>> OVERRIDING RUNC WITH $RUNC <<<<<"
+            dnf -y install "$RUNC"
+            ;&  # Continue to the next item
         centos-7) ;&
         rhel-7)
             envstr='unset BUILDTAGS'  # Use default from Makefile

--- a/contrib/cirrus/unit_test.sh
+++ b/contrib/cirrus/unit_test.sh
@@ -20,6 +20,7 @@ case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
         make "BUILDTAGS=$BUILDTAGS"
         ;;
     fedora-29) ;&  # Continue to the next item
+    fedora-28) ;&
     centos-7) ;&
     rhel-7)
         make install.tools

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 
 	"github.com/containers/libpod/pkg/criu"
 	. "github.com/containers/libpod/test/utils"
@@ -29,8 +30,9 @@ var _ = Describe("Podman checkpoint", func() {
 			Skip("CRIU is missing or too old.")
 		}
 		hostInfo := podmanTest.Host
-		if hostInfo.Distribution == "fedora" && hostInfo.Version == "29" {
-			Skip("Checkpoint tests appear to fail on F29.")
+		hostDistVer, _ := strconv.Atoi(hostInfo.Version)
+		if hostInfo.Distribution == "fedora" && hostDistVer <= 29 {
+			Skip("Checkpoint tests appear to fail on older (<30) Fedora versions .")
 		}
 	})
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -109,7 +109,7 @@ func PodmanTestCreate(tempDir string) *PodmanTestIntegration {
 	}
 	conmonBinary := filepath.Join("/usr/libexec/podman/conmon")
 	altConmonBinary := "/usr/libexec/crio/conmon"
-	if _, err := os.Stat(altConmonBinary); err == nil {
+	if _, err := os.Stat(conmonBinary); os.IsNotExist(err) {
 		conmonBinary = altConmonBinary
 	}
 	if os.Getenv("CONMON_BINARY") != "" {


### PR DESCRIPTION
Since the most recent TWO versions of Fedora are officially supported
upstream, both need to be tested.  Implement the concept of a 'prior'
Fedora release in both base-image and cache-image production.  Utilize
the produced cache-image to test libpod.  Remove F28 testing from PAPR.

Signed-off-by: Chris Evich <cevich@redhat.com>