### PR TITLE
Preserve exited state across reboot

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -392,7 +392,9 @@ func resetState(state *ContainerState) error {
 	state.PID = 0
 	state.Mountpoint = ""
 	state.Mounted = false
-	state.State = ContainerStateConfigured
+	if state.State != ContainerStateExited {
+		state.State = ContainerStateConfigured
+	}
 	state.ExecSessions = make(map[string]*ExecSession)
 	state.NetworkStatus = nil
 	state.BindMounts = make(map[string]string)


### PR DESCRIPTION
Instead of unconditionally resetting to ContainerStateConfigured after a reboot, allow containers in the Exited state to remain there, preserving their exit code in podman ps after a reboot.

This does not affect the ability to use and restart containers after a reboot, as the Exited state can be used (mostly) interchangeably with Configured for starting and managing containers.

Much-delayed fix for #1703 