### PR TITLE
rootless: fix export when using fuse-overlayfs

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -30,6 +30,7 @@ var cmdsNotRequiringRootless = map[string]bool{
 	"version": true,
 	"create":  true,
 	"exec":    true,
+	"export":  true,
 	// `info` must be executed in an user namespace.
 	// If this change, please also update libpod.refreshRootless()
 	"login":   true,

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/stringid"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -153,6 +154,10 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 			}
 		}
 	}()
+
+	if rootless.IsRootless() && ctr.config.ConmonPidFile == "" {
+		ctr.config.ConmonPidFile = filepath.Join(ctr.state.RunDir, "conmon.pid")
+	}
 
 	// Go through the volume mounts and check for named volumes
 	// If the named volme already exists continue, otherwise create

--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -99,7 +99,7 @@ get_cmd_line_args (pid_t pid)
 }
 
 int
-reexec_userns_join (int userns)
+reexec_userns_join (int userns, int mountns)
 {
   pid_t ppid = getpid ();
   char uid[16];
@@ -125,6 +125,13 @@ reexec_userns_join (int userns)
   setenv ("_LIBPOD_ROOTLESS_UID", uid, 1);
 
   if (setns (userns, 0) < 0)
+    {
+      fprintf (stderr, "cannot setns: %s\n", strerror (errno));
+      _exit (EXIT_FAILURE);
+    }
+  close (userns);
+
+  if (mountns >= 0 && setns (mountns, 0) < 0)
     {
       fprintf (stderr, "cannot setns: %s\n", strerror (errno));
       _exit (EXIT_FAILURE);


### PR DESCRIPTION
Fix usage of export when rootless containers are used without vfs.  We join the conmon process namespaces as the container is running in a different one.

There can be a problem if the user specify a different path for the conmon process, and then the file is deleted.  In this case podman won't be able to find the conmon process to join.
    
Closes: https://github.com/containers/libpod/issues/2027
