### PR TITLE
Consistency in verbs in podman help command

### DIFF
--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -40,7 +40,7 @@ var (
 	inspectDescription = "This displays the low-level information on containers and images identified by name or ID. By default, this will render all results in a JSON array. If the container and image have the same name, this will return container JSON for unspecified type."
 	inspectCommand     = cli.Command{
 		Name:         "inspect",
-		Usage:        "Displays the configuration of a container or image",
+		Usage:        "Display the configuration of a container or image",
 		Description:  inspectDescription,
 		Flags:        sortFlags(inspectFlags),
 		Action:       inspectCmd,

--- a/cmd/podman/pause.go
+++ b/cmd/podman/pause.go
@@ -25,7 +25,7 @@ var (
 `
 	pauseCommand = cli.Command{
 		Name:         "pause",
-		Usage:        "Pauses all the processes in one or more containers",
+		Usage:        "Pause all the processes in one or more containers",
 		Description:  pauseDescription,
 		Flags:        pauseFlags,
 		Action:       pauseCmd,

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -24,7 +24,7 @@ var (
 	}
 	rmiCommand = cli.Command{
 		Name:                   "rmi",
-		Usage:                  "Removes one or more images from local storage",
+		Usage:                  "Remove one or more images from local storage",
 		Description:            rmiDescription,
 		Action:                 rmiCmd,
 		ArgsUsage:              "IMAGE-NAME-OR-ID [...]",

--- a/cmd/podman/umount.go
+++ b/cmd/podman/umount.go
@@ -34,7 +34,7 @@ An unmount can be forced with the --force flag.
 	umountCommand = cli.Command{
 		Name:         "umount",
 		Aliases:      []string{"unmount"},
-		Usage:        "Unmounts working container's root filesystem",
+		Usage:        "Unmount working container's root filesystem",
 		Description:  description,
 		Flags:        sortFlags(umountFlags),
 		Action:       umountCmd,

--- a/vendor/github.com/urfave/cli/help.go
+++ b/vendor/github.com/urfave/cli/help.go
@@ -82,7 +82,7 @@ OPTIONS:
 var helpCommand = Command{
 	Name:      "help",
 	Aliases:   []string{"h"},
-	Usage:     "Shows a list of commands or help for one command",
+	Usage:     "Show a list of commands or help for one command",
 	ArgsUsage: "[command]",
 	Action: func(c *Context) error {
 		args := c.Args()


### PR DESCRIPTION
Most of verbs used to describe different podman commands is written in 1st person, like "Attach", "Run". But for some commands it is written in 3rd person, like "Displays", "Umounts". This request changes those to 1st person verbs for consistency. 