### PR TITLE
Increase e2e info/json test exit timeout

### DIFF
--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Podman Info", func() {
 
 	It("podman info json output", func() {
 		session := podmanTest.Podman([]string{"info", "--format=json"})
-		session.Wait()
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 	})


### PR DESCRIPTION
Increase e2e info/json test exit timeout

For whatever reason, this specific test frequently fails on Ubuntu with
an error similar to: 

```
  Timed out after 1.000s.
  Expected process to exit.  It did not.

  /var/tmp/go/src/github.com/containers/libpod/test/e2e/info_test.go:38
```

Ths changes alters the test behavior to use the `defaultWaitTimeout`
value (so 90 vs former 60 seconds) only for this test.

Signed-off-by: Chris Evich <cevich@redhat.com>