### PR TITLE
--password-stdin flag in `podman login`

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -172,12 +172,13 @@ type LoadValues struct {
 
 type LoginValues struct {
 	PodmanCommand
-	Password  string
-	Username  string
-	Authfile  string
-	CertDir   string
-	GetLogin  bool
-	TlsVerify bool
+	Password      string
+	StdinPassword bool
+	Username      string
+	Authfile      string
+	CertDir       string
+	GetLogin      bool
+	TlsVerify     bool
 }
 
 type LogoutValues struct {

--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -43,6 +43,7 @@ func init() {
 	flags.StringVarP(&loginCommand.Password, "password", "p", "", "Password for registry")
 	flags.BoolVar(&loginCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
 	flags.StringVarP(&loginCommand.Username, "username", "u", "", "Username for registry")
+	flags.BoolVar(&loginCommand.StdinPassword, "password-stdin", false, "Take the password from stdin")
 
 	rootCmd.AddCommand(loginCommand.Command)
 }
@@ -90,8 +91,26 @@ func loginCmd(c *cliconfig.LoginValues) error {
 	}
 
 	ctx := getContext()
+
+	password := c.Password
+
+	if c.Flag("password-stdin").Changed {
+		var stdinPasswordStrBuilder strings.Builder
+		if c.Password != "" {
+			return errors.Errorf("Can't specify both --password-stdin and --password")
+		}
+		if c.Username == "" {
+			return errors.Errorf("Must provide --username with --password-stdin")
+		}
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			fmt.Fprint(&stdinPasswordStrBuilder, scanner.Text())
+		}
+		password = stdinPasswordStrBuilder.String()
+	}
+
 	// If no username and no password is specified, try to use existing ones.
-	if c.Username == "" && c.Password == "" {
+	if c.Username == "" && password == "" {
 		fmt.Println("Authenticating with existing credentials...")
 		if err := docker.CheckAuth(ctx, sc, userFromAuthFile, passFromAuthFile, server); err == nil {
 			fmt.Println("Existing credentials are valid. Already logged in to", server)
@@ -100,7 +119,7 @@ func loginCmd(c *cliconfig.LoginValues) error {
 		fmt.Println("Existing credentials are invalid, please enter valid username and password")
 	}
 
-	username, password, err := getUserAndPass(c.Username, c.Password, userFromAuthFile)
+	username, password, err := getUserAndPass(c.Username, password, userFromAuthFile)
 	if err != nil {
 		return errors.Wrapf(err, "error getting username and password")
 	}

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2319,6 +2319,7 @@ _podman_login() {
      local boolean_options="
 	  --help
 	  -h
+	  --password-stdin
      "
      _complete_ "$options_with_args" "$boolean_options"
 }

--- a/docs/podman-login.1.md
+++ b/docs/podman-login.1.md
@@ -25,6 +25,10 @@ flag. The default path used is **${XDG\_RUNTIME_DIR}/containers/auth.json**.
 
 Password for registry
 
+**--password-stdin**
+
+Take the password from stdin
+
 **--username, -u**
 
 Username for registry
@@ -83,6 +87,16 @@ Login Succeeded!
 
 ```
 $ podman login --cert-dir /etc/containers/certs.d/ -u foo -p bar localhost:5000
+Login Succeeded!
+```
+
+```
+$ podman login -u testuser  --password-stdin < testpassword.txt docker.io
+Login Succeeded!
+```
+
+```
+$ echo $testpassword | podman login -u testuser --password-stdin docker.io
 Login Succeeded!
 ```
 


### PR DESCRIPTION
Support `--password-stdin` flag, reads a password from STDIN and pass it to `podman login`.
enhancement mentioned https://github.com/containers/libpod/issues/1675#issuecomment-440265632
Signed-off-by: Qi Wang <qiwan@redhat.com>