### PR TITLE
Add common_test.go to single test instructions

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -66,7 +66,7 @@ switch is optional.
 You can run a single file of integration tests using the go test command:
 
 ```
-GOPATH=~/go go test -v test/e2e/libpod_suite_test.go test/e2e/config.go test/e2e/config_amd64.go test/e2e/your_test.go
+GOPATH=~/go go test -v test/e2e/libpod_suite_test.go test/e2e/common_test.go test/e2e/config.go test/e2e/config_amd64.go test/e2e/your_test.go
 ```
 
 #### Run all tests like PAPR


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Add e2e/test/common_test.go to the single integration test
instructions.  Without it the documented process fails.