### PR TITLE
Rename libpod.Config back to ContainerConfig

### DIFF
--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -52,7 +52,7 @@ type PsOptions struct {
 // BatchContainerStruct is the return obkect from BatchContainer and contains
 // container related information
 type BatchContainerStruct struct {
-	ConConfig   *libpod.Config
+	ConConfig   *libpod.ContainerConfig
 	ConState    libpod.ContainerStatus
 	ExitCode    int32
 	Exited      bool
@@ -329,7 +329,7 @@ func PBatch(containers []*libpod.Container, workers int, opts PsOptions) []PsCon
 // locks.
 func BatchContainerOp(ctr *libpod.Container, opts PsOptions) (BatchContainerStruct, error) {
 	var (
-		conConfig   *libpod.Config
+		conConfig   *libpod.ContainerConfig
 		conState    libpod.ContainerStatus
 		err         error
 		exitCode    int32

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -322,7 +322,7 @@ func (s *BoltState) Container(id string) (*Container, error) {
 	ctrID := []byte(id)
 
 	ctr := new(Container)
-	ctr.config = new(Config)
+	ctr.config = new(ContainerConfig)
 	ctr.state = new(containerState)
 
 	db, err := s.getDBCon()
@@ -358,7 +358,7 @@ func (s *BoltState) LookupContainer(idOrName string) (*Container, error) {
 	}
 
 	ctr := new(Container)
-	ctr.config = new(Config)
+	ctr.config = new(ContainerConfig)
 	ctr.state = new(containerState)
 
 	db, err := s.getDBCon()
@@ -751,7 +751,7 @@ func (s *BoltState) AllContainers() ([]*Container, error) {
 			}
 
 			ctr := new(Container)
-			ctr.config = new(Config)
+			ctr.config = new(ContainerConfig)
 			ctr.state = new(containerState)
 
 			if err := s.getContainerFromDB(id, ctr, ctrBucket); err != nil {
@@ -1137,7 +1137,7 @@ func (s *BoltState) PodContainers(pod *Pod) ([]*Container, error) {
 		// Iterate through all containers in the pod
 		err = podCtrs.ForEach(func(id, val []byte) error {
 			newCtr := new(Container)
-			newCtr.config = new(Config)
+			newCtr.config = new(ContainerConfig)
 			newCtr.state = new(containerState)
 			ctrs = append(ctrs, newCtr)
 

--- a/libpod/common_test.go
+++ b/libpod/common_test.go
@@ -17,7 +17,7 @@ import (
 
 func getTestContainer(id, name string, manager lock.Manager) (*Container, error) {
 	ctr := &Container{
-		config: &Config{
+		config: &ContainerConfig{
 			ID:              id,
 			Name:            name,
 			RootfsImageID:   id,
@@ -165,8 +165,8 @@ func testContainersEqual(t *testing.T, a, b *Container, allowedEmpty bool) {
 	require.NotNil(t, a.state)
 	require.NotNil(t, b.state)
 
-	aConfig := new(Config)
-	bConfig := new(Config)
+	aConfig := new(ContainerConfig)
+	bConfig := new(ContainerConfig)
 	aState := new(containerState)
 	bState := new(containerState)
 

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -113,7 +113,7 @@ func (ns LinuxNS) String() string {
 // syncContainer() immediately after locking.
 // ffjson: skip
 type Container struct {
-	config *Config
+	config *ContainerConfig
 
 	state *containerState
 
@@ -200,11 +200,11 @@ type ExecSession struct {
 	PID     int      `json:"pid"`
 }
 
-// Config contains all information that was used to create the
+// ContainerConfig contains all information that was used to create the
 // container. It may not be changed once created.
 // It is stored, read-only, on disk
 // easyjson:json
-type Config struct {
+type ContainerConfig struct {
 	Spec *spec.Spec `json:"spec"`
 	ID   string     `json:"id"`
 	Name string     `json:"name"`
@@ -385,8 +385,8 @@ func (t ContainerStatus) String() string {
 // Unlocked
 
 // Config returns the configuration used to create the container
-func (c *Container) Config() *Config {
-	returnConfig := new(Config)
+func (c *Container) Config() *ContainerConfig {
+	returnConfig := new(ContainerConfig)
 	deepcopier.Copy(c.config).To(returnConfig)
 
 	return returnConfig

--- a/libpod/container_easyjson.go
+++ b/libpod/container_easyjson.go
@@ -1238,7 +1238,7 @@ func (v *ExecSession) UnmarshalJSON(data []byte) error {
 func (v *ExecSession) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson1dbef17bDecodeGithubComContainersLibpodLibpod1(l, v)
 }
-func easyjson1dbef17bDecodeGithubComContainersLibpodLibpod2(in *jlexer.Lexer, out *Config) {
+func easyjson1dbef17bDecodeGithubComContainersLibpodLibpod2(in *jlexer.Lexer, out *ContainerConfig) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1722,7 +1722,7 @@ func easyjson1dbef17bDecodeGithubComContainersLibpodLibpod2(in *jlexer.Lexer, ou
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComContainersLibpodLibpod2(out *jwriter.Writer, in Config) {
+func easyjson1dbef17bEncodeGithubComContainersLibpodLibpod2(out *jwriter.Writer, in ContainerConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2427,26 +2427,26 @@ func easyjson1dbef17bEncodeGithubComContainersLibpodLibpod2(out *jwriter.Writer,
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v Config) MarshalJSON() ([]byte, error) {
+func (v ContainerConfig) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson1dbef17bEncodeGithubComContainersLibpodLibpod2(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Config) MarshalEasyJSON(w *jwriter.Writer) {
+func (v ContainerConfig) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson1dbef17bEncodeGithubComContainersLibpodLibpod2(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
-func (v *Config) UnmarshalJSON(data []byte) error {
+func (v *ContainerConfig) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
 	easyjson1dbef17bDecodeGithubComContainersLibpodLibpod2(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *Config) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *ContainerConfig) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson1dbef17bDecodeGithubComContainersLibpodLibpod2(l, v)
 }
 func easyjson1dbef17bDecodeGithubComContainersLibpodVendorGithubComCriOOcicniPkgOcicni(in *jlexer.Lexer, out *ocicni.PortMapping) {

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -28,7 +28,7 @@ func TestPostDeleteHooks(t *testing.T) {
 	statePath := filepath.Join(dir, "state")
 	copyPath := filepath.Join(dir, "copy")
 	c := Container{
-		config: &Config{
+		config: &ContainerConfig{
 			ID: "123abc",
 			Spec: &rspec.Spec{
 				Annotations: map[string]string{

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -47,7 +47,7 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 	}
 
 	ctr := new(Container)
-	ctr.config = new(Config)
+	ctr.config = new(ContainerConfig)
 	ctr.state = new(containerState)
 
 	ctr.config.ID = stringid.GenerateNonCryptoID()

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -156,7 +156,7 @@ func TestGetContainerPodSameIDFails(t *testing.T) {
 
 func TestAddInvalidContainerFails(t *testing.T) {
 	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
-		err := state.AddContainer(&Container{config: &Config{ID: "1234"}})
+		err := state.AddContainer(&Container{config: &ContainerConfig{ID: "1234"}})
 		assert.Error(t, err)
 	})
 }
@@ -756,7 +756,7 @@ func TestUpdateContainerNotInDatabaseReturnsError(t *testing.T) {
 
 func TestUpdateInvalidContainerReturnsError(t *testing.T) {
 	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
-		err := state.UpdateContainer(&Container{config: &Config{ID: "1234"}})
+		err := state.UpdateContainer(&Container{config: &ContainerConfig{ID: "1234"}})
 		assert.Error(t, err)
 	})
 }
@@ -780,7 +780,7 @@ func TestUpdateContainerNotInNamespaceReturnsError(t *testing.T) {
 
 func TestSaveInvalidContainerReturnsError(t *testing.T) {
 	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
-		err := state.SaveContainer(&Container{config: &Config{ID: "1234"}})
+		err := state.SaveContainer(&Container{config: &ContainerConfig{ID: "1234"}})
 		assert.Error(t, err)
 	})
 }
@@ -2604,7 +2604,7 @@ func TestAddContainerToPodInvalidCtr(t *testing.T) {
 		err = state.AddPod(testPod)
 		assert.NoError(t, err)
 
-		err = state.AddContainerToPod(testPod, &Container{config: &Config{ID: "1234"}})
+		err = state.AddContainerToPod(testPod, &Container{config: &ContainerConfig{ID: "1234"}})
 		assert.Error(t, err)
 
 		ctrs, err := state.PodContainersByID(testPod)


### PR DESCRIPTION
During an earlier bugfix, we swapped all instances of ContainerConfig to Config, which was meant to fix some data we were returning from Inspect. This unfortunately also renamed a libpod internal struct for container configs. Undo the rename here.