### PR TITLE
Add darwin support for remote-client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GO ?= go
 DESTDIR ?= /
-EPOCH_TEST_COMMIT ?= e1732a5213147e3c0b7bf60b55a332c3720ecb4b
+EPOCH_TEST_COMMIT ?= bd40dcfc2bc7c9014ea1f33482fb63aacbcdfe87
 HEAD ?= HEAD
 CHANGELOG_BASE ?= HEAD~
 CHANGELOG_TARGET ?= HEAD
@@ -108,6 +108,9 @@ podman: .gopathok $(PODMAN_VARLINK_DEPENDENCIES)
 
 podman-remote: .gopathok $(PODMAN_VARLINK_DEPENDENCIES)
 	$(GO) build -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS) remoteclient" -o bin/$@ $(PROJECT)/cmd/podman
+
+podman-remote-darwin: .gopathok $(PODMAN_VARLINK_DEPENDENCIES)
+	GOOS=darwin $(GO) build -ldflags '$(LDFLAGS_PODMAN)' -tags "remoteclient containers_image_openpgp exclude_graphdriver_devicemapper" -o bin/$@ $(PROJECT)/cmd/podman
 
 local-cross: $(CROSS_BUILD_TARGETS)
 

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -120,7 +120,7 @@ func main() {
 			os.Exit(1)
 		}
 		args := c.Args()
-		if args.Present() {
+		if args.Present() && rootless.IsRootless() {
 			if _, notRequireRootless := cmdsNotRequiringRootless[args.First()]; !notRequireRootless {
 				became, ret, err := rootless.BecomeRootInUserNS()
 				if err != nil {
@@ -265,11 +265,10 @@ func main() {
 			Usage: "output logging information to syslog as well as the console",
 		},
 	}
-	if _, err := os.Stat("/etc/containers/registries.conf"); err != nil {
-		if os.IsNotExist(err) {
-			logrus.Warn("unable to find /etc/containers/registries.conf. some podman (image shortnames) commands may be limited")
-		}
-	}
+	// Check if /etc/containers/registries.conf exists when running in
+	// in a local environment.
+	CheckForRegistries()
+
 	if err := app.Run(os.Args); err != nil {
 		if debug {
 			logrus.Errorf(err.Error())

--- a/cmd/podman/platform_linux.go
+++ b/cmd/podman/platform_linux.go
@@ -1,0 +1,17 @@
+// +build linux
+
+package main
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+func CheckForRegistries() {
+	if _, err := os.Stat("/etc/containers/registries.conf"); err != nil {
+		if os.IsNotExist(err) {
+			logrus.Warn("unable to find /etc/containers/registries.conf. some podman (image shortnames) commands may be limited")
+		}
+	}
+}

--- a/cmd/podman/platform_unsupported.go
+++ b/cmd/podman/platform_unsupported.go
@@ -1,0 +1,6 @@
+// +build !linux
+
+package main
+
+func CheckForRegistries() {
+}

--- a/cmd/podman/tag.go
+++ b/cmd/podman/tag.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/containers/libpod/cmd/podman/libpodruntime"
+	"github.com/containers/libpod/libpod/adapter"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -23,13 +23,13 @@ func tagCmd(c *cli.Context) error {
 	if len(args) < 2 {
 		return errors.Errorf("image name and at least one new name must be specified")
 	}
-	runtime, err := libpodruntime.GetRuntime(c)
+	localRuntime, err := adapter.GetRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not create runtime")
 	}
-	defer runtime.Shutdown(false)
+	defer localRuntime.Runtime.Shutdown(false)
 
-	newImage, err := runtime.ImageRuntime().NewFromLocal(args[0])
+	newImage, err := localRuntime.NewImageFromLocal(args[0])
 	if err != nil {
 		return err
 	}

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -411,6 +412,25 @@ func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir 
 	}
 
 	return waitErr
+}
+
+// AttachStreams contains streams that will be attached to the container
+type AttachStreams struct {
+	// OutputStream will be attached to container's STDOUT
+	OutputStream io.WriteCloser
+	// ErrorStream will be attached to container's STDERR
+	ErrorStream io.WriteCloser
+	// InputStream will be attached to container's STDIN
+	InputStream io.Reader
+	// AttachOutput is whether to attach to STDOUT
+	// If false, stdout will not be attached
+	AttachOutput bool
+	// AttachError is whether to attach to STDERR
+	// If false, stdout will not be attached
+	AttachError bool
+	// AttachInput is whether to attach to STDIN
+	// If false, stdout will not be attached
+	AttachInput bool
 }
 
 // Attach attaches to a container

--- a/libpod/container_attach_linux.go
+++ b/libpod/container_attach_linux.go
@@ -1,3 +1,5 @@
+//+build linux
+
 package libpod
 
 import (
@@ -26,25 +28,6 @@ const (
 	AttachPipeStdout = 2
 	AttachPipeStderr = 3
 )
-
-// AttachStreams contains streams that will be attached to the container
-type AttachStreams struct {
-	// OutputStream will be attached to container's STDOUT
-	OutputStream io.WriteCloser
-	// ErrorStream will be attached to container's STDERR
-	ErrorStream io.WriteCloser
-	// InputStream will be attached to container's STDIN
-	InputStream io.Reader
-	// AttachOutput is whether to attach to STDOUT
-	// If false, stdout will not be attached
-	AttachOutput bool
-	// AttachError is whether to attach to STDERR
-	// If false, stdout will not be attached
-	AttachError bool
-	// AttachInput is whether to attach to STDIN
-	// If false, stdout will not be attached
-	AttachInput bool
-}
 
 // Attach to the given container
 // Does not check if state is appropriate

--- a/libpod/container_attach_unsupported.go
+++ b/libpod/container_attach_unsupported.go
@@ -1,0 +1,11 @@
+//+build !linux
+
+package libpod
+
+import (
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool) error {
+	return ErrNotImplemented
+}

--- a/libpod/lock/shm_lock_manager_unsupported.go
+++ b/libpod/lock/shm_lock_manager_unsupported.go
@@ -9,12 +9,12 @@ import "fmt"
 type SHMLockManager struct{}
 
 // NewSHMLockManager is not supported on this platform
-func NewSHMLockManager(numLocks uint32) (Manager, error) {
+func NewSHMLockManager(path string, numLocks uint32) (Manager, error) {
 	return nil, fmt.Errorf("not supported")
 }
 
 // OpenSHMLockManager is not supported on this platform
-func OpenSHMLockManager(numLocks uint32) (Manager, error) {
+func OpenSHMLockManager(path string, numLocks uint32) (Manager, error) {
 	return nil, fmt.Errorf("not supported")
 }
 

--- a/libpod/runtime_volume_unsupported.go
+++ b/libpod/runtime_volume_unsupported.go
@@ -1,0 +1,19 @@
+// +build !linux
+
+package libpod
+
+import (
+	"context"
+)
+
+func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force, prune bool) error {
+	return ErrNotImplemented
+}
+
+func (r *Runtime) newVolume(ctx context.Context, options ...VolumeCreateOption) (*Volume, error) {
+	return nil, ErrNotImplemented
+}
+
+func (r *Runtime) NewVolume(ctx context.Context, options ...VolumeCreateOption) (*Volume, error) {
+	return nil, ErrNotImplemented
+}

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -14,7 +14,7 @@ func IsRootless() bool {
 // BecomeRootInUserNS is a stub function that always returns false and an
 // error on unsupported OS's
 func BecomeRootInUserNS() (bool, int, error) {
-	return false, -1, errors.New("this function is not supported on this os")
+	return false, -1, errors.New("this function is not supported on this os1")
 }
 
 // GetRootlessUID returns the UID of the user in the parent userNS
@@ -34,11 +34,18 @@ func SkipStorageSetup() bool {
 // JoinNS re-exec podman in a new userNS and join the user namespace of the specified
 // PID.
 func JoinNS(pid uint) (bool, int, error) {
-	return false, -1, errors.New("this function is not supported on this os")
+	return false, -1, errors.New("this function is not supported on this os2")
 }
 
 // JoinNSPath re-exec podman in a new userNS and join the owner user namespace of the
 // specified path.
 func JoinNSPath(path string) (bool, int, error) {
-	return false, -1, errors.New("this function is not supported on this os")
+	return false, -1, errors.New("this function is not supported on this os3")
+}
+
+// JoinDirectUserAndMountNS re-exec podman in a new userNS and join the user and mount
+// namespace of the specified PID without looking up its parent.  Useful to join directly
+// the conmon process.
+func JoinDirectUserAndMountNS(pid uint) (bool, int, error) {
+	return false, -1, errors.New("this function is not supported on this os4")
 }

--- a/pkg/spec/config_unsupported.go
+++ b/pkg/spec/config_unsupported.go
@@ -26,3 +26,7 @@ func (c *CreateConfig) createBlockIO() (*spec.LinuxBlockIO, error) {
 func makeThrottleArray(throttleInput []string, rateType int) ([]spec.LinuxThrottleDevice, error) {
 	return nil, errors.New("function not implemented")
 }
+
+func devicesFromPath(g *generate.Generator, devicePath string) error {
+	return errors.New("function not implemented")
+}


### PR DESCRIPTION
Add the ability to cross-compile podman remote for OSX.

Also, add image exists and tag to remote-client.

Signed-off-by: baude <bbaude@redhat.com>