### PR TITLE
vendor latest buildah

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -92,7 +92,7 @@ k8s.io/kube-openapi 275e2ce91dec4c05a4094a7b1daee5560b555ac9 https://github.com/
 k8s.io/utils 258e2a2fa64568210fbd6267cf1d8fd87c3cb86e https://github.com/kubernetes/utils
 github.com/mrunalp/fileutils master
 github.com/varlink/go master
-github.com/containers/buildah bb710f39d01868e47224f35f48a128fbea6539c4
+github.com/containers/buildah a4200ae6b590c4b08b223e45513b1894636d1d02
 github.com/Nvveen/Gotty master
 github.com/fsouza/go-dockerclient master
 github.com/openshift/imagebuilder master

--- a/vendor/github.com/containers/buildah/common.go
+++ b/vendor/github.com/containers/buildah/common.go
@@ -6,10 +6,8 @@ import (
 	"path/filepath"
 
 	cp "github.com/containers/image/copy"
-	"github.com/containers/image/transports"
 	"github.com/containers/image/types"
 	"github.com/containers/libpod/pkg/rootless"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -34,12 +32,6 @@ func getCopyOptions(reportWriter io.Writer, sourceReference types.ImageReference
 
 		}
 	}
-	sourceInsecure, err := isReferenceInsecure(sourceReference, sourceCtx)
-	if err != nil {
-		logrus.Debugf("error determining if registry for %q is insecure: %v", transports.ImageName(sourceReference), err)
-	} else if sourceInsecure {
-		sourceCtx.OCIInsecureSkipTLSVerify = true
-	}
 
 	destinationCtx := &types.SystemContext{}
 	if destinationSystemContext != nil {
@@ -50,12 +42,6 @@ func getCopyOptions(reportWriter io.Writer, sourceReference types.ImageReference
 				destinationCtx.SystemRegistriesConfPath = userRegistriesFile
 			}
 		}
-	}
-	destinationInsecure, err := isReferenceInsecure(destinationReference, destinationCtx)
-	if err != nil {
-		logrus.Debugf("error determining if registry for %q is insecure: %v", transports.ImageName(destinationReference), err)
-	} else if destinationInsecure {
-		destinationCtx.OCIInsecureSkipTLSVerify = true
 	}
 
 	return &cp.Options{

--- a/vendor/github.com/containers/buildah/util.go
+++ b/vendor/github.com/containers/buildah/util.go
@@ -173,24 +173,6 @@ func (b *Builder) tarPath() func(path string) (io.ReadCloser, error) {
 	}
 }
 
-// isRegistryInsecure checks if the named registry is marked as not secure
-func isRegistryInsecure(registry string, sc *types.SystemContext) (bool, error) {
-	reginfo, err := sysregistriesv2.FindRegistry(sc, registry)
-	if err != nil {
-		return false, errors.Wrapf(err, "unable to parse the registries configuration (%s)", sysregistries.RegistriesConfPath(sc))
-	}
-	if reginfo != nil {
-		if reginfo.Insecure {
-			logrus.Debugf("registry %q is marked insecure in registries configuration %q", registry, sysregistries.RegistriesConfPath(sc))
-		} else {
-			logrus.Debugf("registry %q is not marked insecure in registries configuration %q", registry, sysregistries.RegistriesConfPath(sc))
-		}
-		return reginfo.Insecure, nil
-	}
-	logrus.Debugf("registry %q is not listed in registries configuration %q, assuming it's secure", registry, sysregistries.RegistriesConfPath(sc))
-	return false, nil
-}
-
 // isRegistryBlocked checks if the named registry is marked as blocked
 func isRegistryBlocked(registry string, sc *types.SystemContext) (bool, error) {
 	reginfo, err := sysregistriesv2.FindRegistry(sc, registry)
@@ -219,11 +201,6 @@ func isReferenceSomething(ref types.ImageReference, sc *types.SystemContext, wha
 		}
 	}
 	return false, nil
-}
-
-// isReferenceInsecure checks if the registry part of a reference is insecure
-func isReferenceInsecure(ref types.ImageReference, sc *types.SystemContext) (bool, error) {
-	return isReferenceSomething(ref, sc, isRegistryInsecure)
 }
 
 // isReferenceBlocked checks if the registry part of a reference is blocked


### PR DESCRIPTION
Pulls in fixes for determining insecure registries by removing redundant
wrapper code and instead using the API of sysregistriesv2 directly.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>