### PR TITLE
Add documentation on running systemd on SELinux systems

### DIFF
--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -610,6 +610,12 @@ It will also set the default stop signal to SIGRTMIN+3.
 
 This allow systemd to run in a confined container without any modifications.
 
+Note: On `SELinux` systems, systemd attempts to write to the cgroup
+file system.  Containers writing to the cgroup file system are denied by default.
+The `container_manage_cgroup` boolean must be enabled for this to be allowed on an SELinux separated system.
+
+`setsebool -P container_manage_cgroup true`
+
 **--tmpfs**=[] Create a tmpfs mount
 
 Mount a temporary filesystem (`tmpfs`) mount into a container, for example:
@@ -804,7 +810,7 @@ WantedBy=multi-user.target
 **/etc/subgid**
 
 ## SEE ALSO
-subgid(5), subuid(5), libpod.conf(5), systemd.unit(5)
+subgid(5), subuid(5), libpod.conf(5), systemd.unit(5), setsebool(8)
 
 ## HISTORY
 October 2017, converted from Docker documentation to podman by Dan Walsh for podman <dwalsh@redhat.com>

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -612,6 +612,12 @@ It will also set the default stop signal to SIGRTMIN+3.
 
 This allow systemd to run in a confined container without any modifications.
 
+Note: On `SELinux` systems, systemd attempts to write to the cgroup
+file system.  Containers writing to the cgroup file system are denied by default.
+The `container_manage_cgroup` boolean must be enabled for this to be allowed on an SELinux separated system.
+
+`setsebool -P container_manage_cgroup true`
+
 **--tmpfs**=[] Create a tmpfs mount
 
 Mount a temporary filesystem (`tmpfs`) mount into a container, for example:
@@ -1096,7 +1102,7 @@ WantedBy=multi-user.target
 **/etc/subgid**
 
 ## SEE ALSO
-subgid(5), subuid(5), libpod.conf(5), systemd.unit(5)
+subgid(5), subuid(5), libpod.conf(5), systemd.unit(5), setsebool(8)
 
 ## HISTORY
 September 2018, updated by Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -173,3 +173,21 @@ cat ~/.config/containers/storage.conf
   [storage.options]
     mount_program = "/bin/fuse-overlayfs"
 ```
+
+### 8) Permission denied when running systemd within a Podman container
+
+When running systemd as PID 1 inside of a container on an SELinux
+separated machine, it needs to write to the cgroup file system.
+
+#### Symptom
+
+Systemd gets permission denied when attempting to write to the cgroup file
+system, and AVC messages start to show up in the audit.log file or journal on
+the system.
+
+#### Solution
+
+SELinux provides a boolean `container_manage_cgroup`, which allows container
+processes to write to the cgroup file system. Turn on this boolean, on SELinux separated systems, to allow systemd to run properly in the container.
+
+`setsebool -P container_manage_cgroup true`


### PR DESCRIPTION
Lots of users are attempting to run systemd within a container.  They are
being blocked from running SELinux systems since they need the
container_manage_cgroup which is not enabled by default.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>