### PR TITLE
mount: allow mount only when using vfs

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -34,6 +34,7 @@ var cmdsNotRequiringRootless = map[string]bool{
 	// If this change, please also update libpod.refreshRootless()
 	"login":   true,
 	"logout":  true,
+	"mount":   true,
 	"kill":    true,
 	"pause":   true,
 	"restart": true,


### PR DESCRIPTION
when using a driver different than vfs, the mount is probably in a
different mount namespace thus not accessible from the host.  Avoid
the confusion by not allowing mount when a different driver is used.

Closes: https://github.com/containers/libpod/issues/1964

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>