### PR TITLE
Fix handling of nil volumes

### DIFF
--- a/cmd/podman/create_cli.go
+++ b/cmd/podman/create_cli.go
@@ -201,6 +201,9 @@ func parseVolumesFrom(volumesFrom []string) error {
 }
 
 func validateVolumeHostDir(hostDir string) error {
+	if len(hostDir) == 0 {
+		return errors.Errorf("host directory cannot be empty")
+	}
 	if filepath.IsAbs(hostDir) {
 		if _, err := os.Stat(hostDir); err != nil {
 			return errors.Wrapf(err, "error checking path %q", hostDir)
@@ -212,6 +215,9 @@ func validateVolumeHostDir(hostDir string) error {
 }
 
 func validateVolumeCtrDir(ctrDir string) error {
+	if len(ctrDir) == 0 {
+		return errors.Errorf("container directory cannot be empty")
+	}
 	if !filepath.IsAbs(ctrDir) {
 		return errors.Errorf("invalid container path, must be an absolute path %q", ctrDir)
 	}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -596,6 +596,21 @@ USER mail`
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman run --volumes flag with empty host dir", func() {
+		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
+		err := os.MkdirAll(vol1, 0755)
+		Expect(err).To(BeNil())
+
+		session := podmanTest.Podman([]string{"run", "--volume", ":/myvol1:z", ALPINE, "touch", "/myvol2/foo.txt"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session.ErrorToString()).To(ContainSubstring("directory cannot be empty"))
+		session = podmanTest.Podman([]string{"run", "--volume", vol1 + ":", ALPINE, "touch", "/myvol2/foo.txt"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session.ErrorToString()).To(ContainSubstring("directory cannot be empty"))
+	})
+
 	It("podman run --mount flag with multiple mounts", func() {
 		vol1 := filepath.Join(podmanTest.TempDir, "vol-test1")
 		err := os.MkdirAll(vol1, 0755)


### PR DESCRIPTION
Currently if a user passes in a -v with
-v $bogus:/foobar

We crash.  This will throw a proper error.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>