### PR TITLE
pod: drop invalid check for rootless

### DIFF
--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/libpod"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -81,9 +80,6 @@ func podCreateCmd(c *cliconfig.PodCreateValues) error {
 	if len(c.Publish) > 0 {
 		if !c.Infra {
 			return errors.Errorf("you must have an infra container to publish port bindings to the host")
-		}
-		if rootless.IsRootless() {
-			return errors.Errorf("rootless networking does not allow port binding to the host")
 		}
 	}
 

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -321,7 +321,6 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 	cmd.Env = append(cmd.Env, fmt.Sprintf("_LIBPOD_USERNS_CONFIGURED=%s", os.Getenv("_LIBPOD_USERNS_CONFIGURED")))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("_LIBPOD_ROOTLESS_UID=%s", os.Getenv("_LIBPOD_ROOTLESS_UID")))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", os.Getenv("HOME")))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", runtimeDir))
 
 	if r.reservePorts && !ctr.config.NetMode.IsSlirp4netns() {
 		ports, err := bindPorts(ctr.config.PortMappings)


### PR DESCRIPTION
rootless networks support port binding if the underlying slirp4netns
is new enough.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>