### PR TITLE
Warn on overriding user-specified storage driver w/ DB

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -511,6 +511,11 @@ func makeRuntime(runtime *Runtime) (err error) {
 
 	// Reset defaults if they were not explicitly set
 	if !runtime.configuredFrom.storageGraphDriverSet && dbConfig.GraphDriver != "" {
+		if runtime.config.StorageConfig.GraphDriverName != dbConfig.GraphDriver &&
+			runtime.config.StorageConfig.GraphDriverName != "" {
+			logrus.Errorf("User-selected graph driver %s overwritten by graph driver %s from database - delete libpod local files to resolve",
+				runtime.config.StorageConfig.GraphDriverName, dbConfig.GraphDriver)
+		}
 		runtime.config.StorageConfig.GraphDriverName = dbConfig.GraphDriver
 	}
 	if !runtime.configuredFrom.storageGraphRootSet && dbConfig.StorageRoot != "" {


### PR DESCRIPTION
Overriding storage.conf is not intuitive behavior, so pop up an error message when it happens, so people know that bad things are happening.

We have to retain this behaviour (the alternative was a breaking change), but the least we can do it make it obvious something unusual is happening.

I'm torn on Errorf vs Warnf here - Errorf makes this seem more serious than it is, but always prints, whereas Warnf is only visible with a log-level=debug