### PR TITLE
rootless: fix usage of create --pod=new:FOO

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -422,6 +422,16 @@ func parseCreateOpts(ctx context.Context, c *cli.Context, runtime *libpod.Runtim
 	}
 	if c.IsSet("pod") {
 		if strings.HasPrefix(originalPodName, "new:") {
+			if rootless.IsRootless() {
+				// To create a new pod, we must immediately create the userns.
+				became, ret, err := rootless.BecomeRootInUserNS()
+				if err != nil {
+					return nil, err
+				}
+				if became {
+					os.Exit(ret)
+				}
+			}
 			// pod does not exist; lets make it
 			var podOptions []libpod.PodCreateOption
 			podOptions = append(podOptions, libpod.WithPodName(podName), libpod.WithInfraContainer(), libpod.WithPodCgroups())

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -227,7 +227,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 			Options:     []string{"bind", "private"},
 		}
 		if c.IsReadOnly() && dstPath != "/dev/shm" {
-			newMount.Options = append(newMount.Options, "ro")
+			newMount.Options = append(newMount.Options, "ro", "nosuid", "noexec", "nodev")
 		}
 		if !MountExists(g.Mounts(), dstPath) {
 			g.AddMount(newMount)


### PR DESCRIPTION
some fixes that enable using `--pod=new:FOO` with rootless containers

Closes: https://github.com/containers/libpod/issues/2124