### PR TITLE
container runlabel NAME implementation

### DIFF
--- a/cmd/podman/shared/funcs.go
+++ b/cmd/podman/shared/funcs.go
@@ -65,6 +65,8 @@ func GenerateCommand(command, imageName, name string) ([]string, error) {
 		switch arg {
 		case "IMAGE":
 			newArg = imageName
+		case "$IMAGE":
+			newArg = imageName
 		case "IMAGE=IMAGE":
 			newArg = fmt.Sprintf("IMAGE=%s", imageName)
 		case "IMAGE=$IMAGE":
@@ -75,6 +77,8 @@ func GenerateCommand(command, imageName, name string) ([]string, error) {
 			newArg = fmt.Sprintf("NAME=%s", name)
 		case "NAME=$NAME":
 			newArg = fmt.Sprintf("NAME=%s", name)
+		case "$NAME":
+			newArg = name
 		default:
 			newArg = arg
 		}

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -22,6 +22,18 @@ func isRegistry(name string) bool {
 	return strings.ContainsAny(name, ".:") || name == "localhost"
 }
 
+// GetImageBaseName uses decompose and string splits to obtain the base
+// name of an image.  Doing this here because it beats changing the
+// imageParts struct names to be exported as well.
+func GetImageBaseName(input string) (string, error) {
+	decomposedImage, err := decompose(input)
+	if err != nil {
+		return "", err
+	}
+	splitImageName := strings.Split(decomposedImage.name, "/")
+	return splitImageName[len(splitImageName)-1], nil
+}
+
 // decompose breaks an input name into an imageParts description
 func decompose(input string) (imageParts, error) {
 	var (


### PR DESCRIPTION
when using container runlabel, if a --name is not provided, we must
deduce the container name from the base name of the image to maintain
parity with the atomic cli.

fixed small bug where we split the cmd on " " rather than using fields could
lead to extra spaces in command output.

Signed-off-by: baude <bbaude@redhat.com>