### PR TITLE
oci: allow to define multiple OCI runtimes

### DIFF
--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -68,7 +68,7 @@ Default state dir is configured in /etc/containers/storage.conf.
 
 **--runtime**=**value**
 
-Path to the OCI compatible binary used to run containers
+Name of the OCI runtime as specified in libpod.conf or absolute path to the OCI compatible binary used to run containers.
 
 **--storage-driver, -s**=**value**
 

--- a/libpod.conf
+++ b/libpod.conf
@@ -4,17 +4,6 @@
 # Default transport method for pulling and pushing for images
 image_default_transport = "docker://"
 
-# Paths to look for a valid OCI runtime (runc, runv, etc)
-runtime_path = [
-	     "/usr/bin/runc",
-	     "/usr/sbin/runc",
-	     "/usr/local/bin/runc",
-	     "/usr/local/sbin/runc",
-	     "/sbin/runc",
-	     "/bin/runc",
-	     "/usr/lib/cri-o-runc/sbin/runc"
-]
-
 # Paths to look for the Conmon container manager binary
 conmon_path = [
 	    "/usr/libexec/podman/conmon",
@@ -98,3 +87,15 @@ pause_command = "/pause"
 
 # Default libpod support for container labeling
 # label=true
+
+# Paths to look for a valid OCI runtime (runc, runv, etc)
+[runtimes]
+runc = [
+	    "/usr/bin/runc",
+	    "/usr/sbin/runc",
+	    "/usr/local/bin/runc",
+	    "/usr/local/sbin/runc",
+	    "/sbin/runc",
+	    "/bin/runc",
+	    "/usr/lib/cri-o-runc/sbin/runc"
+]

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -350,6 +350,9 @@ type ContainerConfig struct {
 
 	PostConfigureNetNS bool `json:"postConfigureNetNS"`
 
+	// OCIRuntime used to create the container
+	OCIRuntime string `json:"runtime,omitempty"`
+
 	// ExitCommand is the container's exit command.
 	// This Command will be executed when the container exits
 	ExitCommand []string `json:"exitCommand,omitempty"`

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/containers/buildah"
 	"io/ioutil"
 	"os"
 	"runtime"
@@ -12,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/buildah"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/libpod/utils"
@@ -184,12 +184,12 @@ func (r *Runtime) GetConmonVersion() (string, error) {
 
 // GetOCIRuntimePath returns the path to the OCI Runtime Path the runtime is using
 func (r *Runtime) GetOCIRuntimePath() string {
-	return r.ociRuntimePath
+	return r.ociRuntimePath.Paths[0]
 }
 
 // GetOCIRuntimeVersion returns a string representation of the oci runtimes version
 func (r *Runtime) GetOCIRuntimeVersion() (string, error) {
-	output, err := utils.ExecCmd(r.ociRuntimePath, "--version")
+	output, err := utils.ExecCmd(r.ociRuntimePath.Paths[0], "--version")
 	if err != nil {
 		return "", err
 	}

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -75,10 +75,10 @@ type syncInfo struct {
 }
 
 // Make a new OCI runtime with provided options
-func newOCIRuntime(name string, path string, conmonPath string, conmonEnv []string, cgroupManager string, tmpDir string, logSizeMax int64, noPivotRoot bool, reservePorts bool) (*OCIRuntime, error) {
+func newOCIRuntime(oruntime OCIRuntimePath, conmonPath string, conmonEnv []string, cgroupManager string, tmpDir string, logSizeMax int64, noPivotRoot bool, reservePorts bool) (*OCIRuntime, error) {
 	runtime := new(OCIRuntime)
-	runtime.name = name
-	runtime.path = path
+	runtime.name = oruntime.Name
+	runtime.path = oruntime.Paths[0]
 	runtime.conmonPath = conmonPath
 	runtime.conmonEnv = conmonEnv
 	runtime.cgroupManager = cgroupManager

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -147,7 +147,11 @@ func WithOCIRuntime(runtimePath string) RuntimeOption {
 			return errors.Wrapf(ErrInvalidArg, "must provide a valid path")
 		}
 
-		rt.config.RuntimePath = []string{runtimePath}
+		rt.config.OCIRuntimes = []OCIRuntimePath{
+			{
+				Paths: []string{runtimePath},
+			},
+		}
 
 		return nil
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -137,21 +137,17 @@ func WithStateType(storeType RuntimeStateStore) RuntimeOption {
 }
 
 // WithOCIRuntime specifies an OCI runtime to use for running containers.
-func WithOCIRuntime(runtimePath string) RuntimeOption {
+func WithOCIRuntime(runtime string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
 			return ErrRuntimeFinalized
 		}
 
-		if runtimePath == "" {
+		if runtime == "" {
 			return errors.Wrapf(ErrInvalidArg, "must provide a valid path")
 		}
 
-		rt.config.OCIRuntimes = []OCIRuntimePath{
-			{
-				Paths: []string{runtimePath},
-			},
-		}
+		rt.config.OCIRuntime = runtime
 
 		return nil
 	}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -62,6 +62,8 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 
 	ctr.config.StopTimeout = CtrRemoveTimeout
 
+	ctr.config.OCIRuntime = r.config.OCIRuntime
+
 	// Set namespace based on current runtime namespace
 	// Do so before options run so they can override it
 	if r.config.Namespace != "" {


### PR DESCRIPTION
we can define multiple OCI runtimes that can be chosen with --runtime.
    
in libpod.conf is possible to specify them with:

```toml    
 [runtimes]
    foo = [
                 "/usr/bin/foo",
                 "/usr/sbin/foo",
    ]
    bar = [
                 "/usr/bin/foo",
                 "/usr/sbin/foo",
    ]
```

If the argument to --runtime is an absolute path then it is used directly without any lookup in the configuration.
    
Closes: https://github.com/containers/libpod/issues/1750

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
