### PR TITLE
Cleanup coverity scan issues

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -70,9 +70,12 @@ get_cmd_line_args (pid_t pid)
       if (allocated == used)
         {
           allocated += 512;
-          buffer = realloc (buffer, allocated);
-          if (buffer == NULL)
-            return NULL;
+          char *tmp = realloc (buffer, allocated);
+          if (buffer == NULL) {
+		  free(buffer);
+		  return NULL;
+	  }
+	  buffer=tmp;
         }
     }
   close (fd);


### PR DESCRIPTION
If realloc fails, then buffer will be leaked, this change frees up the buffer.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>