### PR TITLE
Allow alias for list, ls, ps to work

### DIFF
--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -18,7 +18,7 @@ var (
 		inspectCommand,
 		killCommand,
 		logsCommand,
-		lsCommand,
+		psCommand,
 		mountCommand,
 		pauseCommand,
 		portCommand,

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -131,7 +131,8 @@ var (
 		OnUsageError:           usageErrorHandler,
 	}
 	lsImagesCommand = cli.Command{
-		Name:                   "ls",
+		Name:                   "list",
+		Aliases:                []string{"ls"},
 		Usage:                  "list images in local storage",
 		Description:            imagesDescription,
 		Flags:                  imagesFlags,

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -207,20 +207,11 @@ var (
 	}
 	psDescription = "Prints out information about the containers"
 	psCommand     = cli.Command{
-		Name:                   "ps",
+		Name:                   "list",
+		Aliases:                []string{"ls", "ps"},
 		Usage:                  "List containers",
 		Description:            psDescription,
 		Flags:                  sortFlags(psFlags),
-		Action:                 psCmd,
-		ArgsUsage:              "",
-		UseShortOptionHandling: true,
-		OnUsageError:           usageErrorHandler,
-	}
-	lsCommand = cli.Command{
-		Name:                   "ls",
-		Usage:                  "List containers",
-		Description:            psDescription,
-		Flags:                  psFlags,
 		Action:                 psCmd,
 		ArgsUsage:              "",
 		UseShortOptionHandling: true,

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -784,6 +784,10 @@ _podman_container_kill() {
      _podman_kill
 }
 
+_podman_container_list() {
+     _podman_ls
+}
+
 _podman_container_ls() {
      _podman_ls
 }
@@ -802,6 +806,10 @@ _podman_container_pause() {
 
 _podman_container_port() {
      _podman_port
+}
+
+_podman_container_ps() {
+     _podman_ls
 }
 
 _podman_container_refresh() {

--- a/docs/links/podman-container-ps.1
+++ b/docs/links/podman-container-ps.1
@@ -1,0 +1,1 @@
+.so man1/podman-ps.1

--- a/docs/links/podman-image-list.1
+++ b/docs/links/podman-image-list.1
@@ -1,0 +1,1 @@
+.so man1/podman-images.1

--- a/docs/links/podman-list.1
+++ b/docs/links/podman-list.1
@@ -1,0 +1,1 @@
+.so man1/podman-ps.1

--- a/docs/links/podman-ls.1
+++ b/docs/links/podman-ls.1
@@ -1,0 +1,1 @@
+.so man1/podman-ps.1

--- a/docs/links/podman-unmount.1
+++ b/docs/links/podman-unmount.1
@@ -1,0 +1,1 @@
+.so man1/podman-umount.1

--- a/docs/podman-container.1.md
+++ b/docs/podman-container.1.md
@@ -24,12 +24,14 @@ The container command allows you to manage containers
 | export   | [podman-export(1)](podman-export.1.md)              | Export a container's filesystem contents as a tar archive.                   |
 | inspect  | [podman-inspect(1)](podman-inspect.1.md)            | Display a container or image's configuration.                                |
 | kill     | [podman-kill(1)](podman-kill.1.md)                  | Kill the main process in one or more containers.                             |
+| list     | [podman-ps(1)](podman-ps.1.md)                 | List the containers on the system.                                     |
 | logs     | [podman-logs(1)](podman-logs.1.md)                  | Display the logs of a container.                                             |
-| ls       | [podman-ps(1)](podman-ps.1.md)                      | Prints out information about containers.                                     |
+| ls       | [podman-ps(1)](podman-ps.1.md)                 | List the containers on the system.                                     |
 | mount    | [podman-mount(1)](podman-mount.1.md)                | Mount a working container's root filesystem.                                 |
 | pause    | [podman-pause(1)](podman-pause.1.md)                | Pause one or more containers.                                                |
 | port     | [podman-port(1)](podman-port.1.md)                  | List port mappings for the container.                                        |
 | prune    | [podman-container-prune(1)](podman-container-prune.1.md)                  | Remove all stopped containers from local storage        |
+| ps       | [podman-ps(1)](podman-ps.1.md)                 | List the containers on the system.                                     |
 | refresh  | [podman-refresh(1)](podman-container-refresh.1.md)  | Refresh the state of all containers                                          |
 | restart  | [podman-restart(1)](podman-restart.1.md)            | Restart one or more containers.                                              |
 | restore  | [podman-container-restore(1)](podman-container-restore.1.md)  | Restores one or more containers from a checkpoint.                 |
@@ -40,6 +42,7 @@ The container command allows you to manage containers
 | stop     | [podman-stop(1)](podman-stop.1.md)                  | Stop one or more running containers.                                         |
 | top      | [podman-top(1)](podman-top.1.md)                    | Display the running processes of a container.                                |
 | umount   | [podman-umount(1)](podman-umount.1.md)              | Unmount a working container's root filesystem.                               |
+| unmount  | [podman-umount(1)](podman-umount.1.md)              | Unmount a working container's root filesystem.                               |
 | unpause  | [podman-unpause(1)](podman-unpause.1.md)            | Unpause one or more containers.                                              |
 | wait     | [podman-wait(1)](podman-wait.1.md)                  | Wait on one or more containers to stop and print their exit codes.           |
 

--- a/docs/podman-image.1.md
+++ b/docs/podman-image.1.md
@@ -18,8 +18,9 @@ The image command allows you to manage images
 | history  | [podman-history(1)](podman-history.1.md)  | Show the history of an image.                                                  |
 | import   | [podman-import(1)](podman-import.1.md)    | Import a tarball and save it as a filesystem image.                            |
 | inspect  | [podman-inspect(1)](podman-inspect.1.md)  | Display a image or image's configuration.                                      |
+| list     | [podman-images(1)](podman-images.1.md)    | List the container images on the system.                                           |
 | load     | [podman-load(1)](podman-load.1.md)        | Load an image from the docker archive.                                         |
-| ls       | [podman-images(1)](podman-images.1.md)    | Prints out information about images.                                           |
+| ls       | [podman-images(1)](podman-images.1.md)    | List the container images on the system.                                           |
 | pull     | [podman-pull(1)](podman-pull.1.md)        | Pull an image from a registry.                                                 |
 | prune| [podman-container-prune(1)](podman-container-prune.1.md)        | Removed all unused images from the local store                                 |
 | push     | [podman-push(1)](podman-push.1.md)        | Push an image from local storage to elsewhere.                                 |


### PR DESCRIPTION
Allow multiple alias for listing containers and images.

Also fix documentation for umount and unmount

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>