### PR TITLE
Show image only once with images -q

### DIFF
--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -280,7 +280,9 @@ func getImagesTemplateOutput(ctx context.Context, runtime *libpod.Runtime, image
 		if !opts.noTrunc {
 			imageID = shortID(img.ID())
 		}
+
 		// get all specified repo:tag pairs and print them separately
+	outer:
 		for repo, tags := range image.ReposToMap(img.Names()) {
 			for _, tag := range tags {
 				size, err := img.Size(ctx)
@@ -302,6 +304,10 @@ func getImagesTemplateOutput(ctx context.Context, runtime *libpod.Runtime, image
 					Size:        sizeStr,
 				}
 				imagesOutput = append(imagesOutput, params)
+				if opts.quiet { // Show only one image ID when quiet
+					break outer
+				}
+
 			}
 		}
 	}

--- a/test/README.md
+++ b/test/README.md
@@ -79,7 +79,7 @@ switch is optional.
 You can run a single file of integration tests using the go test command:
 
 ```
-GOPATH=~/go go test -v test/e2e/libpod_suite_test.go test/e2e/your_test.go
+GOPATH=~/go go test -v test/e2e/libpod_suite_test.go test/e2e/config.go test/e2e/config_amd64.go test/e2e/your_test.go
 ```
 
 #### Run all tests like PAPR

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -63,6 +63,10 @@ var _ = Describe("Podman images", func() {
 		session.LineInOutputContainsTag("foo", "c")
 		session.LineInOutputContainsTag("bar", "a")
 		session.LineInOutputContainsTag("bar", "b")
+		session = podmanTest.Podman([]string{"images", "-qn"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(BeNumerically("==", 2))
 	})
 
 	It("podman images with digests", func() {


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

When doing `podman images -q` we should only show each image ID once, not once for every tag that is associated with it.

Fixes: #1997 
```
Test:
=============
# podman images
REPOSITORY                                TAG      IMAGE ID       CREATED         SIZE
localhost/scratch-image                   latest   a3188de88ec3   2 minutes ago   1.71 kB
docker.io/library/another-scratch-image   latest   a3188de88ec3   2 minutes ago   1.71 kB
localhost/so-many-scratch-images          latest   a3188de88ec3   2 minutes ago   1.71 kB
docker.io/library/alpine                  latest   196d12cf6ab1   3 months ago    4.67 MB

# podman images -q
a3188de88ec3
196d12cf6ab1
```
