### PR TITLE
Add openSUSE Kubic to install.md

### DIFF
--- a/install.md
+++ b/install.md
@@ -29,6 +29,10 @@ sudo emerge app-emulation/libpod
 sudo zypper install podman
 ```
 
+#### [openSUSE Kubic](https://kubic.opensuse.org)
+
+Built-in, no need to install
+
 #### [RHEL7](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux)
 
 Subscribe, then enable Extras channel and install podman.


### PR DESCRIPTION
Kubic's default container runtime is podman, so users shouldn't need to read the install.md, but if they do, now they can know they don't need to do anything :)