### PR TITLE
show container ports of network namespace

### DIFF
--- a/cmd/podman/port.go
+++ b/cmd/podman/port.go
@@ -125,8 +125,13 @@ func portCmd(c *cliconfig.PortValues) error {
 		if c.All {
 			fmt.Println(con.ID())
 		}
+
+		portmappings, err := con.PortMappings()
+		if err != nil {
+			return err
+		}
 		// Iterate mappings
-		for _, v := range con.Config().PortMappings {
+		for _, v := range portmappings {
 			hostIP := v.HostIP
 			// Set host IP to 0.0.0.0 if blank
 			if hostIP == "" {

--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -213,11 +213,16 @@ func NewBatchContainer(ctr *libpod.Container, opts PsOptions) (PsContainerOutput
 		}
 	}
 
+	ports, err := ctr.PortMappings()
+	if err != nil {
+		logrus.Errorf("unable to lookup namespace container for %s", ctr.ID())
+	}
+
 	pso.ID = cid
 	pso.Image = imageName
 	pso.Command = command
 	pso.Created = created
-	pso.Ports = portsToString(ctr.PortMappings())
+	pso.Ports = portsToString(ports)
 	pso.Names = ctr.Name()
 	pso.IsInfra = ctr.IsInfra()
 	pso.Status = status

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -228,7 +228,11 @@ func containerToV1Container(c *Container) (v1.Container, error) {
 		return kubeContainer, nil
 	}
 
-	ports, err := ocicniPortMappingToContainerPort(c.PortMappings())
+	portmappings, err := c.PortMappings()
+	if err != nil {
+		return kubeContainer, err
+	}
+	ports, err := ocicniPortMappingToContainerPort(portmappings)
 	if err != nil {
 		return kubeContainer, nil
 	}


### PR DESCRIPTION
in cases where a container is part of a network namespace, we should
show the network namespace's ports when dealing with ports. this
impacts ps, kube, and port.

fixes: #846

Signed-off-by: baude <bbaude@redhat.com>