### PR TITLE
remove sudo

### DIFF
--- a/docs/tutorials/podman_tutorial.md
+++ b/docs/tutorials/podman_tutorial.md
@@ -112,7 +112,7 @@ sudo make install PREFIX=/usr
 This sample container will run a very basic httpd server that serves only its index
 page.
 ```console
-sudo podman run -dt -e HTTPD_VAR_RUN=/var/run/httpd -e HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+podman run -dt -e HTTPD_VAR_RUN=/var/run/httpd -e HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
                   -e HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
                   -e HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
                   registry.fedoraproject.org/f27/httpd /usr/bin/run-httpd
@@ -123,7 +123,7 @@ will print the container ID after it has run.
 ### Listing running containers
 The Podman *ps* command is used to list creating and running containers.
 ```console
-sudo podman ps
+podman ps
 ```
 
 Note: If you add *-a* to the *ps* command, Podman will show all containers.


### PR DESCRIPTION
just tested with podman 1.0.0 on fedora 29
we don't need sudo 

```console
[kus@mcny ~]$ podman run -dt -e HTTPD_VAR_RUN=/var/run/httpd -e HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
>                   -e HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
>                   -e HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
>                   registry.fedoraproject.org/f27/httpd /usr/bin/run-httpd
Trying to pull registry.fedoraproject.org/f27/httpd...Getting image source signatures
Copying blob ff3dab903f92: 80.73 MiB / 80.73 MiB [=========================] 14s
Copying blob 9347d6e9d864: 7.30 MiB / 7.30 MiB [===========================] 14s
Copying blob 2fc5c44251d4: 44.82 MiB / 44.82 MiB [=========================] 14s
Copying config 18f01f6f77ef: 6.55 KiB / 6.55 KiB [==========================] 0s
Writing manifest to image destination
Storing signatures
d0362571c3850159315778700a63a305296150177578a9339cca0d9c86ed97f1
[kus@mcny ~]$ podman ps
CONTAINER ID  IMAGE                                        COMMAND               CREATED         STATUS             PORTS  NAMES
d0362571c385  registry.fedoraproject.org/f27/httpd:latest  container-entrypo...  36 seconds ago  Up 36 seconds ago         happy_babbage
[kus@mcny ~]$ 
```