### PR TITLE
libpod/image: Use RepoDigests() in Inspect()

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -823,9 +823,9 @@ func (i *Image) Inspect(ctx context.Context) (*inspect.ImageData, error) {
 		return nil, err
 	}
 
-	var repoDigests []string
-	for _, name := range i.Names() {
-		repoDigests = append(repoDigests, strings.SplitN(name, ":", 2)[0]+"@"+i.Digest().String())
+	repoDigests, err := i.RepoDigests()
+	if err != nil {
+		return nil, err
 	}
 
 	driver, err := i.DriverData()


### PR DESCRIPTION
To get the more-robust handling from 0f6535cf (#2106) here too.

Fixes #2086 (again :).