### PR TITLE
Only build varlink when buildtag is available

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -42,9 +42,12 @@ func getMainCommands() []*cobra.Command {
 		_topCommand,
 		_umountCommand,
 		_unpauseCommand,
-		_varlinkCommand,
 		volumeCommand.Command,
 		_waitCommand,
+	}
+
+	if len(_varlinkCommand.Use) > 0 {
+		rootCommands = append(rootCommands, _varlinkCommand)
 	}
 	return rootCommands
 }

--- a/cmd/podman/varlink_dummy.go
+++ b/cmd/podman/varlink_dummy.go
@@ -2,8 +2,10 @@
 
 package main
 
-import (
-	"github.com/containers/libpod/cmd/podman/cliconfig"
-)
+import "github.com/spf13/cobra"
 
-var varlinkCommand *cliconfig.PodmanCommand
+var (
+	_varlinkCommand = &cobra.Command{
+		Use: "",
+	}
+)


### PR DESCRIPTION
Correct mistake that broke things like dlv where we should only
try to add the varlink command to podman when the 'varlink' build
tag is present.

Signed-off-by: baude <bbaude@redhat.com>