### PR TITLE
podman build is not using the default oci-runtime

### DIFF
--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -205,6 +205,10 @@ func buildCmd(c *cli.Context) error {
 	}
 	namespaceOptions.AddOrReplace(usernsOption...)
 
+	ociruntime := runtime.GetOCIRuntimePath()
+	if c.IsSet("runtime") {
+		ociruntime = c.String("runtime")
+	}
 	options := imagebuildah.BuildOptions{
 		ContextDirectory:        contextDir,
 		PullPolicy:              pullPolicy,
@@ -217,7 +221,7 @@ func buildCmd(c *cli.Context) error {
 		Out:                     stdout,
 		Err:                     stderr,
 		ReportWriter:            reporter,
-		Runtime:                 c.String("runtime"),
+		Runtime:                 ociruntime,
 		RuntimeArgs:             runtimeFlags,
 		OutputFormat:            format,
 		SystemContext:           systemContext,

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -180,6 +180,11 @@ func (r *Runtime) GetConmonVersion() (string, error) {
 	return strings.TrimSuffix(strings.Replace(output, "\n", ", ", 1), "\n"), nil
 }
 
+// GetOCIRuntimePath returns the path to the OCI Runtime Path the runtime is using
+func (r *Runtime) GetOCIRuntimePath() string {
+	return r.ociRuntimePath
+}
+
 // GetOCIRuntimeVersion returns a string representation of the oci runtimes version
 func (r *Runtime) GetOCIRuntimeVersion() (string, error) {
 	output, err := utils.ExecCmd(r.ociRuntimePath, "--version")


### PR DESCRIPTION
Currently if the user installs runc in an alternative path
podman run uses it but podman build does not.

This patch will pass the default oci runtime to be used by podman
down to the image builder.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>