### PR TITLE
rootless: fix --pid=host without --privileged

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -376,6 +376,10 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 }
 
 func blockAccessToKernelFilesystems(config *CreateConfig, g *generate.Generator) {
+	if config.PidMode.IsHost() && rootless.IsRootless() {
+		return
+	}
+
 	if !config.Privileged {
 		for _, mp := range []string{
 			"/proc/acpi",

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -276,6 +276,10 @@ var _ = Describe("Podman rootless", func() {
 		runRootlessHelper([]string{"--net", "host"})
 	})
 
+	It("podman rootless rootfs --pid host", func() {
+		runRootlessHelper([]string{"--pid", "host"})
+	})
+
 	It("podman rootless rootfs --privileged", func() {
 		runRootlessHelper([]string{"--privileged"})
 	})


### PR DESCRIPTION
When using --pid=host don't try to cover /proc paths, as they are
coming from the /proc bind mounted from the host.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>