### PR TITLE
[skip ci] Cirrus: Container for tracking image use

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -109,7 +109,6 @@ gating_task:
         - '/usr/local/bin/entrypoint.sh validate'
         - '/usr/local/bin/entrypoint.sh lint'
 
-
 build_each_commit_task:
 
     depends_on:
@@ -133,6 +132,7 @@ build_each_commit_task:
         - $SCRIPT_BASE/setup_environment.sh
         - git fetch --depth $CIRRUS_CLONE_DEPTH origin $CIRRUS_BASE_BRANCH
         - env GOPATH=/var/tmp/go/ make build-all-new-commits GIT_BASE_BRANCH=origin/$CIRRUS_BASE_BRANCH
+
 
 # This task does the unit and integration testing for every platform
 testing_task:

--- a/contrib/imgts/Dockerfile
+++ b/contrib/imgts/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos:7
+
+# Only needed for installing build-time dependencies
+COPY /contrib/imgts/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
+RUN yum -y update && \
+    yum -y install epel-release && \
+    yum -y install google-cloud-sdk && \
+    yum clean all
+
+COPY /contrib/imgts/entrypoint.sh /usr/local/bin/entrypoint.sh
+ENV GCPJSON="__unknown__" \
+    GCPNAME="__unknown__" \
+    GCPPROJECT="__unknown__" \
+    IMGNAMES="__unknown__" \
+    TIMESTAMP="__unknown__" \
+    BUILDID="__unknown__" \
+    REPOREF="__unknown__"
+RUN chmod 755 /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/contrib/imgts/README.md
+++ b/contrib/imgts/README.md
@@ -1,0 +1,11 @@
+![PODMAN logo](../../logo/podman-logo-source.svg)
+
+A container image for tracking automation metadata.
+Currently this is used to update last-used timestamps on
+VM images.
+
+Example build (from repository root):
+
+```bash
+sudo podman build -t $IMAGE_NAME -f contrib/imgts/Dockerfile .
+```

--- a/contrib/imgts/entrypoint.sh
+++ b/contrib/imgts/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+RED="\e[1;36;41m"
+YEL="\e[1;33;44m"
+NOR="\e[0m"
+
+die() {
+    echo -e "$2" >&2
+    exit "$1"
+}
+
+SENTINEL="__unknown__"  # default set in dockerfile
+
+[[ "$GCPJSON" != "$SENTINEL" ]] || \
+    die 1 "Must specify service account JSON in \$GCPJSON"
+[[ "$GCPNAME" != "$SENTINEL" ]] || \
+    die 2 "Must specify service account name in \$GCPNAME"
+[[ "$GCPPROJECT" != "$SENTINEL" ]] || \
+    die 4 "Must specify GCP Project ID in \$GCPPROJECT"
+[[ -n "$GCPPROJECT" ]] || \
+    die 5 "Must specify non-empty GCP Project ID in \$GCPPROJECT"
+[[ "$IMGNAMES" != "$SENTINEL" ]] || \
+    die 6 "Must specify space separated list of GCE image names in \$IMGNAMES"
+[[ "$BUILDID" != "$SENTINEL" ]] || \
+    die 7 "Must specify the number of current build in \$BUILDID"
+[[ "$REPOREF" != "$SENTINEL" ]] || \
+    die 8 "Must specify a PR number or Branch name in \$REPOREF"
+
+ARGS="--update-labels=last-used=$(date +%s)"
+# optional
+[[ -z "$BUILDID" ]] || ARGS="$ARGS --update-labels=build-id=$BUILDID"
+[[ -z "$REPOREF" ]] || ARGS="$ARGS --update-labels=repo-ref=$REPOREF"
+
+gcloud config set account "$GCPNAME"
+gcloud config set project "$GCPPROJECT"
+echo "$GCPJSON" > /tmp/gcp.json
+gcloud auth activate-service-account --key-file=/tmp/gcp.json || rm /tmp/gcp.json
+for image in $IMGNAMES
+do
+    gcloud compute images update "$image" $ARGS &
+done
+set +e  # Actual update failures are only warnings
+wait || die 0 "${RED}WARNING:$NOR ${YEL}Failed to update labels on one or more images:$NOR '$IMGNAMES'"

--- a/contrib/imgts/google-cloud-sdk.repo
+++ b/contrib/imgts/google-cloud-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
Once built, this container can be utilized by automation to help keep
track of VM images.  All parameters are passed in via env. vars.

Signed-off-by: Chris Evich <cevich@redhat.com>