### PR TITLE
Add --all-tags to pull command

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -334,6 +334,7 @@ type PsValues struct {
 
 type PullValues struct {
 	PodmanCommand
+	AllTags         bool
 	Authfile        string
 	CertDir         string
 	Creds           string

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -45,6 +45,10 @@ Image stored in local container/storage
 
 ## OPTIONS
 
+**--all-tags, a**
+
+All tagged images in the repository will be pulled.
+
 **--authfile**
 
 Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -163,4 +163,20 @@ var _ = Describe("Podman pull", func() {
 
 		Expect(pull.OutputToString()).To(ContainSubstring(shortImageId))
 	})
+
+	It("podman pull check all tags", func() {
+		session := podmanTest.Podman([]string{"pull", "--all-tags", "alpine"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOuputStartsWith("Pulled Images:")).To(BeTrue())
+
+		session = podmanTest.Podman([]string{"images"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 4))
+
+		rmi := podmanTest.Podman([]string{"rmi", "-a", "-f"})
+		rmi.WaitWithDefaultTimeout()
+		Expect(rmi.ExitCode()).To(Equal(0))
+	})
 })

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -270,7 +270,7 @@ func (s *PodmanSession) LineInOuputStartsWith(term string) bool {
 }
 
 //LineInOutputContains returns true if a line in a
-// session output starts with the supplied string
+// session output contains the supplied string
 func (s *PodmanSession) LineInOutputContains(term string) bool {
 	for _, i := range s.OutputToStringArray() {
 		if strings.Contains(i, term) {


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add --all-tags for the `podman pull` command so all tags
of an image will be pulled, not just ':latest'.  Emulates
the change in Buildah https://github.com/containers/buildah/pull/1263

FWIW the bash completions for all-tags were already in place.

=========
Test Results:
```
# podman pull --all-tags alpine
Trying to pull docker://alpine:2.6...Getting image source signatures
Copying blob 2a3ebcb7fbcc: 1.86 MiB / ? [-------------------=--------------] 0s 
Writing manifest to image destination
Storing signatures
Trying to pull docker://alpine:2.7...Getting image source signatures
Copying blob 4dea34575ff3: 1.88 MiB / ? [------------------------------=---] 0s 
Writing manifest to image destination
Storing signatures
Trying to pull docker://alpine:3.1...Getting image source signatures
Copying blob e34e7deb60d9: 2.20 MiB / 2.20 MiB [============================] 0s
Copying config 9f5479c8fc7d: 1.48 KiB / 1.48 KiB [==========================] 0s
Writing manifest to image destination
Storing signatures
Trying to pull docker://alpine:3.2...Getting image source signatures
Copying blob 720c84076e4e: 2.45 MiB / 2.45 MiB [============================] 0s
Copying config 7aa5410358f6: 1.48 KiB / 1.48 KiB [==========================] 0s
Writing manifest to image destination
Storing signatures
Trying to pull docker://alpine:3.3...Getting image source signatures
Copying blob da1f53af4030: 2.29 MiB / 2.29 MiB [============================] 0s
Copying config 4253f833edc5: 1.48 KiB / 1.48 KiB [==========================] 0s
Writing manifest to image destination
Storing signatures
Trying to pull docker://alpine:3.4...Getting image source signatures
Copying blob 456f9d0bf1d1: 2.28 MiB / 2.28 MiB [============================] 0s
Copying config b955fa398a69: 1.48 KiB / 1.48 KiB [==========================] 0s
Writing manifest to image destination
Storing signatures
Trying to pull docker://alpine:3.5...Getting image source signatures
Copying blob a44d943737e8: 1.88 MiB / 1.88 MiB [============================] 0s
Copying config eec2d71b4945: 1.48 KiB / 1.48 KiB [==========================] 0s
Writing manifest to image destination
Storing signatures
Trying to pull docker://alpine:3.6...Getting image source signatures
Copying blob ab3d5dc0b96d: 1.92 MiB / 1.92 MiB [============================] 0s
Copying config dc58420c6c13: 1.48 KiB / 1.48 KiB [==========================] 0s
Writing manifest to image destination
Storing signatures
Trying to pull docker://alpine:3.7...Getting image source signatures
Copying blob 407ea412d82c: 2.01 MiB / 2.01 MiB [============================] 0s
Copying config 9bea9e12e381: 1.48 KiB / 1.48 KiB [==========================] 0s
Writing manifest to image destination
Storing signatures
Trying to pull docker://alpine:3.8...Getting image source signatures
Copying blob cd784148e348: 2.10 MiB / 2.10 MiB [============================] 0s
Copying config 3f53bb00af94: 1.48 KiB / 1.48 KiB [==========================] 0s
Writing manifest to image destination
Storing signatures
Trying to pull docker://alpine:edge...Getting image source signatures
Copying blob ba7f5deea89d: 2.50 MiB / 2.50 MiB [============================] 0s
Copying config dacde26455ab: 1.48 KiB / 1.48 KiB [==========================] 0s
Writing manifest to image destination
Storing signatures
Trying to pull docker://alpine:latest...Getting image source signatures
Skipping blob cd784148e348 (already present): 2.10 MiB / 2.10 MiB [=========] 0s
Copying config 3f53bb00af94: 1.48 KiB / 1.48 KiB [==========================] 0s
Writing manifest to image destination
Storing signatures
Pulled Images:
e738dfbe7a10356ea998e8acc7493c0bfae5ed919ad7eb99550ab60d7f47e214
93f518ec2c41722d6c21e55f96cef4dc4c9ba521cab51a757b1d7272b393902f
9f5479c8fc7de1adab7ade224d6960c4a24a981343df8636095c752470da3fe4
7aa5410358f6024756ed218e690063ed94aa34275c4b23da173c739bc845c0e3
4253f833edc5020a6c9ab9659f4a2093f73053ccd6bca97738b8a56b6365db24
b955fa398a69d4ba8a8ee9ccad0d09789fc4bf22237bb062113890001a7144d5
eec2d71b4945e8e974f8ecc4334673fc0c9b6666b1936966df1828e6e8a71400
dc58420c6c139fc7244477b484dbe0734cd54dd988edd13d54ccee48482303d3
9bea9e12e381b8cc4d57145d4e98dc2a53b544e121efbc316a9d4e08e24af97c
3f53bb00af943dfdf815650be70c0fa7b426e56a66f5e3362b47a129d57d5991
dacde26455ab47a96ed5b69e8a64a43f07b27956a95065f78d601c33b4a59ab4
3f53bb00af943dfdf815650be70c0fa7b426e56a66f5e3362b47a129d57d5991

# podman images
REPOSITORY                 TAG      IMAGE ID       CREATED       SIZE
docker.io/library/alpine   3.5      eec2d71b4945   4 weeks ago   4.24 MB
docker.io/library/alpine   3.4      b955fa398a69   4 weeks ago   5.06 MB
docker.io/library/alpine   3.3      4253f833edc5   4 weeks ago   5.06 MB
docker.io/library/alpine   3.2      7aa5410358f6   4 weeks ago   5.65 MB
docker.io/library/alpine   3.1      9f5479c8fc7d   4 weeks ago   5.42 MB
docker.io/library/alpine   edge     dacde26455ab   4 weeks ago   5.54 MB
docker.io/library/alpine   latest   3f53bb00af94   4 weeks ago   4.67 MB
docker.io/library/alpine   3.8      3f53bb00af94   4 weeks ago   4.67 MB
docker.io/library/alpine   3.7      9bea9e12e381   4 weeks ago   4.47 MB
docker.io/library/alpine   3.6      dc58420c6c13   4 weeks ago   4.29 MB
docker.io/library/alpine   2.7      93f518ec2c41   3 years ago   5.09 MB
docker.io/library/alpine   2.6      e738dfbe7a10   3 years ago   4.87 MB
```