### PR TITLE
Clean up some existing varlink endpoints

### DIFF
--- a/API.md
+++ b/API.md
@@ -87,9 +87,9 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func Ping() StringResponse](#Ping)
 
-[func PullImage(name: string) string](#PullImage)
+[func PullImage(name: string, certDir: string, creds: string, signaturePolicy: string, tlsVerify: bool) string](#PullImage)
 
-[func PushImage(name: string, tag: string, tlsverify: bool) string](#PushImage)
+[func PushImage(name: string, tag: string, tlsverify: bool, signaturePolicy: string, creds: string, certDir: string, compress: bool, format: string, removeSignatures: bool, signBy: string) string](#PushImage)
 
 [func RemoveContainer(name: string, force: bool) string](#RemoveContainer)
 
@@ -739,7 +739,7 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.Ping
 ### <a name="PullImage"></a>func PullImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
-method PullImage(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+method PullImage(name: [string](https://godoc.org/builtin#string), certDir: [string](https://godoc.org/builtin#string), creds: [string](https://godoc.org/builtin#string), signaturePolicy: [string](https://godoc.org/builtin#string), tlsVerify: [bool](https://godoc.org/builtin#bool)) [string](https://godoc.org/builtin#string)</div>
 PullImage pulls an image from a repository to local storage.  After the pull is successful, the ID of the image
 is returned.
 #### Example
@@ -752,7 +752,7 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.PullImage '{"name": "regi
 ### <a name="PushImage"></a>func PushImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
-method PushImage(name: [string](https://godoc.org/builtin#string), tag: [string](https://godoc.org/builtin#string), tlsverify: [bool](https://godoc.org/builtin#bool)) [string](https://godoc.org/builtin#string)</div>
+method PushImage(name: [string](https://godoc.org/builtin#string), tag: [string](https://godoc.org/builtin#string), tlsverify: [bool](https://godoc.org/builtin#bool), signaturePolicy: [string](https://godoc.org/builtin#string), creds: [string](https://godoc.org/builtin#string), certDir: [string](https://godoc.org/builtin#string), compress: [bool](https://godoc.org/builtin#bool), format: [string](https://godoc.org/builtin#string), removeSignatures: [bool](https://godoc.org/builtin#bool), signBy: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
 PushImage takes three input arguments: the name or ID of an image, the fully-qualified destination name of the image,
 and a boolean as to whether tls-verify should be used (with false disabling TLS, not affecting the default behavior).
 It will return an [ImageNotFound](#ImageNotFound) error if
@@ -1499,9 +1499,8 @@ reason [string](https://godoc.org/builtin#string)
 ### <a name="PodCreate"></a>type PodCreate
 
 PodCreate is an input structure for creating pods.
-It emulates options to podman pod create, however
-changing pause image name and pause container
-is not currently supported
+It emulates options to podman pod create. The infraCommand and
+infraImage options are currently NotSupported.
 
 name [string](https://godoc.org/builtin#string)
 
@@ -1512,6 +1511,12 @@ labels [map[string]](#map[string])
 share [[]string](#[]string)
 
 infra [bool](https://godoc.org/builtin#bool)
+
+infraCommand [string](https://godoc.org/builtin#string)
+
+infraImage [string](https://godoc.org/builtin#string)
+
+publish [[]string](#[]string)
 ### <a name="PodmanInfo"></a>type PodmanInfo
 
 PodmanInfo describes the Podman host and build

--- a/cmd/podman/shared/pod.go
+++ b/cmd/podman/shared/pod.go
@@ -1,7 +1,11 @@
 package shared
 
 import (
+	"strconv"
+
 	"github.com/containers/libpod/libpod"
+	"github.com/cri-o/ocicni/pkg/ocicni"
+	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
 )
 
@@ -94,4 +98,37 @@ func GetNamespaceOptions(ns []string) ([]libpod.PodCreateOption, error) {
 		}
 	}
 	return options, nil
+}
+
+// CreatePortBindings iterates ports mappings and exposed ports into a format CNI understands
+func CreatePortBindings(ports []string) ([]ocicni.PortMapping, error) {
+	var portBindings []ocicni.PortMapping
+	// The conversion from []string to natBindings is temporary while mheon reworks the port
+	// deduplication code.  Eventually that step will not be required.
+	_, natBindings, err := nat.ParsePortSpecs(ports)
+	if err != nil {
+		return nil, err
+	}
+	for containerPb, hostPb := range natBindings {
+		var pm ocicni.PortMapping
+		pm.ContainerPort = int32(containerPb.Int())
+		for _, i := range hostPb {
+			var hostPort int
+			var err error
+			pm.HostIP = i.HostIP
+			if i.HostPort == "" {
+				hostPort = containerPb.Int()
+			} else {
+				hostPort, err = strconv.Atoi(i.HostPort)
+				if err != nil {
+					return nil, errors.Wrapf(err, "unable to convert host port to integer")
+				}
+			}
+
+			pm.HostPort = int32(hostPort)
+			pm.Protocol = containerPb.Proto()
+			portBindings = append(portBindings, pm)
+		}
+	}
+	return portBindings, nil
 }

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -343,15 +343,17 @@ type ListPodContainerInfo (
 )
 
 # PodCreate is an input structure for creating pods.
-# It emulates options to podman pod create, however
-# changing pause image name and pause container
-# is not currently supported
+# It emulates options to podman pod create. The infraCommand and
+# infraImage options are currently NotSupported.
 type PodCreate (
     name: string,
     cgroupParent: string,
     labels: [string]string,
     share: []string,
-    infra: bool
+    infra: bool,
+    infraCommand: string,
+    infraImage: string,
+    publish: []string
 )
 
 # ListPodData is the returned struct for an individual pod
@@ -632,7 +634,7 @@ method HistoryImage(name: string) -> (history: []ImageHistory)
 # and a boolean as to whether tls-verify should be used (with false disabling TLS, not affecting the default behavior).
 # It will return an [ImageNotFound](#ImageNotFound) error if
 # the image cannot be found in local storage; otherwise the ID of the image will be returned on success.
-method PushImage(name: string, tag: string, tlsverify: bool) -> (image: string)
+method PushImage(name: string, tag: string, tlsverify: bool, signaturePolicy: string, creds: string, certDir: string, compress: bool, format: string, removeSignatures: bool, signBy: string) -> (image: string)
 
 # TagImage takes the name or ID of an image in local storage as well as the desired tag name.  If the image cannot
 # be found, an [ImageNotFound](#ImageNotFound) error will be returned; otherwise, the ID of the image is returned on success.
@@ -700,7 +702,7 @@ method ExportImage(name: string, destination: string, compress: bool, tags: []st
 #   "id": "426866d6fa419873f97e5cbd320eeb22778244c1dfffa01c944db3114f55772e"
 # }
 # ~~~
-method PullImage(name: string) -> (id: string)
+method PullImage(name: string, certDir: string, creds: string, signaturePolicy: string, tlsVerify: bool) -> (id: string)
 
 # CreatePod creates a new empty pod.  It uses a [PodCreate](#PodCreate) type for input.
 # On success, the ID of the newly created pod will be returned.


### PR DESCRIPTION
Going through and adding options (like tls-verify, signature option, etc)
to some varlink endpoints (like push/pull) many of which had not been
updated since their original authoring.

Signed-off-by: baude <bbaude@redhat.com>