### PR TITLE
Add support for short option -s in podman inspect

### DIFF
--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -32,7 +32,7 @@ var (
 			Usage: "Change the output format to a Go template",
 		},
 		cli.BoolFlag{
-			Name:  "size",
+			Name:  "size, s",
 			Usage: "Display total file size if the type is container",
 		},
 		LatestFlag,

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1366,6 +1366,7 @@ _podman_inspect() {
      --type
      -t
      --size
+     -s
   "
 
   local all_options="$options_with_args $boolean_options"

--- a/docs/podman-inspect.1.md
+++ b/docs/podman-inspect.1.md
@@ -27,7 +27,7 @@ The keys of the returned JSON can be used as the values for the --format flag (s
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods.
 
-**--size**
+**--size, -s**
 
 Display the total file size if the type is a container
 


### PR DESCRIPTION
docker inspect supports a short -s option for --size.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>