### PR TITLE
cleanup: use the correct runtime

### DIFF
--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -331,6 +331,9 @@ func (c *CreateConfig) createExitCommand() []string {
 		"--cgroup-manager", config.CgroupManager,
 		"--tmpdir", config.TmpDir,
 	}
+	if config.OCIRuntime != "" {
+		command = append(command, []string{"--runtime", config.OCIRuntime}...)
+	}
 	if config.StorageConfig.GraphDriverName != "" {
 		command = append(command, []string{"--storage-driver", config.StorageConfig.GraphDriverName}...)
 	}


### PR DESCRIPTION
make sure "containers cleanup" uses the correct runtime if it was
overriden.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>