### PR TITLE
Rootless with shmlocks was not working.

### DIFF
--- a/libpod/lock/shm/shm_lock.go
+++ b/libpod/lock/shm/shm_lock.go
@@ -48,7 +48,7 @@ func CreateSHMLock(path string, numLocks uint32) (*SHMLocks, error) {
 	lockStruct := C.setup_lock_shm(cPath, C.uint32_t(numLocks), &errCode)
 	if lockStruct == nil {
 		// We got a null pointer, so something errored
-		return nil, syscall.Errno(-1 * errCode)
+		return nil, errors.Wrapf(syscall.Errno(-1*errCode), "failed to create %d locks in %s", numLocks, path)
 	}
 
 	locks.lockStruct = lockStruct
@@ -77,7 +77,7 @@ func OpenSHMLock(path string, numLocks uint32) (*SHMLocks, error) {
 	lockStruct := C.open_lock_shm(cPath, C.uint32_t(numLocks), &errCode)
 	if lockStruct == nil {
 		// We got a null pointer, so something errored
-		return nil, syscall.Errno(-1 * errCode)
+		return nil, errors.Wrapf(syscall.Errno(-1*errCode), "failed to open %d locks in %s", numLocks, path)
 	}
 
 	locks.lockStruct = lockStruct

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -695,7 +696,7 @@ func makeRuntime(runtime *Runtime) (err error) {
 	var manager lock.Manager
 	lockPath := DefaultSHMLockPath
 	if rootless.IsRootless() {
-		lockPath = DefaultRootlessSHMLockPath
+		lockPath = fmt.Sprintf("%s_%d", DefaultRootlessSHMLockPath, rootless.GetRootlessUID())
 	}
 	if doRefresh {
 		// If SHM locks already exist, delete them and reinitialize
@@ -705,12 +706,12 @@ func makeRuntime(runtime *Runtime) (err error) {
 
 		manager, err = lock.NewSHMLockManager(lockPath, runtime.config.NumLocks)
 		if err != nil {
-			return errors.Wrapf(err, "error creating SHM locks for libpod")
+			return err
 		}
 	} else {
 		manager, err = lock.OpenSHMLockManager(lockPath, runtime.config.NumLocks)
 		if err != nil {
-			return errors.Wrapf(err, "error opening libpod SHM locks")
+			return err
 		}
 	}
 	runtime.lockManager = manager


### PR DESCRIPTION
This patch makes the path unigue to each UID.

Also cleans up some return code to return the path it is trying to lock.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>