### PR TITLE
Add support for short option -f in podman version

### DIFF
--- a/cmd/podman/version.go
+++ b/cmd/podman/version.go
@@ -57,7 +57,7 @@ var (
 	}
 	versionFlags = []cli.Flag{
 		cli.StringFlag{
-			Name:  "format",
+			Name:  "format, f",
 			Usage: "Change the output format to JSON or a Go template",
 		},
 	}

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2036,6 +2036,7 @@ _podman_version() {
     "
     local options_with_args="
      --format
+     -f
     "
     local all_options="$options_with_args $boolean_options"
 

--- a/docs/podman-version.1.md
+++ b/docs/podman-version.1.md
@@ -16,7 +16,7 @@ OS, and Architecture.
 
 Print usage statement
 
-**--format**
+**--format**, **-f**
 
 Change output format to "json" or a Go template.
 


### PR DESCRIPTION
docker version supports a short options -f for --format

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>