### PR TITLE
libpod/image: Use ParseNormalizedNamed in RepoDigests

### DIFF
--- a/cmd/podman/sign.go
+++ b/cmd/podman/sign.go
@@ -126,7 +126,10 @@ func signCmd(c *cli.Context) error {
 			sigStoreDir = SignatureStoreDir
 		}
 
-		repos := newImage.RepoDigests()
+		repos, err := newImage.RepoDigests()
+		if err != nil {
+			return errors.Wrapf(err, "error calculating repo digests for %s", signimage)
+		}
 		if len(repos) == 0 {
 			logrus.Errorf("no repodigests associated with the image %s", signimage)
 			continue

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -305,12 +305,24 @@ func (i *Image) Names() []string {
 }
 
 // RepoDigests returns a string array of repodigests associated with the image
-func (i *Image) RepoDigests() []string {
+func (i *Image) RepoDigests() ([]string, error) {
 	var repoDigests []string
+	digest := i.Digest()
+
 	for _, name := range i.Names() {
-		repoDigests = append(repoDigests, strings.SplitN(name, ":", 2)[0]+"@"+i.Digest().String())
+		named, err := reference.ParseNormalizedNamed(name)
+		if err != nil {
+			return nil, err
+		}
+
+		canonical, err := reference.WithDigest(reference.TrimNamed(named), digest)
+		if err != nil {
+			return nil, err
+		}
+
+		repoDigests = append(repoDigests, canonical.String())
 	}
-	return repoDigests
+	return repoDigests, nil
 }
 
 // Created returns the time the image was created

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -41,13 +41,18 @@ func (i *LibpodAPI) ListImages(call iopodman.VarlinkCall) error {
 	for _, image := range images {
 		labels, _ := image.Labels(getContext())
 		containers, _ := image.Containers()
+		repoDigests, err := image.RepoDigests()
+		if err != nil {
+			return err
+		}
+
 		size, _ := image.Size(getContext())
 
 		i := iopodman.ImageInList{
 			Id:          image.ID(),
 			ParentId:    image.Parent,
 			RepoTags:    image.Names(),
-			RepoDigests: image.RepoDigests(),
+			RepoDigests: repoDigests,
 			Created:     image.Created().String(),
 			Size:        int64(*size),
 			VirtualSize: image.VirtualSize,
@@ -73,6 +78,10 @@ func (i *LibpodAPI) GetImage(call iopodman.VarlinkCall, name string) error {
 	if err != nil {
 		return err
 	}
+	repoDigests, err := newImage.RepoDigests()
+	if err != nil {
+		return err
+	}
 	size, err := newImage.Size(getContext())
 	if err != nil {
 		return err
@@ -82,7 +91,7 @@ func (i *LibpodAPI) GetImage(call iopodman.VarlinkCall, name string) error {
 		Id:          newImage.ID(),
 		ParentId:    newImage.Parent,
 		RepoTags:    newImage.Names(),
-		RepoDigests: newImage.RepoDigests(),
+		RepoDigests: repoDigests,
 		Created:     newImage.Created().String(),
 		Size:        int64(*size),
 		VirtualSize: newImage.VirtualSize,


### PR DESCRIPTION
Avoid generating `quay.io/openshift-release-dev/ocp-release@sha256@sha256:239...` and similar when the image name is already digest-based.  It's not clear exactly how we get into this state, but as shown by the unit tests, the new code handles this case correctly (while the previous code does not).


Fixes #2086