### PR TITLE
Mask unimplemeted commands for remote client

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -1,0 +1,151 @@
+// +build !remoteclient
+
+package main
+
+import "github.com/urfave/cli"
+
+func getAppCommands() []cli.Command {
+	return []cli.Command{
+		attachCommand,
+		commitCommand,
+		buildCommand,
+		createCommand,
+		diffCommand,
+		execCommand,
+		exportCommand,
+		importCommand,
+		killCommand,
+		kubeCommand,
+		loadCommand,
+		loginCommand,
+		logoutCommand,
+		logsCommand,
+		mountCommand,
+		pauseCommand,
+		psCommand,
+		podCommand,
+		portCommand,
+		pushCommand,
+		playCommand,
+		restartCommand,
+		rmCommand,
+		runCommand,
+		saveCommand,
+		searchCommand,
+		startCommand,
+		statsCommand,
+		stopCommand,
+		topCommand,
+		umountCommand,
+		unpauseCommand,
+		versionCommand,
+		volumeCommand,
+		waitCommand,
+	}
+}
+
+func getImageSubCommands() []cli.Command {
+	return []cli.Command{
+		buildCommand,
+		importCommand,
+		loadCommand,
+		pullCommand,
+		saveCommand,
+		trustCommand,
+		signCommand,
+	}
+}
+
+func getContainerSubCommands() []cli.Command {
+	return []cli.Command{
+		attachCommand,
+		checkpointCommand,
+		cleanupCommand,
+		containerExistsCommand,
+		commitCommand,
+		createCommand,
+		diffCommand,
+		execCommand,
+		exportCommand,
+		killCommand,
+		logsCommand,
+		psCommand,
+		mountCommand,
+		pauseCommand,
+		portCommand,
+		pruneContainersCommand,
+		refreshCommand,
+		restartCommand,
+		restoreCommand,
+		rmCommand,
+		runCommand,
+		runlabelCommand,
+		startCommand,
+		statsCommand,
+		stopCommand,
+		topCommand,
+		umountCommand,
+		unpauseCommand,
+		//		updateCommand,
+		waitCommand,
+	}
+}
+func getMainAppFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:  "cgroup-manager",
+			Usage: "cgroup manager to use (cgroupfs or systemd, default systemd)",
+		},
+		cli.StringFlag{
+			Name:  "cni-config-dir",
+			Usage: "path of the configuration directory for CNI networks",
+		},
+		cli.StringFlag{
+			Name:  "conmon",
+			Usage: "path of the conmon binary",
+		},
+		cli.StringFlag{
+			Name:   "default-mounts-file",
+			Usage:  "path to default mounts file",
+			Hidden: true,
+		},
+		cli.StringSliceFlag{
+			Name:  "hooks-dir",
+			Usage: "set the OCI hooks directory path (may be set multiple times)",
+		},
+		cli.IntFlag{
+			Name:   "max-workers",
+			Usage:  "the maximum number of workers for parallel operations",
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:  "namespace",
+			Usage: "set the libpod namespace, used to create separate views of the containers and pods on the system",
+			Value: "",
+		},
+		cli.StringFlag{
+			Name:  "root",
+			Usage: "path to the root directory in which data, including images, is stored",
+		},
+		cli.StringFlag{
+			Name:  "runroot",
+			Usage: "path to the 'run directory' where all state information is stored",
+		},
+		cli.StringFlag{
+			Name:  "runtime",
+			Usage: "path to the OCI-compatible binary used to run containers, default is /usr/bin/runc",
+		},
+		cli.StringFlag{
+			Name:  "storage-driver, s",
+			Usage: "select which storage driver is used to manage storage of images and containers (default is overlay)",
+		},
+		cli.StringSliceFlag{
+			Name:  "storage-opt",
+			Usage: "used to pass an option to the storage driver",
+		},
+		cli.BoolFlag{
+			Name:  "syslog",
+			Usage: "output logging information to syslog as well as the console",
+		},
+	}
+}

--- a/cmd/podman/commands_remoteclient.go
+++ b/cmd/podman/commands_remoteclient.go
@@ -1,0 +1,21 @@
+// +build remoteclient
+
+package main
+
+import "github.com/urfave/cli"
+
+func getAppCommands() []cli.Command {
+	return []cli.Command{}
+}
+
+func getImageSubCommands() []cli.Command {
+	return []cli.Command{}
+}
+
+func getContainerSubCommands() []cli.Command {
+	return []cli.Command{}
+}
+
+func getMainAppFlags() []cli.Flag {
+	return []cli.Flag{}
+}

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -1,52 +1,29 @@
 package main
 
 import (
+	"sort"
+
 	"github.com/urfave/cli"
 )
 
 var (
-	subCommands = []cli.Command{
-		attachCommand,
-		checkpointCommand,
-		cleanupCommand,
-		containerExistsCommand,
-		commitCommand,
-		createCommand,
-		diffCommand,
-		execCommand,
-		exportCommand,
+	containerSubCommands = []cli.Command{
 		inspectCommand,
-		killCommand,
-		logsCommand,
-		psCommand,
-		mountCommand,
-		pauseCommand,
-		portCommand,
-		pruneContainersCommand,
-		refreshCommand,
-		restartCommand,
-		restoreCommand,
-		rmCommand,
-		runCommand,
-		runlabelCommand,
-		startCommand,
-		statsCommand,
-		stopCommand,
-		topCommand,
-		umountCommand,
-		unpauseCommand,
-		//		updateCommand,
-		waitCommand,
 	}
-
 	containerDescription = "Manage containers"
 	containerCommand     = cli.Command{
 		Name:                   "container",
 		Usage:                  "Manage Containers",
 		Description:            containerDescription,
 		ArgsUsage:              "",
-		Subcommands:            subCommands,
+		Subcommands:            getContainerSubCommandsSorted(),
 		UseShortOptionHandling: true,
 		OnUsageError:           usageErrorHandler,
 	}
 )
+
+func getContainerSubCommandsSorted() []cli.Command {
+	containerSubCommands = append(containerSubCommands, getContainerSubCommands()...)
+	sort.Sort(commandSortedAlpha{containerSubCommands})
+	return containerSubCommands
+}

--- a/cmd/podman/image.go
+++ b/cmd/podman/image.go
@@ -1,36 +1,36 @@
 package main
 
 import (
+	"sort"
+
 	"github.com/urfave/cli"
 )
 
 var (
 	imageSubCommands = []cli.Command{
-		buildCommand,
 		historyCommand,
-		importCommand,
 		imageExistsCommand,
 		inspectCommand,
-		loadCommand,
 		lsImagesCommand,
 		pruneImagesCommand,
 		pullCommand,
-		pushCommand,
 		rmImageCommand,
-		saveCommand,
 		tagCommand,
-		trustCommand,
-		signCommand,
 	}
-
 	imageDescription = "Manage images"
 	imageCommand     = cli.Command{
 		Name:                   "image",
 		Usage:                  "Manage images",
 		Description:            imageDescription,
 		ArgsUsage:              "",
-		Subcommands:            imageSubCommands,
+		Subcommands:            getImageSubCommandsSorted(),
 		UseShortOptionHandling: true,
 		OnUsageError:           usageErrorHandler,
 	}
 )
+
+func getImageSubCommandsSorted() []cli.Command {
+	imageSubCommands = append(imageSubCommands, getImageSubCommands()...)
+	sort.Sort(commandSortedAlpha{imageSubCommands})
+	return imageSubCommands
+}

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -172,28 +172,6 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 	return p
 }
 
-//MakeOptions assembles all the podman main options
-func (p *PodmanTestIntegration) makeOptions(args []string) []string {
-	podmanOptions := strings.Split(fmt.Sprintf("--root %s --runroot %s --runtime %s --conmon %s --cni-config-dir %s --cgroup-manager %s",
-		p.CrioRoot, p.RunRoot, p.RunCBinary, p.ConmonBinary, p.CNIConfigDir, p.CgroupManager), " ")
-	if os.Getenv("HOOK_OPTION") != "" {
-		podmanOptions = append(podmanOptions, os.Getenv("HOOK_OPTION"))
-	}
-	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
-	podmanOptions = append(podmanOptions, args...)
-	return podmanOptions
-}
-
-// RestoreArtifact puts the cached image into our test store
-func (p *PodmanTestIntegration) RestoreArtifact(image string) error {
-	fmt.Printf("Restoring %s...\n", image)
-	dest := strings.Split(image, "/")
-	destName := fmt.Sprintf("/tmp/%s.tar", strings.Replace(strings.Join(strings.Split(dest[len(dest)-1], "/"), ""), ":", "-", -1))
-	restore := p.Podman([]string{"load", "-q", "-i", destName})
-	restore.Wait(90)
-	return nil
-}
-
 // RestoreAllArtifacts unpacks all cached images
 func (p *PodmanTestIntegration) RestoreAllArtifacts() error {
 	if os.Getenv("NO_TEST_CACHE") != "" {


### PR DESCRIPTION
Masking main level, image, and container commands that are not yet
implemented for the remote client. As each command is completed, be
sure to unmask it.

Also, masking podman command line switches that are not applicable
to the remote client.

Signed-off-by: baude <bbaude@redhat.com>