### PR TITLE
Fix handling of memory limits via varlink

### DIFF
--- a/pkg/varlinkapi/containers_create.go
+++ b/pkg/varlinkapi/containers_create.go
@@ -68,17 +68,11 @@ func (i *LibpodAPI) CreateContainer(call iopodman.VarlinkCall, config iopodman.C
 // varlinkCreateToCreateConfig takes  the varlink input struct and maps it to a pointer
 // of a CreateConfig, which eventually can be used to create the OCI spec.
 func varlinkCreateToCreateConfig(ctx context.Context, create iopodman.Create, runtime *libpod.Runtime, imageName string, data *inspect.ImageData) (*cc.CreateConfig, error) {
-	var (
-		inputCommand, command                                    []string
-		memoryLimit, memoryReservation, memorySwap, memoryKernel int64
-		blkioWeight                                              uint16
-	)
-
 	idmappings, err := util.ParseIDMapping(create.Uidmap, create.Gidmap, create.Subuidname, create.Subgidname)
 	if err != nil {
 		return nil, err
 	}
-	inputCommand = create.Command
+	inputCommand := create.Command
 	entrypoint := create.Entrypoint
 
 	// ENTRYPOINT
@@ -92,19 +86,13 @@ func varlinkCreateToCreateConfig(ctx context.Context, create iopodman.Create, ru
 	}
 	// Build the command
 	// If we have an entry point, it goes first
-	if len(entrypoint) > 0 {
-		command = entrypoint
-	}
+	command := entrypoint
 	if len(inputCommand) > 0 {
 		// User command overrides data CMD
 		command = append(command, inputCommand...)
 	} else if len(data.Config.Cmd) > 0 && len(command) == 0 {
 		// If not user command, add CMD
 		command = append(command, data.Config.Cmd...)
-	}
-
-	if create.Resources.Blkio_weight != 0 {
-		blkioWeight = uint16(create.Resources.Blkio_weight)
 	}
 
 	stopSignal := syscall.SIGTERM
@@ -183,7 +171,7 @@ func varlinkCreateToCreateConfig(ctx context.Context, create iopodman.Create, ru
 		Quiet:             create.Quiet,
 		ReadOnlyRootfs:    create.Readonly_rootfs,
 		Resources: cc.CreateResourceConfig{
-			BlkioWeight:       blkioWeight,
+			BlkioWeight:       uint16(create.Resources.Blkio_weight),
 			BlkioWeightDevice: create.Resources.Blkio_weight_device,
 			CPUShares:         uint64(create.Resources.Cpu_shares),
 			CPUPeriod:         uint64(create.Resources.Cpu_period),
@@ -199,11 +187,11 @@ func varlinkCreateToCreateConfig(ctx context.Context, create iopodman.Create, ru
 			DeviceWriteIOps:   create.Resources.Device_write_iops,
 			DisableOomKiller:  create.Resources.Disable_oomkiller,
 			ShmSize:           create.Resources.Shm_size,
-			Memory:            memoryLimit,
-			MemoryReservation: memoryReservation,
-			MemorySwap:        memorySwap,
+			Memory:            create.Resources.Memory,
+			MemoryReservation: create.Resources.Memory_reservation,
+			MemorySwap:        create.Resources.Memory_swap,
 			MemorySwappiness:  int(create.Resources.Memory_swappiness),
-			KernelMemory:      memoryKernel,
+			KernelMemory:      create.Resources.Kernel_memory,
 			OomScoreAdj:       int(create.Resources.Oom_score_adj),
 			PidsLimit:         create.Resources.Pids_limit,
 			Ulimit:            create.Resources.Ulimit,


### PR DESCRIPTION
Currently handlin memory via varlink is hard coded to 0
Changing to
```
			Memory:            create.Resources.Memory,
			MemoryReservation: create.Resources.Memory_reservation,
			MemorySwap:        create.Resources.Memory_swap,
			MemorySwappiness:  int(create.Resources.Memory_swappiness),
			KernelMemory:      create.Resources.Kernel_memory,
```
Allows callers to modify these memory settings.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>