### PR TITLE
Reduce Dockerfile based build time for libpod.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,16 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     && apt-get clean
 
-ADD . /go/src/github.com/containers/libpod
-
-RUN set -x && cd /go/src/github.com/containers/libpod && make install.libseccomp.sudo
+ENV LIBSECCOMP_COMMIT release-2.3
+RUN set -x \
+       && git clone https://github.com/seccomp/libseccomp "$GOPATH/src/github.com/seccomp/libseccomp" \
+       && cd "$GOPATH/src/github.com/seccomp/libseccomp" \
+       && git fetch origin --tags \
+       && git checkout -q "$LIBSECCOMP_COMMIT" \
+       && ./autogen.sh \
+       && ./configure --prefix=/usr \
+       && make all \
+       && make install
 
 # Install runc
 ENV RUNC_COMMIT 96ec2177ae841256168fcf76954f7177af9446eb
@@ -125,5 +132,9 @@ RUN mkdir -p /etc/containers && curl https://raw.githubusercontent.com/projectat
 
 COPY test/policy.json /etc/containers/policy.json
 COPY test/redhat_sigstore.yaml /etc/containers/registries.d/registry.access.redhat.com.yaml
+
+ADD . /go/src/github.com/containers/libpod
+
+RUN set -x && cd /go/src/github.com/containers/libpod
 
 WORKDIR /go/src/github.com/containers/libpod

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ BUILD_INFO ?= $(shell date +%s)
 LIBPOD := ${PROJECT}/libpod
 LDFLAGS_PODMAN ?= $(LDFLAGS) -X $(LIBPOD).gitCommit=$(GIT_COMMIT) -X $(LIBPOD).buildInfo=$(BUILD_INFO)
 ISODATE ?= $(shell date --iso-8601)
+#Update to LIBSECCOMP_COMMIT should reflect in Dockerfile too.
 LIBSECCOMP_COMMIT := release-2.3
 
 # If GOPATH not specified, use one in the local directory


### PR DESCRIPTION
libpod code added at end of Dockerfile, avoids
git clone of other packages in Dockerfile on subsequent builds.

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>