### PR TITLE
Remove container from storage on --force

### DIFF
--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/cmd/podman/shared"
+	"github.com/containers/libpod/libpod"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -61,10 +62,18 @@ func rmCmd(c *cliconfig.RmValues) error {
 
 	delContainers, err := getAllOrLatestContainers(&c.PodmanCommand, runtime, -1, "all")
 	if err != nil {
+		if c.Force && len(c.InputArgs) > 0 {
+			if errors.Cause(err) == libpod.ErrNoSuchCtr {
+				err = nil
+			}
+			runtime.RemoveContainersFromStorage(c.InputArgs)
+		}
 		if len(delContainers) == 0 {
 			return err
 		}
-		fmt.Println(err.Error())
+		if err != nil {
+			fmt.Println(err.Error())
+		}
 	}
 
 	for _, container := range delContainers {

--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -17,7 +17,9 @@ Remove all containers.  Can be used in conjunction with -f as well.
 
 **--force, f**
 
-Force the removal of a running and paused containers
+Force the removal of running and paused containers.  Forcing a containers removal also
+removes containers from container storage even if the container is not known to podman.
+Containers could have been created by a different container engine.
 
 **--latest, -l**
 

--- a/libpod/errors.go
+++ b/libpod/errors.go
@@ -2,15 +2,20 @@ package libpod
 
 import (
 	"errors"
+
+	"github.com/containers/libpod/libpod/image"
 )
 
 var (
 	// ErrNoSuchCtr indicates the requested container does not exist
-	ErrNoSuchCtr = errors.New("no such container")
+	ErrNoSuchCtr = image.ErrNoSuchCtr
+
 	// ErrNoSuchPod indicates the requested pod does not exist
-	ErrNoSuchPod = errors.New("no such pod")
+	ErrNoSuchPod = image.ErrNoSuchPod
+
 	// ErrNoSuchImage indicates the requested image does not exist
-	ErrNoSuchImage = errors.New("no such image")
+	ErrNoSuchImage = image.ErrNoSuchImage
+
 	// ErrNoSuchVolume indicates the requested volume does not exist
 	ErrNoSuchVolume = errors.New("no such volume")
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/stringid"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -563,4 +565,17 @@ func (r *Runtime) Export(name string, path string) error {
 	}
 	return ctr.Export(path)
 
+}
+
+// RemoveContainersFromStorage attempt to remove containers from storage that do not exist in libpod database
+func (r *Runtime) RemoveContainersFromStorage(ctrs []string) {
+	for _, i := range ctrs {
+		// if the container does not exist in database, attempt to remove it from storage
+		if _, err := r.LookupContainer(i); err != nil && errors.Cause(err) == image.ErrNoSuchCtr {
+			r.storageService.UnmountContainerImage(i, true)
+			if err := r.storageService.DeleteContainer(i); err != nil && errors.Cause(err) != storage.ErrContainerUnknown {
+				logrus.Errorf("Failed to remove container %q from storage: %s", i, err)
+			}
+		}
+	}
 }


### PR DESCRIPTION
Currently we can get into a state where a container exists in
storage but does not exist in libpod.  If the user forces a
removal of this container, then we should remove it from storage
even if the container is owned by another tool.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>