### PR TITLE
podman-remote import|export

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -12,8 +12,6 @@ func getAppCommands() []cli.Command {
 		createCommand,
 		diffCommand,
 		execCommand,
-		exportCommand,
-		importCommand,
 		killCommand,
 		kubeCommand,
 		loadCommand,

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	containerSubCommands = []cli.Command{
+		exportCommand,
 		inspectCommand,
 	}
 	containerDescription = "Manage containers"

--- a/cmd/podman/image.go
+++ b/cmd/podman/image.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	imageSubCommands = []cli.Command{
+		importCommand,
 		historyCommand,
 		imageExistsCommand,
 		inspectCommand,

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -88,9 +88,11 @@ func main() {
 
 	app.Commands = []cli.Command{
 		containerCommand,
+		exportCommand,
 		historyCommand,
 		imageCommand,
 		imagesCommand,
+		importCommand,
 		infoCommand,
 		inspectCommand,
 		pullCommand,

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -688,7 +688,7 @@ method Commit(name: string, image_name: string, changes: []string, author: strin
 
 # ImportImage imports an image from a source (like tarball) into local storage.  The image can have additional
 # descriptions added to it using the message and changes options. See also [ExportImage](ExportImage).
-method ImportImage(source: string, reference: string, message: string, changes: []string) -> (image: string)
+method ImportImage(source: string, reference: string, message: string, changes: []string, delete: bool) -> (image: string)
 
 # ExportImage takes the name or ID of an image and exports it to a destination like a tarball.  There is also
 # a booleon option to force compression.  It also takes in a string array of tags to be able to save multiple
@@ -1049,6 +1049,9 @@ method ContainerInspectData(name: string) -> (config: string)
 # ContainerStateData returns a container's state config in string form.  This call is for
 # development of Podman only and generally should not be used.
 method ContainerStateData(name: string) -> (config: string)
+
+method SendFile(type: string, length: int) -> (file_handle: string)
+method ReceiveFile(path: string, delete: bool) -> (len: int)
 
 # ImageNotFound means the image could not be found by the provided name or ID in local storage.
 error ImageNotFound (name: string)

--- a/libpod/adapter/client.go
+++ b/libpod/adapter/client.go
@@ -34,3 +34,14 @@ func (r RemoteRuntime) Connect() (*varlink.Connection, error) {
 	}
 	return connection, nil
 }
+
+// RefreshConnection is used to replace the current r.Conn after things like
+// using an upgraded varlink connection
+func (r RemoteRuntime) RefreshConnection() error {
+	newConn, err := r.Connect()
+	if err != nil {
+		return err
+	}
+	r.Conn = newConn
+	return nil
+}

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -500,7 +500,7 @@ func (i *LibpodAPI) Commit(call iopodman.VarlinkCall, name, imageName string, ch
 }
 
 // ImportImage imports an image from a tarball to the image store
-func (i *LibpodAPI) ImportImage(call iopodman.VarlinkCall, source, reference, message string, changes []string) error {
+func (i *LibpodAPI) ImportImage(call iopodman.VarlinkCall, source, reference, message string, changes []string, delete bool) error {
 	configChanges, err := util.GetImageConfig(changes)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -516,6 +516,12 @@ func (i *LibpodAPI) ImportImage(call iopodman.VarlinkCall, source, reference, me
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
+	if delete {
+		if err := os.Remove(source); err != nil {
+			return call.ReplyErrorOccurred(err.Error())
+		}
+	}
+
 	return call.ReplyImportImage(newImage.ID())
 }
 

--- a/pkg/varlinkapi/transfers.go
+++ b/pkg/varlinkapi/transfers.go
@@ -1,0 +1,75 @@
+package varlinkapi
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/containers/libpod/cmd/podman/varlink"
+)
+
+// SendFile allows a client to send a file to the varlink server
+func (i *LibpodAPI) SendFile(call iopodman.VarlinkCall, ftype string, length int64) error {
+	if !call.WantsUpgrade() {
+		return call.ReplyErrorOccurred("client must use upgraded connection to send files")
+	}
+
+	outputFile, err := ioutil.TempFile("", "varlink_send")
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	defer outputFile.Close()
+
+	if err = call.ReplySendFile(outputFile.Name()); err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+
+	writer := bufio.NewWriter(outputFile)
+	defer writer.Flush()
+
+	reader := call.Call.Reader
+	if _, err := io.CopyN(writer, reader, length); err != nil {
+		return err
+	}
+
+	// Send an ACK to the client
+	call.Call.Writer.WriteString(fmt.Sprintf("%s:", outputFile.Name()))
+	call.Call.Writer.Flush()
+	return nil
+
+}
+
+// ReceiveFile allows the varlink server to send a file to a client
+func (i *LibpodAPI) ReceiveFile(call iopodman.VarlinkCall, filepath string, delete bool) error {
+	if !call.WantsUpgrade() {
+		return call.ReplyErrorOccurred("client must use upgraded connection to send files")
+	}
+	fs, err := os.Open(filepath)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	fileInfo, err := fs.Stat()
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+
+	// Send the file length down to client
+	// Varlink connection upraded
+	if err = call.ReplyReceiveFile(fileInfo.Size()); err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+
+	reader := bufio.NewReader(fs)
+	_, err = reader.WriteTo(call.Writer)
+	if err != nil {
+		return err
+	}
+	if delete {
+		if err := os.Remove(filepath); err != nil {
+			return err
+		}
+	}
+	return call.Writer.Flush()
+}

--- a/test/e2e/export_test.go
+++ b/test/e2e/export_test.go
@@ -1,5 +1,3 @@
-// +build !remoteclient
-
 package integration
 
 import (
@@ -37,6 +35,7 @@ var _ = Describe("Podman export", func() {
 	})
 
 	It("podman export output flag", func() {
+		SkipIfRemote()
 		_, ec, cid := podmanTest.RunLsContainer("")
 		Expect(ec).To(Equal(0))
 

--- a/vendor/github.com/varlink/go/varlink/bridge.go
+++ b/vendor/github.com/varlink/go/varlink/bridge.go
@@ -5,13 +5,13 @@ package varlink
 import (
 	"bufio"
 	"io"
-	"log"
 	"net"
 	"os/exec"
 )
 
 type PipeCon struct {
 	net.Conn
+	cmd    *exec.Cmd
 	reader *io.ReadCloser
 	writer *io.WriteCloser
 }
@@ -25,6 +25,8 @@ func (p PipeCon) Close() error {
 	if err2 != nil {
 		return err2
 	}
+	p.cmd.Wait()
+
 	return nil
 }
 
@@ -42,18 +44,15 @@ func NewBridge(bridge string) (*Connection, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.conn = PipeCon{nil, &r, &w}
+	c.conn = PipeCon{nil, cmd, &r, &w}
 	c.address = ""
-	c.reader = bufio.NewReader(r)
-	c.writer = bufio.NewWriter(w)
+	c.Reader = bufio.NewReader(r)
+	c.Writer = bufio.NewWriter(w)
 
-	go func() {
-		err := cmd.Run()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
 
 	return &c, nil
 }
-

--- a/vendor/github.com/varlink/go/varlink/orgvarlinkservice.go
+++ b/vendor/github.com/varlink/go/varlink/orgvarlinkservice.go
@@ -1,5 +1,42 @@
 package varlink
 
+// The requested interface was not found.
+type InterfaceNotFound struct {
+	Interface string `json:"interface"`
+}
+
+func (e InterfaceNotFound) Error() string {
+	return "org.varlink.service.InterfaceNotFound"
+}
+
+// The requested method was not found
+type MethodNotFound struct {
+	Method string `json:"method"`
+}
+
+func (e MethodNotFound) Error() string {
+	return "org.varlink.service.MethodNotFound"
+}
+
+// The interface defines the requested method, but the service does not
+// implement it.
+type MethodNotImplemented struct {
+	Method string `json:"method"`
+}
+
+func (e MethodNotImplemented) Error() string {
+	return "org.varlink.service.MethodNotImplemented"
+}
+
+// One of the passed parameters is invalid.
+type InvalidParameter struct {
+	Parameter string `json:"parameter"`
+}
+
+func (e InvalidParameter) Error() string {
+	return "org.varlink.service.InvalidParameter"
+}
+
 func doReplyError(c *Call, name string, parameters interface{}) error {
 	return c.sendMessage(&serviceReply{
 		Error:      name,
@@ -9,36 +46,28 @@ func doReplyError(c *Call, name string, parameters interface{}) error {
 
 // ReplyInterfaceNotFound sends a org.varlink.service errror reply to this method call
 func (c *Call) ReplyInterfaceNotFound(interfaceA string) error {
-	var out struct {
-		Interface string `json:"interface,omitempty"`
-	}
+	var out InterfaceNotFound
 	out.Interface = interfaceA
 	return doReplyError(c, "org.varlink.service.InterfaceNotFound", &out)
 }
 
 // ReplyMethodNotFound sends a org.varlink.service errror reply to this method call
 func (c *Call) ReplyMethodNotFound(method string) error {
-	var out struct {
-		Method string `json:"method,omitempty"`
-	}
+	var out MethodNotFound
 	out.Method = method
 	return doReplyError(c, "org.varlink.service.MethodNotFound", &out)
 }
 
 // ReplyMethodNotImplemented sends a org.varlink.service errror reply to this method call
 func (c *Call) ReplyMethodNotImplemented(method string) error {
-	var out struct {
-		Method string `json:"method,omitempty"`
-	}
+	var out MethodNotImplemented
 	out.Method = method
 	return doReplyError(c, "org.varlink.service.MethodNotImplemented", &out)
 }
 
 // ReplyInvalidParameter sends a org.varlink.service errror reply to this method call
 func (c *Call) ReplyInvalidParameter(parameter string) error {
-	var out struct {
-		Parameter string `json:"parameter,omitempty"`
-	}
+	var out InvalidParameter
 	out.Parameter = parameter
 	return doReplyError(c, "org.varlink.service.InvalidParameter", &out)
 }


### PR DESCRIPTION
addition of import and export for the podman-remote client.  This includes
the ability to send and receive files between the remote-client and the
"podman" host using an upgraded varlink connection.

Signed-off-by: baude <bbaude@redhat.com>