### PR TITLE
rootless tests using stop is more reliable

### DIFF
--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Podman rootless", func() {
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
-			cmd = rootlessTest.PodmanAsUser([]string{"kill", "-l"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"stop", "-l", "-t", "0"}, 1000, 1000, env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 


### PR DESCRIPTION
when testing rootless containers, it is more reliable to stop
a container with a zero timeout than kill a container.  We made
this change in non-rootless tests as well.  When IO or CPU are
taxed, it avoids a situation where the kill signal is sent but the
container has not been able to update its status when a subsequent
action occurs.

Signed-off-by: baude <bbaude@redhat.com>