### PR TITLE
Add ability to build golang remote client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ test/goecho/goecho: .gopathok $(wildcard test/goecho/*.go)
 podman: .gopathok $(PODMAN_VARLINK_DEPENDENCIES)
 	$(GO) build -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS)" -o bin/$@ $(PROJECT)/cmd/podman
 
+podman-remote: .gopathok $(PODMAN_VARLINK_DEPENDENCIES)
+	$(GO) build -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS) remoteclient" -o bin/$@ $(PROJECT)/cmd/podman
+
 local-cross: $(CROSS_BUILD_TARGETS)
 
 bin/podman.cross.%: .gopathok

--- a/cmd/podman/info.go
+++ b/cmd/podman/info.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"github.com/containers/libpod/libpod/adapter"
 	"runtime"
 
 	"github.com/containers/libpod/cmd/podman/formats"
-	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -39,18 +39,20 @@ func infoCmd(c *cli.Context) error {
 	}
 	info := map[string]interface{}{}
 
-	runtime, err := libpodruntime.GetRuntime(c)
+	localRuntime, err := adapter.GetRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}
-	defer runtime.Shutdown(false)
+	defer localRuntime.Runtime.Shutdown(false)
 
-	infoArr, err := runtime.Info()
+	infoArr, err := localRuntime.Runtime.Info()
 	if err != nil {
 		return errors.Wrapf(err, "error getting info")
 	}
 
-	if c.Bool("debug") {
+	// TODO This is no a problem child because we don't know if we should add information
+	// TODO about the client or the backend.  Only do for traditional podman for now.
+	if !localRuntime.Remote && c.Bool("debug") {
 		debugInfo := debugInfo(c)
 		infoArr = append(infoArr, libpod.InfoData{Type: "debug", Data: debugInfo})
 	}

--- a/libpod/adapter/client.go
+++ b/libpod/adapter/client.go
@@ -1,0 +1,16 @@
+// +build remoteclient
+
+package adapter
+
+import (
+	"github.com/varlink/go/varlink"
+)
+
+// Connect provides a varlink connection
+func (r RemoteRuntime) Connect() (*varlink.Connection, error) {
+	connection, err := varlink.NewConnection("unix:/run/podman/io.podman")
+	if err != nil {
+		return nil, err
+	}
+	return connection, nil
+}

--- a/libpod/adapter/info_remote.go
+++ b/libpod/adapter/info_remote.go
@@ -1,0 +1,56 @@
+// +build remoteclient
+
+package adapter
+
+import (
+	"encoding/json"
+
+	"github.com/containers/libpod/cmd/podman/varlink"
+	"github.com/containers/libpod/libpod"
+)
+
+// Info returns information for the host system and its components
+func (r RemoteRuntime) Info() ([]libpod.InfoData, error) {
+	// TODO the varlink implementation for info should be updated to match the output for regular info
+	var (
+		reply    []libpod.InfoData
+		hostInfo map[string]interface{}
+		store    map[string]interface{}
+	)
+
+	registries := make(map[string]interface{})
+	insecureRegistries := make(map[string]interface{})
+	conn, err := r.Connect()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	info, err := iopodman.GetInfo().Call(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	// info.host -> map[string]interface{}
+	h, err := json.Marshal(info.Host)
+	if err != nil {
+		return nil, err
+	}
+	json.Unmarshal(h, &hostInfo)
+
+	// info.store -> map[string]interface{}
+	s, err := json.Marshal(info.Store)
+	if err != nil {
+		return nil, err
+	}
+	json.Unmarshal(s, &store)
+
+	registries["registries"] = info.Registries
+	insecureRegistries["registries"] = info.Insecure_registries
+
+	// Add everything to the reply
+	reply = append(reply, libpod.InfoData{Type: "host", Data: hostInfo})
+	reply = append(reply, libpod.InfoData{Type: "registries", Data: registries})
+	reply = append(reply, libpod.InfoData{Type: "insecure registries", Data: insecureRegistries})
+	reply = append(reply, libpod.InfoData{Type: "store", Data: store})
+	return reply, nil
+}

--- a/libpod/adapter/runtime.go
+++ b/libpod/adapter/runtime.go
@@ -1,0 +1,26 @@
+// +build !remoteclient
+
+package adapter
+
+import (
+	"github.com/containers/libpod/cmd/podman/libpodruntime"
+	"github.com/containers/libpod/libpod"
+	"github.com/urfave/cli"
+)
+
+// LocalRuntime describes a typical libpod runtime
+type LocalRuntime struct {
+	Runtime *libpod.Runtime
+	Remote  bool
+}
+
+// GetRuntime returns a LocalRuntime struct with the actual runtime embedded in it
+func GetRuntime(c *cli.Context) (*LocalRuntime, error) {
+	runtime, err := libpodruntime.GetRuntime(c)
+	if err != nil {
+		return nil, err
+	}
+	return &LocalRuntime{
+		Runtime: runtime,
+	}, nil
+}

--- a/libpod/adapter/runtime_remote.go
+++ b/libpod/adapter/runtime_remote.go
@@ -1,0 +1,28 @@
+// +build remoteclient
+
+package adapter
+
+import "github.com/urfave/cli"
+
+// RemoteRuntime describes a wrapper runtime struct
+type RemoteRuntime struct{}
+
+// LocalRuntime describes a typical libpod runtime
+type LocalRuntime struct {
+	Runtime *RemoteRuntime
+	Remote  bool
+}
+
+// GetRuntime returns a LocalRuntime struct with the actual runtime embedded in it
+func GetRuntime(c *cli.Context) (*LocalRuntime, error) {
+	runtime := RemoteRuntime{}
+	return &LocalRuntime{
+		Runtime: &runtime,
+		Remote:  true,
+	}, nil
+}
+
+// Shutdown is a bogus wrapper for compat with the libpod runtime
+func (r RemoteRuntime) Shutdown(force bool) error {
+	return nil
+}

--- a/pkg/varlinkapi/system.go
+++ b/pkg/varlinkapi/system.go
@@ -102,6 +102,5 @@ func (i *LibpodAPI) GetInfo(call iopodman.VarlinkCall) error {
 	podmanInfo.Podman = pmaninfo
 	podmanInfo.Registries = registries
 	podmanInfo.Insecure_registries = insecureRegistries
-
 	return call.ReplyGetInfo(podmanInfo)
 }


### PR DESCRIPTION
Add the ability to build a remote client in golang that uses all
the same front-end cli code and output code. The initial limitations
here are that it can only be a local client while the bridge and
resolver code is being written for the golang varlink client.

Tests and docs will be added in subsequent PRs.

Signed-off-by: baude <bbaude@redhat.com>