### PR TITLE
Add support to migrate containers

### DIFF
--- a/cmd/podman/checkpoint.go
+++ b/cmd/podman/checkpoint.go
@@ -46,6 +46,7 @@ func init() {
 	flags.BoolVar(&checkpointCommand.TcpEstablished, "tcp-established", false, "Checkpoint a container with established TCP connections")
 	flags.BoolVarP(&checkpointCommand.All, "all", "a", false, "Checkpoint all running containers")
 	flags.BoolVarP(&checkpointCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
+	flags.StringVarP(&checkpointCommand.Export, "export", "e", "", "Export the checkpoint image to a tar.gz")
 	markFlagHiddenForRemoteClient("latest", flags)
 }
 
@@ -64,6 +65,7 @@ func checkpointCmd(c *cliconfig.CheckpointValues) error {
 		Keep:           c.Keep,
 		KeepRunning:    c.LeaveRunning,
 		TCPEstablished: c.TcpEstablished,
+		TargetFile:     c.Export,
 	}
 	return runtime.Checkpoint(c, options)
 }

--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -428,6 +428,7 @@ type RestoreValues struct {
 	Latest         bool
 	TcpEstablished bool
 	Import         string
+	Name           string
 }
 
 type RmValues struct {

--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -89,6 +89,7 @@ type CheckpointValues struct {
 	TcpEstablished bool
 	All            bool
 	Latest         bool
+	Export         string
 }
 
 type CommitValues struct {
@@ -426,6 +427,7 @@ type RestoreValues struct {
 	Keep           bool
 	Latest         bool
 	TcpEstablished bool
+	Import         string
 }
 
 type RmValues struct {

--- a/cmd/podman/restore.go
+++ b/cmd/podman/restore.go
@@ -45,6 +45,7 @@ func init() {
 	flags.BoolVarP(&restoreCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&restoreCommand.TcpEstablished, "tcp-established", false, "Restore a container with established TCP connections")
 	flags.StringVarP(&restoreCommand.Import, "import", "i", "", "Restore from exported checkpoint archive (tar.gz)")
+	flags.StringVarP(&restoreCommand.Name, "name", "n", "", "Specify new name for container restored from exported checkpoint (only works with --import)")
 
 	markFlagHiddenForRemoteClient("latest", flags)
 }
@@ -64,6 +65,15 @@ func restoreCmd(c *cliconfig.RestoreValues, cmd *cobra.Command) error {
 		Keep:           c.Keep,
 		TCPEstablished: c.TcpEstablished,
 		TargetFile:     c.Import,
+		Name:           c.Name,
+	}
+
+	if c.Import == "" && c.Name != "" {
+		return errors.Errorf("--name can only used with --import")
+	}
+
+	if c.Name != "" && c.TcpEstablished {
+		return errors.Errorf("--tcp-established cannot be used with --name")
 	}
 
 	if (c.Import != "") && (c.All || c.Latest) {

--- a/cmd/podman/restore.go
+++ b/cmd/podman/restore.go
@@ -43,8 +43,7 @@ func init() {
 	flags.BoolVarP(&restoreCommand.All, "all", "a", false, "Restore all checkpointed containers")
 	flags.BoolVarP(&restoreCommand.Keep, "keep", "k", false, "Keep all temporary checkpoint files")
 	flags.BoolVarP(&restoreCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
-	// TODO: add ContainerStateCheckpointed
-	flags.BoolVar(&restoreCommand.TcpEstablished, "tcp-established", false, "Checkpoint a container with established TCP connections")
+	flags.BoolVar(&restoreCommand.TcpEstablished, "tcp-established", false, "Restore a container with established TCP connections")
 
 	markFlagHiddenForRemoteClient("latest", flags)
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -857,6 +857,8 @@ _podman_container_restore() {
      local options_with_args="
      -i
      --import
+     -n
+     --name
      "
      local boolean_options="
 	  -a

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -742,6 +742,10 @@ _podman_container_attach() {
 }
 
 _podman_container_checkpoint() {
+     local options_with_args="
+     -e
+     --export
+     "
      local boolean_options="
      -a
      --all
@@ -755,9 +759,15 @@ _podman_container_checkpoint() {
      --leave-running
      --tcp-established
      "
+     case "$prev" in
+        -e|--export)
+            _filedir
+            return
+            ;;
+     esac
      case "$cur" in
 	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options" -- "$cur"))
+	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
 	    ;;
 	*)
 	    __podman_complete_containers_running
@@ -844,6 +854,10 @@ _podman_container_restart() {
 }
 
 _podman_container_restore() {
+     local options_with_args="
+     -i
+     --import
+     "
      local boolean_options="
 	  -a
 	  --all
@@ -855,9 +869,15 @@ _podman_container_restore() {
 	  --latest
 	  --tcp-established
      "
+     case "$prev" in
+        -i|--import)
+            _filedir
+            return
+            ;;
+     esac
      case "$cur" in
 	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options" -- "$cur"))
+	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
 	    ;;
 	*)
 	    __podman_complete_containers_created

--- a/docs/podman-container-checkpoint.1.md
+++ b/docs/podman-container-checkpoint.1.md
@@ -38,6 +38,12 @@ image contains established TCP connections, this options is required during
 restore. Defaults to not checkpointing containers with established TCP
 connections.
 
+**--export, -e**
+
+Export the checkpoint to a tar.gz file. The exported checkpoint can be used
+to import the container on another system and thus enabling container live
+migration.
+
 ## EXAMPLE
 
 podman container checkpoint mywebserver

--- a/docs/podman-container-restore.1.md
+++ b/docs/podman-container-restore.1.md
@@ -42,6 +42,12 @@ If the checkpoint image does not contain established TCP connections this
 option is ignored. Defaults to not restoring containers with established TCP
 connections.
 
+**--import, -i**
+
+Import a checkpoint tar.gz file, which was exported by Podman. This can be used
+to import a checkpointed container from another host. It is not necessary to specify
+a container when restoring from an exported checkpoint.
+
 ## EXAMPLE
 
 podman container restore mywebserver

--- a/docs/podman-container-restore.1.md
+++ b/docs/podman-container-restore.1.md
@@ -48,6 +48,18 @@ Import a checkpoint tar.gz file, which was exported by Podman. This can be used
 to import a checkpointed container from another host. It is not necessary to specify
 a container when restoring from an exported checkpoint.
 
+**--name, -n**
+
+This is only available in combination with **--import, -i**. If a container is restored
+from a checkpoint tar.gz file it is possible to rename it with **--name, -n**. This
+way it is possible to restore a container from a checkpoint multiple times with different
+names.
+
+If the **--name, -n** option is used, Podman will not attempt to assign the same IP
+address to the container it was using before checkpointing as each IP address can only
+be used once and the restored container will have another IP address. This also means
+that **--name, -n** cannot be used in combination with **--tcp-established**.
+
 ## EXAMPLE
 
 podman container restore mywebserver

--- a/docs/tutorials/podman_tutorial.md
+++ b/docs/tutorials/podman_tutorial.md
@@ -96,6 +96,28 @@ After being restored, the container will answer requests again as it did before 
 curl http://<IP_address>:8080
 ```
 
+### Migrate the container
+To live migrate a container from one host to another the container is checkpointed on the source
+system of the migration, transferred to the destination system and then restored on the destination
+system. When transferring the checkpoint, it is possible to specify an output-file.
+
+On the source system:
+```console
+sudo podman container checkpoint <container_id> -e /tmp/checkpoint.tar.gz
+scp /tmp/checkpoint.tar.gz <destination_system>:/tmp
+```
+
+On the destination system:
+```console
+sudo podman container restore -i /tmp/checkpoint.tar.gz
+```
+
+After being restored, the container will answer requests again as it did before checkpointing. This
+time the container will continue to run on the destination system.
+```console
+curl http://<IP_address>:8080
+```
+
 ### Stopping the container
 To stop the httpd container:
 ```console

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -820,6 +820,10 @@ type ContainerCheckpointOptions struct {
 	// Import tells the API to read the checkpoint image from
 	// the filename set in TargetFile
 	TargetFile string
+	// Name tells the API that during restore from an exported
+	// checkpoint archive a new name should be used for the
+	// restored container
+	Name string
 }
 
 // Checkpoint checkpoints a container

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -815,6 +815,11 @@ type ContainerCheckpointOptions struct {
 	// TCPEstablished tells the API to checkpoint a container
 	// even if it contains established TCP connections
 	TCPEstablished bool
+	// Export tells the API to write the checkpoint image to
+	// the filename set in TargetFile
+	// Import tells the API to read the checkpoint image from
+	// the filename set in TargetFile
+	TargetFile string
 }
 
 // Checkpoint checkpoints a container

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -825,6 +825,13 @@ type ContainerCheckpointOptions struct {
 // Checkpoint checkpoints a container
 func (c *Container) Checkpoint(ctx context.Context, options ContainerCheckpointOptions) error {
 	logrus.Debugf("Trying to checkpoint container %s", c.ID())
+
+	if options.TargetFile != "" {
+		if err := c.prepareCheckpointExport(); err != nil {
+			return err
+		}
+	}
+
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/mount"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -1497,6 +1498,43 @@ func (c *Container) checkReadyForRemoval() error {
 
 	if len(c.state.ExecSessions) != 0 {
 		return errors.Wrapf(ErrCtrStateInvalid, "cannot remove container %s as it has active exec sessions", c.ID())
+	}
+
+	return nil
+}
+
+// writeJSONFile marshalls and writes the given data to a JSON file
+// in the bundle path
+func (c *Container) writeJSONFile(v interface{}, file string) (err error) {
+	fileJSON, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errors.Wrapf(err, "error writing JSON to %s for container %s", file, c.ID())
+	}
+	file = filepath.Join(c.bundlePath(), file)
+	if err := ioutil.WriteFile(file, fileJSON, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// prepareCheckpointExport writes the config and spec to
+// JSON files for later export
+func (c *Container) prepareCheckpointExport() (err error) {
+	// save live config
+	if err := c.writeJSONFile(c.Config(), "config.dump"); err != nil {
+		return err
+	}
+
+	// save spec
+	jsonPath := filepath.Join(c.bundlePath(), "config.json")
+	g, err := generate.NewFromFile(jsonPath)
+	if err != nil {
+		logrus.Debugf("generating spec for container %q failed with %v", c.ID(), err)
+		return err
+	}
+	if err := c.writeJSONFile(g.Spec(), "spec.dump"); err != nil {
+		return err
 	}
 
 	return nil

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1346,7 +1346,7 @@ func (c *Container) appendStringToRundir(destFile, output string) (string, error
 	return filepath.Join(c.state.RunDir, destFile), nil
 }
 
-// Save OCI spec to disk, replacing any existing specs for the container
+// saveSpec saves the OCI spec to disk, replacing any existing specs for the container
 func (c *Container) saveSpec(spec *spec.Spec) error {
 	// If the OCI spec already exists, we need to replace it
 	// Cannot guarantee some things, e.g. network namespaces, have the same

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -681,7 +681,13 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 	// Read network configuration from checkpoint
 	// Currently only one interface with one IP is supported.
 	networkStatusFile, err := os.Open(filepath.Join(c.bundlePath(), "network.status"))
-	if err == nil {
+	// If the restored container should get a new name, the IP address of
+	// the container will not be restored. This assumes that if a new name is
+	// specified, the container is restored multiple times.
+	// TODO: This implicit restoring with or without IP depending on an
+	//       unrelated restore parameter (--name) does not seem like the
+	//       best solution.
+	if err == nil && options.Name == "" {
 		// The file with the network.status does exist. Let's restore the
 		// container with the same IP address as during checkpointing.
 		defer networkStatusFile.Close()

--- a/pkg/adapter/checkpoint_restore.go
+++ b/pkg/adapter/checkpoint_restore.go
@@ -1,0 +1,99 @@
+// +build !remoteclient
+
+package adapter
+
+import (
+	"context"
+	"github.com/containers/libpod/libpod"
+	"github.com/containers/storage/pkg/archive"
+	jsoniter "github.com/json-iterator/go"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// Prefixing the checkpoint/restore related functions with 'cr'
+
+// crImportFromJSON imports the JSON files stored in the exported
+// checkpoint tarball
+func crImportFromJSON(filePath string, v interface{}) error {
+	jsonFile, err := os.Open(filePath)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to open container definition %s for restore", filePath)
+	}
+	defer jsonFile.Close()
+
+	content, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to read container definition %s for restore", filePath)
+	}
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	if err = json.Unmarshal([]byte(content), v); err != nil {
+		return errors.Wrapf(err, "Failed to unmarshal container definition %s for restore", filePath)
+	}
+
+	return nil
+}
+
+// crImportCheckpoint it the function which imports the information
+// from checkpoint tarball and re-creates the container from that information
+func crImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, input string) ([]*libpod.Container, error) {
+	// First get the container definition from the
+	// tarball to a temporary directory
+	archiveFile, err := os.Open(input)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to open checkpoint archive %s for import", input)
+	}
+	defer archiveFile.Close()
+	options := &archive.TarOptions{
+		// Here we only need the files config.dump and spec.dump
+		ExcludePatterns: []string{
+			"checkpoint",
+			"artifacts",
+			"ctr.log",
+			"network.status",
+		},
+	}
+	dir, err := ioutil.TempDir("", "checkpoint")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+	err = archive.Untar(archiveFile, dir, options)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unpacking of checkpoint archive %s failed", input)
+	}
+
+	// Load spec.dump from temporary directory
+	spec := new(spec.Spec)
+	if err := crImportFromJSON(filepath.Join(dir, "spec.dump"), spec); err != nil {
+		return nil, err
+	}
+
+	// Load config.dump from temporary directory
+	config := new(libpod.ContainerConfig)
+	if err = crImportFromJSON(filepath.Join(dir, "config.dump"), config); err != nil {
+		return nil, err
+	}
+
+	// This should not happen as checkpoints with these options are not exported.
+	if (len(config.Dependencies) > 0) || (len(config.NamedVolumes) > 0) {
+		return nil, errors.Errorf("Cannot import checkpoints of containers with named volumes or dependencies")
+	}
+
+	// Now create a new container from the just loaded information
+	container, err := runtime.RestoreContainer(ctx, spec, config)
+	if err != nil {
+		return nil, err
+	}
+
+	var containers []*libpod.Container
+	if container == nil {
+		return nil, nil
+	}
+
+	containers = append(containers, container)
+	return containers, nil
+}

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -526,7 +526,7 @@ func (r *LocalRuntime) Checkpoint(c *cliconfig.CheckpointValues, options libpod.
 }
 
 // Restore one or more containers
-func (r *LocalRuntime) Restore(c *cliconfig.RestoreValues, options libpod.ContainerCheckpointOptions) error {
+func (r *LocalRuntime) Restore(ctx context.Context, c *cliconfig.RestoreValues, options libpod.ContainerCheckpointOptions) error {
 	var (
 		containers     []*libpod.Container
 		err, lastError error
@@ -538,7 +538,9 @@ func (r *LocalRuntime) Restore(c *cliconfig.RestoreValues, options libpod.Contai
 		return state == libpod.ContainerStateExited
 	})
 
-	if c.All {
+	if c.Import != "" {
+		containers, err = crImportCheckpoint(ctx, r.Runtime, c.Import)
+	} else if c.All {
 		containers, err = r.GetContainers(filterFuncs...)
 	} else {
 		containers, err = shortcuts.GetContainersByContext(false, c.Latest, c.InputArgs, r.Runtime)

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -539,7 +539,7 @@ func (r *LocalRuntime) Restore(ctx context.Context, c *cliconfig.RestoreValues, 
 	})
 
 	if c.Import != "" {
-		containers, err = crImportCheckpoint(ctx, r.Runtime, c.Import)
+		containers, err = crImportCheckpoint(ctx, r.Runtime, c.Import, c.Name)
 	} else if c.All {
 		containers, err = r.GetContainers(filterFuncs...)
 	} else {

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -664,6 +664,10 @@ func (r *LocalRuntime) Attach(ctx context.Context, c *cliconfig.AttachValues) er
 
 // Checkpoint one or more containers
 func (r *LocalRuntime) Checkpoint(c *cliconfig.CheckpointValues, options libpod.ContainerCheckpointOptions) error {
+	if c.Export != "" {
+		return errors.New("the remote client does not support exporting checkpoints")
+	}
+
 	var lastError error
 	ids, err := iopodman.GetContainersByContext().Call(r.Conn, c.All, c.Latest, c.InputArgs)
 	if err != nil {
@@ -699,7 +703,11 @@ func (r *LocalRuntime) Checkpoint(c *cliconfig.CheckpointValues, options libpod.
 }
 
 // Restore one or more containers
-func (r *LocalRuntime) Restore(c *cliconfig.RestoreValues, options libpod.ContainerCheckpointOptions) error {
+func (r *LocalRuntime) Restore(ctx context.Context, c *cliconfig.RestoreValues, options libpod.ContainerCheckpointOptions) error {
+	if c.Import != "" {
+		return errors.New("the remote client does not support importing checkpoints")
+	}
+
 	var lastError error
 	ids, err := iopodman.GetContainersByContext().Call(r.Conn, c.All, c.Latest, c.InputArgs)
 	if err != nil {

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -376,9 +376,20 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
+		// Restore container a second time with different name
+		result = podmanTest.Podman([]string{"container", "restore", "-i", "/tmp/checkpoint.tar.gz", "-n", "restore_again"})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
+
 		result = podmanTest.Podman([]string{"rm", "-fa"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+
+		// Remove exported checkpoint
+		os.Remove("/tmp/checkpoint.tar.gz")
 	})
 })

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -347,4 +347,38 @@ var _ = Describe("Podman checkpoint", func() {
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 	})
 
+	// This test does the same steps which are necessary for migrating
+	// a container from one host to another
+	It("podman checkpoint container with export (migration)", func() {
+		// CRIU does not work with seccomp correctly on RHEL7
+		session := podmanTest.Podman([]string{"run", "-it", "--security-opt", "seccomp=unconfined", "-d", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+
+		result := podmanTest.Podman([]string{"container", "checkpoint", "-l", "-e", "/tmp/checkpoint.tar.gz"})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Exited"))
+
+		// Remove all containers to simulate migration
+		result = podmanTest.Podman([]string{"rm", "-fa"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+
+		result = podmanTest.Podman([]string{"container", "restore", "-i", "/tmp/checkpoint.tar.gz"})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
+
+		result = podmanTest.Podman([]string{"rm", "-fa"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
This series adds container migration support to Podman.

The basic steps to migrate containers are:

     Source system:
      * podman container checkpoint -l -e /tmp/checkpoint.tar.gz
      * scp /tmp/checkpoint.tar.gz destination:/tmp
    
     Destination system:
      * podman pull 'container-image-as-on-source-system'
      * podman container restore -i /tmp/checkpoint.tar.gz
    
For the newly added test to work an updated runc is required, which is still under review: https://github.com/opencontainers/runc/pull/1968

Tries to solve: https://github.com/containers/libpod/issues/1618

This PR includes the actual code, man-pages, bash-completion, tests, tutorial update.

Once this is merged I would also like to publish a related article on podman.io.