### PR TITLE
Cirrus: Skip build all commits test on master

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -103,6 +103,9 @@ build_each_commit_task:
     depends_on:
         - "gating"
 
+    # $CIRRUS_BASE_BRANCH is only set when testing a PR
+    only_if: $CIRRUS_BRANCH != 'master'
+
     gce_instance:
         image_project: "libpod-218412"
         zone: "us-central1-a"  # Required by Cirrus for the time being


### PR DESCRIPTION
Fixes:

    git rebase origin/ -x make
    fatal: Needed a single revision
    invalid upstream 'origin/'
    make: *** [Makefile:351: build-all-new-commits] Error 1

By not running this test post-merge.

Signed-off-by: Chris Evich <cevich@redhat.com>