### PR TITLE
Add support for short option -f

### DIFF
--- a/cmd/podman/info.go
+++ b/cmd/podman/info.go
@@ -29,7 +29,7 @@ var (
 			Usage: "display additional debug information",
 		},
 		cli.StringFlag{
-			Name:  "format",
+			Name:  "format, f",
 			Usage: "Change the output format to JSON or a Go template",
 		},
 	}

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1219,6 +1219,7 @@ _podman_info() {
 	 --debug
      "
     local options_with_args="
+    -f
     --format
   "
 

--- a/docs/podman-info.1.md
+++ b/docs/podman-info.1.md
@@ -19,7 +19,7 @@ Displays information pertinent to the host, current storage stats, configured co
 
 Show additional information
 
-**--format**
+**--format, -f**
 
 Change output format to "json" or a Go template.
 


### PR DESCRIPTION
docker info supports a short -f option for --format.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>