### PR TITLE
failed containers with --rm should remove themselves

### DIFF
--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -116,6 +116,11 @@ func runCmd(c *cli.Context) error {
 		if strings.Index(err.Error(), "permission denied") > -1 {
 			exitCode = 126
 		}
+		if c.IsSet("rm") {
+			if deleteError := runtime.RemoveContainer(ctx, ctr, true); deleteError != nil {
+				logrus.Errorf("unable to remove container %s after failing to start and attach to it", ctr.ID())
+			}
+		}
 		return err
 	}
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -639,4 +639,31 @@ USER mail`
 		match, _ := check.GrepString("foobar")
 		Expect(match).To(BeTrue())
 	})
+
+	It("podman run --rm should work", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		numContainers := podmanTest.NumberOfContainers()
+		Expect(numContainers).To(Equal(0))
+	})
+
+	It("podman run --rm failed container should delete itself", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+
+		numContainers := podmanTest.NumberOfContainers()
+		Expect(numContainers).To(Equal(0))
+	})
+
+	It("podman run failed container should NOT delete itself", func() {
+		session := podmanTest.Podman([]string{"run", ALPINE, "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+
+		numContainers := podmanTest.NumberOfContainers()
+		Expect(numContainers).To(Equal(1))
+	})
 })

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -89,4 +89,30 @@ var _ = Describe("Podman start", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(125))
 	})
+
+	It("podman failed to start with --rm should delete the container", func() {
+		session := podmanTest.Podman([]string{"create", "-it", "--rm", ALPINE, "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		start := podmanTest.Podman([]string{"start", "-l"})
+		start.WaitWithDefaultTimeout()
+		Expect(start.ExitCode()).To(Not(Equal(0)))
+
+		numContainers := podmanTest.NumberOfContainers()
+		Expect(numContainers).To(BeZero())
+	})
+
+	It("podman failed to start without --rm should NOT delete the container", func() {
+		session := podmanTest.Podman([]string{"create", "-it", ALPINE, "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		start := podmanTest.Podman([]string{"start", "-l"})
+		start.WaitWithDefaultTimeout()
+		Expect(start.ExitCode()).To(Not(Equal(0)))
+
+		numContainers := podmanTest.NumberOfContainers()
+		Expect(numContainers).To(Equal(1))
+	})
 })


### PR DESCRIPTION
when starting or running a container that has --rm, if the starting
container fails (like due to an invalid command), the container should
get removed.

Resolves: #1985

Signed-off-by: baude <bbaude@redhat.com>