### PR TITLE
Cirrus: Remove "too new" runc hack

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,7 +49,7 @@ env:
     CNI_COMMIT: "7480240de9749f9a0a5c8614b17f1f03e0c06ab9"
     CRIO_COMMIT: "7a283c391abb7bd25086a8ff91dbb36ebdd24466"
     CRIU_COMMIT: "c74b83cd49c00589c0c0468ba5fe685b67fdbd0a"
-    RUNC_COMMIT: "25f3f893c86d07426df93b7aa172f33fdf093fbd"
+    RUNC_COMMIT: "6635b4f0c6af3810594d2770f662f34ddc15b40d"
     # CSV of cache-image names to build (see $PACKER_BASE/libpod_images.json)
     PACKER_BUILDS: "ubuntu-18,fedora-29,fedora-28,rhel-7"  # TODO: rhel-8,centos-7
     # Version of packer to use
@@ -237,11 +237,6 @@ testing_task:
             image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
             image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
 
-            # TODO: Make these work (also optional_testing_task below)
-            # image_name: "${PRIOR_RHEL_CACHE_IMAGE_NAME}"
-            # image_name: "${RHEL_CACHE_IMAGE_NAME}"
-            # image_name: "${CENTOS_CACHE_IMAGE_NAME}"
-
     timeout_in: 120m
 
     # Every *_script runs in sequence, for each task. The name prefix is for
@@ -302,10 +297,8 @@ optional_testing_task:
             image_name: "${FEDORA_CACHE_IMAGE_NAME}"
             image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
             image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
-            # TODO: Make these work (also testing_task above)
-            # image_name: "${RHEL_CACHE_IMAGE_NAME}"
-            # image_name: "${PRIOR_RHEL_CACHE_IMAGE_NAME}"
-            # image_name: "${CENTOS_CACHE_IMAGE_NAME}"
+            image_name: "${PRIOR_RHEL_CACHE_IMAGE_NAME}"
+            image_name: "${CENTOS_CACHE_IMAGE_NAME}"
 
     timeout_in: 60m
 

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -53,21 +53,17 @@ then
         X=$(echo "$envstr" | tee -a "$HOME/$ENVLIB") && eval "$X" && echo "$X"
     done
 
-    # Some setup needs to vary between distros
+    # Some environment setup needs to vary between distros
+    # Note: This should only be used for environment variables, and minor details.
+    #       Anything that could vary from one run to the next, should go into
+    #       contrib/cirrus/packer/*_setup.sh and be incorporated into VM cache-images
+    #       (see docs)
     case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
-        ubuntu-18)
-            # Always install runc on Ubuntu
-            install_runc_from_git
-            ;;
-        fedora-29) ;&  # Continue to the next item
-        fedora-28)
-            RUNC="https://kojipkgs.fedoraproject.org/packages/runc/1.0.0/55.dev.git578fe65.fc${OS_RELEASE_VER}/x86_64/runc-1.0.0-55.dev.git578fe65.fc${OS_RELEASE_VER}.x86_64.rpm"
-            echo ">>>>> OVERRIDING RUNC WITH $RUNC <<<<<"
-            dnf -y install "$RUNC"
-            ;&  # Continue to the next item
-        centos-7) ;&
-        rhel-7)
-            ;;
+        ubuntu-18) ;;
+        fedora-29) ;;
+        fedora-28) ;;
+        centos-7) ;;
+        rhel-7) ;;
         *) bad_os_id_ver ;;
     esac
 
@@ -81,7 +77,6 @@ then
         make install.catatonit
         go get github.com/onsi/ginkgo/ginkgo
         go get github.com/onsi/gomega/...
-        dnf -y update runc
     fi
 fi
 


### PR DESCRIPTION
Ref: https://bodhi.fedoraproject.org/updates/FEDORA-2019-b4356521ba

Signed-off-by: Chris Evich <cevich@redhat.com>