### PR TITLE
Ensure that wait exits on state transition

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -540,7 +540,7 @@ func (c *Container) isStopped() (bool, error) {
 	if err != nil {
 		return true, err
 	}
-	return (c.state.State == ContainerStateStopped || c.state.State == ContainerStateExited), nil
+	return (c.state.State != ContainerStateRunning && c.state.State != ContainerStatePaused), nil
 }
 
 // save container state to the database


### PR DESCRIPTION
When waiting for a container, there is a long interval between status checks - plenty long enough for the container in question to start, then subsequently be cleaned up and returned to Created state to be restarted. As such, we can't wait on container state to go to Stopped or Exited - anything that is not Running or Paused indicates the container is dead.