### PR TITLE
build varlink without GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ help:
 ifeq ("$(wildcard $(GOPKGDIR))","")
 	mkdir -p "$(GOPKGBASEDIR)"
 	ln -sf "$(CURDIR)" "$(GOPKGBASEDIR)"
+	ln -sf "$(CURDIR)/vendor/github.com/varlink" "$(FIRST_GOPATH)/src/github.com/varlink"
 endif
 	touch $@
 


### PR DESCRIPTION
when gopath was not explicitly set, make would fail due
to the varlink generator.  this symlink in the makefile
addresses that.

fixes: #1842

Signed-off-by: baude <bbaude@redhat.com>