### PR TITLE
Add StartPeriod to cmd/podman/docker.HealthConfig

### DIFF
--- a/cmd/podman/docker/types.go
+++ b/cmd/podman/docker/types.go
@@ -69,8 +69,9 @@ type HealthConfig struct {
 	Test []string `json:",omitempty"`
 
 	// Zero means to inherit. Durations are expressed as integer nanoseconds.
-	Interval time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
-	Timeout  time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	Interval    time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout     time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+	StartPeriod time.Duration `json:",omitempty"` // Time to wait after the container starts before running the first check.
 
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.


### PR DESCRIPTION
Backport the addition of the `StartPeriod` field to our copy of the `HealthConfig` type, added in docker v17.05.0-ce.