### PR TITLE
podman-inspect: don't ignore errors

### DIFF
--- a/cmd/podman/formats/formats.go
+++ b/cmd/podman/formats/formats.go
@@ -20,6 +20,8 @@ const (
 	JSONString = "json"
 	// IDString const to save on duplicates for Go templates
 	IDString = "{{.ID}}"
+
+	parsingErrorStr = "Template parsing error"
 )
 
 // Writer interface for outputs
@@ -96,7 +98,7 @@ func (t StdoutTemplateArray) Out() error {
 		t.Template = strings.Replace(strings.TrimSpace(t.Template[5:]), " ", "\t", -1)
 		headerTmpl, err := template.New("header").Funcs(headerFunctions).Parse(t.Template)
 		if err != nil {
-			return errors.Wrapf(err, "Template parsing error")
+			return errors.Wrapf(err, parsingErrorStr)
 		}
 		err = headerTmpl.Execute(w, t.Fields)
 		if err != nil {
@@ -107,13 +109,12 @@ func (t StdoutTemplateArray) Out() error {
 	t.Template = strings.Replace(t.Template, " ", "\t", -1)
 	tmpl, err := template.New("image").Funcs(basicFunctions).Parse(t.Template)
 	if err != nil {
-		return errors.Wrapf(err, "Template parsing error")
+		return errors.Wrapf(err, parsingErrorStr)
 	}
-	for i, img := range t.Output {
+	for i, raw := range t.Output {
 		basicTmpl := tmpl.Funcs(basicFunctions)
-		err = basicTmpl.Execute(w, img)
-		if err != nil {
-			return err
+		if err := basicTmpl.Execute(w, raw); err != nil {
+			return errors.Wrapf(err, parsingErrorStr)
 		}
 		if i != len(t.Output)-1 {
 			fmt.Fprintln(w, "")

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -87,6 +87,9 @@ func inspectCmd(c *cli.Context) error {
 	}
 
 	inspectedObjects, iterateErr := iterateInput(getContext(), c, args, runtime, inspectType)
+	if iterateErr != nil {
+		return iterateErr
+	}
 
 	var out formats.Writer
 	if outputFormat != "" && outputFormat != formats.JSONString {
@@ -97,8 +100,7 @@ func inspectCmd(c *cli.Context) error {
 		out = formats.JSONStructArray{Output: inspectedObjects}
 	}
 
-	formats.Writer(out).Out()
-	return iterateErr
+	return formats.Writer(out).Out()
 }
 
 // func iterateInput iterates the images|containers the user has requested and returns the inspect data and error


### PR DESCRIPTION
Return errors when executing the --format templates.  Otherwise,
Podman will just silently ignore them and not print any output
that could guide user into solving the issue.

Fixes: #2159
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>