### PR TITLE
Containers sharing a netns should share resolv/hosts

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1003,7 +1003,7 @@ func (c *Container) IsReadOnly() bool {
 // NetworkDisabled returns whether the container is running with a disabled network
 func (c *Container) NetworkDisabled() (bool, error) {
 	if c.config.NetNsCtr != "" {
-		container, err := c.runtime.LookupContainer(c.config.NetNsCtr)
+		container, err := c.runtime.state.Container(c.config.NetNsCtr)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
When sharing a network namespace, containers should also share resolv.conf and /etc/hosts in case a container process made changes to either (for example, if I set up a VPN client in container A and join container B to its network namespace, I expect container B to use the DNS servers from A to ensure it can see everything on the VPN).

Resolves: #1546