### PR TITLE
Cirrus: Consolidate VM image names in once place

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,6 +25,16 @@ env:
     CIRRUS_CLONE_DEPTH: 200
 
     ####
+    #### Cache-image names to test with
+    ###
+    FEDORA_CACHE_IMAGE_NAME: "fedora-29-libpod-9afa57a9"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-28-libpod-9afa57a9"
+    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-18-libpod-9afa57a9"
+    RHEL_CACHE_IMAGE_NAME: "rhel-8-notready"
+    PRIOR_RHEL_CACHE_IMAGE_NAME: "rhel-7-notready"
+    CENTOS_CACHE_IMAGE_NAME: "centos-7-notready"
+
+    ####
     #### Variables for composing new cache-images (used in PR testing) from
     #### base-images (pre-existing in GCE)
     ####
@@ -38,6 +48,8 @@ env:
     PACKER_BUILDS: "ubuntu-18,fedora-29,fedora-28"  # TODO: fah-29,rhel-7,centos-7
     # Version of packer to use
     PACKER_VER: "1.3.1"
+    # Special image w/ nested-libvirt + tools for creating new cache and base images
+    IMAGE_BUILDER_CACHE_IMAGE_NAME: "image-builder-image-1541772081"
     # Google-maintained base-image names
     UBUNTU_BASE_IMAGE: "ubuntu-1804-bionic-v20181203a"
     CENTOS_BASE_IMAGE: "centos-7-v20181113"
@@ -113,7 +125,7 @@ build_each_commit_task:
         memory: "4Gb"
         disk: 40
         matrix:
-            image_name: "fedora-29-libpod-9afa57a9"
+            image_name: "${FEDORA_CACHE_IMAGE_NAME}"
 
     timeout_in: 30m
 
@@ -139,14 +151,14 @@ testing_task:
         # 'matrix' combinations.
         matrix:
             # Images are generated separately, from build_images_task (below)
-            image_name: fedora-29-libpod-9afa57a9
-            image_name: fedora-28-libpod-9afa57a9
-            image_name: ubuntu-18-libpod-9afa57a9
+            image_name: "${FEDORA_CACHE_IMAGE_NAME}"
+            image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
+            image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
 
             # TODO: tests fail
-            # image_name: "rhel-7-something-something"
-            # image_name: "centos-7-something-something"
-            # image_name: "fah-29-libpod-5070733157859328"
+            # image_name: "${RHEL_CACHE_IMAGE_NAME}
+            # image_name: "${PRIOR_RHEL_CACHE_IMAGE_NAME}
+            # image_name: "${CENTOS_CACHE_IMAGE_NAME}"
 
     timeout_in: 120m
 
@@ -176,12 +188,13 @@ optional_testing_task:
     gce_instance:
         image_project: "libpod-218412"
         matrix:
-            image_name: fedora-29-libpod-9afa57a9
-            image_name: fedora-28-libpod-9afa57a9
-            image_name: ubuntu-18-libpod-9afa57a9
+            image_name: "${FEDORA_CACHE_IMAGE_NAME}"
+            image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
+            image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
             # TODO: Make these work (also build_images_task below)
-            #image_name: "rhel-server-ec2-7-5-165-1-libpod-fce09afe"
-            #image_name: "centos-7-v20180911-libpod-fce09afe"
+            # image_name: "${RHEL_CACHE_IMAGE_NAME}
+            # image_name: "${PRIOR_RHEL_CACHE_IMAGE_NAME}
+            # image_name: "${CENTOS_CACHE_IMAGE_NAME}"
 
     timeout_in: 60m
 
@@ -214,7 +227,7 @@ cache_images_task:
         cpu: 4
         memory: "4Gb"
         disk: 200
-        image_name: "image-builder-image-1541772081"  # Simply CentOS 7 + packer dependencies
+        image_name: "${IMAGE_BUILDER_CACHE_IMAGE_NAME}"
         # Additional permissions for building GCE images, within a GCE VM
         scopes:
             - compute

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -54,15 +54,19 @@ delvm() {
     showrun $CLEANUP_CMD  # prompts for Yes/No
 }
 
-show_usage(){
+image_hints() {
+    egrep '[[:space:]]+[[:alnum:]].+_CACHE_IMAGE_NAME:[[:space:]+"[[:print:]]+"' \
+        "$LIBPODROOT/.cirrus.yml" | cut -d: -f 2 | tr -d '"[:blank:]' | \
+        grep -v 'notready' | grep -v 'image-builder' | sort -u
+}
+
+show_usage() {
     echo -e "\n${RED}ERROR: $1${NOR}"
     echo -e "${YEL}Usage: $(basename $0) [-s | -p] <image_name>${NOR}\n"
     if [[ -r ".cirrus.yml" ]]
     then
-        egrep 'image_name' ".cirrus.yml" | grep -v '#' | cut -d: -f 2 | \
-            tr -d [:blank:] | sort -u > "$TEMPFILE"
         echo -e "${YEL}Some possible image_name values (from .cirrus.yml):${NOR}"
-        cat $TEMPFILE
+        image_hints
         echo ""
     fi
     exit 1


### PR DESCRIPTION
Previously it was not possible to specify keys from the ``env`` section
in the various GCE sections.  Now that features is added, consolidate
all the cache image definitions into a single place, reducing
maintenance burden.

This also results in the names passing through into the VMs. This is
useful, e.g. for future tracking of image usage statistics.

Update ``get_ci_vm`` script hints for new image name definition format

Signed-off-by: Chris Evich <cevich@redhat.com>