### PR TITLE
RFC: Mostly replace imageParts

### DIFF
--- a/libpod/adapter/runtime_remote.go
+++ b/libpod/adapter/runtime_remote.go
@@ -5,13 +5,13 @@ package adapter
 import (
 	"context"
 	"fmt"
-	"github.com/containers/libpod/cmd/podman/varlink"
-	"github.com/containers/libpod/libpod/image"
-	"github.com/opencontainers/go-digest"
-	"github.com/urfave/cli"
-	"github.com/varlink/go/varlink"
 	"strings"
 	"time"
+
+	iopodman "github.com/containers/libpod/cmd/podman/varlink"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/urfave/cli"
+	"github.com/varlink/go/varlink"
 )
 
 // ImageRuntime is wrapper for image runtime
@@ -59,8 +59,6 @@ type remoteImage struct {
 	RepoDigests []string
 	Parent      string
 	Size        int64
-	Tag         string
-	Repository  string
 	Created     time.Time
 	InputName   string
 	Names       []string
@@ -91,10 +89,6 @@ func (r *LocalRuntime) GetImages() ([]*ContainerImage, error) {
 }
 
 func imageInListToContainerImage(i iopodman.ImageInList, name string, runtime *LocalRuntime) (*ContainerImage, error) {
-	imageParts, err := image.DecomposeString(name)
-	if err != nil {
-		return nil, err
-	}
 	created, err := splitStringDate(i.Created)
 	if err != nil {
 		return nil, err
@@ -108,8 +102,6 @@ func imageInListToContainerImage(i iopodman.ImageInList, name string, runtime *L
 		Parent:      i.ParentId,
 		Size:        i.Size,
 		Created:     created,
-		Tag:         imageParts.Tag,
-		Repository:  imageParts.Registry,
 		Names:       i.RepoTags,
 		isParent:    i.IsParent,
 		Runtime:     runtime,

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -471,12 +471,9 @@ func normalizeTag(tag string) (string, error) {
 			return "", err
 		}
 	}
-	tag = ref.String()
 	// If the input does not have a tag, we need to add one (latest)
-	if !decomposedTag.isTagged {
-		tag = fmt.Sprintf("%s:%s", tag, decomposedTag.tag)
-	}
-	return tag, nil
+	ref = reference.TagNameOnly(ref)
+	return ref.String(), nil
 }
 
 // TagImage adds a tag to the given image

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/reexec"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -460,7 +460,7 @@ func normalizeTag(tag string) (string, error) {
 	}
 	// If the input does not have a tag, we need to add one (latest)
 	if !decomposedTag.isTagged {
-		tag = fmt.Sprintf("%s:%s", tag, decomposedTag.Tag)
+		tag = fmt.Sprintf("%s:%s", tag, decomposedTag.tag)
 	}
 	// If the input doesn't specify a registry, set the registry to localhost
 	if !decomposedTag.hasRegistry {
@@ -937,7 +937,7 @@ func (i *Image) MatchRepoTag(input string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if dcRepoName.Registry == dcImage.Registry && dcImage.Registry != "" {
+		if dcRepoName.registry == dcImage.registry && dcImage.registry != "" {
 			count++
 		}
 		if dcRepoName.name == dcImage.name && dcImage.name != "" {
@@ -945,7 +945,7 @@ func (i *Image) MatchRepoTag(input string) (string, error) {
 		} else if splitString(dcRepoName.name) == splitString(dcImage.name) {
 			count++
 		}
-		if dcRepoName.Tag == dcImage.Tag {
+		if dcRepoName.tag == dcImage.tag {
 			count++
 		}
 		results[count] = append(results[count], repoName)

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -243,12 +243,14 @@ func (i *Image) getLocalImage() (*storage.Image, error) {
 	// with a tag.  It cannot be local.
 	if decomposedImage.hasRegistry {
 		return nil, errors.Wrapf(ErrNoSuchImage, imageError)
-
 	}
-
 	// if the image is saved with the repository localhost, searching with localhost prepended is necessary
 	// We don't need to strip the sha because we have already determined it is not an ID
-	img, err = i.imageruntime.getImage(fmt.Sprintf("%s/%s", DefaultLocalRegistry, i.InputName))
+	ref, err := decomposedImage.referenceWithRegistry(DefaultLocalRegistry)
+	if err != nil {
+		return nil, err
+	}
+	img, err = i.imageruntime.getImage(ref.String())
 	if err == nil {
 		return img.image, err
 	}

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -226,7 +226,6 @@ func (i *Image) getLocalImage() (*storage.Image, error) {
 		i.InputName = dest.DockerReference().String()
 	}
 
-	var taggedName string
 	img, err := i.imageruntime.getImage(stripSha256(i.InputName))
 	if err == nil {
 		return img.image, err
@@ -238,15 +237,6 @@ func (i *Image) getLocalImage() (*storage.Image, error) {
 	decomposedImage, err := decompose(i.InputName)
 	if err != nil {
 		return nil, err
-	}
-
-	// the inputname isn't tagged, so we assume latest and try again
-	if !decomposedImage.isTagged {
-		taggedName = fmt.Sprintf("%s:latest", i.InputName)
-		img, err = i.imageruntime.getImage(taggedName)
-		if err == nil {
-			return img.image, nil
-		}
 	}
 
 	// The image has a registry name in it and we made sure we looked for it locally

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -458,13 +458,13 @@ func normalizeTag(tag string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// If the input does not have a tag, we need to add one (latest)
-	if !decomposedTag.isTagged {
-		tag = fmt.Sprintf("%s:%s", tag, decomposedTag.tag)
-	}
 	// If the input doesn't specify a registry, set the registry to localhost
 	if !decomposedTag.hasRegistry {
 		tag = fmt.Sprintf("%s/%s", DefaultLocalRegistry, tag)
+	}
+	// If the input does not have a tag, we need to add one (latest)
+	if !decomposedTag.isTagged {
+		tag = fmt.Sprintf("%s:%s", tag, decomposedTag.tag)
 	}
 	return tag, nil
 }

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -459,13 +459,19 @@ func normalizeTag(tag string) (string, error) {
 		return "", err
 	}
 	// If the input doesn't specify a registry, set the registry to localhost
+	var ref reference.Named
 	if !decomposedTag.hasRegistry {
-		ref, err := decomposedTag.referenceWithRegistry(DefaultLocalRegistry)
+		ref, err = decomposedTag.referenceWithRegistry(DefaultLocalRegistry)
 		if err != nil {
 			return "", err
 		}
-		tag = ref.String()
+	} else {
+		ref, err = decomposedTag.normalizedReference()
+		if err != nil {
+			return "", err
+		}
 	}
+	tag = ref.String()
 	// If the input does not have a tag, we need to add one (latest)
 	if !decomposedTag.isTagged {
 		tag = fmt.Sprintf("%s:%s", tag, decomposedTag.tag)

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -460,7 +460,11 @@ func normalizeTag(tag string) (string, error) {
 	}
 	// If the input doesn't specify a registry, set the registry to localhost
 	if !decomposedTag.hasRegistry {
-		tag = fmt.Sprintf("%s/%s", DefaultLocalRegistry, tag)
+		ref, err := decomposedTag.referenceWithRegistry(DefaultLocalRegistry)
+		if err != nil {
+			return "", err
+		}
+		tag = ref.String()
 	}
 	// If the input does not have a tag, we need to add one (latest)
 	if !decomposedTag.isTagged {

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -930,21 +930,23 @@ func (i *Image) MatchRepoTag(input string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	imageRegistry, imageName, imageSuspiciousTagValueForSearch := dcImage.suspiciousRefNameTagValuesForSearch()
 	for _, repoName := range i.Names() {
 		count := 0
 		dcRepoName, err := decompose(repoName)
 		if err != nil {
 			return "", err
 		}
-		if dcRepoName.registry == dcImage.registry && dcImage.registry != "" {
+		repoNameRegistry, repoNameName, repoNameSuspiciousTagValueForSearch := dcRepoName.suspiciousRefNameTagValuesForSearch()
+		if repoNameRegistry == imageRegistry && imageRegistry != "" {
 			count++
 		}
-		if dcRepoName.name == dcImage.name && dcImage.name != "" {
+		if repoNameName == imageName && imageName != "" {
 			count++
-		} else if splitString(dcRepoName.name) == splitString(dcImage.name) {
+		} else if splitString(repoNameName) == splitString(imageName) {
 			count++
 		}
-		if dcRepoName.tag == dcImage.tag {
+		if repoNameSuspiciousTagValueForSearch == imageSuspiciousTagValueForSearch {
 			count++
 		}
 		results[count] = append(results[count], repoName)

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -264,7 +264,7 @@ func TestNormalizeTag(t *testing.T) {
 		{"#", ""}, // Clearly invalid
 		{"example.com/busybox", "example.com/busybox:latest"},                                            // Qualified name-only
 		{"example.com/busybox:notlatest", "example.com/busybox:notlatest"},                               // Qualified name:tag
-		{"example.com/busybox" + digestSuffix, "example.com/busybox" + digestSuffix + ":none"},           // Qualified name@digest; FIXME: The result is not even syntactically valid!
+		{"example.com/busybox" + digestSuffix, "example.com/busybox" + digestSuffix},                     // Qualified name@digest; FIXME? Should we allow tagging with a digest at all?
 		{"example.com/busybox:notlatest" + digestSuffix, "example.com/busybox:notlatest" + digestSuffix}, // Qualified name:tag@digest
 		{"busybox:latest", "localhost/busybox:latest"},                                                   // Unqualified name-only
 		{"ns/busybox:latest", "localhost/ns/busybox:latest"},                                             // Unqualified with a dot-less namespace

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -268,6 +268,7 @@ func TestNormalizeTag(t *testing.T) {
 		{"example.com/busybox:notlatest" + digestSuffix, "example.com/busybox:notlatest" + digestSuffix}, // Qualified name:tag@digest
 		{"busybox:latest", "localhost/busybox:latest"},                                                   // Unqualified name-only
 		{"ns/busybox:latest", "localhost/ns/busybox:latest"},                                             // Unqualified with a dot-less namespace
+		{"docker.io/busybox:latest", "docker.io/library/busybox:latest"},                                 // docker.io without /library/
 	} {
 		res, err := normalizeTag(c.input)
 		if c.expected == "" {

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -257,7 +257,7 @@ func Test_stripSha256(t *testing.T) {
 	assert.Equal(t, stripSha256("sha256:a"), "a")
 }
 
-func TestNormalizeTag(t *testing.T) {
+func TestNormalizedTag(t *testing.T) {
 	const digestSuffix = "@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 	for _, c := range []struct{ input, expected string }{
@@ -270,12 +270,12 @@ func TestNormalizeTag(t *testing.T) {
 		{"ns/busybox:latest", "localhost/ns/busybox:latest"},                                             // Unqualified with a dot-less namespace
 		{"docker.io/busybox:latest", "docker.io/library/busybox:latest"},                                 // docker.io without /library/
 	} {
-		res, err := normalizeTag(c.input)
+		res, err := normalizedTag(c.input)
 		if c.expected == "" {
 			assert.Error(t, err, c.input)
 		} else {
 			assert.NoError(t, err, c.input)
-			assert.Equal(t, c.expected, res)
+			assert.Equal(t, c.expected, res.String())
 		}
 	}
 }

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -92,3 +92,17 @@ func (ip *imageParts) referenceWithRegistry(registry string) (reference.Named, e
 	}
 	return ref, nil
 }
+
+// normalizedReference returns a (normalized) reference for ip (with ip.hasRegistry)
+func (ip *imageParts) normalizedReference() (reference.Named, error) {
+	if !ip.hasRegistry {
+		return nil, errors.Errorf("internal error: normalizedReference called on imageParts without a registry (%#v)", *ip)
+	}
+	// We need to round-trip via a string to get the right normalization of docker.io/library
+	s := ip.unnormalizedRef.String()
+	ref, err := reference.ParseNormalizedNamed(s)
+	if err != nil { // Should never happen
+		return nil, errors.Wrapf(err, "error normalizing qualified reference %#v", s)
+	}
+	return ref, nil
+}

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -30,7 +30,7 @@ func GetImageBaseName(input string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	splitImageName := strings.Split(decomposedImage.name, "/")
+	splitImageName := strings.Split(decomposedImage.unnormalizedRef.Name(), "/")
 	return splitImageName[len(splitImageName)-1], nil
 }
 

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/containers/image/docker/reference"
@@ -92,14 +91,4 @@ func (ip *imageParts) referenceWithRegistry(registry string) (reference.Named, e
 		return nil, errors.Wrapf(err, "error normalizing registry+unqualified reference %#v", qualified)
 	}
 	return ref, nil
-}
-
-// assemble concatenates an image's parts into a string
-func (ip *imageParts) assemble() string {
-	spec := fmt.Sprintf("%s:%s", ip.name, ip.tag)
-
-	if ip.registry != "" {
-		spec = fmt.Sprintf("%s/%s", ip.registry, spec)
-	}
-	return spec
 }

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -10,7 +10,6 @@ import (
 // imageParts describes the parts of an image's name
 type imageParts struct {
 	unnormalizedRef reference.Named // WARNING: Did not go through docker.io[/library] normalization
-	transport       string
 	registry        string
 	name            string
 	tag             string
@@ -74,7 +73,6 @@ func decompose(input string) (imageParts, error) {
 		name:            imageName,
 		tag:             tag,
 		isTagged:        isTagged,
-		transport:       DefaultTransport,
 	}, nil
 }
 

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -7,12 +7,12 @@ import (
 	"github.com/containers/image/docker/reference"
 )
 
-// Parts describes the parts of an image's name
-type Parts struct {
+// imageParts describes the parts of an image's name
+type imageParts struct {
 	transport   string
-	Registry    string
+	registry    string
 	name        string
-	Tag         string
+	tag         string
 	isTagged    bool
 	hasRegistry bool
 }
@@ -34,16 +34,10 @@ func GetImageBaseName(input string) (string, error) {
 	return splitImageName[len(splitImageName)-1], nil
 }
 
-// DecomposeString decomposes a string name into imageParts description. This
-// is a wrapper for decompose
-func DecomposeString(input string) (Parts, error) {
-	return decompose(input)
-}
-
 // decompose breaks an input name into an imageParts description
-func decompose(input string) (Parts, error) {
+func decompose(input string) (imageParts, error) {
 	var (
-		parts       Parts
+		parts       imageParts
 		hasRegistry bool
 		tag         string
 	)
@@ -62,7 +56,7 @@ func decompose(input string) (Parts, error) {
 	}
 	registry := reference.Domain(imgRef.(reference.Named))
 	imageName := reference.Path(imgRef.(reference.Named))
-	// Is this a Registry or a repo?
+	// Is this a registry or a repo?
 	if isRegistry(registry) {
 		hasRegistry = true
 	} else {
@@ -71,27 +65,27 @@ func decompose(input string) (Parts, error) {
 			registry = ""
 		}
 	}
-	return Parts{
-		Registry:    registry,
+	return imageParts{
+		registry:    registry,
 		hasRegistry: hasRegistry,
 		name:        imageName,
-		Tag:         tag,
+		tag:         tag,
 		isTagged:    isTagged,
 		transport:   DefaultTransport,
 	}, nil
 }
 
 // assemble concatenates an image's parts into a string
-func (ip *Parts) assemble() string {
-	spec := fmt.Sprintf("%s:%s", ip.name, ip.Tag)
+func (ip *imageParts) assemble() string {
+	spec := fmt.Sprintf("%s:%s", ip.name, ip.tag)
 
-	if ip.Registry != "" {
-		spec = fmt.Sprintf("%s/%s", ip.Registry, spec)
+	if ip.registry != "" {
+		spec = fmt.Sprintf("%s/%s", ip.registry, spec)
 	}
 	return spec
 }
 
 // assemble concatenates an image's parts with transport into a string
-func (ip *Parts) assembleWithTransport() string {
+func (ip *imageParts) assembleWithTransport() string {
 	return fmt.Sprintf("%s%s", ip.transport, ip.assemble())
 }

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -87,8 +87,3 @@ func (ip *imageParts) assemble() string {
 	}
 	return spec
 }
-
-// assemble concatenates an image's parts with transport into a string
-func (ip *imageParts) assembleWithTransport() string {
-	return fmt.Sprintf("%s%s", ip.transport, ip.assemble())
-}

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -17,7 +17,8 @@ type imageParts struct {
 	hasRegistry     bool
 }
 
-// Registries must contain a ":" or a "." or be localhost
+// Registries must contain a ":" or a "." or be localhost; this helper exists for users of reference.Parse.
+// For inputs that should use the docker.io[/library] normalization, use reference.ParseNormalizedNamed instead.
 func isRegistry(name string) bool {
 	return strings.ContainsAny(name, ".:") || name == "localhost"
 }
@@ -57,7 +58,9 @@ func decompose(input string) (imageParts, error) {
 	}
 	registry := reference.Domain(unnormalizedNamed)
 	imageName := reference.Path(unnormalizedNamed)
-	// Is this a registry or a repo?
+	// ip.unnormalizedRef, because it uses reference.Parse and not reference.ParseNormalizedNamed,
+	// does not use the standard heuristics for domains vs. namespaces/repos, so we need to check
+	// explicitly.
 	if isRegistry(registry) {
 		hasRegistry = true
 	} else {

--- a/libpod/image/parts_test.go
+++ b/libpod/image/parts_test.go
@@ -11,9 +11,9 @@ func TestDecompose(t *testing.T) {
 	const digestSuffix = "@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 	for _, c := range []struct {
-		input                 string
-		registry, name, tag   string
-		isTagged, hasRegistry bool
+		input                                       string
+		registry, name, suspiciousTagValueForSearch string
+		isTagged, hasRegistry                       bool
 	}{
 		{"#", "", "", "", false, false}, // Entirely invalid input
 		{ // Fully qualified docker.io, name-only input
@@ -32,7 +32,7 @@ func TestDecompose(t *testing.T) {
 			"example.com/ns/busybox:notlatest", "example.com", "ns/busybox", "notlatest", true, true,
 		},
 		{ // name@digest
-			// FIXME? .tag == "none"
+			// FIXME? .suspiciousTagValueForSearch == "none"
 			"example.com/ns/busybox" + digestSuffix, "example.com", "ns/busybox", "none", false, true,
 		},
 		{ // name:tag@digest
@@ -44,9 +44,10 @@ func TestDecompose(t *testing.T) {
 			assert.Error(t, err, c.input)
 		} else {
 			assert.NoError(t, err, c.input)
-			assert.Equal(t, c.registry, parts.registry, c.input)
-			assert.Equal(t, c.name, parts.name, c.input)
-			assert.Equal(t, c.tag, parts.tag, c.input)
+			registry, name, suspiciousTagValueForSearch := parts.suspiciousRefNameTagValuesForSearch()
+			assert.Equal(t, c.registry, registry, c.input)
+			assert.Equal(t, c.name, name, c.input)
+			assert.Equal(t, c.suspiciousTagValueForSearch, suspiciousTagValueForSearch, c.input)
 			assert.Equal(t, c.isTagged, parts.isTagged, c.input)
 			assert.Equal(t, c.hasRegistry, parts.hasRegistry, c.input)
 		}

--- a/libpod/image/parts_test.go
+++ b/libpod/image/parts_test.go
@@ -55,9 +55,9 @@ func TestDecompose(t *testing.T) {
 		} else {
 			assert.NoError(t, err, c.input)
 			assert.Equal(t, c.transport, parts.transport, c.input)
-			assert.Equal(t, c.registry, parts.Registry, c.input)
+			assert.Equal(t, c.registry, parts.registry, c.input)
 			assert.Equal(t, c.name, parts.name, c.input)
-			assert.Equal(t, c.tag, parts.Tag, c.input)
+			assert.Equal(t, c.tag, parts.tag, c.input)
 			assert.Equal(t, c.isTagged, parts.isTagged, c.input)
 			assert.Equal(t, c.hasRegistry, parts.hasRegistry, c.input)
 			assert.Equal(t, c.assembled, parts.assemble(), c.input)

--- a/libpod/image/parts_test.go
+++ b/libpod/image/parts_test.go
@@ -14,39 +14,38 @@ func TestDecompose(t *testing.T) {
 		transport, registry, name, tag string
 		isTagged, hasRegistry          bool
 		assembled                      string
-		assembledWithTransport         string
 	}{
-		{"#", "", "", "", "", false, false, "", ""}, // Entirely invalid input
+		{"#", "", "", "", "", false, false, ""}, // Entirely invalid input
 		{ // Fully qualified docker.io, name-only input
 			"docker.io/library/busybox", "docker://", "docker.io", "library/busybox", "latest", false, true,
-			"docker.io/library/busybox:latest", "docker://docker.io/library/busybox:latest",
+			"docker.io/library/busybox:latest",
 		},
 		{ // Fully qualified example.com, name-only input
 			"example.com/ns/busybox", "docker://", "example.com", "ns/busybox", "latest", false, true,
-			"example.com/ns/busybox:latest", "docker://example.com/ns/busybox:latest",
+			"example.com/ns/busybox:latest",
 		},
 		{ // Unqualified single-name input
 			"busybox", "docker://", "", "busybox", "latest", false, false,
-			"busybox:latest", "docker://busybox:latest",
+			"busybox:latest",
 		},
 		{ // Unqualified namespaced input
 			"ns/busybox", "docker://", "", "ns/busybox", "latest", false, false,
-			"ns/busybox:latest", "docker://ns/busybox:latest",
+			"ns/busybox:latest",
 		},
 		{ // name:tag
 			"example.com/ns/busybox:notlatest", "docker://", "example.com", "ns/busybox", "notlatest", true, true,
-			"example.com/ns/busybox:notlatest", "docker://example.com/ns/busybox:notlatest",
+			"example.com/ns/busybox:notlatest",
 		},
 		{ // name@digest
 			// FIXME? .tag == "none"
 			"example.com/ns/busybox" + digestSuffix, "docker://", "example.com", "ns/busybox", "none", false, true,
 			// FIXME: this drops the digest and replaces it with an incorrect tag.
-			"example.com/ns/busybox:none", "docker://example.com/ns/busybox:none",
+			"example.com/ns/busybox:none",
 		},
 		{ // name:tag@digest
 			"example.com/ns/busybox:notlatest" + digestSuffix, "docker://", "example.com", "ns/busybox", "notlatest", true, true,
 			// FIXME: This drops the digest
-			"example.com/ns/busybox:notlatest", "docker://example.com/ns/busybox:notlatest",
+			"example.com/ns/busybox:notlatest",
 		},
 	} {
 		parts, err := decompose(c.input)
@@ -61,7 +60,6 @@ func TestDecompose(t *testing.T) {
 			assert.Equal(t, c.isTagged, parts.isTagged, c.input)
 			assert.Equal(t, c.hasRegistry, parts.hasRegistry, c.input)
 			assert.Equal(t, c.assembled, parts.assemble(), c.input)
-			assert.Equal(t, c.assembledWithTransport, parts.assembleWithTransport(), c.input)
 		}
 	}
 }

--- a/libpod/image/parts_test.go
+++ b/libpod/image/parts_test.go
@@ -10,50 +10,49 @@ func TestDecompose(t *testing.T) {
 	const digestSuffix = "@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 	for _, c := range []struct {
-		input                          string
-		transport, registry, name, tag string
-		isTagged, hasRegistry          bool
-		assembled                      string
+		input                 string
+		registry, name, tag   string
+		isTagged, hasRegistry bool
+		assembled             string
 	}{
-		{"#", "", "", "", "", false, false, ""}, // Entirely invalid input
+		{"#", "", "", "", false, false, ""}, // Entirely invalid input
 		{ // Fully qualified docker.io, name-only input
-			"docker.io/library/busybox", "docker://", "docker.io", "library/busybox", "latest", false, true,
+			"docker.io/library/busybox", "docker.io", "library/busybox", "latest", false, true,
 			"docker.io/library/busybox:latest",
 		},
 		{ // Fully qualified example.com, name-only input
-			"example.com/ns/busybox", "docker://", "example.com", "ns/busybox", "latest", false, true,
+			"example.com/ns/busybox", "example.com", "ns/busybox", "latest", false, true,
 			"example.com/ns/busybox:latest",
 		},
 		{ // Unqualified single-name input
-			"busybox", "docker://", "", "busybox", "latest", false, false,
+			"busybox", "", "busybox", "latest", false, false,
 			"busybox:latest",
 		},
 		{ // Unqualified namespaced input
-			"ns/busybox", "docker://", "", "ns/busybox", "latest", false, false,
+			"ns/busybox", "", "ns/busybox", "latest", false, false,
 			"ns/busybox:latest",
 		},
 		{ // name:tag
-			"example.com/ns/busybox:notlatest", "docker://", "example.com", "ns/busybox", "notlatest", true, true,
+			"example.com/ns/busybox:notlatest", "example.com", "ns/busybox", "notlatest", true, true,
 			"example.com/ns/busybox:notlatest",
 		},
 		{ // name@digest
 			// FIXME? .tag == "none"
-			"example.com/ns/busybox" + digestSuffix, "docker://", "example.com", "ns/busybox", "none", false, true,
+			"example.com/ns/busybox" + digestSuffix, "example.com", "ns/busybox", "none", false, true,
 			// FIXME: this drops the digest and replaces it with an incorrect tag.
 			"example.com/ns/busybox:none",
 		},
 		{ // name:tag@digest
-			"example.com/ns/busybox:notlatest" + digestSuffix, "docker://", "example.com", "ns/busybox", "notlatest", true, true,
+			"example.com/ns/busybox:notlatest" + digestSuffix, "example.com", "ns/busybox", "notlatest", true, true,
 			// FIXME: This drops the digest
 			"example.com/ns/busybox:notlatest",
 		},
 	} {
 		parts, err := decompose(c.input)
-		if c.transport == "" {
+		if c.assembled == "" {
 			assert.Error(t, err, c.input)
 		} else {
 			assert.NoError(t, err, c.input)
-			assert.Equal(t, c.transport, parts.transport, c.input)
 			assert.Equal(t, c.registry, parts.registry, c.input)
 			assert.Equal(t, c.name, parts.name, c.input)
 			assert.Equal(t, c.tag, parts.tag, c.input)

--- a/libpod/image/parts_test.go
+++ b/libpod/image/parts_test.go
@@ -14,43 +14,33 @@ func TestDecompose(t *testing.T) {
 		input                 string
 		registry, name, tag   string
 		isTagged, hasRegistry bool
-		assembled             string
 	}{
-		{"#", "", "", "", false, false, ""}, // Entirely invalid input
+		{"#", "", "", "", false, false}, // Entirely invalid input
 		{ // Fully qualified docker.io, name-only input
 			"docker.io/library/busybox", "docker.io", "library/busybox", "latest", false, true,
-			"docker.io/library/busybox:latest",
 		},
 		{ // Fully qualified example.com, name-only input
 			"example.com/ns/busybox", "example.com", "ns/busybox", "latest", false, true,
-			"example.com/ns/busybox:latest",
 		},
 		{ // Unqualified single-name input
 			"busybox", "", "busybox", "latest", false, false,
-			"busybox:latest",
 		},
 		{ // Unqualified namespaced input
 			"ns/busybox", "", "ns/busybox", "latest", false, false,
-			"ns/busybox:latest",
 		},
 		{ // name:tag
 			"example.com/ns/busybox:notlatest", "example.com", "ns/busybox", "notlatest", true, true,
-			"example.com/ns/busybox:notlatest",
 		},
 		{ // name@digest
 			// FIXME? .tag == "none"
 			"example.com/ns/busybox" + digestSuffix, "example.com", "ns/busybox", "none", false, true,
-			// FIXME: this drops the digest and replaces it with an incorrect tag.
-			"example.com/ns/busybox:none",
 		},
 		{ // name:tag@digest
 			"example.com/ns/busybox:notlatest" + digestSuffix, "example.com", "ns/busybox", "notlatest", true, true,
-			// FIXME: This drops the digest
-			"example.com/ns/busybox:notlatest",
 		},
 	} {
 		parts, err := decompose(c.input)
-		if c.assembled == "" {
+		if c.name == "" {
 			assert.Error(t, err, c.input)
 		} else {
 			assert.NoError(t, err, c.input)
@@ -59,7 +49,6 @@ func TestDecompose(t *testing.T) {
 			assert.Equal(t, c.tag, parts.tag, c.input)
 			assert.Equal(t, c.isTagged, parts.isTagged, c.input)
 			assert.Equal(t, c.hasRegistry, parts.hasRegistry, c.input)
-			assert.Equal(t, c.assembled, parts.assemble(), c.input)
 		}
 	}
 }

--- a/libpod/image/parts_test.go
+++ b/libpod/image/parts_test.go
@@ -13,30 +13,30 @@ func TestDecompose(t *testing.T) {
 	for _, c := range []struct {
 		input                                       string
 		registry, name, suspiciousTagValueForSearch string
-		isTagged, hasRegistry                       bool
+		hasRegistry                                 bool
 	}{
-		{"#", "", "", "", false, false}, // Entirely invalid input
+		{"#", "", "", "", false}, // Entirely invalid input
 		{ // Fully qualified docker.io, name-only input
-			"docker.io/library/busybox", "docker.io", "library/busybox", "latest", false, true,
+			"docker.io/library/busybox", "docker.io", "library/busybox", "latest", true,
 		},
 		{ // Fully qualified example.com, name-only input
-			"example.com/ns/busybox", "example.com", "ns/busybox", "latest", false, true,
+			"example.com/ns/busybox", "example.com", "ns/busybox", "latest", true,
 		},
 		{ // Unqualified single-name input
-			"busybox", "", "busybox", "latest", false, false,
+			"busybox", "", "busybox", "latest", false,
 		},
 		{ // Unqualified namespaced input
-			"ns/busybox", "", "ns/busybox", "latest", false, false,
+			"ns/busybox", "", "ns/busybox", "latest", false,
 		},
 		{ // name:tag
-			"example.com/ns/busybox:notlatest", "example.com", "ns/busybox", "notlatest", true, true,
+			"example.com/ns/busybox:notlatest", "example.com", "ns/busybox", "notlatest", true,
 		},
 		{ // name@digest
 			// FIXME? .suspiciousTagValueForSearch == "none"
-			"example.com/ns/busybox" + digestSuffix, "example.com", "ns/busybox", "none", false, true,
+			"example.com/ns/busybox" + digestSuffix, "example.com", "ns/busybox", "none", true,
 		},
 		{ // name:tag@digest
-			"example.com/ns/busybox:notlatest" + digestSuffix, "example.com", "ns/busybox", "notlatest", true, true,
+			"example.com/ns/busybox:notlatest" + digestSuffix, "example.com", "ns/busybox", "notlatest", true,
 		},
 	} {
 		parts, err := decompose(c.input)
@@ -48,7 +48,6 @@ func TestDecompose(t *testing.T) {
 			assert.Equal(t, c.registry, registry, c.input)
 			assert.Equal(t, c.name, name, c.input)
 			assert.Equal(t, c.suspiciousTagValueForSearch, suspiciousTagValueForSearch, c.input)
-			assert.Equal(t, c.isTagged, parts.isTagged, c.input)
 			assert.Equal(t, c.hasRegistry, parts.hasRegistry, c.input)
 		}
 	}

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -76,9 +76,11 @@ func (ir *Runtime) getPullRefPair(srcRef types.ImageReference, destName string) 
 	decomposedDest, err := decompose(destName)
 	if err == nil && !decomposedDest.hasRegistry {
 		// If the image doesn't have a registry, set it as the default repo
-		decomposedDest.registry = DefaultLocalRegistry
-		decomposedDest.hasRegistry = true
-		destName = decomposedDest.assemble()
+		ref, err := decomposedDest.referenceWithRegistry(DefaultLocalRegistry)
+		if err != nil {
+			return pullRefPair{}, err
+		}
+		destName = ref.String()
 	}
 
 	reference := destName

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -286,11 +286,11 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 	if decomposedImage.hasRegistry {
 		var imageName, destName string
 		if hasShaInInputName(inputName) {
-			imageName = fmt.Sprintf("%s%s", decomposedImage.transport, inputName)
+			imageName = inputName
 		} else {
-			imageName = fmt.Sprintf("%s%s", decomposedImage.transport, decomposedImage.assemble())
+			imageName = decomposedImage.assemble()
 		}
-		srcRef, err := alltransports.ParseImageName(imageName)
+		srcRef, err := alltransports.ParseImageName(fmt.Sprintf("%s%s", decomposedImage.transport, imageName))
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to parse '%s'", inputName)
 		}
@@ -318,11 +318,11 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 	var refPairs []pullRefPair
 	for _, registry := range searchRegistries {
 		decomposedImage.registry = registry
-		imageName := fmt.Sprintf("%s%s", decomposedImage.transport, decomposedImage.assemble())
+		imageName := decomposedImage.assemble()
 		if hasShaInInputName(inputName) {
-			imageName = fmt.Sprintf("%s%s/%s", decomposedImage.transport, registry, inputName)
+			imageName = fmt.Sprintf("%s/%s", registry, inputName)
 		}
-		srcRef, err := alltransports.ParseImageName(imageName)
+		srcRef, err := alltransports.ParseImageName(fmt.Sprintf("%s%s", decomposedImage.transport, imageName))
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to parse '%s'", inputName)
 		}

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -290,7 +290,7 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 		} else {
 			imageName = decomposedImage.assemble()
 		}
-		srcRef, err := alltransports.ParseImageName(fmt.Sprintf("%s%s", DefaultTransport, imageName))
+		srcRef, err := docker.ParseReference("//" + imageName)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to parse '%s'", inputName)
 		}
@@ -322,7 +322,7 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 		if hasShaInInputName(inputName) {
 			imageName = fmt.Sprintf("%s/%s", registry, inputName)
 		}
-		srcRef, err := alltransports.ParseImageName(fmt.Sprintf("%s%s", DefaultTransport, imageName))
+		srcRef, err := docker.ParseReference("//" + imageName)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to parse '%s'", inputName)
 		}

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -290,7 +290,7 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 		} else {
 			imageName = decomposedImage.assemble()
 		}
-		srcRef, err := alltransports.ParseImageName(fmt.Sprintf("%s%s", decomposedImage.transport, imageName))
+		srcRef, err := alltransports.ParseImageName(fmt.Sprintf("%s%s", DefaultTransport, imageName))
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to parse '%s'", inputName)
 		}
@@ -322,7 +322,7 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 		if hasShaInInputName(inputName) {
 			imageName = fmt.Sprintf("%s/%s", registry, inputName)
 		}
-		srcRef, err := alltransports.ParseImageName(fmt.Sprintf("%s%s", decomposedImage.transport, imageName))
+		srcRef, err := alltransports.ParseImageName(fmt.Sprintf("%s%s", DefaultTransport, imageName))
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to parse '%s'", inputName)
 		}

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -284,24 +284,13 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 		return nil, err
 	}
 	if decomposedImage.hasRegistry {
-		var imageName, destName string
-		if hasShaInInputName(inputName) {
-			imageName = inputName
-		} else {
-			imageName = decomposedImage.assemble()
-		}
-		srcRef, err := docker.ParseReference("//" + imageName)
+		srcRef, err := docker.ParseReference("//" + inputName)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to parse '%s'", inputName)
 		}
-		if hasShaInInputName(inputName) {
-			destName = decomposedImage.assemble()
-		} else {
-			destName = inputName
-		}
-		destRef, err := is.Transport.ParseStoreReference(ir.store, destName)
+		destRef, err := is.Transport.ParseStoreReference(ir.store, inputName)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing dest reference name %#v", destName)
+			return nil, errors.Wrapf(err, "error parsing dest reference name %#v", inputName)
 		}
 		ps := pullRefPair{
 			image:  inputName,

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -76,7 +76,7 @@ func (ir *Runtime) getPullRefPair(srcRef types.ImageReference, destName string) 
 	decomposedDest, err := decompose(destName)
 	if err == nil && !decomposedDest.hasRegistry {
 		// If the image doesn't have a registry, set it as the default repo
-		decomposedDest.Registry = DefaultLocalRegistry
+		decomposedDest.registry = DefaultLocalRegistry
 		decomposedDest.hasRegistry = true
 		destName = decomposedDest.assemble()
 	}
@@ -317,7 +317,7 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 	}
 	var refPairs []pullRefPair
 	for _, registry := range searchRegistries {
-		decomposedImage.Registry = registry
+		decomposedImage.registry = registry
 		imageName := decomposedImage.assembleWithTransport()
 		if hasShaInInputName(inputName) {
 			imageName = fmt.Sprintf("%s%s/%s", decomposedImage.transport, registry, inputName)

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -288,7 +288,7 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 		if hasShaInInputName(inputName) {
 			imageName = fmt.Sprintf("%s%s", decomposedImage.transport, inputName)
 		} else {
-			imageName = decomposedImage.assembleWithTransport()
+			imageName = fmt.Sprintf("%s%s", decomposedImage.transport, decomposedImage.assemble())
 		}
 		srcRef, err := alltransports.ParseImageName(imageName)
 		if err != nil {
@@ -318,7 +318,7 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 	var refPairs []pullRefPair
 	for _, registry := range searchRegistries {
 		decomposedImage.registry = registry
-		imageName := decomposedImage.assembleWithTransport()
+		imageName := fmt.Sprintf("%s%s", decomposedImage.transport, decomposedImage.assemble())
 		if hasShaInInputName(inputName) {
 			imageName = fmt.Sprintf("%s%s/%s", decomposedImage.transport, registry, inputName)
 		}

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -283,16 +283,7 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to parse '%s'", inputName)
 		}
-		destRef, err := is.Transport.ParseStoreReference(ir.store, inputName)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing dest reference name %#v", inputName)
-		}
-		ps := pullRefPair{
-			image:  inputName,
-			srcRef: srcRef,
-			dstRef: destRef,
-		}
-		return singlePullRefPairGoal(ps), nil
+		return ir.getSinglePullRefPairGoal(srcRef, inputName)
 	}
 
 	searchRegistries, err := registries.GetRegistries()
@@ -310,13 +301,9 @@ func (ir *Runtime) pullGoalFromPossiblyUnqualifiedName(inputName string) (*pullG
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to parse '%s'", imageName)
 		}
-		ps := pullRefPair{
-			image:  imageName,
-			srcRef: srcRef,
-		}
-		ps.dstRef, err = is.Transport.ParseStoreReference(ir.store, ps.image)
+		ps, err := ir.getPullRefPair(srcRef, imageName)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing dest reference name %#v", ps.image)
+			return nil, err
 		}
 		refPairs = append(refPairs, ps)
 	}

--- a/libpod/image/pull_test.go
+++ b/libpod/image/pull_test.go
@@ -328,16 +328,16 @@ func TestPullGoalFromPossiblyUnqualifiedName(t *testing.T) {
 		{ // Unqualified, single-name, name-only
 			"busybox",
 			[]pullRefStrings{
-				{"example.com/busybox:latest", "docker://example.com/busybox:latest", "example.com/busybox:latest"},
+				{"example.com/busybox", "docker://example.com/busybox:latest", "example.com/busybox:latest"},
 				// (The docker:// representation is shortened by c/image/docker.Reference but it refers to "docker.io/library".)
-				{"docker.io/busybox:latest", "docker://busybox:latest", "docker.io/library/busybox:latest"},
+				{"docker.io/library/busybox", "docker://busybox:latest", "docker.io/library/busybox:latest"},
 			},
 			true,
 		},
 		{ // Unqualified, namespaced, name-only
 			"ns/busybox",
 			[]pullRefStrings{
-				{"example.com/ns/busybox:latest", "docker://example.com/ns/busybox:latest", "example.com/ns/busybox:latest"},
+				{"example.com/ns/busybox", "docker://example.com/ns/busybox:latest", "example.com/ns/busybox:latest"},
 			},
 			true,
 		},
@@ -346,17 +346,16 @@ func TestPullGoalFromPossiblyUnqualifiedName(t *testing.T) {
 			[]pullRefStrings{
 				{"example.com/busybox:notlatest", "docker://example.com/busybox:notlatest", "example.com/busybox:notlatest"},
 				// (The docker:// representation is shortened by c/image/docker.Reference but it refers to "docker.io/library".)
-				{"docker.io/busybox:notlatest", "docker://busybox:notlatest", "docker.io/library/busybox:notlatest"},
+				{"docker.io/library/busybox:notlatest", "docker://busybox:notlatest", "docker.io/library/busybox:notlatest"},
 			},
 			true,
 		},
 		{ // Unqualified, name@digest
 			"busybox" + digestSuffix,
 			[]pullRefStrings{
-				// FIXME?! Why is .input and .dstName dropping the digest, and adding :none?!
-				{"example.com/busybox:none", "docker://example.com/busybox" + digestSuffix, "example.com/busybox:none"},
+				{"example.com/busybox" + digestSuffix, "docker://example.com/busybox" + digestSuffix, "example.com/busybox" + digestSuffix},
 				// (The docker:// representation is shortened by c/image/docker.Reference but it refers to "docker.io/library".)
-				{"docker.io/busybox:none", "docker://busybox" + digestSuffix, "docker.io/library/busybox:none"},
+				{"docker.io/library/busybox" + digestSuffix, "docker://busybox" + digestSuffix, "docker.io/library/busybox" + digestSuffix},
 			},
 			true,
 		},

--- a/libpod/image/pull_test.go
+++ b/libpod/image/pull_test.go
@@ -76,9 +76,7 @@ func TestGetPullRefPair(t *testing.T) {
 		},
 		{ // name, no registry, no tag:
 			"dir:/dev/this-does-not-exist", "from-directory",
-			// FIXME(?) Adding a registry also adds a :latest tag.  OTOH that actually matches the used destination.
-			// Either way it is surprising that the localhost/ addition changes this.  (mitr hoping to remove the "image" member).
-			"localhost/from-directory:latest", "localhost/from-directory:latest",
+			"localhost/from-directory", "localhost/from-directory:latest",
 		},
 		{ // registry/name:tag :
 			"dir:/dev/this-does-not-exist", "example.com/from-directory:notlatest",
@@ -90,8 +88,7 @@ func TestGetPullRefPair(t *testing.T) {
 		},
 		{ // name@digest, no registry:
 			"dir:/dev/this-does-not-exist", "from-directory" + digestSuffix,
-			// FIXME?! Why is this dropping the digest, and adding :none?!
-			"localhost/from-directory:none", "localhost/from-directory:none",
+			"localhost/from-directory" + digestSuffix, "localhost/from-directory" + digestSuffix,
 		},
 		{ // registry/name@digest:
 			"dir:/dev/this-does-not-exist", "example.com/from-directory" + digestSuffix,
@@ -211,14 +208,13 @@ func TestPullGoalFromImageReference(t *testing.T) {
 			false,
 		},
 		{ // Relative path, single element.
-			// FIXME? Note the :latest difference in .image.
 			"dir:this-does-not-exist",
-			[]expected{{"localhost/this-does-not-exist:latest", "localhost/this-does-not-exist:latest"}},
+			[]expected{{"localhost/this-does-not-exist", "localhost/this-does-not-exist:latest"}},
 			false,
 		},
 		{ // Relative path, multiple elements.
 			"dir:testdata/this-does-not-exist",
-			[]expected{{"localhost/testdata/this-does-not-exist:latest", "localhost/testdata/this-does-not-exist:latest"}},
+			[]expected{{"localhost/testdata/this-does-not-exist", "localhost/testdata/this-does-not-exist:latest"}},
 			false,
 		},
 

--- a/libpod/image/pull_test.go
+++ b/libpod/image/pull_test.go
@@ -324,8 +324,7 @@ func TestPullGoalFromPossiblyUnqualifiedName(t *testing.T) {
 		{ // Qualified example.com, name@digest.
 			"example.com/ns/busybox" + digestSuffix,
 			[]pullRefStrings{{"example.com/ns/busybox" + digestSuffix, "docker://example.com/ns/busybox" + digestSuffix,
-				// FIXME?! Why is .dstName dropping the digest, and adding :none?!
-				"example.com/ns/busybox:none"}},
+				"example.com/ns/busybox" + digestSuffix}},
 			false,
 		},
 		// Qualified example.com, name:tag@digest.  This code is happy to try, but .srcRef parsing currently rejects such input.

--- a/libpod/image/utils.go
+++ b/libpod/image/utils.go
@@ -17,6 +17,7 @@ import (
 // findImageInRepotags takes an imageParts struct and searches images' repotags for
 // a match on name:tag
 func findImageInRepotags(search imageParts, images []*Image) (*storage.Image, error) {
+	_, searchName, searchSuspiciousTagValueForSearch := search.suspiciousRefNameTagValuesForSearch()
 	var results []*storage.Image
 	for _, image := range images {
 		for _, name := range image.Names() {
@@ -25,21 +26,22 @@ func findImageInRepotags(search imageParts, images []*Image) (*storage.Image, er
 			if err != nil {
 				continue
 			}
-			if d.name == search.name && d.tag == search.tag {
+			_, dName, dSuspiciousTagValueForSearch := d.suspiciousRefNameTagValuesForSearch()
+			if dName == searchName && dSuspiciousTagValueForSearch == searchSuspiciousTagValueForSearch {
 				results = append(results, image.image)
 				continue
 			}
 			// account for registry:/somedir/image
-			if strings.HasSuffix(d.name, search.name) && d.tag == search.tag {
+			if strings.HasSuffix(dName, searchName) && dSuspiciousTagValueForSearch == searchSuspiciousTagValueForSearch {
 				results = append(results, image.image)
 				continue
 			}
 		}
 	}
 	if len(results) == 0 {
-		return &storage.Image{}, errors.Errorf("unable to find a name and tag match for %s in repotags", search.name)
+		return &storage.Image{}, errors.Errorf("unable to find a name and tag match for %s in repotags", searchName)
 	} else if len(results) > 1 {
-		return &storage.Image{}, errors.Errorf("found multiple name and tag matches for %s in repotags", search.name)
+		return &storage.Image{}, errors.Errorf("found multiple name and tag matches for %s in repotags", searchName)
 	}
 	return results[0], nil
 }

--- a/libpod/image/utils.go
+++ b/libpod/image/utils.go
@@ -16,7 +16,7 @@ import (
 
 // findImageInRepotags takes an imageParts struct and searches images' repotags for
 // a match on name:tag
-func findImageInRepotags(search Parts, images []*Image) (*storage.Image, error) {
+func findImageInRepotags(search imageParts, images []*Image) (*storage.Image, error) {
 	var results []*storage.Image
 	for _, image := range images {
 		for _, name := range image.Names() {
@@ -25,12 +25,12 @@ func findImageInRepotags(search Parts, images []*Image) (*storage.Image, error) 
 			if err != nil {
 				continue
 			}
-			if d.name == search.name && d.Tag == search.Tag {
+			if d.name == search.name && d.tag == search.tag {
 				results = append(results, image.image)
 				continue
 			}
 			// account for registry:/somedir/image
-			if strings.HasSuffix(d.name, search.name) && d.Tag == search.Tag {
+			if strings.HasSuffix(d.name, search.name) && d.tag == search.tag {
 				results = append(results, image.image)
 				continue
 			}


### PR DESCRIPTION
This reduces `imageParts` from various individual fields to a pair of (unnormalized `reference.Named`, `hasRegistry`), with the capability to get a normalized `reference.Named` value (either directly or by supplying the missing registry hostname); and ports most users to use the references.

Notably this removes the `.assemble()` method which could return a `:none` tag for digested inputs, hopefully addressing #2026, and _partially_ #1139 .

This involves _several_ behavior changes; not using the `:none` tag seems clearly desirable, others should be harmless but are less clear:
- The names used during pull output on the console, and returned by `PullFrom…`, now do not include any tag if the user did not specify one. AFAICS that should not break the subsequent image lookup.
- Tagging as `docker.io/busybox:foo` will actually create a `docker.io/library/busybox:foo` tag.
- It’s might now be possible to tag images with a digested reference (previously this created a nonsensical tag which was probably mostly ignored)

Also, some of the old behavior, notably WRT tags, while expunged from `imageParts` proper, has been preserved in a new method `imageParts.suspiciousRefNameTagValuesForSearch`, used in `Image.MatchRepoTag` and `findImageInRepoTags`. The heuristics in both of these methods don’t really make sense to me, but because I don’t understand them, I didn’t touch them. At least the code computing those values is now off the primary code paths.

See the individual commit messages for details.

Absolutely untested, apart from `libpod/image` unit tests.

@baude RFC

