### PR TITLE
Update Pod Create help and man pages

### DIFF
--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -19,10 +19,11 @@ var (
 	DefaultKernelNamespaces = "cgroup,ipc,net,uts"
 )
 
-var podCreateDescription = "Creates a new empty pod. The pod ID is then" +
-	" printed to stdout. You can then start it at any time with the" +
-	" podman pod start <pod_id> command. The pod will be created with the" +
-	" initial state 'created'."
+var podCreateDescription = "Creates a new pod. The pod ID is then" +
+	" printed to stdout. If an infra container is attached to the pod (as is default)," +
+	" the pod will have an initial state of 'running', as the infra container is started after it's created." +
+    " Otherwise, the pod will have an initial state of 'created', and can be started with 'podman pod start <POD ID>'" +
+    " after containers are attached to it."
 
 var podCreateFlags = []cli.Flag{
 	cli.StringFlag{
@@ -152,7 +153,6 @@ func podCreateCmd(c *cli.Context) error {
 			return err
 		}
 		options = append(options, libpod.WithInfraContainerPorts(portBindings))
-
 	}
 	// always have containers use pod cgroups
 	// User Opt out is not yet supported

--- a/docs/podman-pod-create.1.md
+++ b/docs/podman-pod-create.1.md
@@ -8,10 +8,11 @@ podman\-pod\-create - Create a new pod
 
 ## DESCRIPTION
 
-Creates an empty pod, or unit of multiple containers, and prepares it to have
-containers added to it. The pod id is printed to STDOUT. You can then use
-**podman create --pod <pod_id|pod_name> ...** to add containers to the pod, and
-**podman pod start <pod_id|pod_name>** to start the pod.
+Creates a new pod, or unit of multiple containers, and prepares it to have containers added to it.
+The pod ID is then printed to STDOUT. If an infra container is attached to the pod (as is default),
+the pod will have an initial state of 'running', as the infra container is started after it's created.
+Otherwise, the pod will have an initial state of 'created', and can be started with **podman pod start \<pod_id|pod_name\>**
+after containers are attached to it (which can be done with **podman create --pod \<pod_id|pod_name\> ...**
 
 ## OPTIONS
 


### PR DESCRIPTION
infra-containers in a pod are now started after a pod is created, but the change wasn't reflected in the man page or help string. Update them to reflect this behavior.

Signed-off-by: Peter Hunt <pehunt@redhat.com>