### PR TITLE
libpod.conf: add backward compatibility for runtime_path

### DIFF
--- a/docs/libpod.conf.5.md
+++ b/docs/libpod.conf.5.md
@@ -12,8 +12,11 @@ libpod to manage containers.
 **image_default_transport**=""
   Default transport method for pulling and pushing images
 
-**runtime_path**=""
-  Paths to search for a valid OCI runtime binary
+**runtime**=""
+  Default OCI runtime to use if nothing is specified
+
+**runtimes**
+  For each OCI runtime, specify a list of paths to look for.  The first one found is used.
 
 **conmon_path**=""
   Paths to search for the Conmon container manager binary

--- a/libpod.conf
+++ b/libpod.conf
@@ -88,6 +88,8 @@ pause_command = "/pause"
 # Default libpod support for container labeling
 # label=true
 
+runtime = "runc"
+
 # Paths to look for a valid OCI runtime (runc, runv, etc)
 [runtimes]
 runc = [

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -389,7 +389,7 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 		// If the configuration file was not found but we are running in rootless, a subset of the
 		// global config file is used.
 		for _, path := range []string{OverrideConfigPath, ConfigPath} {
-			contents, err := ioutil.ReadFile(OverrideConfigPath)
+			contents, err := ioutil.ReadFile(path)
 			if err != nil {
 				// Ignore any error, the file might not be readable by us.
 				continue

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -130,6 +130,12 @@ type RuntimeConfig struct {
 	OCIRuntime string `toml:"runtime"`
 	// OCIRuntimes are the set of configured OCI runtimes (default is runc)
 	OCIRuntimes map[string][]string `toml:"runtimes"`
+	// RuntimePath is the path to OCI runtime binary for launching
+	// containers.
+	// The first path pointing to a valid file will be used
+	// This is used only when there are no OCIRuntime/OCIRuntimes defined.  It
+	// is used only to be backward compatible with older versions of Podman.
+	RuntimePath []string `toml:"runtime_path"`
 	// ConmonPath is the path to the Conmon binary used for managing
 	// containers
 	// The first path pointing to a valid file will be used
@@ -403,6 +409,7 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 			runtime.config.ConmonPath = tmpConfig.ConmonPath
 			runtime.config.ConmonEnvVars = tmpConfig.ConmonEnvVars
 			runtime.config.OCIRuntimes = tmpConfig.OCIRuntimes
+			runtime.config.RuntimePath = tmpConfig.RuntimePath
 			runtime.config.CNIPluginDir = tmpConfig.CNIPluginDir
 			runtime.config.NoPivotRoot = tmpConfig.NoPivotRoot
 			break
@@ -485,10 +492,25 @@ func NewRuntimeFromConfig(configPath string, options ...RuntimeOption) (runtime 
 // Make a new runtime based on the given configuration
 // Sets up containers/storage, state store, OCI runtime
 func makeRuntime(runtime *Runtime) (err error) {
+
+	// Backward compatibility for `runtime_path`
+	if runtime.config.RuntimePath != nil {
+		// Don't print twice in rootless mode.
+		if os.Geteuid() == 0 {
+			logrus.Warningf("The configuration is using `runtime_path`, which is deprecated and will be removed in future.  Please use `runtimes` and `runtime`")
+			logrus.Warningf("If you are using both `runtime_path` and `runtime`, the configuration from `runtime_path` is used")
+		}
+
+		// Transform `runtime_path` into `runtimes` and `runtime`.
+		name := filepath.Base(runtime.config.RuntimePath[0])
+		runtime.config.OCIRuntime = name
+		runtime.config.OCIRuntimes = map[string][]string{name: runtime.config.RuntimePath}
+	}
+
 	// Find a working OCI runtime binary
 	foundRuntime := false
 	// If runtime is an absolute path, then use it as it is.
-	if runtime.config.OCIRuntime[0] == '/' {
+	if runtime.config.OCIRuntime != "" && runtime.config.OCIRuntime[0] == '/' {
 		foundRuntime = true
 		runtime.ociRuntimePath = OCIRuntimePath{Name: filepath.Base(runtime.config.OCIRuntime), Paths: []string{runtime.config.OCIRuntime}}
 	} else {


### PR DESCRIPTION
Add backward compatibility for `runtime_path` that was used by older versions of Podman.
    
The issue was introduced with: 650cf122e1b33f4d8f4426ee1cc1a4bf00c14798
    
If `runtime_path` is specified, it overrides any other configuration and a warning is printed.
    
`runtime_path` should be considered deprecated and will be removed in future.
