### PR TITLE
createconfig: always cleanup a rootless container

### DIFF
--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -518,7 +518,9 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime) ([]lib
 	if c.CgroupParent != "" {
 		options = append(options, libpod.WithCgroupParent(c.CgroupParent))
 	}
-	if c.Detach {
+	// For a rootless container always cleanup the storage/network as they
+	// run in a different namespace thus not reusable when we restart.
+	if c.Detach || rootless.IsRootless() {
 		options = append(options, libpod.WithExitCommand(c.createExitCommand()))
 	}
 


### PR DESCRIPTION
the rootless container storage is always mounted in a different mount
namespace, owned by the unprivileged user.  Even if it is mounted, a
process running in another namespace cannot reuse the already mounted
storage.

Make sure the storage is always cleaned up once the container
terminates.

This has worked with vfs since there is no real mounted storage.

Closes: https://github.com/containers/libpod/issues/2112

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>