### PR TITLE
Run integrations test with remote-client

### DIFF
--- a/.papr.sh
+++ b/.papr.sh
@@ -110,6 +110,7 @@ fi
 if [ $build -eq 1 ]; then
     make_install_tools
     make TAGS="${TAGS}" GOPATH=$GOPATH
+    make podman-remote TAGS="${TAGS}" GOPATH=$GOPATH
 fi
 
 # Install Podman
@@ -126,4 +127,5 @@ if [ $integrationtest -eq 1 ]; then
     make TAGS="${TAGS}" test-binaries
     make varlink_generate GOPATH=/go
     make ginkgo GOPATH=/go $INTEGRATION_TEST_ENVS
+    make ginkgo-remote GOPATH=/go $INTEGRATION_TEST_ENVS
 fi

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,10 @@ localunit: test/goecho/goecho varlink_generate
 ginkgo:
 	ginkgo -v -tags "$(BUILDTAGS)" -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.
 
-localintegration: varlink_generate test-binaries ginkgo
+ginkgo-remote:
+	ginkgo -v -tags "$(BUILDTAGS) remoteclient" -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.
+
+localintegration: varlink_generate test-binaries ginkgo ginkgo-remote
 
 localsystem: .install.ginkgo .install.gomega
 	ginkgo -v -noColor test/system/
@@ -188,7 +191,7 @@ run-perftest: perftest
 vagrant-check:
 	BOX=$(BOX) sh ./vagrant.sh
 
-binaries: varlink_generate podman
+binaries: varlink_generate podman podman-remote
 
 install.catatonit:
 	./hack/install_catatonit.sh

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/containers/libpod/libpod/adapter"
 	"io"
 	"os"
 	"strings"
@@ -9,7 +10,6 @@ import (
 	dockerarchive "github.com/containers/image/docker/archive"
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
-	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	image2 "github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
@@ -64,11 +64,11 @@ specified, the image with the 'latest' tag (if it exists) is pulled
 // pullCmd gets the data from the command line and calls pullImage
 // to copy an image from a registry to a local machine
 func pullCmd(c *cli.Context) error {
-	runtime, err := libpodruntime.GetRuntime(c)
+	localRuntime, err := adapter.GetRuntime(c)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}
-	defer runtime.Shutdown(false)
+	defer localRuntime.Runtime.Shutdown(false)
 
 	args := c.Args()
 	if len(args) == 0 {
@@ -116,14 +116,14 @@ func pullCmd(c *cli.Context) error {
 		if err != nil {
 			return errors.Wrapf(err, "error parsing %q", image)
 		}
-		newImage, err := runtime.ImageRuntime().LoadFromArchiveReference(getContext(), srcRef, c.String("signature-policy"), writer)
+		newImage, err := localRuntime.LoadFromArchiveReference(getContext(), srcRef, c.String("signature-policy"), writer)
 		if err != nil {
 			return errors.Wrapf(err, "error pulling image from %q", image)
 		}
 		imgID = newImage[0].ID()
 	} else {
 		authfile := getAuthFile(c.String("authfile"))
-		newImage, err := runtime.ImageRuntime().New(getContext(), image, c.String("signature-policy"), authfile, writer, &dockerRegistryOptions, image2.SigningOptions{}, true)
+		newImage, err := localRuntime.New(getContext(), image, c.String("signature-policy"), authfile, writer, &dockerRegistryOptions, image2.SigningOptions{}, true)
 		if err != nil {
 			return errors.Wrapf(err, "error pulling image %q", image)
 		}

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -24,6 +24,8 @@ case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
     centos-7) ;&
     rhel-7)
         make install PREFIX=/usr ETCDIR=/etc
+        make podman-remote
+        install bin/podman-remote /usr/bin
         make test-binaries
         make localintegration
         ;;

--- a/libpod/adapter/runtime.go
+++ b/libpod/adapter/runtime.go
@@ -3,6 +3,10 @@
 package adapter
 
 import (
+	"context"
+	"io"
+
+	"github.com/containers/image/types"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/image"
@@ -48,6 +52,29 @@ func (r *LocalRuntime) GetImages() ([]*ContainerImage, error) {
 // NewImageFromLocal returns a containerimage representation of a image from local storage
 func (r *LocalRuntime) NewImageFromLocal(name string) (*ContainerImage, error) {
 	img, err := r.Runtime.ImageRuntime().NewFromLocal(name)
+	if err != nil {
+		return nil, err
+	}
+	return &ContainerImage{img}, nil
+}
+
+// LoadFromArchiveReference calls into local storage to load an image from an archive
+func (r *LocalRuntime) LoadFromArchiveReference(ctx context.Context, srcRef types.ImageReference, signaturePolicyPath string, writer io.Writer) ([]*ContainerImage, error) {
+	var containerImages []*ContainerImage
+	imgs, err := r.Runtime.ImageRuntime().LoadFromArchiveReference(ctx, srcRef, signaturePolicyPath, writer)
+	if err != nil {
+		return nil, err
+	}
+	for _, i := range imgs {
+		ci := ContainerImage{i}
+		containerImages = append(containerImages, &ci)
+	}
+	return containerImages, nil
+}
+
+// New calls into local storage to look for an image in local storage or to pull it
+func (r *LocalRuntime) New(ctx context.Context, name, signaturePolicyPath, authfile string, writer io.Writer, dockeroptions *image.DockerRegistryOptions, signingoptions image.SigningOptions, forcePull bool) (*ContainerImage, error) {
+	img, err := r.Runtime.ImageRuntime().New(ctx, name, signaturePolicyPath, authfile, writer, dockeroptions, signingoptions, forcePull)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1,0 +1,229 @@
+package integration
+
+import (
+	"fmt"
+	. "github.com/containers/libpod/test/utils"
+	"os"
+	"os/exec"
+
+	"github.com/containers/storage/pkg/reexec"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var (
+	PODMAN_BINARY      string
+	CONMON_BINARY      string
+	CNI_CONFIG_DIR     string
+	RUNC_BINARY        string
+	INTEGRATION_ROOT   string
+	CGROUP_MANAGER     = "systemd"
+	ARTIFACT_DIR       = "/tmp/.artifacts"
+	RESTORE_IMAGES     = []string{ALPINE, BB}
+	defaultWaitTimeout = 90
+)
+
+// PodmanTestIntegration struct for command line options
+type PodmanTestIntegration struct {
+	PodmanTest
+	ConmonBinary        string
+	CrioRoot            string
+	CNIConfigDir        string
+	RunCBinary          string
+	RunRoot             string
+	StorageOptions      string
+	SignaturePolicyPath string
+	CgroupManager       string
+	Host                HostOS
+}
+
+// PodmanSessionIntegration sturct for command line session
+type PodmanSessionIntegration struct {
+	*PodmanSession
+}
+
+// TestLibpod ginkgo master function
+func TestLibpod(t *testing.T) {
+	if reexec.Init() {
+		os.Exit(1)
+	}
+	if os.Getenv("NOCACHE") == "1" {
+		CACHE_IMAGES = []string{}
+		RESTORE_IMAGES = []string{}
+	}
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Libpod Suite")
+}
+
+var _ = BeforeSuite(func() {
+	//Cache images
+	cwd, _ := os.Getwd()
+	INTEGRATION_ROOT = filepath.Join(cwd, "../../")
+	podman := PodmanTestCreate("/tmp")
+	podman.ArtifactPath = ARTIFACT_DIR
+	if _, err := os.Stat(ARTIFACT_DIR); os.IsNotExist(err) {
+		if err = os.Mkdir(ARTIFACT_DIR, 0777); err != nil {
+			fmt.Printf("%q\n", err)
+			os.Exit(1)
+		}
+	}
+	for _, image := range CACHE_IMAGES {
+		if err := podman.CreateArtifact(image); err != nil {
+			fmt.Printf("%q\n", err)
+			os.Exit(1)
+		}
+	}
+	host := GetHostDistributionInfo()
+	if host.Distribution == "rhel" && strings.HasPrefix(host.Version, "7") {
+		f, err := os.OpenFile("/proc/sys/user/max_user_namespaces", os.O_WRONLY, 0644)
+		if err != nil {
+			fmt.Println("Unable to enable userspace on RHEL 7")
+			os.Exit(1)
+		}
+		_, err = f.WriteString("15000")
+		if err != nil {
+			fmt.Println("Unable to enable userspace on RHEL 7")
+			os.Exit(1)
+		}
+		f.Close()
+	}
+})
+
+// PodmanTestCreate creates a PodmanTestIntegration instance for the tests
+func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
+	var (
+		podmanRemoteBinary string
+	)
+
+	host := GetHostDistributionInfo()
+	cwd, _ := os.Getwd()
+
+	podmanBinary := filepath.Join(cwd, "../../bin/podman")
+	if os.Getenv("PODMAN_BINARY") != "" {
+		podmanBinary = os.Getenv("PODMAN_BINARY")
+	}
+
+	if remote {
+		podmanRemoteBinary = filepath.Join(cwd, "../../bin/podman-remote")
+		if os.Getenv("PODMAN_REMOTE_BINARY") != "" {
+			podmanRemoteBinary = os.Getenv("PODMAN_REMOTE_BINARY")
+		}
+	}
+	conmonBinary := filepath.Join("/usr/libexec/podman/conmon")
+	altConmonBinary := "/usr/libexec/crio/conmon"
+	if _, err := os.Stat(conmonBinary); os.IsNotExist(err) {
+		conmonBinary = altConmonBinary
+	}
+	if os.Getenv("CONMON_BINARY") != "" {
+		conmonBinary = os.Getenv("CONMON_BINARY")
+	}
+	storageOptions := STORAGE_OPTIONS
+	if os.Getenv("STORAGE_OPTIONS") != "" {
+		storageOptions = os.Getenv("STORAGE_OPTIONS")
+	}
+	cgroupManager := CGROUP_MANAGER
+	if os.Getenv("CGROUP_MANAGER") != "" {
+		cgroupManager = os.Getenv("CGROUP_MANAGER")
+	}
+
+	// Ubuntu doesn't use systemd cgroups
+	if host.Distribution == "ubuntu" {
+		cgroupManager = "cgroupfs"
+	}
+
+	runCBinary, err := exec.LookPath("runc")
+	// If we cannot find the runc binary, setting to something static as we have no way
+	// to return an error.  The tests will fail and point out that the runc binary could
+	// not be found nicely.
+	if err != nil {
+		runCBinary = "/usr/bin/runc"
+	}
+
+	CNIConfigDir := "/etc/cni/net.d"
+
+	p := &PodmanTestIntegration{
+		PodmanTest: PodmanTest{
+			PodmanBinary: podmanBinary,
+			ArtifactPath: ARTIFACT_DIR,
+			TempDir:      tempDir,
+			RemoteTest:   remote,
+		},
+		ConmonBinary:        conmonBinary,
+		CrioRoot:            filepath.Join(tempDir, "crio"),
+		CNIConfigDir:        CNIConfigDir,
+		RunCBinary:          runCBinary,
+		RunRoot:             filepath.Join(tempDir, "crio-run"),
+		StorageOptions:      storageOptions,
+		SignaturePolicyPath: filepath.Join(INTEGRATION_ROOT, "test/policy.json"),
+		CgroupManager:       cgroupManager,
+		Host:                host,
+	}
+	if remote {
+		p.PodmanTest.RemotePodmanBinary = podmanRemoteBinary
+	}
+
+	// Setup registries.conf ENV variable
+	p.setDefaultRegistriesConfigEnv()
+	// Rewrite the PodmanAsUser function
+	p.PodmanMakeOptions = p.makeOptions
+	return p
+}
+
+//MakeOptions assembles all the podman main options
+func (p *PodmanTestIntegration) makeOptions(args []string) []string {
+	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --cni-config-dir %s --cgroup-manager %s",
+		p.CrioRoot, p.RunRoot, p.RunCBinary, p.ConmonBinary, p.CNIConfigDir, p.CgroupManager), " ")
+	if os.Getenv("HOOK_OPTION") != "" {
+		podmanOptions = append(podmanOptions, os.Getenv("HOOK_OPTION"))
+	}
+	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
+	podmanOptions = append(podmanOptions, args...)
+	return podmanOptions
+}
+
+// RestoreArtifact puts the cached image into our test store
+func (p *PodmanTestIntegration) RestoreArtifact(image string) error {
+	fmt.Printf("Restoring %s...\n", image)
+	dest := strings.Split(image, "/")
+	destName := fmt.Sprintf("/tmp/%s.tar", strings.Replace(strings.Join(strings.Split(dest[len(dest)-1], "/"), ""), ":", "-", -1))
+	restore := p.Podman([]string{"load", "-q", "-i", destName})
+	restore.Wait(90)
+	return nil
+}
+
+// RestoreAllArtifacts unpacks all cached images
+func (p *PodmanTestIntegration) RestoreAllArtifacts() error {
+	if os.Getenv("NO_TEST_CACHE") != "" {
+		return nil
+	}
+	for _, image := range RESTORE_IMAGES {
+		if err := p.RestoreArtifact(image); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CreateArtifact creates a cached image in the artifact dir
+func (p *PodmanTestIntegration) CreateArtifact(image string) error {
+	if os.Getenv("NO_TEST_CACHE") != "" {
+		return nil
+	}
+	fmt.Printf("Caching %s...", image)
+	dest := strings.Split(image, "/")
+	destName := fmt.Sprintf("/tmp/%s.tar", strings.Replace(strings.Join(strings.Split(dest[len(dest)-1], "/"), ""), ":", "-", -1))
+	if _, err := os.Stat(destName); os.IsNotExist(err) {
+		pull := p.Podman([]string{"pull", image})
+		pull.Wait(90)
+
+		save := p.Podman([]string{"save", "-o", destName, image})
+		save.Wait(90)
+		fmt.Printf("\n")
+	} else {
+		fmt.Printf(" already exists.\n")
+	}
+	return nil
+}

--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/exists_test.go
+++ b/test/e2e/exists_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (
@@ -32,6 +34,7 @@ var _ = Describe("Podman image|container exists", func() {
 		GinkgoWriter.Write([]byte(timedResult))
 
 	})
+
 	It("podman image exists in local storage by fq name", func() {
 		session := podmanTest.Podman([]string{"image", "exists", ALPINE})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/export_test.go
+++ b/test/e2e/export_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/history_test.go
+++ b/test/e2e/history_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -106,6 +106,9 @@ var _ = Describe("Podman images", func() {
 	})
 
 	It("podman images filter before image", func() {
+		if podmanTest.RemoteTest {
+			Skip("Does not work on remote client")
+		}
 		dockerfile := `FROM docker.io/library/alpine:latest
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
@@ -116,6 +119,9 @@ var _ = Describe("Podman images", func() {
 	})
 
 	It("podman images filter after image", func() {
+		if podmanTest.RemoteTest {
+			Skip("Does not work on remote client")
+		}
 		rmi := podmanTest.Podman([]string{"rmi", "busybox"})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
@@ -130,6 +136,9 @@ var _ = Describe("Podman images", func() {
 	})
 
 	It("podman images filter dangling", func() {
+		if podmanTest.RemoteTest {
+			Skip("Does not work on remote client")
+		}
 		dockerfile := `FROM docker.io/library/alpine:latest
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
@@ -141,6 +150,9 @@ var _ = Describe("Podman images", func() {
 	})
 
 	It("podman check for image with sha256: prefix", func() {
+		if podmanTest.RemoteTest {
+			Skip("Does not work on remote client")
+		}
 		session := podmanTest.Podman([]string{"inspect", "--format=json", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -175,6 +187,9 @@ var _ = Describe("Podman images", func() {
 	})
 
 	It("podman images --all flag", func() {
+		if podmanTest.RemoteTest {
+			Skip("Does not work on remote client")
+		}
 		dockerfile := `FROM docker.io/library/alpine:latest
 RUN mkdir hello
 RUN touch test.txt

--- a/test/e2e/import_test.go
+++ b/test/e2e/import_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/libpod_suite_remoteclient_test.go
+++ b/test/e2e/libpod_suite_remoteclient_test.go
@@ -1,0 +1,153 @@
+// +build remoteclient
+
+package integration
+
+import (
+	"fmt"
+	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/pkg/inspect"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Cleanup cleans up the temporary store
+func (p *PodmanTestIntegration) Cleanup() {
+	p.StopVarlink()
+	// TODO
+	// Stop all containers
+	// Rm all containers
+	// Rm all  images
+
+	if err := os.RemoveAll(p.TempDir); err != nil {
+		fmt.Printf("%q\n", err)
+	}
+
+	// Clean up the registries configuration file ENV variable set in Create
+	resetRegistriesConfigEnv()
+}
+
+// Podman is the exec call to podman on the filesystem
+func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration {
+	podmanSession := p.PodmanBase(args)
+	return &PodmanSessionIntegration{podmanSession}
+}
+
+//RunTopContainer runs a simple container in the background that
+// runs top.  If the name passed != "", it will have a name
+func (p *PodmanTestIntegration) RunTopContainer(name string) *PodmanSessionIntegration {
+	// TODO
+	return nil
+}
+
+//RunLsContainer runs a simple container in the background that
+// simply runs ls. If the name passed != "", it will have a name
+func (p *PodmanTestIntegration) RunLsContainer(name string) (*PodmanSessionIntegration, int, string) {
+	// TODO
+	return nil, 0, ""
+}
+
+// InspectImageJSON takes the session output of an inspect
+// image and returns json
+func (s *PodmanSessionIntegration) InspectImageJSON() []inspect.ImageData {
+	// TODO
+	return nil
+}
+
+func (p *PodmanTestIntegration) setDefaultRegistriesConfigEnv() {
+	defaultFile := filepath.Join(INTEGRATION_ROOT, "test/registries.conf")
+	os.Setenv("REGISTRIES_CONFIG_PATH", defaultFile)
+}
+
+func (p *PodmanTestIntegration) setRegistriesConfigEnv(b []byte) {
+	outfile := filepath.Join(p.TempDir, "registries.conf")
+	os.Setenv("REGISTRIES_CONFIG_PATH", outfile)
+	ioutil.WriteFile(outfile, b, 0644)
+}
+
+func resetRegistriesConfigEnv() {
+	os.Setenv("REGISTRIES_CONFIG_PATH", "")
+}
+
+// InspectContainerToJSON takes the session output of an inspect
+// container and returns json
+func (s *PodmanSessionIntegration) InspectContainerToJSON() []inspect.ContainerData {
+	// TODO
+	return nil
+}
+
+// CreatePod creates a pod with no infra container
+// it optionally takes a pod name
+func (p *PodmanTestIntegration) CreatePod(name string) (*PodmanSessionIntegration, int, string) {
+	// TODO
+	return nil, 0, ""
+}
+
+func (p *PodmanTestIntegration) RunTopContainerInPod(name, pod string) *PodmanSessionIntegration {
+	// TODO
+	return nil
+}
+
+// BuildImage uses podman build and buildah to build an image
+// called imageName based on a string dockerfile
+func (p *PodmanTestIntegration) BuildImage(dockerfile, imageName string, layers string) {
+	// TODO
+}
+
+// CleanupPod cleans up the temporary store
+func (p *PodmanTestIntegration) CleanupPod() {
+	// TODO
+}
+
+// InspectPodToJSON takes the sessions output from a pod inspect and returns json
+func (s *PodmanSessionIntegration) InspectPodToJSON() libpod.PodInspect {
+	// TODO
+	return libpod.PodInspect{}
+}
+func (p *PodmanTestIntegration) RunLsContainerInPod(name, pod string) (*PodmanSessionIntegration, int, string) {
+	// TODO
+	return nil, 0, ""
+}
+
+// PullImages pulls multiple images
+func (p *PodmanTestIntegration) PullImages(images []string) error {
+	// TODO
+	return libpod.ErrNotImplemented
+}
+
+// PodmanPID execs podman and returns its PID
+func (p *PodmanTestIntegration) PodmanPID(args []string) (*PodmanSessionIntegration, int) {
+	// TODO
+	return nil, 0
+}
+
+// CleanupVolume cleans up the temporary store
+func (p *PodmanTestIntegration) CleanupVolume() {
+	// TODO
+}
+
+func PodmanTestCreate(tempDir string) *PodmanTestIntegration {
+	pti := PodmanTestCreateUtil(tempDir, true)
+	pti.StartVarlink()
+	return pti
+}
+
+func (p *PodmanTestIntegration) StartVarlink() {
+	if _, err := os.Stat("/path/to/whatever"); os.IsNotExist(err) {
+		os.MkdirAll("/run/podman", 0755)
+	}
+	args := []string{"varlink", "--timeout", "0", "unix:/run/podman/io.podman"}
+	podmanOptions := p.MakeOptions(args)
+	command := exec.Command(p.PodmanBinary, podmanOptions...)
+	fmt.Printf("Running: %s %s\n", p.PodmanBinary, strings.Join(podmanOptions, " "))
+	command.Start()
+	p.VarlinkSession = command.Process
+}
+
+func (p *PodmanTestIntegration) StopVarlink() {
+	varlinkSession := p.VarlinkSession
+	varlinkSession.Kill()
+	varlinkSession.Wait()
+}

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (
@@ -8,172 +10,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"testing"
 
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/inspect"
 	. "github.com/containers/libpod/test/utils"
-	"github.com/containers/storage/pkg/reexec"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 )
-
-var (
-	PODMAN_BINARY      string
-	CONMON_BINARY      string
-	CNI_CONFIG_DIR     string
-	RUNC_BINARY        string
-	INTEGRATION_ROOT   string
-	CGROUP_MANAGER     = "systemd"
-	ARTIFACT_DIR       = "/tmp/.artifacts"
-	RESTORE_IMAGES     = []string{ALPINE, BB}
-	defaultWaitTimeout = 90
-)
-
-// PodmanTestIntegration struct for command line options
-type PodmanTestIntegration struct {
-	PodmanTest
-	ConmonBinary        string
-	CrioRoot            string
-	CNIConfigDir        string
-	RunCBinary          string
-	RunRoot             string
-	StorageOptions      string
-	SignaturePolicyPath string
-	CgroupManager       string
-	Host                HostOS
-}
-
-// PodmanSessionIntegration sturct for command line session
-type PodmanSessionIntegration struct {
-	*PodmanSession
-}
-
-// TestLibpod ginkgo master function
-func TestLibpod(t *testing.T) {
-	if reexec.Init() {
-		os.Exit(1)
-	}
-	if os.Getenv("NOCACHE") == "1" {
-		CACHE_IMAGES = []string{}
-		RESTORE_IMAGES = []string{}
-	}
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Libpod Suite")
-}
-
-var _ = BeforeSuite(func() {
-	//Cache images
-	cwd, _ := os.Getwd()
-	INTEGRATION_ROOT = filepath.Join(cwd, "../../")
-	podman := PodmanTestCreate("/tmp")
-	podman.ArtifactPath = ARTIFACT_DIR
-	if _, err := os.Stat(ARTIFACT_DIR); os.IsNotExist(err) {
-		if err = os.Mkdir(ARTIFACT_DIR, 0777); err != nil {
-			fmt.Printf("%q\n", err)
-			os.Exit(1)
-		}
-	}
-	for _, image := range CACHE_IMAGES {
-		if err := podman.CreateArtifact(image); err != nil {
-			fmt.Printf("%q\n", err)
-			os.Exit(1)
-		}
-	}
-	host := GetHostDistributionInfo()
-	if host.Distribution == "rhel" && strings.HasPrefix(host.Version, "7") {
-		f, err := os.OpenFile("/proc/sys/user/max_user_namespaces", os.O_WRONLY, 0644)
-		if err != nil {
-			fmt.Println("Unable to enable userspace on RHEL 7")
-			os.Exit(1)
-		}
-		_, err = f.WriteString("15000")
-		if err != nil {
-			fmt.Println("Unable to enable userspace on RHEL 7")
-			os.Exit(1)
-		}
-		f.Close()
-	}
-})
-
-// PodmanTestCreate creates a PodmanTestIntegration instance for the tests
-func PodmanTestCreate(tempDir string) *PodmanTestIntegration {
-
-	host := GetHostDistributionInfo()
-	cwd, _ := os.Getwd()
-
-	podmanBinary := filepath.Join(cwd, "../../bin/podman")
-	if os.Getenv("PODMAN_BINARY") != "" {
-		podmanBinary = os.Getenv("PODMAN_BINARY")
-	}
-	conmonBinary := filepath.Join("/usr/libexec/podman/conmon")
-	altConmonBinary := "/usr/libexec/crio/conmon"
-	if _, err := os.Stat(conmonBinary); os.IsNotExist(err) {
-		conmonBinary = altConmonBinary
-	}
-	if os.Getenv("CONMON_BINARY") != "" {
-		conmonBinary = os.Getenv("CONMON_BINARY")
-	}
-	storageOptions := STORAGE_OPTIONS
-	if os.Getenv("STORAGE_OPTIONS") != "" {
-		storageOptions = os.Getenv("STORAGE_OPTIONS")
-	}
-	cgroupManager := CGROUP_MANAGER
-	if os.Getenv("CGROUP_MANAGER") != "" {
-		cgroupManager = os.Getenv("CGROUP_MANAGER")
-	}
-
-	// Ubuntu doesn't use systemd cgroups
-	if host.Distribution == "ubuntu" {
-		cgroupManager = "cgroupfs"
-	}
-
-	runCBinary, err := exec.LookPath("runc")
-	// If we cannot find the runc binary, setting to something static as we have no way
-	// to return an error.  The tests will fail and point out that the runc binary could
-	// not be found nicely.
-	if err != nil {
-		runCBinary = "/usr/bin/runc"
-	}
-
-	CNIConfigDir := "/etc/cni/net.d"
-
-	p := &PodmanTestIntegration{
-		PodmanTest: PodmanTest{
-			PodmanBinary: podmanBinary,
-			ArtifactPath: ARTIFACT_DIR,
-			TempDir:      tempDir,
-		},
-		ConmonBinary:        conmonBinary,
-		CrioRoot:            filepath.Join(tempDir, "crio"),
-		CNIConfigDir:        CNIConfigDir,
-		RunCBinary:          runCBinary,
-		RunRoot:             filepath.Join(tempDir, "crio-run"),
-		StorageOptions:      storageOptions,
-		SignaturePolicyPath: filepath.Join(INTEGRATION_ROOT, "test/policy.json"),
-		CgroupManager:       cgroupManager,
-		Host:                host,
-	}
-
-	// Setup registries.conf ENV variable
-	p.setDefaultRegistriesConfigEnv()
-	// Rewrite the PodmanAsUser function
-	p.PodmanMakeOptions = p.makeOptions
-	return p
-}
-
-//MakeOptions assembles all the podman main options
-func (p *PodmanTestIntegration) makeOptions(args []string) []string {
-	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --cni-config-dir %s --cgroup-manager %s",
-		p.CrioRoot, p.RunRoot, p.RunCBinary, p.ConmonBinary, p.CNIConfigDir, p.CgroupManager), " ")
-	if os.Getenv("HOOK_OPTION") != "" {
-		podmanOptions = append(podmanOptions, os.Getenv("HOOK_OPTION"))
-	}
-	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
-	podmanOptions = append(podmanOptions, args...)
-	return podmanOptions
-}
 
 // Podman is the exec call to podman on the filesystem
 func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration {
@@ -281,50 +125,6 @@ func (s *PodmanSessionIntegration) InspectImageJSON() []inspect.ImageData {
 	return i
 }
 
-// CreateArtifact creates a cached image in the artifact dir
-func (p *PodmanTestIntegration) CreateArtifact(image string) error {
-	if os.Getenv("NO_TEST_CACHE") != "" {
-		return nil
-	}
-	fmt.Printf("Caching %s...", image)
-	dest := strings.Split(image, "/")
-	destName := fmt.Sprintf("/tmp/%s.tar", strings.Replace(strings.Join(strings.Split(dest[len(dest)-1], "/"), ""), ":", "-", -1))
-	if _, err := os.Stat(destName); os.IsNotExist(err) {
-		pull := p.Podman([]string{"pull", image})
-		pull.Wait(90)
-
-		save := p.Podman([]string{"save", "-o", destName, image})
-		save.Wait(90)
-		fmt.Printf("\n")
-	} else {
-		fmt.Printf(" already exists.\n")
-	}
-	return nil
-}
-
-// RestoreArtifact puts the cached image into our test store
-func (p *PodmanTestIntegration) RestoreArtifact(image string) error {
-	fmt.Printf("Restoring %s...\n", image)
-	dest := strings.Split(image, "/")
-	destName := fmt.Sprintf("/tmp/%s.tar", strings.Replace(strings.Join(strings.Split(dest[len(dest)-1], "/"), ""), ":", "-", -1))
-	restore := p.Podman([]string{"load", "-q", "-i", destName})
-	restore.Wait(90)
-	return nil
-}
-
-// RestoreAllArtifacts unpacks all cached images
-func (p *PodmanTestIntegration) RestoreAllArtifacts() error {
-	if os.Getenv("NO_TEST_CACHE") != "" {
-		return nil
-	}
-	for _, image := range RESTORE_IMAGES {
-		if err := p.RestoreArtifact(image); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // CreatePod creates a pod with no infra container
 // it optionally takes a pod name
 func (p *PodmanTestIntegration) CreatePod(name string) (*PodmanSessionIntegration, int, string) {
@@ -406,3 +206,10 @@ func (p *PodmanTestIntegration) setRegistriesConfigEnv(b []byte) {
 func resetRegistriesConfigEnv() {
 	os.Setenv("REGISTRIES_CONFIG_PATH", "")
 }
+
+func PodmanTestCreate(tempDir string) *PodmanTestIntegration {
+	return PodmanTestCreateUtil(tempDir, false)
+}
+
+//func (p *PodmanTestIntegration) StartVarlink() {}
+//func (p *PodmanTestIntegration) StopVarlink() {}

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_inspect_test.go
+++ b/test/e2e/pod_inspect_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_kill_test.go
+++ b/test/e2e/pod_kill_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_pause_test.go
+++ b/test/e2e/pod_pause_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_pod_namespaces.go
+++ b/test/e2e/pod_pod_namespaces.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_restart_test.go
+++ b/test/e2e/pod_restart_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_rm_test.go
+++ b/test/e2e/pod_rm_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_start_test.go
+++ b/test/e2e/pod_start_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_stats_test.go
+++ b/test/e2e/pod_stats_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_stop_test.go
+++ b/test/e2e/pod_stop_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pod_top_test.go
+++ b/test/e2e/pod_top_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/port_test.go
+++ b/test/e2e/port_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/refresh_test.go
+++ b/test/e2e/refresh_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_cleanup_test.go
+++ b/test/e2e/run_cleanup_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_exit_test.go
+++ b/test/e2e/run_exit_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_memory_test.go
+++ b/test/e2e/run_memory_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_ns_test.go
+++ b/test/e2e/run_ns_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_passwd_test.go
+++ b/test/e2e/run_passwd_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_restart_test.go
+++ b/test/e2e/run_restart_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_selinux_test.go
+++ b/test/e2e/run_selinux_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/tag_test.go
+++ b/test/e2e/tag_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/top_test.go
+++ b/test/e2e/top_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/trust_test.go
+++ b/test/e2e/trust_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/volume_inspect_test.go
+++ b/test/e2e/volume_inspect_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/volume_rm_test.go
+++ b/test/e2e/volume_rm_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (

--- a/test/e2e/wait_test.go
+++ b/test/e2e/wait_test.go
@@ -1,3 +1,5 @@
+// +build !remoteclient
+
 package integration
 
 import (


### PR DESCRIPTION
Add the ability to run the integration (ginkgo) suite using
the remote client.

Only the images_test.go file is run right now; all the rest are
isolated with a // +build !remotelinux.  As more content is
developed for the remote client, we can unblock the files and
just block single tests as needed.

Signed-off-by: baude <bbaude@redhat.com>