### PR TITLE
Podman pod stats -- fix GO template output

### DIFF
--- a/docs/podman-stats.1.md
+++ b/docs/podman-stats.1.md
@@ -36,16 +36,17 @@ Valid placeholders for the Go template are listed below:
 
 | **Placeholder** | **Description**   |
 | --------------- | ---------------   |
-| .ID             | Container ID      |
+| .Pod            | Pod ID      |
+| .CID            | Container ID      |
 | .Name           | Container Name    |
-| .CPUPerc        | CPU percentage    |
+| .CPU            | CPU percentage    |
 | .MemUsage       | Memory usage      |
-| .MemPerc        | Memory percentage |
+| .Mem            | Memory percentage |
 | .NetIO          | Network IO        |
 | .BlockIO        | Block IO          |
 | .PIDS           | Number of PIDs    |
 
-
+When using a GO template, you may preceed the format with `table` to print headers.
 ## EXAMPLE
 
 ```

--- a/test/e2e/pod_stats_test.go
+++ b/test/e2e/pod_stats_test.go
@@ -147,5 +147,28 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(stats.ExitCode()).To(Equal(0))
 		Expect(stats.IsJSONOutputValid()).To(BeTrue())
 	})
+	It("podman stats with GO template", func() {
+		_, ec, podid := podmanTest.CreatePod("")
+		Expect(ec).To(Equal(0))
+
+		session := podmanTest.RunTopContainerInPod("", podid)
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		stats := podmanTest.Podman([]string{"pod", "stats", "-a", "--no-reset", "--no-stream", "--format", "\"table {{.CID}} {{.Pod}} {{.Mem}} {{.MemUsage}} {{.CPU}} {{.NetIO}} {{.BlockIO}} {{.PIDS}} {{.Pod}}\""})
+		stats.WaitWithDefaultTimeout()
+		Expect(stats.ExitCode()).To(Equal(0))
+	})
+
+	It("podman stats with invalid GO template", func() {
+		_, ec, podid := podmanTest.CreatePod("")
+		Expect(ec).To(Equal(0))
+
+		session := podmanTest.RunTopContainerInPod("", podid)
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		stats := podmanTest.Podman([]string{"pod", "stats", "-a", "--no-reset", "--no-stream", "--format", "\"table {{.ID}} \""})
+		stats.WaitWithDefaultTimeout()
+		Expect(stats.ExitCode()).ToNot(Equal(0))
+	})
 
 })


### PR DESCRIPTION
Go templates were not being processed or printed correctly for podman
pod stats.  Added the ability to do templates as well as honor the
table identifier.

Fixes #2258

Signed-off-by: baude <bbaude@redhat.com>