### PR TITLE
Add volume mounts to PS output

### DIFF
--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -88,6 +88,7 @@ type PsContainerOutput struct {
 	PIDNS     string
 	User      string
 	UTS       string
+	Mounts    string
 }
 
 // Namespace describes output for ps namespace
@@ -228,6 +229,7 @@ func NewBatchContainer(ctr *libpod.Container, opts PsOptions) (PsContainerOutput
 	pso.CreatedAt = ctr.CreatedTime()
 	pso.StartedAt = startedAt
 	pso.Labels = ctr.Labels()
+	pso.Mounts = strings.Join(ctr.UserVolumes(), " ")
 
 	if opts.Namespace {
 		pso.Cgroup = ns.Cgroup


### PR DESCRIPTION
When listing containers, you should be able to list the mounts
with something like --format "table{{".Mounts}}".

Resolves: #2238

Signed-off-by: baude <bbaude@redhat.com>