### PR TITLE
Readd Python testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ localunit: test/goecho/goecho varlink_generate
 ginkgo:
 	ginkgo -v -tags "$(BUILDTAGS)" -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.
 
-localintegration: varlink_generate test-binaries ginkgo
+localintegration: varlink_generate test-binaries clientintegration ginkgo
 
 localsystem: .install.ginkgo .install.gomega
 	ginkgo -v -noColor test/system/


### PR DESCRIPTION
We accidentally merged a PR with a commit temporarily disabling the Python tests. Reenable them here.