### PR TITLE
apparmor: don't load default profile in rootless mode

### DIFF
--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -17,9 +17,9 @@ set -x
 cd "$GOSRC"
 case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
     ubuntu-18)
-        make install PREFIX=/usr ETCDIR=/etc "BUILDTAGS=$BUILDTAGS"
-        make test-binaries "BUILDTAGS=$BUILDTAGS"
-        SKIP_USERNS=1 make localintegration "BUILDTAGS=$BUILDTAGS"
+        make install PREFIX=/usr ETCDIR=/etc
+        make test-binaries
+        SKIP_USERNS=1 make localintegration
         ;;
     fedora-29) ;&  # Continue to the next item
     fedora-28) ;&

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -57,7 +57,6 @@ then
         ubuntu-18)
             # Always install runc on Ubuntu
             install_runc_from_git
-            envstr='export BUILDTAGS="seccomp $($GOSRC/hack/btrfs_tag.sh) $($GOSRC/hack/btrfs_installed_tag.sh) $($GOSRC/hack/ostree_tag.sh) varlink exclude_graphdriver_devicemapper"'
             ;;
         fedora-29) ;&  # Continue to the next item
         fedora-28)
@@ -67,11 +66,9 @@ then
             ;&  # Continue to the next item
         centos-7) ;&
         rhel-7)
-            envstr='unset BUILDTAGS'  # Use default from Makefile
             ;;
         *) bad_os_id_ver ;;
     esac
-    X=$(echo "$envstr" | tee -a "$HOME/$ENVLIB") && eval "$X" && echo "$X"
 
     # Do the same for golang env. vars
     go env | while read envline

--- a/contrib/cirrus/system_test.sh
+++ b/contrib/cirrus/system_test.sh
@@ -15,11 +15,7 @@ set -x
 cd "$GOSRC"
 
 case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
-    ubuntu-18)
-        make install.tools "BUILDTAGS=$BUILDTAGS"
-        make "BUILDTAGS=$BUILDTAGS"
-        make test-binaries "BUILDTAGS=$BUILDTAGS"
-        ;;
+    ubuntu-18) ;&  # Continue to the next item
     fedora-28) ;&
     centos-7) ;&
     rhel-7)

--- a/contrib/cirrus/unit_test.sh
+++ b/contrib/cirrus/unit_test.sh
@@ -16,12 +16,8 @@ clean_env
 set -x
 cd "$GOSRC"
 case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
-    ubuntu-18)
-        make install.tools "BUILDTAGS=$BUILDTAGS"
-        make localunit "BUILDTAGS=$BUILDTAGS"
-        make "BUILDTAGS=$BUILDTAGS"
-        ;;
-    fedora-29) ;&  # Continue to the next item
+    ubuntu-18) ;&  # Continue to the next item
+    fedora-29) ;&
     fedora-28) ;&
     centos-7) ;&
     rhel-7)

--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -214,8 +214,15 @@ func CheckProfileAndLoadDefault(name string) (string, error) {
 		return name, nil
 	}
 
-	if name != "" && rootless.IsRootless() {
-		return "", errors.Wrapf(ErrApparmorRootless, "cannot load AppArmor profile %q", name)
+	// AppArmor is not supported in rootless mode as it requires root
+	// privileges.  Return an error in case a specific profile is specified.
+	if rootless.IsRootless() {
+		if name != "" {
+			return "", errors.Wrapf(ErrApparmorRootless, "cannot load AppArmor profile %q", name)
+		} else {
+			logrus.Debug("skipping loading default AppArmor profile (rootless mode)")
+			return "", nil
+		}
 	}
 
 	if name != "" && !runcaa.IsEnabled() {
@@ -230,7 +237,7 @@ func CheckProfileAndLoadDefault(name string) (string, error) {
 			return "", err
 		}
 		if !isLoaded {
-			return "", fmt.Errorf("AppArmor profile %q specified but not loaded")
+			return "", fmt.Errorf("AppArmor profile %q specified but not loaded", name)
 		}
 		return name, nil
 	}


### PR DESCRIPTION
AppArmor requires root privileges, so skip loading the default profile
in rootless mode.  Also add a log to ease debugging.

Fixes: #2223
Reported-by: @dmacvicar
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>