### PR TITLE
create: don't append version to AppArmor profile

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -21,7 +21,6 @@ import (
 	"github.com/containers/libpod/pkg/rootless"
 	cc "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/libpod/pkg/util"
-	libpodVersion "github.com/containers/libpod/version"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
@@ -182,9 +181,10 @@ func loadAppArmor(config *cc.CreateConfig) error {
 		// Unless specified otherwise, make sure that the default AppArmor
 		// profile is installed.  To avoid redundantly loading the profile
 		// on each invocation, check if it's loaded before installing it.
-		// Suffix the profile with the current libpod version to allow
-		// loading the new, potentially updated profile after an update.
-		profile := fmt.Sprintf("%s-%s", apparmor.DefaultLibpodProfile, libpodVersion.Version)
+		// Note that updates to the default AppArmor profile require
+		// to remove the `libpod-default` profile manually or via a
+		// reboot.
+		profile := apparmor.DefaultLibpodProfile
 
 		loadProfile := func() error {
 			isLoaded, err := apparmor.IsLoaded(profile)


### PR DESCRIPTION
Do not append `-$VERSION` to Podman's default AppArmor profile.  The
initial intention was to immediately load new AppArmor profiles when
Podman gets updated.  However, this breaks when the host is rebooted
and pre-existing containers cause runc to load the profile of the
previous version of Podman which is not loaded anymore.

Note that this means that we need to make users aware whenever the
default AppArmor profile is changed.

Fixes: #2107
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>