### PR TITLE
Do not unmarshal into c.config.Spec

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -415,14 +415,15 @@ func (c *Container) Spec() *spec.Spec {
 // config does not exist (e.g., because the container was never started) return
 // the spec from the config.
 func (c *Container) specFromState() (*spec.Spec, error) {
-	spec := c.config.Spec
+	returnSpec := c.config.Spec
 
 	if f, err := os.Open(c.state.ConfigPath); err == nil {
+		returnSpec = new(spec.Spec)
 		content, err := ioutil.ReadAll(f)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error reading container config")
 		}
-		if err := json.Unmarshal([]byte(content), &spec); err != nil {
+		if err := json.Unmarshal([]byte(content), &returnSpec); err != nil {
 			return nil, errors.Wrapf(err, "error unmarshalling container config")
 		}
 	} else {
@@ -432,7 +433,7 @@ func (c *Container) specFromState() (*spec.Spec, error) {
 		}
 	}
 
-	return spec, nil
+	return returnSpec, nil
 }
 
 // ID returns the container's ID


### PR DESCRIPTION
We try to keep c.config immutable, but Go doesn't really agree with me that things other than strings and ints can be immutable, so occasionally things like this slip through.

When unmarshalling the OCI spec from disk, do it into a separate struct, to ensure we don't make lasting modifications to the spec in the Container struct (which could affect container restart).