### PR TITLE
Recursively start a pod if a container is run in it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 /cmd/podman/varlink/ioprojectatomicpodman.go
 /cmd/podman/varlink/iopodman.go
 .gopathok
+test/e2e/e2e.coverprofile

--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -74,7 +74,8 @@ func attachCmd(c *cliconfig.AttachValues) error {
 		inputStream = nil
 	}
 
-	if err := startAttachCtr(ctr, os.Stdout, os.Stderr, inputStream, c.DetachKeys, c.SigProxy, false); err != nil && errors.Cause(err) != libpod.ErrDetach {
+	// If the container is in a pod, also set to recursively start dependencies
+	if err := startAttachCtr(ctr, os.Stdout, os.Stderr, inputStream, c.DetachKeys, c.SigProxy, false, ctr.PodID() != ""); err != nil && errors.Cause(err) != libpod.ErrDetach {
 		return errors.Wrapf(err, "error attaching to container %s", ctr.ID())
 	}
 

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -154,7 +154,7 @@ func playKubeYAMLCmd(c *cliconfig.KubePlayValues) error {
 
 	// start the containers
 	for _, ctr := range containers {
-		if err := ctr.Start(ctx); err != nil {
+		if err := ctr.Start(ctx, false); err != nil {
 			// Making this a hard failure here to avoid a mess
 			// the other containers are in created status
 			return err

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -72,7 +72,8 @@ func runCmd(c *cliconfig.RunValues) error {
 	ctx := getContext()
 	// Handle detached start
 	if createConfig.Detach {
-		if err := ctr.Start(ctx); err != nil {
+		// if the container was created as part of a pod, also start its dependencies, if any.
+		if err := ctr.Start(ctx, c.IsSet("pod")); err != nil {
 			// This means the command did not exist
 			exitCode = 127
 			if strings.Index(err.Error(), "permission denied") > -1 {
@@ -117,7 +118,8 @@ func runCmd(c *cliconfig.RunValues) error {
 			}
 		}
 	}
-	if err := startAttachCtr(ctr, outputStream, errorStream, inputStream, c.String("detach-keys"), c.Bool("sig-proxy"), true); err != nil {
+	// if the container was created as part of a pod, also start its dependencies, if any.
+	if err := startAttachCtr(ctr, outputStream, errorStream, inputStream, c.String("detach-keys"), c.Bool("sig-proxy"), true, c.IsSet("pod")); err != nil {
 		// We've manually detached from the container
 		// Do not perform cleanup, or wait for container exit code
 		// Just exit immediately
@@ -125,7 +127,6 @@ func runCmd(c *cliconfig.RunValues) error {
 			exitCode = 0
 			return nil
 		}
-
 		// This means the command did not exist
 		exitCode = 127
 		if strings.Index(err.Error(), "permission denied") > -1 {

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -105,7 +105,8 @@ func startCmd(c *cliconfig.StartValues) error {
 			}
 
 			// attach to the container and also start it not already running
-			err = startAttachCtr(ctr, os.Stdout, os.Stderr, inputStream, c.DetachKeys, sigProxy, !ctrRunning)
+			// If the container is in a pod, also set to recursively start dependencies
+			err = startAttachCtr(ctr, os.Stdout, os.Stderr, inputStream, c.DetachKeys, sigProxy, !ctrRunning, ctr.PodID() != "")
 			if errors.Cause(err) == libpod.ErrDetach {
 				// User manually detached
 				// Exit cleanly immediately
@@ -144,7 +145,8 @@ func startCmd(c *cliconfig.StartValues) error {
 			continue
 		}
 		// Handle non-attach start
-		if err := ctr.Start(ctx); err != nil {
+		// If the container is in a pod, also set to recursively start dependencies
+		if err := ctr.Start(ctx, ctr.PodID() != ""); err != nil {
 			if lastError != nil {
 				fmt.Fprintln(os.Stderr, lastError)
 			}

--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -20,7 +20,7 @@ type RawTtyFormatter struct {
 }
 
 // Start (if required) and attach to a container
-func startAttachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys string, sigProxy bool, startContainer bool) error {
+func startAttachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys string, sigProxy bool, startContainer bool, recursive bool) error {
 	ctx := context.Background()
 	resize := make(chan remotecommand.TerminalSize)
 
@@ -76,7 +76,7 @@ func startAttachCtr(ctr *libpod.Container, stdout, stderr, stdin *os.File, detac
 		return ctr.Attach(streams, detachKeys, resize)
 	}
 
-	attachChan, err := ctr.StartAndAttach(getContext(), streams, detachKeys, resize)
+	attachChan, err := ctr.StartAndAttach(getContext(), streams, detachKeys, resize, recursive)
 	if err != nil {
 		return err
 	}

--- a/contrib/perftest/main.go
+++ b/contrib/perftest/main.go
@@ -201,7 +201,7 @@ func runSingleThreadedStressTest(ctx context.Context, client *libpod.Runtime, im
 
 		// Start container
 		startStartTime := time.Now()
-		err = ctr.Start(ctx)
+		err = ctr.Start(ctx, false)
 		if err != nil {
 			return nil, err
 		}

--- a/docs/podman-pod-create.1.md
+++ b/docs/podman-pod-create.1.md
@@ -10,8 +10,8 @@ podman\-pod\-create - Create a new pod
 
 Creates an empty pod, or unit of multiple containers, and prepares it to have
 containers added to it. The pod id is printed to STDOUT. You can then use
-**podman create --pod <pod_id|pod_name> ...** to add containers to the pod, and
-**podman pod start <pod_id|pod_name>** to start the pod.
+**podman create --pod \<pod_id|pod_name\> ...** to add containers to the pod, and
+**podman pod start \<pod_id|pod_name\>** to start the pod.
 
 ## OPTIONS
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -449,6 +449,7 @@ Tune the container's pids limit. Set `-1` to have unlimited pids for the contain
 
 Run container in an existing pod. If you want podman to make the pod for you, preference the pod name with `new:`.
 To make a pod with more granular options, use the `podman pod create` command before creating a container.
+If a container is run with a pod, and the pod has an infra-container, the infra-container will be started before the container is.
 
 **--privileged**=*true*|*false*
 

--- a/docs/podman-start.1.md
+++ b/docs/podman-start.1.md
@@ -8,7 +8,7 @@ podman\-start - Start one or more containers
 
 ## DESCRIPTION
 Start one or more containers.  You may use container IDs or names as input.  The *attach* and *interactive*
-options cannot be used to override the *--tty** and *--interactive* options from when the container
+options cannot be used to override the *--tty* and *--interactive* options from when the container
 was created. If you attempt to start a running container with the *--attach* option, podman will simply
 attach to the container.
 
@@ -32,6 +32,7 @@ Attach container's STDIN. The default is false.
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods.
+
 
 **--sig-proxy**=*true*|*false*
 

--- a/libpod/container_graph.go
+++ b/libpod/container_graph.go
@@ -1,6 +1,9 @@
 package libpod
 
 import (
+	"context"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -168,4 +171,98 @@ func detectCycles(graph *containerGraph) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// Visit a node on a container graph and start the container, or set an error if
+// a dependency failed to start. if restart is true, startNode will restart the node instead of starting it.
+func startNode(ctx context.Context, node *containerNode, setError bool, ctrErrors map[string]error, ctrsVisited map[string]bool, restart bool) {
+	// First, check if we have already visited the node
+	if ctrsVisited[node.id] {
+		return
+	}
+
+	// If setError is true, a dependency of us failed
+	// Mark us as failed and recurse
+	if setError {
+		// Mark us as visited, and set an error
+		ctrsVisited[node.id] = true
+		ctrErrors[node.id] = errors.Wrapf(ErrCtrStateInvalid, "a dependency of container %s failed to start", node.id)
+
+		// Hit anyone who depends on us, and set errors on them too
+		for _, successor := range node.dependedOn {
+			startNode(ctx, successor, true, ctrErrors, ctrsVisited, restart)
+		}
+
+		return
+	}
+
+	// Have all our dependencies started?
+	// If not, don't visit the node yet
+	depsVisited := true
+	for _, dep := range node.dependsOn {
+		depsVisited = depsVisited && ctrsVisited[dep.id]
+	}
+	if !depsVisited {
+		// Don't visit us yet, all dependencies are not up
+		// We'll hit the dependencies eventually, and when we do it will
+		// recurse here
+		return
+	}
+
+	// Going to try to start the container, mark us as visited
+	ctrsVisited[node.id] = true
+
+	ctrErrored := false
+
+	// Check if dependencies are running
+	// Graph traversal means we should have started them
+	// But they could have died before we got here
+	// Does not require that the container be locked, we only need to lock
+	// the dependencies
+	depsStopped, err := node.container.checkDependenciesRunning()
+	if err != nil {
+		ctrErrors[node.id] = err
+		ctrErrored = true
+	} else if len(depsStopped) > 0 {
+		// Our dependencies are not running
+		depsList := strings.Join(depsStopped, ",")
+		ctrErrors[node.id] = errors.Wrapf(ErrCtrStateInvalid, "the following dependencies of container %s are not running: %s", node.id, depsList)
+		ctrErrored = true
+	}
+
+	// Lock before we start
+	node.container.lock.Lock()
+
+	// Sync the container to pick up current state
+	if !ctrErrored {
+		if err := node.container.syncContainer(); err != nil {
+			ctrErrored = true
+			ctrErrors[node.id] = err
+		}
+	}
+
+	// Start the container (only if it is not running)
+	if !ctrErrored {
+		if !restart && node.container.state.State != ContainerStateRunning {
+			if err := node.container.initAndStart(ctx); err != nil {
+				ctrErrored = true
+				ctrErrors[node.id] = err
+			}
+		}
+		if restart && node.container.state.State != ContainerStatePaused && node.container.state.State != ContainerStateUnknown {
+			if err := node.container.restartWithTimeout(ctx, node.container.config.StopTimeout); err != nil {
+				ctrErrored = true
+				ctrErrors[node.id] = err
+			}
+		}
+	}
+
+	node.container.lock.Unlock()
+
+	// Recurse to anyone who depends on us and start them
+	for _, successor := range node.dependedOn {
+		startNode(ctx, successor, ctrErrored, ctrErrors, ctrsVisited, restart)
+	}
+
+	return
 }

--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -117,15 +117,6 @@ func (r *Runtime) NewPod(ctx context.Context, options ...PodCreateOption) (*Pod,
 		if err := pod.save(); err != nil {
 			return nil, err
 		}
-
-		// Once the pod infra container has been created, we start it
-		if err := ctr.Start(ctx); err != nil {
-			// If the infra container does not start, we need to tear the pod down.
-			if err2 := r.removePod(ctx, pod, true, true); err2 != nil {
-				logrus.Errorf("Error removing pod after infra container failed to start: %v", err2)
-			}
-			return nil, errors.Wrapf(err, "error starting Infra Container")
-		}
 	}
 
 	return pod, nil

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -260,7 +260,7 @@ func (i *LibpodAPI) StartContainer(call iopodman.VarlinkCall, name string) error
 	if state == libpod.ContainerStateRunning || state == libpod.ContainerStatePaused {
 		return call.ReplyErrorOccurred("container is already running or paused")
 	}
-	if err := ctr.Start(getContext()); err != nil {
+	if err := ctr.Start(getContext(), false); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
 	return call.ReplyStartContainer(ctr.ID())

--- a/test/e2e/e2e.coverprofile
+++ b/test/e2e/e2e.coverprofile
@@ -1,0 +1,11 @@
+mode: atomic
+github.com/containers/libpod/test/e2e/pod_pod_namespaces.go:14.46,21.20 2 1
+github.com/containers/libpod/test/e2e/pod_pod_namespaces.go:31.2,31.19 1 1
+github.com/containers/libpod/test/e2e/pod_pod_namespaces.go:38.2,38.53 1 1
+github.com/containers/libpod/test/e2e/pod_pod_namespaces.go:65.2,65.52 1 1
+github.com/containers/libpod/test/e2e/pod_pod_namespaces.go:21.20,23.17 2 2
+github.com/containers/libpod/test/e2e/pod_pod_namespaces.go:26.3,28.36 3 2
+github.com/containers/libpod/test/e2e/pod_pod_namespaces.go:23.17,25.4 1 0
+github.com/containers/libpod/test/e2e/pod_pod_namespaces.go:31.19,36.3 4 2
+github.com/containers/libpod/test/e2e/pod_pod_namespaces.go:38.53,63.3 20 1
+github.com/containers/libpod/test/e2e/pod_pod_namespaces.go:65.52,90.3 20 1

--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -309,4 +309,55 @@ var _ = Describe("Podman pod create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
+
+	It("podman run in pod starts infra", func() {
+		session := podmanTest.Podman([]string{"pod", "create"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		podID := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"ps", "-aq"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		infraID := result.OutputToString()
+
+		result = podmanTest.Podman([]string{"run", "--pod", podID, "-d", ALPINE, "top"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		result = podmanTest.Podman([]string{"ps", "-aq"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(len(result.OutputToStringArray())).Should(BeNumerically(">", 0))
+
+		Expect(result.OutputToString()).To(ContainSubstring(infraID))
+	})
+
+	It("podman start in pod starts infra", func() {
+		session := podmanTest.Podman([]string{"pod", "create"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		podID := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"ps", "-aq"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		infraID := result.OutputToString()
+
+		result = podmanTest.Podman([]string{"create", "--pod", podID, ALPINE, "ls"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		ctrID := result.OutputToString()
+
+		result = podmanTest.Podman([]string{"start", ctrID})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		result = podmanTest.Podman([]string{"ps", "-aq"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(len(result.OutputToStringArray())).Should(BeNumerically(">", 0))
+
+		Expect(result.OutputToString()).To(ContainSubstring(infraID))
+	})
 })

--- a/test/trust_set_test.json
+++ b/test/trust_set_test.json
@@ -1,0 +1,8 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ],
+    "transports": null
+}


### PR DESCRIPTION
Prior, a pod would have to be started immediately when created, leading to confusion about what a pod state should be immediately after creation. The problem was podman run --pod ... would error out if the infra container wasn't started (as it is a dependency). Fix this by allowing for recursive start, where each of the container's dependencies are started prior to the new container. Only apply this when a container is run in a "created" pod

Also rework container_api Start, StartAndAttach, and Init functions, as there was some duplicated code, which made addressing the --recursive problem easier to fix.

Signed-off-by: Peter Hunt <pehunt@redhat.com>