### PR TITLE
e2e tests: sigproxy: fix rare hang condition

### DIFF
--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 
 		_, pid := podmanTest.PodmanPID([]string{"run", "-it", "-v", fmt.Sprintf("%s:/h:Z", udsDir), fedoraMinimal, "bash", "-c", sigCatch})
 
-		uds, _ := os.OpenFile(udsPath, os.O_RDONLY, 0600)
+		uds, _ := os.OpenFile(udsPath, os.O_RDONLY|syscall.O_NONBLOCK, 0600)
 		defer uds.Close()
 
 		// Wait for the script in the container to alert us that it is READY
@@ -73,7 +73,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 			}
 			time.Sleep(1 * time.Second)
 			if counter == 15 {
-				os.Exit(1)
+				Fail("Timed out waiting for READY from container")
 			}
 			counter++
 		}
@@ -99,7 +99,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 			}
 			time.Sleep(1 * time.Second)
 			if counter == 15 {
-				os.Exit(1)
+				Fail("timed out waiting for FOO from container")
 			}
 			counter++
 		}


### PR DESCRIPTION
The sig-proxy test creates a FIFO, runs podman with actions
that write to it, then tries reading from the FIFO.

Opening a FIFO for read or write blocks until the other end is
opened for the corresponding write/read. If our podman process
fails for any reason, the test's FIFO open will hang forever.

Solution: open with O_NONBLOCK.

Signed-off-by: Ed Santiago <santiago@redhat.com>