### PR TITLE
Fix `podman login` lying problem

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -110,7 +110,7 @@ func loginCmd(c *cliconfig.LoginValues) error {
 	}
 
 	// If no username and no password is specified, try to use existing ones.
-	if c.Username == "" && password == "" {
+	if c.Username == "" && password == "" && userFromAuthFile != "" && passFromAuthFile != "" {
 		fmt.Println("Authenticating with existing credentials...")
 		if err := docker.CheckAuth(ctx, sc, userFromAuthFile, passFromAuthFile, server); err == nil {
 			fmt.Println("Existing credentials are valid. Already logged in to", server)


### PR DESCRIPTION
`podman login` lied when it doesn't login successfully

```
$ podman logout -a docker.io
Removed login credentials for all registries
$ podman login docker.io
Authenticating with existing credentials...
Existing credentials are valid. Already logged in to docker.io
$ podman logout docker.io
Error: error logging out of "docker.io": error updating "/run/user/1000/containers/auth.json": not logged in

```
`docker.CheckAuth` doesn't return error if `userFromAuthFile, passFromAuthFile` are `""`can lead to this always successful problem.

https://github.com/containers/libpod/blob/ae8cc41295c4ff6f6f82372221c66c250691e4f6/cmd/podman/login.go#L115

Signed-off-by: Qi Wang <qiwan@redhat.com>