### PR TITLE
add init support

### DIFF
--- a/API.md
+++ b/API.md
@@ -1169,6 +1169,10 @@ image [string](https://godoc.org/builtin#string)
 
 image_id [string](https://godoc.org/builtin#string)
 
+init [bool](https://godoc.org/builtin#bool)
+
+init_path [string](https://godoc.org/builtin#string)
+
 builtin_imgvolumes [[]string](#[]string)
 
 id_mappings [IDMappingOptions](#IDMappingOptions)

--- a/Makefile
+++ b/Makefile
@@ -154,10 +154,10 @@ dbuild: libpodimage
 	${CONTAINER_RUNTIME} run --name=${LIBPOD_INSTANCE} --privileged -v ${PWD}:/go/src/${PROJECT} --rm ${LIBPOD_IMAGE} make all
 
 test: libpodimage
-	${CONTAINER_RUNTIME} run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e CGROUP_MANAGER=cgroupfs -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make clean all localunit localintegration
+	${CONTAINER_RUNTIME} run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e CGROUP_MANAGER=cgroupfs -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make clean all localunit install.catatonit localintegration
 
 integration: libpodimage
-	${CONTAINER_RUNTIME} run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e CGROUP_MANAGER=cgroupfs -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make clean all localintegration
+	${CONTAINER_RUNTIME} run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e CGROUP_MANAGER=cgroupfs -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make clean all install.catatonit localintegration
 
 integration.fedora:
 	DIST=Fedora sh .papr_prepare.sh
@@ -201,7 +201,10 @@ vagrant-check:
 
 binaries: varlink_generate easyjson_generate podman
 
-test-binaries: test/bin2img/bin2img test/copyimg/copyimg test/checkseccomp/checkseccomp test/goecho/goecho
+install.catatonit:
+	./hack/install_catatonit.sh
+
+test-binaries: test/bin2img/bin2img test/copyimg/copyimg test/checkseccomp/checkseccomp test/goecho/goecho install.catatonit
 
 MANPAGES_MD ?= $(wildcard docs/*.md pkg/*/docs/*.md)
 MANPAGES ?= $(MANPAGES_MD:%.md=%)

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -321,6 +321,15 @@ var createFlags = []cli.Flag{
 		Value: "bind",
 	},
 	cli.BoolFlag{
+		Name:  "init",
+		Usage: "Run an init binary inside the container that forwards signals and reaps processes",
+	},
+	cli.StringFlag{
+		Name: "init-path",
+		// Do not use  the Value field for setting the default value to determine user input (i.e., non-empty string)
+		Usage: fmt.Sprintf("Path to the container-init binary (default: %q)", libpod.DefaultInitPath),
+	},
+	cli.BoolFlag{
 		Name:  "interactive, i",
 		Usage: "Keep STDIN open even if not attached",
 	},

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -809,6 +809,16 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 		Syslog:      c.GlobalBool("syslog"),
 	}
 
+	if c.Bool("init") {
+		initPath := c.String("init-path")
+		if initPath == "" {
+			initPath = runtime.GetConfig().InitPath
+		}
+		if err := config.AddContainerInitBinary(initPath); err != nil {
+			return nil, err
+		}
+	}
+
 	if config.Privileged {
 		config.LabelOpts = label.DisableSecOpt()
 	} else {

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -211,6 +211,8 @@ type Create (
     hostname: string,
     image: string,
     image_id: string,
+    init: bool,
+    init_path: string,
     builtin_imgvolumes: []string,
     id_mappings: IDMappingOptions,
     image_volume_type: string,

--- a/docs/libpod.conf.5.md
+++ b/docs/libpod.conf.5.md
@@ -24,6 +24,9 @@ libpod to manage containers.
 **cgroup_manager**=""
   Specify the CGroup Manager to use; valid values are "systemd" and "cgroupfs"
 
+**init_path**=""
+  Path to the container-init binary, which forwards signals and reaps processes within containers.  Note that the container-init binary will only be used when the `--init` for podman-create and podman-run is set.
+
 **hooks_dir**=["*path*", ...]
 
   Each `*.json` file in the path configures a hook for Podman containers.  For more details on the syntax of the JSON files and the semantics of hook injection, see `oci-hooks(5)`.  Podman and libpod currently support both the 1.0.0 and 0.1.0 hook schemas, although the 0.1.0 schema is deprecated.

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -276,6 +276,14 @@ tmpfs: The volume is mounted onto the container as a tmpfs, which allows the use
 content that disappears when the container is stopped.
 ignore: All volumes are just ignored and no action is taken.
 
+**--init**
+
+Run an init inside the container that forwards signals and reaps processes.
+
+**--init-path**=""
+
+Path to the container-init binary.
+
 **-i**, **--interactive**=*true*|*false*
 
 Keep STDIN open even if not attached. The default is *false*.

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -285,6 +285,14 @@ the container for the volumes.
 content that disappears when the container is stopped.
 - `ignore`: All volumes are just ignored and no action is taken.
 
+**--init**
+
+Run an init inside the container that forwards signals and reaps processes.
+
+**--init-path**=""
+
+Path to the container-init binary.
+
 **-i**, **--interactive**=*true*|*false*
 
 Keep STDIN open even if not attached. The default is *false*.

--- a/hack/install_catatonit.sh
+++ b/hack/install_catatonit.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+BASE_PATH="/usr/libexec/podman"
+CATATONIT_PATH="${BASE_PATH}/catatonit"
+CATATONIT_VERSION="v0.1.3"
+
+if [ -f $CATATONIT_PATH ]; then
+	echo "skipping ... catatonit is already installed"
+else
+	echo "downloading catatonit to $CATATONIT_PATH"
+	curl -o catatonit -L https://github.com/openSUSE/catatonit/releases/download/$CATATONIT_VERSION/catatonit.x86_64
+	chmod +x catatonit
+	install ${SELINUXOPT} -d -m 755 $BASE_PATH
+	install ${SELINUXOPT} -m 755 catatonit $CATATONIT_PATH
+	rm catatonit
+fi

--- a/libpod.conf
+++ b/libpod.conf
@@ -35,6 +35,9 @@ conmon_env_vars = [
 # CGroup Manager - valid values are "systemd" and "cgroupfs"
 cgroup_manager = "systemd"
 
+# Container init binary
+#init_path = "/usr/libexec/podman/catatonit"
+
 # Directory for persistent libpod files (database, etc)
 # By default, this will be configured relative to where containers/storage
 # stores containers

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -61,6 +61,9 @@ const (
 	DefaultInfraImage = "k8s.gcr.io/pause:3.1"
 	// DefaultInfraCommand to be run in an infra container
 	DefaultInfraCommand = "/pause"
+
+	// DefaultInitPath is the default path to the container-init binary
+	DefaultInitPath = "/usr/libexec/podman/catatonit"
 )
 
 // A RuntimeOption is a functional option which alters the Runtime created by
@@ -122,6 +125,8 @@ type RuntimeConfig struct {
 	// CGroupManager is the CGroup Manager to use
 	// Valid values are "cgroupfs" and "systemd"
 	CgroupManager string `toml:"cgroup_manager"`
+	// InitPath is the path to the container-init binary.
+	InitPath string `toml:"init_path"`
 	// StaticDir is the path to a persistent directory to store container
 	// files
 	StaticDir string `toml:"static_dir"`
@@ -217,6 +222,7 @@ var (
 		ConmonEnvVars: []string{
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		},
+		InitPath:              DefaultInitPath,
 		CgroupManager:         SystemdCgroupsManager,
 		StaticDir:             filepath.Join(storage.DefaultStoreOptions.GraphRoot, "libpod"),
 		TmpDir:                "",

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -87,6 +87,18 @@ var _ = Describe("Podman run", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman run a container with --init", func() {
+		session := podmanTest.Podman([]string{"run", "--init", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
+	It("podman run a container with --init and --init-path", func() {
+		session := podmanTest.Podman([]string{"run", "--init", "--init-path", "/usr/libexec/podman/catatonit", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman run seccomp test", func() {
 		jsonFile := filepath.Join(podmanTest.TempDir, "seccomp.json")
 		in := []byte(`{"defaultAction":"SCMP_ACT_ALLOW","syscalls":[{"name":"getcwd","action":"SCMP_ACT_ERRNO"}]}`)


### PR DESCRIPTION
Add support for executing an init binary as PID 1 in a container to
forward signals and reap processes.  When the `--init` flag is set for
podman-create or podman-run, the init binary is bind-mounted to
`/dev/init` in the container and "/dev/init --" is prepended to the
container's command.

The default base path of the container-init binary is `/usr/libexec/libpod`
while the default binary is catatonit [1].  This default can be changed
permanently via the `init_path` field in the `libpod.conf` configuration
file or temporarily via the `--init-path` flag of podman-create and
podman-run.

[1] https://github.com/openSUSE/catatonit

Fixes: #1670
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>