### PR TITLE
If local storage file exists, then use it rather then defau…

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -316,6 +316,7 @@ func GetDefaultStoreOptions() (storage.StoreOptions, string, error) {
 
 		storageConf := filepath.Join(os.Getenv("HOME"), ".config/containers/storage.conf")
 		if _, err := os.Stat(storageConf); err == nil {
+			storageOpts = storage.StoreOptions{}
 			storage.ReloadConfigurationFile(storageConf, &storageOpts)
 		} else if os.IsNotExist(err) {
 			os.MkdirAll(filepath.Dir(storageConf), 0755)


### PR DESCRIPTION
…lts.

Currently we always force overlay if it exists even though a user might want
vfs.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>