### PR TITLE
Add information on --restart

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -422,6 +422,10 @@ var createFlags = []cli.Flag{
 		Name:  "read-only",
 		Usage: "Make containers root filesystem read-only",
 	},
+	cli.StringFlag{
+		Name:  "restart",
+		Usage: "Restart is not supported.  Please use a systemd unit file for restart",
+	},
 	cli.BoolFlag{
 		Name:  "rm",
 		Usage: "Remove container (and pod if created) after exit",

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -412,6 +412,10 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 		blkioWeight                                              uint16
 		namespaces                                               map[string]string
 	)
+	if c.IsSet("restart") {
+		return nil, errors.Errorf("--restart option is not supported.\nUse systemd unit files for restarting containers")
+	}
+
 	idmappings, err := util.ParseIDMapping(c.StringSlice("uidmap"), c.StringSlice("gidmap"), c.String("subuidname"), c.String("subgidname"))
 	if err != nil {
 		return nil, err

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -508,6 +508,14 @@ By default a container will have its root filesystem writable allowing processes
 to write files anywhere.  By specifying the `--read-only` flag the container will have
 its root filesystem mounted as read only prohibiting any writes.
 
+**--restart=""**
+
+Not implemented.
+
+Restart should be handled via a systemd unit files. Please add your podman
+commands to a unit file and allow systemd or your init system to handle the
+restarting of the container processes.  See example below.
+
 **--rm**=*true*|*false*
 
 Automatically remove the container when it exits. The default is *false*.
@@ -767,13 +775,28 @@ the uid and gid from the host.
 $ podman create --uidmap 0:30000:7000 --gidmap 0:30000:7000 fedora echo hello
 ```
 
+### Running a podman container to restart inside of a systemd unit file
+
+
+```
+[Unit]
+Description=My App
+[Service]
+Restart=always
+ExecStart=/usr/bin/podman start -a my_app
+ExecStop=/usr/bin/podman stop -t 10 my_app
+KillMode=process
+[Install]
+WantedBy=multi-user.target
+```
+
 ## FILES
 
 **/etc/subuid**
 **/etc/subgid**
 
 ## SEE ALSO
-subgid(5), subuid(5), libpod.conf(5)
+subgid(5), subuid(5), libpod.conf(5), systemd.unit(5)
 
 ## HISTORY
 October 2017, converted from Docker documentation to podman by Dan Walsh for podman <dwalsh@redhat.com>

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -497,6 +497,14 @@ By default a container will have its root filesystem writable allowing processes
 to write files anywhere.  By specifying the `--read-only` flag the container will have
 its root filesystem mounted as read only prohibiting any writes.
 
+**--restart=""**
+
+Not implemented.
+
+Restart should be handled via a systemd unit files. Please add your podman
+commands to a unit file and allow systemd or your init system to handle the
+restarting of the container processes. See example below.
+
 **--rm**=*true*|*false*
 
 Automatically remove the container when it exits. The default is *false*.
@@ -1059,13 +1067,28 @@ the uid and gid from the host.
 $ podman run --uidmap 0:30000:7000 --gidmap 0:30000:7000 fedora echo hello
 ```
 
+### Running a podman container to restart inside of a systemd unit file
+
+
+```
+[Unit]
+Description=My App
+[Service]
+Restart=always
+ExecStart=/usr/bin/podman start -a my_app
+ExecStop=/usr/bin/podman stop -t 10 my_app
+KillMode=process
+[Install]
+WantedBy=multi-user.target
+```
+
 ## FILES
 
 **/etc/subuid**
 **/etc/subgid**
 
 ## SEE ALSO
-subgid(5), subuid(5), libpod.conf(5)
+subgid(5), subuid(5), libpod.conf(5), systemd.unit(5)
 
 ## HISTORY
 September 2018, updated by Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>


### PR DESCRIPTION
We need to recommend that users use Systemd unit files if they want
the container to restart automatically.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>