### PR TITLE
Cirrus: Add text editors to cache-images

### DIFF
--- a/contrib/cirrus/packer/centos_setup.sh
+++ b/contrib/cirrus/packer/centos_setup.sh
@@ -29,6 +29,7 @@ ooe.sh sudo yum -y install \
     btrfs-progs-devel \
     bzip2 \
     device-mapper-devel \
+    emacs-nox \
     findutils \
     glib2-devel \
     glibc-static \
@@ -63,6 +64,7 @@ ooe.sh sudo yum -y install \
     runc \
     skopeo-containers \
     unzip \
+    vim \
     which \
     xz
 

--- a/contrib/cirrus/packer/fedora_setup.sh
+++ b/contrib/cirrus/packer/fedora_setup.sh
@@ -30,6 +30,7 @@ ooe.sh sudo dnf install -y \
     bzip2 \
     conmon \
     device-mapper-devel \
+    emacs-nox \
     findutils \
     git \
     glib2-devel \
@@ -67,6 +68,7 @@ ooe.sh sudo dnf install -y \
     skopeo-containers \
     slirp4netns \
     unzip \
+    vim \
     which \
     xz
 

--- a/contrib/cirrus/packer/rhel_setup.sh
+++ b/contrib/cirrus/packer/rhel_setup.sh
@@ -35,6 +35,7 @@ ooe.sh sudo yum -y install \
     btrfs-progs-devel \
     bzip2 \
     device-mapper-devel \
+    emacs-nox \
     findutils \
     glib2-devel \
     glibc-static \
@@ -69,6 +70,7 @@ ooe.sh sudo yum -y install \
     runc \
     skopeo-containers \
     unzip \
+    vim \
     which \
     xz
 

--- a/contrib/cirrus/packer/ubuntu_setup.sh
+++ b/contrib/cirrus/packer/ubuntu_setup.sh
@@ -37,6 +37,7 @@ ooe.sh sudo -E apt-get -qq install --no-install-recommends \
     build-essential \
     curl \
     e2fslibs-dev \
+    emacs-nox \
     gawk \
     gettext \
     go-md2man \
@@ -76,6 +77,7 @@ ooe.sh sudo -E apt-get -qq install --no-install-recommends \
     python3-setuptools \
     socat \
     unzip \
+    vim \
     xz-utils
 
 echo "Fixing Ubuntu kernel not enabling swap accounting by default"


### PR DESCRIPTION
Occasionally people need to access the VM's for
troubleshooting/debugging.  Having an editor pre-installed makes life
easier and doesn't cost any extra test-time.

***CIRRUS: REBUILD IMAGES***

Signed-off-by: Chris Evich <cevich@redhat.com>