### PR TITLE
WIP DONOT Merge - Test for single line Dockerfile

### DIFF
--- a/vendor/github.com/containers/buildah/imagebuildah/build.go
+++ b/vendor/github.com/containers/buildah/imagebuildah/build.go
@@ -1253,6 +1253,13 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (strin
 	if len(stages) == 0 {
 		errors.New("error building: no stages to build")
 	}
+
+	//Check if we have a one line Dockerfile, if so, layers are irrelevant
+	ignoreLayers := false
+	if len(stages) < 2 && len(stages[0].Node.Children) < 2 {
+		ignoreLayers = true
+	}
+
 	var (
 		stageExecutor *Executor
 		lastErr       error
@@ -1307,7 +1314,7 @@ func (b *Executor) Build(ctx context.Context, stages imagebuilder.Stages) (strin
 
 	var imageRef reference.Canonical
 	imageID := ""
-	if !b.layers && !b.noCache {
+	if (!b.layers && !b.noCache) || ignoreLayers {
 		imgID, ref, err := stageExecutor.Commit(ctx, stages[len(stages)-1].Builder, "")
 		if err != nil {
 			return "", nil, err


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

DO NOT MERGE THIS!  I'm putting this change directly into vendor to see if the tests pass.  If they do I'll make the change in the Buildah project and will then vendor Buildah into Podman.

This addresses #1993.  Podman turns layers on by default with for build.  The layer logic does not behave if there's only a one line Dockerfile given to the build, a commit is never done as the layer logic doesn't do a commit because it's waiting for the last of two ore more layers before doing so.  If we have only one line in one Dockerfile that we're building, the most layers we will have is one, so just ignore layering.