### PR TITLE
Prevent a second lookup of user for image volumes

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -236,7 +236,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 
 	// Bind builtin image volumes
 	if c.config.Rootfs == "" && c.config.ImageVolumes {
-		if err := c.addLocalVolumes(ctx, &g); err != nil {
+		if err := c.addLocalVolumes(ctx, &g, execUser); err != nil {
 			return nil, errors.Wrapf(err, "error mounting image volumes")
 		}
 	}


### PR DESCRIPTION
Instead of forcing another user lookup when mounting image volumes, just use the information we looked up when we started generating the spec.

This may resolve #1817
