### PR TITLE
Separate remote and local commands

### DIFF
--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -34,8 +34,6 @@ func init() {
 	flags.BoolVar(&attachCommand.SigProxy, "sig-proxy", true, "Proxy received signals to the process (default true)")
 
 	flags.BoolVarP(&attachCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
-
-	rootCmd.AddCommand(attachCommand.Command)
 }
 
 func attachCmd(c *cliconfig.AttachValues) error {

--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -58,8 +58,6 @@ func init() {
 
 	flags.AddFlagSet(&budFlags)
 	flags.AddFlagSet(&fromAndBugFlags)
-
-	rootCmd.AddCommand(buildCommand.Command)
 }
 
 func getDockerfiles(files []string) []string {

--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -6,24 +6,66 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Commands that the local client implements
+func getMainCommands() []*cobra.Command {
+	rootCommands := []*cobra.Command{
+		_attachCommand,
+		_buildCommand,
+		_commitCommand,
+		_createCommand,
+		_diffCommand,
+		_execCommand,
+		_killCommand,
+		generateCommand.Command,
+		podCommand.Command,
+		_containerKubeCommand,
+		_psCommand,
+		_loadCommand,
+		_loginCommand,
+		_logoutCommand,
+		_logsCommand,
+		_mountCommand,
+		_pauseCommand,
+		_portCommand,
+		_pushCommand,
+		_refreshCommand,
+		_restartCommand,
+		_restoreCommand,
+		_rmCommand,
+		_runCommmand,
+		_saveCommand,
+		_searchCommand,
+		_signCommand,
+		_startCommand,
+		_statsCommand,
+		_stopCommand,
+		_topCommand,
+		_umountCommand,
+		_unpauseCommand,
+		_varlinkCommand,
+		volumeCommand.Command,
+		_waitCommand,
+	}
+	return rootCommands
+}
+
+// Commands that the local client implements
 func getImageSubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		_buildCommand,
-		_importCommand,
 		_loadCommand,
-		_pullCommand,
-		_rmiCommand,
+		_pushCommand,
 		_saveCommand,
 		_signCommand,
 	}
 }
 
+// Commands that the local client implements
 func getContainerSubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		_attachCommand,
 		_checkpointCommand,
 		_cleanupCommand,
-		_containerExistsCommand,
 		_commitCommand,
 		_createCommand,
 		_diffCommand,
@@ -52,6 +94,7 @@ func getContainerSubCommands() []*cobra.Command {
 	}
 }
 
+// Commands that the local client implements
 func getPodSubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		_podCreateCommand,
@@ -70,6 +113,7 @@ func getPodSubCommands() []*cobra.Command {
 	}
 }
 
+// Commands that the local client implements
 func getVolumeSubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		_volumeCreateCommand,
@@ -80,18 +124,21 @@ func getVolumeSubCommands() []*cobra.Command {
 	}
 }
 
+// Commands that the local client implements
 func getGenerateSubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		_containerKubeCommand,
 	}
 }
 
+// Commands that the local client implements
 func getPlaySubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		_playKubeCommand,
 	}
 }
 
+// Commands that the local client implements
 func getTrustSubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		_setTrustCommand,
@@ -99,9 +146,9 @@ func getTrustSubCommands() []*cobra.Command {
 	}
 }
 
+// Commands that the local client implements
 func getSystemSubCommands() []*cobra.Command {
 	return []*cobra.Command{
-		_infoCommand,
 		_pruneSystemCommand,
 	}
 }

--- a/cmd/podman/commands_remoteclient.go
+++ b/cmd/podman/commands_remoteclient.go
@@ -6,43 +6,52 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//import "github.com/urfave/cli"
-//
+// commands that only the remoteclient implements
+func getMainCommands() []*cobra.Command {
+	return []*cobra.Command{}
+}
+
+// commands that only the remoteclient implements
 func getAppCommands() []*cobra.Command {
 	return []*cobra.Command{}
 }
 
+// commands that only the remoteclient implements
 func getImageSubCommands() []*cobra.Command {
 	return []*cobra.Command{}
 }
 
+// commands that only the remoteclient implements
 func getContainerSubCommands() []*cobra.Command {
 	return []*cobra.Command{}
 }
 
+// commands that only the remoteclient implements
 func getPodSubCommands() []*cobra.Command {
 	return []*cobra.Command{}
 }
 
+// commands that only the remoteclient implements
 func getVolumeSubCommands() []*cobra.Command {
 	return []*cobra.Command{}
 }
 
+// commands that only the remoteclient implements
 func getGenerateSubCommands() []*cobra.Command {
 	return []*cobra.Command{}
 }
 
+// commands that only the remoteclient implements
 func getPlaySubCommands() []*cobra.Command {
 	return []*cobra.Command{}
 }
 
+// commands that only the remoteclient implements
 func getTrustSubCommands() []*cobra.Command {
 	return []*cobra.Command{}
 }
 
-//func getMainAppFlags() []cli.Flag {
-//	return []cli.Flag{}
-//}
+// commands that only the remoteclient implements
 func getSystemSubCommands() []*cobra.Command {
 	return []*cobra.Command{}
 }

--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -47,7 +47,6 @@ func init() {
 	flags.BoolVarP(&commitCommand.Pause, "pause", "p", false, "Pause container during commit")
 	flags.BoolVarP(&commitCommand.Quiet, "quiet", "q", false, "Suppress output")
 
-	rootCmd.AddCommand(commitCommand.Command)
 }
 
 func commitCmd(c *cliconfig.CommitValues) error {

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -15,7 +15,13 @@ var containerCommand = cliconfig.PodmanCommand{
 	},
 }
 
+// Commands that are universally implemented.
+var containerCommands = []*cobra.Command{
+	_containerExistsCommand,
+}
+
 func init() {
+	containerCommand.AddCommand(containerCommands...)
 	containerCommand.AddCommand(getContainerSubCommands()...)
 	rootCmd.AddCommand(containerCommand.Command)
 }

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -65,7 +65,6 @@ func init() {
 	flags := createCommand.Flags()
 	flags.SetInterspersed(true)
 
-	rootCmd.AddCommand(createCommand.Command)
 }
 
 func createCmd(c *cliconfig.CreateValues) error {

--- a/cmd/podman/diff.go
+++ b/cmd/podman/diff.go
@@ -59,9 +59,8 @@ func init() {
 
 	flags.MarkHidden("archive")
 
-	rootCmd.AddCommand(diffCommand.Command)
-
 }
+
 func formatJSON(output []diffOutputParams) (diffJSONOutput, error) {
 	jsonStruct := diffJSONOutput{}
 	for _, output := range output {

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -46,7 +46,6 @@ func init() {
 
 	flags.StringVarP(&execCommand.Workdir, "workdir", "w", "", "Working directory inside the container")
 
-	rootCmd.AddCommand(execCommand.Command)
 }
 
 func execCmd(c *cliconfig.ExecValues) error {

--- a/cmd/podman/export.go
+++ b/cmd/podman/export.go
@@ -33,7 +33,6 @@ func init() {
 	exportCommand.Command = _exportCommand
 	flags := exportCommand.Flags()
 	flags.StringVarP(&exportCommand.Output, "output", "o", "/dev/stdout", "Write to a file, default is STDOUT")
-	rootCmd.AddCommand(exportCommand.Command)
 }
 
 // exportCmd saves a container to a tarball on disk

--- a/cmd/podman/generate.go
+++ b/cmd/podman/generate.go
@@ -17,5 +17,4 @@ var generateCommand = cliconfig.PodmanCommand{
 
 func init() {
 	generateCommand.AddCommand(getGenerateSubCommands()...)
-	rootCmd.AddCommand(generateCommand.Command)
 }

--- a/cmd/podman/history.go
+++ b/cmd/podman/history.go
@@ -60,9 +60,8 @@ func init() {
 	flags.BoolVar(&historyCommand.NoTrunc, "no-trunc", false, "Do not truncate the output")
 	flags.BoolVarP(&historyCommand.Quiet, "quiet", "q", false, "Display the numeric IDs only")
 
-	rootCmd.AddCommand(historyCommand.Command)
-
 }
+
 func historyCmd(c *cliconfig.HistoryValues) error {
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {

--- a/cmd/podman/image.go
+++ b/cmd/podman/image.go
@@ -20,10 +20,11 @@ var (
 var imageSubCommands = []*cobra.Command{
 	_historyCommand,
 	_imageExistsCommand,
-	_inspectCommand,
 	_imagesCommand,
+	_importCommand,
+	_inspectCommand,
 	_pruneImagesCommand,
-	_pushCommand,
+	_pullCommand,
 	_rmiCommand,
 	_tagCommand,
 }
@@ -31,5 +32,4 @@ var imageSubCommands = []*cobra.Command{
 func init() {
 	imageCommand.AddCommand(imageSubCommands...)
 	imageCommand.AddCommand(getImageSubCommands()...)
-	rootCmd.AddCommand(imageCommand.Command)
 }

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -114,8 +114,6 @@ func init() {
 	flags.BoolVarP(&imagesCommand.Quiet, "quiet", "q", false, "Display only image IDs")
 	flags.StringVar(&imagesCommand.Sort, "sort", "created", "Sort by created, id, repository, size, or tag")
 
-	rootCmd.AddCommand(imagesCommand.Command)
-
 }
 
 func imagesCmd(c *cliconfig.ImagesValues) error {

--- a/cmd/podman/import.go
+++ b/cmd/podman/import.go
@@ -36,7 +36,6 @@ func init() {
 	flags.StringVarP(&importCommand.Message, "message", "m", "", "Set commit message for imported image")
 	flags.BoolVarP(&importCommand.Quiet, "quiet", "q", false, "Suppress output")
 
-	rootCmd.AddCommand(importCommand.Command)
 }
 
 func importCmd(c *cliconfig.ImportValues) error {

--- a/cmd/podman/info.go
+++ b/cmd/podman/info.go
@@ -37,7 +37,6 @@ func init() {
 	flags.BoolVarP(&infoCommand.Debug, "debug", "D", false, "Display additional debug information")
 	flags.StringVarP(&infoCommand.Format, "format", "f", "", "Change the output format to JSON or a Go template")
 
-	rootCmd.AddCommand(infoCommand.Command)
 }
 
 func infoCmd(c *cliconfig.InfoValues) error {

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -46,7 +46,6 @@ func init() {
 	flags.BoolVarP(&inspectCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of if the type is a container")
 	flags.BoolVarP(&inspectCommand.Size, "size", "s", false, "Display total file size if the type is container")
 
-	rootCmd.AddCommand(inspectCommand.Command)
 }
 
 func inspectCmd(c *cliconfig.InspectValues) error {

--- a/cmd/podman/kill.go
+++ b/cmd/podman/kill.go
@@ -40,7 +40,6 @@ func init() {
 	flags.StringVarP(&killCommand.Signal, "signal", "s", "KILL", "Signal to send to the container")
 	flags.BoolVarP(&killCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 
-	rootCmd.AddCommand(killCommand.Command)
 }
 
 // killCmd kills one or more containers with a signal

--- a/cmd/podman/load.go
+++ b/cmd/podman/load.go
@@ -39,7 +39,6 @@ func init() {
 	flags.BoolVarP(&loadCommand.Quiet, "quiet", "q", false, "Suppress the output")
 	flags.StringVar(&loadCommand.SignaturePolicy, "signature-policy", "", "Pathname of signature policy file (not usually used)")
 
-	rootCmd.AddCommand(loadCommand.Command)
 }
 
 // loadCmd gets the image/file to be loaded from the command line

--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -44,7 +44,6 @@ func init() {
 	flags.BoolVar(&loginCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
 	flags.StringVarP(&loginCommand.Username, "username", "u", "", "Username for registry")
 
-	rootCmd.AddCommand(loginCommand.Command)
 }
 
 // loginCmd uses the authentication package to store a user's authenticated credentials

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -32,7 +32,6 @@ func init() {
 	flags.BoolVarP(&logoutCommand.All, "all", "a", false, "Remove the cached credentials for all registries in the auth file")
 	flags.StringVar(&logoutCommand.Authfile, "authfile", "", "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")
 
-	rootCmd.AddCommand(logoutCommand.Command)
 }
 
 // logoutCmd uses the authentication package to remove the authenticated of a registry

--- a/cmd/podman/logs.go
+++ b/cmd/podman/logs.go
@@ -43,7 +43,6 @@ func init() {
 
 	flags.SetInterspersed(false)
 
-	rootCmd.AddCommand(logsCommand.Command)
 }
 
 func logsCmd(c *cliconfig.LogsValues) error {

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -27,6 +27,24 @@ var (
 	exitCode = 125
 )
 
+// Commands that the remote and local client have
+// implemented.
+var mainCommands = []*cobra.Command{
+	_exportCommand,
+	_historyCommand,
+	_imagesCommand,
+	_importCommand,
+	_infoCommand,
+	_inspectCommand,
+	_killCommand,
+	_pullCommand,
+	_rmiCommand,
+	_tagCommand,
+	_versionCommand,
+	imageCommand.Command,
+	systemCommand.Command,
+}
+
 var cmdsNotRequiringRootless = map[*cobra.Command]bool{
 	_versionCommand: true,
 	_createCommand:  true,
@@ -92,6 +110,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&MainGlobalOpts.Syslog, "syslog", false, "Output logging information to syslog as well as the console")
 
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.TmpDir, "tmpdir", "", "Path to the tmp directory")
+	rootCmd.AddCommand(mainCommands...)
+	rootCmd.AddCommand(getMainCommands()...)
 
 }
 func initConfig() {

--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -45,7 +45,6 @@ func init() {
 	flags.BoolVarP(&mountCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&mountCommand.NoTrunc, "notruncate", false, "Do not truncate output")
 
-	rootCmd.AddCommand(mountCommand.Command)
 }
 
 // jsonMountPoint stores info about each container

--- a/cmd/podman/pause.go
+++ b/cmd/podman/pause.go
@@ -37,7 +37,6 @@ func init() {
 	flags := pauseCommand.Flags()
 	flags.BoolVarP(&pauseCommand.All, "all", "a", false, "Pause all running containers")
 
-	rootCmd.AddCommand(pauseCommand.Command)
 }
 
 func pauseCmd(c *cliconfig.PauseValues) error {

--- a/cmd/podman/play.go
+++ b/cmd/podman/play.go
@@ -19,5 +19,4 @@ func init() {
 
 func init() {
 	playCommand.AddCommand(getPlaySubCommands()...)
-	rootCmd.AddCommand(playCommand.Command)
 }

--- a/cmd/podman/pod.go
+++ b/cmd/podman/pod.go
@@ -20,5 +20,4 @@ var podCommand = cliconfig.PodmanCommand{
 
 func init() {
 	podCommand.AddCommand(getPodSubCommands()...)
-	rootCmd.AddCommand(podCommand.Command)
 }

--- a/cmd/podman/port.go
+++ b/cmd/podman/port.go
@@ -39,7 +39,6 @@ func init() {
 	flags.BoolVarP(&portCommand.All, "all", "a", false, "Display port information for all containers")
 	flags.BoolVarP(&portCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 
-	rootCmd.AddCommand(portCommand.Command)
 }
 
 func portCmd(c *cliconfig.PortValues) error {

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -187,9 +187,8 @@ func init() {
 	flags.StringVar(&psCommand.Sort, "sort", "created", "Sort output by command, created, id, image, names, runningfor, size, or status")
 	flags.BoolVar(&psCommand.Sync, "sync", false, "Sync container state with OCI runtime")
 
-	rootCmd.AddCommand(psCommand.Command)
-
 }
+
 func psCmd(c *cliconfig.PsValues) error {
 	var (
 		filterFuncs      []libpod.ContainerFilter

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -48,7 +48,6 @@ func init() {
 	flags.StringVar(&pullCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
 	flags.BoolVar(&pullCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
 
-	rootCmd.AddCommand(pullCommand.Command)
 }
 
 // pullCmd gets the data from the command line and calls pullImage

--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -52,7 +52,6 @@ func init() {
 	flags.StringVar(&pushCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
 	flags.StringVar(&pushCommand.SignBy, "sign-by", "", "Add a signature at the destination using the specified key")
 	flags.BoolVar(&pushCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
-	rootCmd.AddCommand(pushCommand.Command)
 }
 
 func pushCmd(c *cliconfig.PushValues) error {

--- a/cmd/podman/refresh.go
+++ b/cmd/podman/refresh.go
@@ -27,7 +27,6 @@ var (
 
 func init() {
 	refreshCommand.Command = _refreshCommand
-	rootCmd.AddCommand(refreshCommand.Command)
 }
 
 func refreshCmd(c *cliconfig.RefreshValues) error {

--- a/cmd/podman/restart.go
+++ b/cmd/podman/restart.go
@@ -39,7 +39,6 @@ func init() {
 	flags.UintVarP(&restartCommand.Timeout, "timeout", "t", libpod.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
 	flags.UintVar(&restartCommand.Timeout, "time", libpod.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
 
-	rootCmd.AddCommand(restartCommand.Command)
 }
 
 func restartCmd(c *cliconfig.RestartValues) error {

--- a/cmd/podman/restore.go
+++ b/cmd/podman/restore.go
@@ -42,7 +42,6 @@ func init() {
 	// TODO: add ContainerStateCheckpointed
 	flags.BoolVar(&restoreCommand.TcpEstablished, "tcp-established", false, "Checkpoint a container with established TCP connections")
 
-	rootCmd.AddCommand(restoreCommand.Command)
 }
 
 func restoreCmd(c *cliconfig.RestoreValues) error {

--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -39,7 +39,6 @@ func init() {
 	flags.BoolVarP(&rmCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVarP(&rmCommand.Volumes, "volumes", "v", false, "Remove the volumes associated with the container (Not implemented yet)")
 
-	rootCmd.AddCommand(rmCommand.Command)
 }
 
 // saveCmd saves the image to either docker-archive or oci

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -32,8 +32,6 @@ func init() {
 	flags := rmiCommand.Flags()
 	flags.BoolVarP(&rmiCommand.All, "all", "a", false, "Remove all images")
 	flags.BoolVarP(&rmiCommand.Force, "force", "f", false, "Force Removal of the image")
-
-	rootCmd.AddCommand(rmiCommand.Command)
 }
 
 func rmiCmd(c *cliconfig.RmiValues) error {

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -40,8 +40,6 @@ func init() {
 	flags.SetInterspersed(false)
 	flags.Bool("sig-proxy", true, "Proxy received signals to the process (default true)")
 	getCreateFlags(&runCommmand.PodmanCommand)
-
-	rootCmd.AddCommand(runCommmand.Command)
 }
 
 func runCmd(c *cliconfig.RunValues) error {

--- a/cmd/podman/save.go
+++ b/cmd/podman/save.go
@@ -52,8 +52,6 @@ func init() {
 	flags.StringVar(&saveCommand.Format, "format", "", "Save image to oci-archive, oci-dir (directory with oci manifest type), docker-dir (directory with v2s2 manifest type)")
 	flags.StringVarP(&saveCommand.Output, "output", "o", "/dev/stdout", "Write to a file, default is STDOUT")
 	flags.BoolVarP(&saveCommand.Quiet, "quiet", "q", false, "Suppress the output")
-
-	rootCmd.AddCommand(saveCommand.Command)
 }
 
 // saveCmd saves the image to either docker-archive or oci

--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -50,8 +50,6 @@ func init() {
 	flags.IntVar(&searchCommand.Limit, "limit", 0, "Limit the number of results")
 	flags.BoolVar(&searchCommand.NoTrunc, "no-trunc", false, "Do not truncate the output")
 	flags.BoolVar(&searchCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
-
-	rootCmd.AddCommand(searchCommand.Command)
 }
 
 type searchParams struct {

--- a/cmd/podman/sign.go
+++ b/cmd/podman/sign.go
@@ -42,8 +42,6 @@ func init() {
 	flags.StringVarP(&signCommand.Directory, "directory", "d", "", "Define an alternate directory to store signatures")
 	flags.StringVar(&signCommand.SignBy, "sign-by", "", "Name of the signing key")
 
-	rootCmd.AddCommand(signCommand.Command)
-
 }
 
 // SignatureStoreDir defines default directory to store signatures

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -42,8 +42,6 @@ func init() {
 	flags.BoolVarP(&startCommand.Interactive, "interactive", "i", false, "Keep STDIN open even if not attached")
 	flags.BoolVarP(&startCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&startCommand.SigProxy, "sig-proxy", true, "Proxy received signals to the process (default true if attaching, false otherwise)")
-
-	rootCmd.AddCommand(startCommand.Command)
 }
 
 func startCmd(c *cliconfig.StartValues) error {

--- a/cmd/podman/stats.go
+++ b/cmd/podman/stats.go
@@ -53,8 +53,6 @@ func init() {
 	flags.BoolVarP(&statsCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&statsCommand.NoReset, "no-reset", false, "Disable resetting the screen between intervals")
 	flags.BoolVar(&statsCommand.NoStream, "no-stream", false, "Disable streaming stats and only pull the first result, default setting is false")
-
-	rootCmd.AddCommand(statsCommand.Command)
 }
 
 func statsCmd(c *cliconfig.StatsValues) error {

--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -42,8 +42,6 @@ func init() {
 	flags.BoolVarP(&stopCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.UintVar(&stopCommand.Timeout, "time", libpod.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
 	flags.UintVarP(&stopCommand.Timeout, "timeout", "t", libpod.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
-
-	rootCmd.AddCommand(stopCommand.Command)
 }
 
 func stopCmd(c *cliconfig.StopValues) error {

--- a/cmd/podman/system.go
+++ b/cmd/podman/system.go
@@ -17,7 +17,11 @@ var (
 	}
 )
 
+var systemCommands = []*cobra.Command{
+	_infoCommand,
+}
+
 func init() {
+	systemCommand.AddCommand(systemCommands...)
 	systemCommand.AddCommand(getSystemSubCommands()...)
-	rootCmd.AddCommand(systemCommand.Command)
 }

--- a/cmd/podman/tag.go
+++ b/cmd/podman/tag.go
@@ -26,8 +26,6 @@ var (
 
 func init() {
 	tagCommand.Command = _tagCommand
-	rootCmd.AddCommand(tagCommand.Command)
-
 }
 
 func tagCmd(c *cliconfig.TagValues) error {

--- a/cmd/podman/top.go
+++ b/cmd/podman/top.go
@@ -52,8 +52,6 @@ func init() {
 	flags.BoolVar(&topCommand.ListDescriptors, "list-descriptors", false, "")
 	flags.MarkHidden("list-descriptors")
 	flags.BoolVarP(&topCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
-
-	rootCmd.AddCommand(topCommand.Command)
 }
 
 func topCmd(c *cliconfig.TopValues) error {

--- a/cmd/podman/umount.go
+++ b/cmd/podman/umount.go
@@ -41,8 +41,6 @@ func init() {
 	flags.BoolVarP(&umountCommand.All, "all", "a", false, "Umount all of the currently mounted containers")
 	flags.BoolVarP(&umountCommand.Force, "force", "f", false, "Force the complete umount all of the currently mounted containers")
 	flags.BoolVarP(&umountCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
-
-	rootCmd.AddCommand(umountCommand.Command)
 }
 
 func umountCmd(c *cliconfig.UmountValues) error {

--- a/cmd/podman/unpause.go
+++ b/cmd/podman/unpause.go
@@ -37,8 +37,6 @@ func init() {
 	unpauseCommand.Command = _unpauseCommand
 	flags := unpauseCommand.Flags()
 	flags.BoolVarP(&unpauseCommand.All, "all", "a", false, "Unpause all paused containers")
-
-	rootCmd.AddCommand(unpauseCommand.Command)
 }
 
 func unpauseCmd(c *cliconfig.UnpauseValues) error {

--- a/cmd/podman/varlink.go
+++ b/cmd/podman/varlink.go
@@ -1,4 +1,4 @@
-// +build varlink
+// +build varlink,!remoteclient
 
 package main
 
@@ -40,8 +40,6 @@ func init() {
 	varlinkCommand.Command = _varlinkCommand
 	flags := varlinkCommand.Flags()
 	flags.Int64VarP(&varlinkCommand.Timeout, "timeout", "t", 1000, "Time until the varlink session expires in milliseconds.  Use 0 to disable the timeout")
-
-	rootCmd.AddCommand(varlinkCommand.Command)
 }
 
 func varlinkCmd(c *cliconfig.VarlinkValues) error {

--- a/cmd/podman/version.go
+++ b/cmd/podman/version.go
@@ -30,7 +30,6 @@ func init() {
 	versionCommand.Command = _versionCommand
 	flags := versionCommand.Flags()
 	flags.StringVarP(&versionCommand.Format, "format", "f", "", "Change the output format to JSON or a Go template")
-	rootCmd.AddCommand(versionCommand.Command)
 }
 
 // versionCmd gets and prints version info for version command

--- a/cmd/podman/volume.go
+++ b/cmd/podman/volume.go
@@ -19,5 +19,4 @@ var volumeCommand = cliconfig.PodmanCommand{
 
 func init() {
 	volumeCommand.AddCommand(getVolumeSubCommands()...)
-	rootCmd.AddCommand(volumeCommand.Command)
 }

--- a/cmd/podman/wait.go
+++ b/cmd/podman/wait.go
@@ -37,8 +37,6 @@ func init() {
 	flags := waitCommand.Flags()
 	flags.UintVarP(&waitCommand.Interval, "interval", "i", 250, "Milliseconds to wait before polling for completion")
 	flags.BoolVarP(&waitCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
-
-	rootCmd.AddCommand(waitCommand.Command)
 }
 
 func waitCmd(c *cliconfig.WaitValues) error {


### PR DESCRIPTION
In the previous CLI, we had an accurate depiction of commands
available for the remote client and those available for the
local client.

Signed-off-by: baude <bbaude@redhat.com>