### PR TITLE
Fixup image prune help

### DIFF
--- a/cmd/podman/images_prune.go
+++ b/cmd/podman/images_prune.go
@@ -11,7 +11,7 @@ var (
 	pruneImagesDescription = `
 	podman image prune
 
-	Removes all unnamed images from local storage
+	Removes all unused images from local storage
 `
 
 	pruneImagesCommand = cli.Command{


### PR DESCRIPTION
Correct the help text for the image prune command to state that it
removes all unused images.

Issue: #2192

Signed-off-by: baude <bbaude@redhat.com>