### PR TITLE
cirrus: Record start/end time of important things

### DIFF
--- a/contrib/cirrus/build_vm_images.sh
+++ b/contrib/cirrus/build_vm_images.sh
@@ -23,6 +23,8 @@ SCRIPT_BASE $SCRIPT_BASE
 PACKER_BASE $PACKER_BASE
 "
 
+record_timestamp "cache-image build start"
+
 show_env_vars
 
 # Everything here is running on the 'image-builder-image' GCE image
@@ -50,3 +52,5 @@ make libpod_images \
     SCRIPT_BASE=$SCRIPT_BASE \
     PACKER_BASE=$PACKER_BASE \
     BUILT_IMAGE_SUFFIX=$BUILT_IMAGE_SUFFIX
+
+record_timestamp "cache-image build end"

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -9,6 +9,8 @@ OS_RELEASE_ID $OS_RELEASE_ID
 OS_RELEASE_VER $OS_RELEASE_VER
 "
 
+record_timestamp "integration test start"
+
 clean_env
 
 set -x
@@ -31,3 +33,5 @@ case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
         ;;
     *) bad_os_id_ver ;;
 esac
+
+record_timestamp "integration test end"

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -17,7 +17,7 @@ PACKER_BASE=${PACKER_BASE:-./contrib/cirrus/packer}
 CIRRUS_BUILD_ID=${CIRRUS_BUILD_ID:-DEADBEEF}  # a human
 CIRRUS_BASE_SHA=${CIRRUS_BASE_SHA:-HEAD}
 CIRRUS_CHANGE_IN_REPO=${CIRRUS_CHANGE_IN_REPO:-FETCH_HEAD}
-START_STAMP_FILEPATH="${START_STAMP_FILEPATH:-/var/tmp/start.timestamp}"
+TIMESTAMPS_FILEPATH="${TIMESTAMPS_FILEPATH:-/var/tmp/timestamps}"
 
 if ! [[ "$PATH" =~ "/usr/local/bin" ]]
 then
@@ -136,11 +136,14 @@ ircmsg() {
     set -e
 }
 
-start_timestamp() {
-    req_env_var "START_STAMP_FILEPATH $START_STAMP_FILEPATH"
-    [[ -r "$START_STAMP_FILEPATH" ]] || \
-        echo -e ".\nThe time at the tone will be:\n$(date --iso-8601=seconds | \
-            tee $START_STAMP_FILEPATH)\nBLEEEEEEEEEEP!\n.\n"  # Cirrus strips blank lines from output
+record_timestamp() {
+    set +x  # sometimes it's turned on
+    req_env_var "TIMESTAMPS_FILEPATH $TIMESTAMPS_FILEPATH"
+    echo "."  # cirrus webui strips blank-lines
+    STAMPMSG="The $1 time at the tone will be:"
+    echo -e "$STAMPMSG\t$(date --iso-8601=seconds)" | \
+        tee -a $TIMESTAMPS_FILEPATH
+    echo -e "BLEEEEEEEEEEP!\n."
 }
 
 # Run sudo in directory with GOPATH set

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -4,7 +4,7 @@ set -e
 
 source $(dirname $0)/lib.sh
 
-start_timestamp
+record_timestamp "env. setup start"
 
 req_env_var "
 USER $USER
@@ -85,3 +85,5 @@ then
     # Only testing-VMs need deps installed
     [[ -n "$PACKER_BUILDS" ]] || install_testing_dependencies  # must exist in $GOPATH
 fi
+
+record_timestamp "env. setup end"

--- a/contrib/cirrus/unit_test.sh
+++ b/contrib/cirrus/unit_test.sh
@@ -9,6 +9,8 @@ OS_RELEASE_ID $OS_RELEASE_ID
 OS_RELEASE_VER $OS_RELEASE_VER
 "
 
+record_timestamp "unit test start"
+
 clean_env
 
 set -x
@@ -29,3 +31,5 @@ case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
         ;;
     *) bad_os_id_ver ;;
 esac
+
+record_timestamp "unit test end"


### PR DESCRIPTION
Previously we only reported the date/time at the beginning of a run
since it's not available in the Cirrus-CI system.  This commit
generalizes the solution, recording start/end times for all major
events.

Also the timestamps are recorded into a local file on the VMs.  This
is intended for future use, for example tracking execution-time
trends.

Signed-off-by: Chris Evich <cevich@redhat.com>