### PR TITLE
Fix down/missing registry.access.redhat.com

### DIFF
--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -63,10 +63,10 @@ var _ = Describe("Podman search", func() {
 	})
 
 	It("podman search single registry flag", func() {
-		search := podmanTest.Podman([]string{"search", "registry.access.redhat.com/rhel7"})
+		search := podmanTest.Podman([]string{"search", "quay.io/libpod/gate:latest"})
 		search.WaitWithDefaultTimeout()
 		Expect(search.ExitCode()).To(Equal(0))
-		Expect(search.LineInOutputContains("registry.access.redhat.com/rhel7")).To(BeTrue())
+		Expect(search.LineInOutputContains("quay.io/libpod/gate")).To(BeTrue())
 	})
 
 	It("podman search format flag", func() {


### PR DESCRIPTION
This registry responds differently depending on the the platform
accessing it.  It also occasionally goes down or returns 404s.  Improve
the reliability of the e2e tests by using the registry/image used
for gating pull-requests.

This way, if there's a registry/networking problem, the gating test
will fail and prevent anything else from running.  This is a better
failure to have early, rather than wait and need to re-run all the
e2e tests again later.

Signed-off-by: Chris Evich <cevich@redhat.com>