### PR TITLE
Mention the default --sig-proxy value for 'podman start'

### DIFF
--- a/docs/podman-start.1.md
+++ b/docs/podman-start.1.md
@@ -35,7 +35,7 @@ to run containers such as CRI-O, the last started container could be from either
 
 **--sig-proxy**=*true*|*false*
 
-Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is false.
+Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true* when attaching, *false* otherwise.
 
 ## EXAMPLE
 

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -115,4 +115,14 @@ var _ = Describe("Podman start", func() {
 		numContainers := podmanTest.NumberOfContainers()
 		Expect(numContainers).To(Equal(1))
 	})
+
+	It("podman start --sig-proxy should not work without --attach", func() {
+		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"start", "-l", "--sig-proxy"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
+	})
 })


### PR DESCRIPTION
The --sig-proxy option has different defaults in 'podman run' and
'podman start'. Hence it's a good idea to be explicit.

Note that this is already mentioned in 'podman run --help', and was
only missing from 'podman start --help'.

Signed-off-by: Debarshi Ray <rishi@fedoraproject.org>