### PR TITLE
rootless: fix restart when using fuse-overlayfs

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -36,6 +36,7 @@ var cmdsNotRequiringRootless = map[string]bool{
 	"logout":  true,
 	"kill":    true,
 	"pause":   true,
+	"restart": true,
 	"run":     true,
 	"unpause": true,
 	"search":  true,

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -187,6 +187,10 @@ var _ = Describe("Podman rootless", func() {
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
+			cmd = rootlessTest.PodmanAsUser([]string{"restart", "-l", "-t", "0"}, 1000, 1000, env)
+			cmd.WaitWithDefaultTimeout()
+			Expect(cmd.ExitCode()).To(Equal(0))
+
 			canUseExec := canExec()
 
 			if canUseExec {


### PR DESCRIPTION
With rootless containers we cannot really restart an existing container
as we would need to join the mount namespace as well to be able to reuse
the storage, so ensure the container is stopped first.

Closes: https://github.com/containers/libpod/issues/1965

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>