### PR TITLE
Makefile: minor fix to reenable system tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ help:
 .gopathok:
 ifeq ("$(wildcard $(GOPKGDIR))","")
 	mkdir -p "$(GOPKGBASEDIR)"
-	ln -s "$(CURDIR)" "$(GOPKGBASEDIR)"
+	ln -sf "$(CURDIR)" "$(GOPKGBASEDIR)"
 endif
 	touch $@
 
@@ -182,10 +182,10 @@ ginkgo-remote:
 
 localintegration: varlink_generate test-binaries ginkgo ginkgo-remote
 
-localsystem: .install.ginkgo .install.gomega
+localsystem: .install.ginkgo
 	ginkgo -v -noColor test/system/
 
-system.test-binary: .install.ginkgo .install.gomega
+system.test-binary: .install.ginkgo
 	$(GO) test -c ./test/system
 
 perftest:


### PR DESCRIPTION
PR #2259 removed the .install.gomega Makefile target but
didn't clean up two references to it. Do so now.

Also, when setting up GOPKGBASEDIR symlink, use -f (force)
flag; otherwise subsequent makes will fail.

Signed-off-by: Ed Santiago <santiago@redhat.com>