### PR TITLE
Patch file inside running containers file system

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -80,6 +80,15 @@ type CommitValues struct {
 	Quiet   bool
 }
 
+type PatchValues struct {
+	PodmanCommand
+	DST     string
+	PATCH   string
+	Change  []string
+	All     bool
+	Ignore  bool
+}
+
 type ContainersPrune struct {
 	PodmanCommand
 }

--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -31,6 +31,7 @@ func getContainerSubCommands() []*cobra.Command {
 		_exportCommand,
 		_killCommand,
 		_logsCommand,
+		_patchCommand,
 		_psCommand,
 		_mountCommand,
 		_pauseCommand,

--- a/cmd/podman/patch.go
+++ b/cmd/podman/patch.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+    "fmt"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "bytes"
+
+    "github.com/containers/libpod/cmd/podman/libpodruntime"
+    "github.com/containers/libpod/libpod"
+    "github.com/containers/libpod/pkg/rootless"
+    "github.com/pkg/errors"
+    "github.com/containers/libpod/cmd/podman/cliconfig"
+    "github.com/spf13/cobra"
+)
+
+var (
+    patchCommand     cliconfig.PatchValues
+    patchDescription = `Patch containers files with the given patch.`
+
+    _patchCommand = &cobra.Command{
+        Use:   "patch",
+        Short: "Apply a patch to the specified containers",
+        Long:  patchDescription,
+        RunE: func(cmd *cobra.Command, args []string) error {
+            patchCommand.InputArgs = args
+            patchCommand.GlobalFlags = MainGlobalOpts
+            return patchCmd(&patchCommand)
+        },
+        Example: "DEST_FILE SRC_PATCH_FILE [CONTAINERS]",
+    }
+)
+
+func init() {
+        patchCommand.Command = _patchCommand
+        flags := patchCommand.Flags()
+        flags.BoolVarP(
+            &patchCommand.All,
+            "all",
+            "a",
+            false,
+            "Apply the patch to all the running containers")
+        flags.BoolVarP(
+            &patchCommand.Ignore,
+            "ignore-fail",
+            "i",
+            false,
+            "Ignore if the file to patch doesn't exist in a container")
+
+        rootCmd.AddCommand(patchCommand.Command)
+}
+
+// Define the entrypoint command
+func patchCmd(c *cliconfig.PatchValues) error {
+//func patchCmd(c *cli.Context) error {
+    runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+    //runtime, err := libpodruntime.GetRuntime(c)
+    if os.Geteuid() != 0 {
+        rootless.SetSkipStorageSetup(true)
+    }
+
+    if os.Geteuid() != 0 {
+        if driver := runtime.GetConfig().StorageConfig.GraphDriverName; driver != "vfs" {
+            // Do not allow to mount a graphdriver that is not vfs if we are
+            // creating the userns as part
+            // of the mount command.
+            fmt.Errorf("cannot mount using driver %s in rootless mode", driver)
+        }
+
+        became, ret, err := rootless.BecomeRootInUserNS()
+        if err != nil {
+            return err
+        }
+        if became {
+            os.Exit(ret)
+        }
+    }
+    args := c.InputArgs
+    if len(args) < 3 {
+        if c.All && len(args) < 2 {
+            return errors.Errorf("too few given arguments")
+        }
+    }
+
+    if err != nil {
+        return errors.Wrapf(err, "could not get runtime")
+    }
+    defer runtime.Shutdown(false)
+
+    dst := args[0]
+    patch := args[1]
+
+    var containers []string
+    if ! c.All {
+        containers = args[2:]
+    } else {
+        containers = retrieveExisting(runtime)
+    }
+
+    if ! canPatch() {
+        fmt.Println("Patch command not on your system")
+        os.Exit(1)
+    }
+
+    if ! exists(patch) {
+        fmt.Println("Patch file not found:", patch)
+        os.Exit(1)
+    }
+
+    return patchContainers(runtime, patch, dst, containers, c.Ignore)
+}
+
+// Retrieve all running containers and return array of name
+func retrieveExisting(runtime *libpod.Runtime) ([]string) {
+    runningPods, err := runtime.GetRunningContainers()
+    if err != nil {
+        fmt.Println(err)
+        os.Exit(1)
+    }
+    var containers []string
+
+    for _, container := range runningPods {
+        containers = append(containers, container.Name())
+    }
+    return containers
+}
+
+// Check if the patch command is available on the current system (host)
+func canPatch() (bool) {
+    _, err := exec.Command("which", "patch").Output()
+    if err != nil {
+        return false
+    }
+    return true
+}
+
+// Check if a file exist
+func exists(path string) (bool) {
+    _, err := os.Stat(path)
+    if os.IsNotExist(err) {
+        return false
+    }
+    if err == nil { return true }
+    return true
+}
+
+// Retrieve all the containers by name and
+// loop over to apply the given patch
+func patchContainers(runtime *libpod.Runtime,
+                     patch string, dst string, containers []string, ignore bool) error {
+    var ctrs []*libpod.Container
+    for _, container := range containers {
+        ctr, err := runtime.LookupContainer(container)
+        if err != nil {
+            fmt.Println(err)
+            os.Exit(1)
+        }
+        ctrs = append(ctrs, ctr)
+    }
+    for _, ctr := range ctrs {
+        applyPatch(patch, dst, ctr, ignore)
+    }
+    return nil
+}
+
+// Apply the given patch file to the given container.
+// The patch is applied to the dst file.
+// If the destintion doesn't exist inside the given container
+// and if the flag ignore-fail is given the command
+// simply continue and doesn't exit with an error code.
+func applyPatch(patch string, dst string, container *libpod.Container, ignore bool) {
+    fmt.Println("Patching: ", container.Name())
+    mountPoint, err := container.Mount()
+    if err != nil {
+        fmt.Println(err)
+        os.Exit(1)
+    }
+
+    fulldest := filepath.Join(mountPoint, dst)
+
+    if ! exists(fulldest) {
+        fmt.Println("File to patch not found:", dst)
+        if ignore {
+            fmt.Println("Skipping container:", container.Name())
+            return
+        } else {
+            os.Exit(1)
+        }
+    }
+    fmt.Println("Execute: patch ", fulldest, patch)
+    cmd := exec.Command("patch", fulldest, patch)
+    var out bytes.Buffer
+    var stderr bytes.Buffer
+    cmd.Stdout = &out
+    cmd.Stderr = &stderr
+    errexec := cmd.Run()
+    if errexec != nil {
+        fmt.Println(fmt.Sprint(errexec) + ": " + stderr.String())
+    }
+    container.Unmount(true)
+    fmt.Println(container.Name(), "patched successfully!")
+}

--- a/commands.md
+++ b/commands.md
@@ -38,6 +38,7 @@
 | [podman-logout(1)](/docs/podman-logout.1.md)             | Logout of a container registry                                            |[![...](/docs/play.png)](https://asciinema.org/a/oNiPgmfo1FjV2YdesiLpvihtV)|
 | [podman-logs(1)](/docs/podman-logs.1.md)                 | Display the logs of a container                                           |[![...](/docs/play.png)](https://asciinema.org/a/MZPTWD5CVs3dMREkBxQBY9C5z)|
 | [podman-mount(1)](/docs/podman-mount.1.md)               | Mount a working container's root filesystem                               |[![...](/docs/play.png)](https://asciinema.org/a/YSP6hNvZo0RGeMHDA97PhPAf3)|
+| [podman-patch(1)](/docs/podman-patch.1.md)               | Patch one or more running containers                                      ||
 | [podman-pause(1)](/docs/podman-pause.1.md)               | Pause one or more running containers                                      |[![...](/docs/play.png)](https://asciinema.org/a/141292)|
 | [podman-pod(1)](/docs/podman-pod.1.md)                   | Simple management tool for groups of containers, called pods              ||
 | [podman-pod-create(1)](/docs/podman-pod-create.1.md)     | Create a new pod                                                          ||

--- a/docs/podman-patch.1.md
+++ b/docs/podman-patch.1.md
@@ -1,0 +1,60 @@
+% podman-patch(1)
+
+## NAME
+podman\-patch - Patch file inside existing running containers
+
+## SYNOPSIS
+**podman patch** [*options*] *file-to-patch* *source-file-patch* *[containers]*
+
+## DESCRIPTION
+`podman patch` patch an existing running container file. If user pass
+the flag `--all` all the running containers are patched.
+If the file to patch doesn't exist inside the running container 
+this command exit in error. If you want to ignore case
+where the running container doesn't have the file to patch the `--ignore-fail` flag can be pass
+and then the command continue to run on other containers.
+
+## OPTIONS
+
+**--all, -a**
+
+Apply the patch to all the running containers
+
+**--ignore-fail, -i**
+
+If the file to patch doesn't exist on a running container and this
+flag was passed by user then `podman patch` skip to apply the patch and 
+continue on other containers.
+
+## EXAMPLES
+
+```
+$ podman run -it --name cont1 ubuntu bash &
+$ podman run -it --name cont2 ubuntu bash &
+$ diff /etc/profile ~/profile > /tmp/profile.patch
+$ podman patch /etc/profile /tmp/profile.patch --all
+Patching:  cont2
+Execute: patch  /var/lib/containers/storage/overlay/1effd969dde77fc5ba09350bb7e1e3a56e1cf68e4a1633cf6320f4dbfeec14a6/merged/etc/profile /tmp/profile.patch
+cont2 patched successfully!
+Patching:  cont1
+Execute: patch  /var/lib/containers/storage/overlay/fa72f57736ec30550a1bcff15d8246c2109ebb781f006771dab963d739294d77/merged/etc/profile /tmp/profile.patch
+cont1 patched successfully!
+
+```
+$ podman patch /etc/profile /tmp/profile.patch cont1
+Patching:  cont1
+Execute: patch  /var/lib/containers/storage/overlay/fa72f57736ec30550a1bcff15d8246c2109ebb781f006771dab963d739294d77/merged/etc/profile /tmp/profile.patch
+cont1 patched successfully!
+```
+
+```
+$ podman patch /etc/boum /tmp/profile.patch cont1
+Patching:  cont1
+File to patch not found: /etc/boum
+```
+
+## SEE ALSO
+podman(1), podman-commit(1)
+
+## HISTORY
+February 2019, Originally compiled by Hervé Beraud <hberaud@redhat.com>

--- a/test/e2e/patch_test.go
+++ b/test/e2e/patch_test.go
@@ -1,0 +1,66 @@
+// +build !remoteclient
+
+package integration
+
+import (
+        "fmt"
+        "io/ioutil"
+        "os"
+        "os/exec"
+        "path/filepath"
+
+        . "github.com/containers/libpod/test/utils"
+        . "github.com/onsi/ginkgo"
+        . "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman patch", func() {
+    var (
+        tempdir    string
+        err        error
+        podmanTest *PodmanTestIntegration
+    )
+
+    BeforeEach(func() {
+        tempdir, err = CreateTempDirInTempDir()
+        if err != nil {
+                os.Exit(1)
+        }
+        podmanTest = PodmanTestCreate(tempdir)
+        podmanTest.RestoreAllArtifacts()
+    })
+
+    AfterEach(func() {
+        podmanTest.Cleanup()
+        f := CurrentGinkgoTestDescription()
+        timedResult := fmt.Sprintf("Test: %s completed in %f seconds", f.TestText, f.Duration.Seconds())
+        GinkgoWriter.Write([]byte(timedResult))
+    })
+
+    It("podman patch file", func() {
+        path, err := os.Getwd()
+        if err != nil {
+                os.Exit(1)
+        }
+        filePath := filepath.Join(path, "profile.patch")
+        contentFile := []byte("27a28,29\n>\n> export BOUM='BOUM'")
+        err = ioutil.WriteFile(filePath, contentFile, 0644)
+        if err != nil {
+                os.Exit(1)
+        }
+
+        session := podmanTest.Podman([]string{"create", ALPINE, "cat", "foo"})
+        session.WaitWithDefaultTimeout()
+        Expect(session.ExitCode()).To(Equal(0))
+        name := session.OutputToString()
+
+        session = podmanTest.Podman([]string{"patch", "/etc/profile", filepath.Join(path, "profile.patch"), name})
+        session.WaitWithDefaultTimeout()
+        Expect(session.ExitCode()).To(Equal(0))
+
+        session = podmanTest.Podman([]string{"start", "-a", name})
+        session.WaitWithDefaultTimeout()
+
+        Expect(session.ExitCode()).To(Equal(0))
+    })
+})


### PR DESCRIPTION
Patch file with a given patch inside running containers

User need to give:
- the full path to the file to patch inside the running containers
- the full patch of the patch file to apply inside the running containers

User can patch all the running containers by pass the `--all` flag.

User can ignore case where the file to patch doesn't exist by pass the `ignore-fail`.

Usage:
podman patch [options] <file-to-patch> <patch-file> [<container>]

Example:
- podman patch /etc/profile /tmp/profile.patch cont1 cont2 cont3
- podman patch /etc/profile /tmp/profile.patch --all

Signed-off-by: Hervé Beraud <hberaud@redhat.com>