### PR TITLE
Vendor in latest opencontainers/selinux

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -173,7 +173,11 @@ func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string) error {
 		if err != nil {
 			return errors.Wrapf(err, "container %q not found", config.PidMode.Container())
 		}
-		labelOpts = append(labelOpts, label.DupSecOpt(ctr.ProcessLabel())...)
+		secopts, err := label.DupSecOpt(ctr.ProcessLabel())
+		if err != nil {
+			return errors.Wrapf(err, "failed to duplicate label %q ", ctr.ProcessLabel())
+		}
+		labelOpts = append(labelOpts, secopts...)
 	}
 
 	if config.IpcMode.IsHost() {
@@ -183,7 +187,11 @@ func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string) error {
 		if err != nil {
 			return errors.Wrapf(err, "container %q not found", config.IpcMode.Container())
 		}
-		labelOpts = append(labelOpts, label.DupSecOpt(ctr.ProcessLabel())...)
+		secopts, err := label.DupSecOpt(ctr.ProcessLabel())
+		if err != nil {
+			return errors.Wrapf(err, "failed to duplicate label %q ", ctr.ProcessLabel())
+		}
+		labelOpts = append(labelOpts, secopts...)
 	}
 
 	for _, opt := range securityOpts {

--- a/vendor.conf
+++ b/vendor.conf
@@ -54,7 +54,7 @@ github.com/opencontainers/image-spec v1.0.0
 github.com/opencontainers/runc v1.0.0-rc6
 github.com/opencontainers/runtime-spec 1722abf79c2f8f2675f47367f827c6491472cf27
 github.com/opencontainers/runtime-tools v0.8.0
-github.com/opencontainers/selinux v1.0.0
+github.com/opencontainers/selinux v1.1
 github.com/ostreedev/ostree-go d0388bd827cfac6fa8eec760246eb8375674b2a0
 github.com/pkg/errors v0.8.1
 github.com/pmezard/go-difflib v1.0.0

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
@@ -75,8 +75,8 @@ func ReleaseLabel(label string) error {
 
 // DupSecOpt takes a process label and returns security options that
 // can be used to set duplicate labels on future container processes
-func DupSecOpt(src string) []string {
-	return nil
+func DupSecOpt(src string) ([]string, error) {
+	return nil, nil
 }
 
 // DisableSecOpt returns a security opt that can disable labeling

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux.go
@@ -4,6 +4,8 @@ package label
 
 import (
 	"fmt"
+	"os"
+	"os/user"
 	"strings"
 
 	"github.com/opencontainers/selinux/go-selinux"
@@ -35,8 +37,15 @@ func InitLabels(options []string) (plabel string, mlabel string, Err error) {
 				ReleaseLabel(mountLabel)
 			}
 		}()
-		pcon := selinux.NewContext(processLabel)
-		mcon := selinux.NewContext(mountLabel)
+		pcon, err := selinux.NewContext(processLabel)
+		if err != nil {
+			return "", "", err
+		}
+
+		mcon, err := selinux.NewContext(mountLabel)
+		if err != nil {
+			return "", "", err
+		}
 		for _, opt := range options {
 			if opt == "disable" {
 				return "", mountLabel, nil
@@ -146,13 +155,56 @@ func Relabel(path string, fileLabel string, shared bool) error {
 		return nil
 	}
 
-	exclude_paths := map[string]bool{"/": true, "/usr": true, "/etc": true, "/tmp": true, "/home": true, "/run": true, "/var": true, "/root": true}
+	exclude_paths := map[string]bool{
+		"/":           true,
+		"/bin":        true,
+		"/boot":       true,
+		"/dev":        true,
+		"/etc":        true,
+		"/etc/passwd": true,
+		"/etc/pki":    true,
+		"/etc/shadow": true,
+		"/home":       true,
+		"/lib":        true,
+		"/lib64":      true,
+		"/media":      true,
+		"/opt":        true,
+		"/proc":       true,
+		"/root":       true,
+		"/run":        true,
+		"/sbin":       true,
+		"/srv":        true,
+		"/sys":        true,
+		"/tmp":        true,
+		"/usr":        true,
+		"/var":        true,
+		"/var/lib":    true,
+		"/var/log":    true,
+	}
+
+	if home := os.Getenv("HOME"); home != "" {
+		exclude_paths[home] = true
+	}
+
+	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+		if usr, err := user.Lookup(sudoUser); err == nil {
+			exclude_paths[usr.HomeDir] = true
+		}
+	}
+
+	if path != "/" {
+		path = strings.TrimSuffix(path, "/")
+	}
 	if exclude_paths[path] {
 		return fmt.Errorf("SELinux relabeling of %s is not allowed", path)
 	}
 
 	if shared {
-		c := selinux.NewContext(fileLabel)
+		c, err := selinux.NewContext(fileLabel)
+		if err != nil {
+			return err
+		}
+
 		c["level"] = "s0"
 		fileLabel = c.Get()
 	}
@@ -195,7 +247,7 @@ func ReleaseLabel(label string) error {
 
 // DupSecOpt takes a process label and returns security options that
 // can be used to set duplicate labels on future container processes
-func DupSecOpt(src string) []string {
+func DupSecOpt(src string) ([]string, error) {
 	return selinux.DupSecOpt(src)
 }
 

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
@@ -115,9 +115,9 @@ func (c Context) Get() string {
 }
 
 // NewContext creates a new Context struct from the specified label
-func NewContext(label string) Context {
+func NewContext(label string) (Context, error) {
 	c := make(Context)
-	return c
+	return c, nil
 }
 
 // ClearLabels clears all reserved MLS/MCS levels
@@ -195,8 +195,8 @@ func Chcon(fpath string, label string, recurse bool) error {
 
 // DupSecOpt takes an SELinux process label and returns security options that
 // can be used to set the SELinux Type and Level for future container processes.
-func DupSecOpt(src string) []string {
-	return nil
+func DupSecOpt(src string) ([]string, error) {
+	return nil, nil
 }
 
 // DisableSecOpt returns a security opt that can be used to disable SELinux


### PR DESCRIPTION
This will now verify labels passed in by the user.
Will also prevent users from accidently relabeling their homedir.

podman run -ti -v ~/home/user:Z fedora sh

Is not a good idea.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>