### PR TITLE
Add lock renumbering

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -548,3 +548,7 @@ type SystemPruneValues struct {
 	Force  bool
 	Volume bool
 }
+
+type SystemRenumberValues struct {
+	PodmanCommand
+}

--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -132,5 +132,6 @@ func getTrustSubCommands() []*cobra.Command {
 func getSystemSubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		_pruneSystemCommand,
+		_renumberCommand,
 	}
 }

--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -8,8 +8,17 @@ import (
 	"github.com/pkg/errors"
 )
 
+// GerRuntimeRenumber gets a libpod runtime that will perform a lock renumber
+func GetRuntimeRenumber(c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
+	return getRuntime(c, true)
+}
+
 // GetRuntime generates a new libpod runtime configured by command line options
 func GetRuntime(c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
+	return getRuntime(c, false)
+}
+
+func getRuntime(c *cliconfig.PodmanCommand, renumber bool) (*libpod.Runtime, error) {
 	options := []libpod.RuntimeOption{}
 
 	storageOpts, volumePath, err := util.GetDefaultStoreOptions()

--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GerRuntimeRenumber gets a libpod runtime that will perform a lock renumber
+// GetRuntimeRenumber gets a libpod runtime that will perform a lock renumber
 func GetRuntimeRenumber(c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
 	return getRuntime(c, true)
 }

--- a/cmd/podman/system_renumber.go
+++ b/cmd/podman/system_renumber.go
@@ -12,7 +12,8 @@ var (
 	renumberDescription = `
         podman system renumber
 
-        Migrate lock numbers to handle a change in maximum number of locks
+        Migrate lock numbers to handle a change in maximum number of locks.
+        Mandatory after the number of locks in libpod.conf is changed.
 `
 
 	_renumberCommand = &cobra.Command{
@@ -34,10 +35,14 @@ func init() {
 
 func renumberCmd(c *cliconfig.SystemRenumberValues) error {
 	// We need to pass one extra option to NewRuntime.
-	// This will inform the OCI runtime to start
-	_, err := libpodruntime.GetRuntimeRenumber(&c.PodmanCommand)
+	// This will inform the OCI runtime to start a renumber.
+	// That's controlled by the last argument to GetRuntime.
+	r, err := libpodruntime.GetRuntimeRenumber(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error renumbering locks")
+	}
+	if err := r.Shutdown(false); err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/podman/system_renumber.go
+++ b/cmd/podman/system_renumber.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/containers/libpod/cmd/podman/libpodruntime"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	renumberCommand     cliconfig.SystemRenumberValues
+	renumberDescription = `
+        podman system renumber
+
+        Migrate lock numbers to handle a change in maximum number of locks
+`
+
+	_renumberCommand = &cobra.Command{
+		Use:   "renumber",
+		Short: "Migrate lock numbers",
+		Long:  renumberDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renumberCommand.InputArgs = args
+			renumberCommand.GlobalFlags = MainGlobalOpts
+			return renumberCmd(&renumberCommand)
+		},
+	}
+)
+
+func init() {
+	renumberCommand.Command = _renumberCommand
+	renumberCommand.SetUsageTemplate(UsageTemplate())
+}
+
+func renumberCmd(c *cliconfig.SystemRenumberValues) error {
+	// We need to pass one extra option to NewRuntime.
+	// This will inform the OCI runtime to start
+	_, err := libpodruntime.GetRuntimeRenumber(&c.PodmanCommand)
+	if err != nil {
+		return errors.Wrapf(err, "error renumbering locks")
+	}
+
+	return nil
+}

--- a/docs/podman-system-renumber.1.md
+++ b/docs/podman-system-renumber.1.md
@@ -1,0 +1,29 @@
+% podman-system-renumber(1) podman
+
+## NAME
+podman\-system\-renumber - Renumber container locks
+
+## SYNOPSIS
+** podman system renumber**
+
+## DESCRIPTION
+** podman system renumber** renumbers locks used by containers and pods.
+
+Each Podman container and pod is allocated a lock at creation time, up to a maximum number controlled by the **num_locks** parameter in **libpod.conf**.
+
+When all available locks are exhausted, no further containers and pods can be created until some existing containers and pods are removed. This can be avoided by increasing the number of locks available via modifying **libpod.conf** and subsequently running **podman system renumber** to prepare the new locks (and reallocate lock numbers to fit the new struct).
+
+**podman system renumber** must be called after any changes to **num_locks** - failure to do so will result in errors starting Podman as the number of locks available conflicts with the configured number of locks.
+
+**podman system renumber** can also be used to migrate 1.0 and earlier versions of Podman, which used a different locking scheme, to the new locking model. It is not strictly required to do this, but it is highly recommended to do so as deadlocks can occur otherwise.
+
+If possible, avoid calling **podman system renumber** while there are other Podman processes running.
+
+## SYNOPSIS
+**podman system renumber**
+
+## SEE ALSO
+`podman(1)`, `libpod.conf(5)`
+
+# HISTORY
+February 2019, Originally compiled by Matt Heon (mheon at redhat dot com)

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -1369,10 +1369,6 @@ func (s *BoltState) RemoveVolume(volume *Volume) error {
 		return ErrDBClosed
 	}
 
-	if !volume.valid {
-		return ErrVolumeRemoved
-	}
-
 	volName := []byte(volume.Name())
 
 	db, err := s.getDBCon()

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -348,13 +348,6 @@ func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bu
 		return errors.Wrapf(err, "error unmarshalling volume %s config from DB", string(name))
 	}
 
-	// Get the lock
-	lock, err := s.runtime.lockManager.RetrieveLock(volume.config.LockID)
-	if err != nil {
-		return errors.Wrapf(err, "error retrieving lockfile for volume %s", string(name))
-	}
-	volume.lock = lock
-
 	volume.runtime = s.runtime
 	volume.valid = true
 

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -410,6 +410,26 @@ func (s *InMemoryState) RewriteContainerConfig(ctr *Container, newCfg *Container
 	return nil
 }
 
+// RewritePodConfig rewrites a pod's configuration.
+// This function is DANGEROUS, even with in-memory state.
+// Please read the full comment on it in state.go before using it.
+func (s *InMemoryState) RewritePodConfig(pod *Pod, newCfg *PodConfig) error {
+	if !pod.valid {
+		return ErrPodRemoved
+	}
+
+	// If the pod does not exist, return error
+	statePod, ok := s.pods[pod.ID()]
+	if !ok {
+		pod.valid = false
+		return errors.Wrapf(ErrNoSuchPod, "pod with ID %s not found in state", pod.ID())
+	}
+
+	statePod.config = newCfg
+
+	return nil
+}
+
 // Volume retrieves a volume from its full name
 func (s *InMemoryState) Volume(name string) (*Volume, error) {
 	if name == "" {

--- a/libpod/lock/in_memory_locks.go
+++ b/libpod/lock/in_memory_locks.go
@@ -89,3 +89,12 @@ func (m *InMemoryManager) RetrieveLock(id uint32) (Locker, error) {
 
 	return m.locks[id], nil
 }
+
+// FreeAllLocks frees all locks
+func (m *InMemoryManager) FreeAllLocks() error {
+	for _, lock := range m.locks {
+		lock.allocated = false
+	}
+
+	return nil
+}

--- a/libpod/lock/in_memory_locks.go
+++ b/libpod/lock/in_memory_locks.go
@@ -90,7 +90,9 @@ func (m *InMemoryManager) RetrieveLock(id uint32) (Locker, error) {
 	return m.locks[id], nil
 }
 
-// FreeAllLocks frees all locks
+// FreeAllLocks frees all locks.
+// This function is DANGEROUS. Please read the full comment in locks.go before
+// trying to use it.
 func (m *InMemoryManager) FreeAllLocks() error {
 	for _, lock := range m.locks {
 		lock.allocated = false

--- a/libpod/lock/lock.go
+++ b/libpod/lock/lock.go
@@ -24,8 +24,19 @@ type Manager interface {
 	// The underlying lock MUST be the same as another other lock with the
 	// same UUID.
 	RetrieveLock(id uint32) (Locker, error)
+	// PLEASE READ FULL DESCRIPTION BEFORE USING.
 	// FreeAllLocks frees all allocated locks, in preparation for lock
 	// reallocation.
+	// As this deallocates all presently-held locks, this can be very
+	// dangerous - if there are other processes running that might be
+	// attempting to allocate new locks and free existing locks, we may
+	// encounter races leading to an inconsistent state.
+	// (This is in addition to the fact that FreeAllLocks instantly makes
+	// the state inconsistent simply by using it, and requires a full
+	// lock renumbering to restore consistency!).
+	// In short, this should only be used as part of unit tests, or lock
+	// renumbering, where reasonable guarantees about other processes can be
+	// made.
 	FreeAllLocks() error
 }
 

--- a/libpod/lock/lock.go
+++ b/libpod/lock/lock.go
@@ -24,6 +24,9 @@ type Manager interface {
 	// The underlying lock MUST be the same as another other lock with the
 	// same UUID.
 	RetrieveLock(id uint32) (Locker, error)
+	// FreeAllLocks frees all allocated locks, in preparation for lock
+	// reallocation.
+	FreeAllLocks() error
 }
 
 // Locker is similar to sync.Locker, but provides a method for freeing the lock

--- a/libpod/lock/shm/shm_lock.c
+++ b/libpod/lock/shm/shm_lock.c
@@ -203,6 +203,8 @@ shm_struct_t *setup_lock_shm(char *path, uint32_t num_locks, int *error_code) {
 // terminating NULL byte.
 // Returns a valid pointer on success or NULL on error.
 // If an error occurs, negative ERRNO values will be written to error_code.
+// ERANGE is returned for a mismatch between num_locks and the number of locks
+// available in the the SHM lock struct.
 shm_struct_t *open_lock_shm(char *path, uint32_t num_locks, int *error_code) {
   int shm_fd;
   shm_struct_t *shm;
@@ -255,11 +257,11 @@ shm_struct_t *open_lock_shm(char *path, uint32_t num_locks, int *error_code) {
 
   // Need to check the SHM to see if it's actually our locks
   if (shm->magic != MAGIC) {
-    *error_code = -1 * errno;
+    *error_code = -1 * EBADF;
     goto CLEANUP;
   }
   if (shm->num_locks != (num_bitmaps * BITMAP_SIZE)) {
-    *error_code = -1 * errno;
+    *error_code = -1 * ERANGE;
     goto CLEANUP;
   }
 

--- a/libpod/lock/shm/shm_lock.go
+++ b/libpod/lock/shm/shm_lock.go
@@ -155,6 +155,22 @@ func (locks *SHMLocks) DeallocateSemaphore(sem uint32) error {
 	return nil
 }
 
+// DeallocateAllSemaphores frees all semaphores so they can be reallocated to
+// other containers and pods.
+func (locks *SHMLocks) DeallocateAllSemaphores() error {
+	if !locks.valid {
+		return errors.Wrapf(syscall.EINVAL, "locks have already been closed")
+	}
+
+	retCode := C.deallocate_all_semaphores(locks.lockStruct)
+	if retCode < 0 {
+		// Negative errno return from C
+		return syscall.Errno(-1 * retCode)
+	}
+
+	return nil
+}
+
 // LockSemaphore locks the given semaphore.
 // If the semaphore is already locked, LockSemaphore will block until the lock
 // can be acquired.

--- a/libpod/lock/shm/shm_lock.h
+++ b/libpod/lock/shm/shm_lock.h
@@ -40,6 +40,7 @@ shm_struct_t *open_lock_shm(char *path, uint32_t num_locks, int *error_code);
 int32_t close_lock_shm(shm_struct_t *shm);
 int64_t allocate_semaphore(shm_struct_t *shm);
 int32_t deallocate_semaphore(shm_struct_t *shm, uint32_t sem_index);
+int32_t deallocate_all_semaphores(shm_struct_t *shm);
 int32_t lock_semaphore(shm_struct_t *shm, uint32_t sem_index);
 int32_t unlock_semaphore(shm_struct_t *shm, uint32_t sem_index);
 

--- a/libpod/lock/shm_lock_manager_linux.go
+++ b/libpod/lock/shm_lock_manager_linux.go
@@ -71,6 +71,11 @@ func (m *SHMLockManager) RetrieveLock(id uint32) (Locker, error) {
 	return lock, nil
 }
 
+// FreeAllLocks frees all locks in the manager
+func (m *SHMLockManager) FreeAllLocks() error {
+	return m.locks.DeallocateAllSemaphores()
+}
+
 // SHMLock is an individual shared memory lock.
 type SHMLock struct {
 	lockID  uint32

--- a/libpod/lock/shm_lock_manager_linux.go
+++ b/libpod/lock/shm_lock_manager_linux.go
@@ -71,7 +71,9 @@ func (m *SHMLockManager) RetrieveLock(id uint32) (Locker, error) {
 	return lock, nil
 }
 
-// FreeAllLocks frees all locks in the manager
+// FreeAllLocks frees all locks in the manager.
+// This function is DANGEROUS. Please read the full comment in locks.go before
+// trying to use it.
 func (m *SHMLockManager) FreeAllLocks() error {
 	return m.locks.DeallocateAllSemaphores()
 }

--- a/libpod/lock/shm_lock_manager_unsupported.go
+++ b/libpod/lock/shm_lock_manager_unsupported.go
@@ -27,3 +27,8 @@ func (m *SHMLockManager) AllocateLock() (Locker, error) {
 func (m *SHMLockManager) RetrieveLock(id string) (Locker, error) {
 	return nil, fmt.Errorf("not supported")
 }
+
+// FreeAllLocks is not supported on this platform
+func (m *SHMLockManager) FreeAllLocks() error {
+	return fmt.Errorf("not supported")
+}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -394,6 +394,26 @@ func WithDefaultInfraCommand(cmd string) RuntimeOption {
 	}
 }
 
+// WithRenumber instructs libpod to perform a lock renumbering instead of a
+// normal init.
+// When this is specified, no valid runtime will be returned by NewRuntime.
+// Instead, libpod will reinitialize lock numbers on all pods and containers,
+// shut down the runtime, and return.
+// Renumber is intended to be used from a dedicated entrypoint, where it will
+// handle a changed maximum number of locks and return, with the program
+// exiting after that.
+func WithRenumber() RuntimeOption {
+	return func(rt *Runtime) error {
+		if rt.valid {
+			return ErrRuntimeFinalized
+		}
+
+		rt.doRenumber = true
+
+		return nil
+	}
+}
+
 // Container Creation Options
 
 // WithShmDir sets the directory that should be mounted on /dev/shm.

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -394,14 +394,10 @@ func WithDefaultInfraCommand(cmd string) RuntimeOption {
 	}
 }
 
-// WithRenumber instructs libpod to perform a lock renumbering instead of a
-// normal init.
-// When this is specified, no valid runtime will be returned by NewRuntime.
-// Instead, libpod will reinitialize lock numbers on all pods and containers,
-// shut down the runtime, and return.
-// Renumber is intended to be used from a dedicated entrypoint, where it will
-// handle a changed maximum number of locks and return, with the program
-// exiting after that.
+// WithRenumber instructs libpod to perform a lock renumbering while
+// initializing. This will handle migrations from early versions of libpod with
+// file locks to newer versions with SHM locking, as well as changes in the
+// number of configured locks.
 func WithRenumber() RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -421,7 +421,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 
 	for _, v := range volumes {
 		if volume, err := runtime.state.Volume(v); err == nil {
-			if err := runtime.removeVolume(ctx, volume, false, true); err != nil && err != ErrNoSuchVolume && err != ErrVolumeBeingUsed {
+			if err := runtime.removeVolume(ctx, volume, false); err != nil && err != ErrNoSuchVolume && err != ErrVolumeBeingUsed {
 				logrus.Errorf("cleanup volume (%s): %v", v, err)
 			}
 		}

--- a/libpod/runtime_renumber.go
+++ b/libpod/runtime_renumber.go
@@ -1,14 +1,11 @@
 package libpod
 
 import (
-	"path/filepath"
-
-	"github.com/containers/storage"
 	"github.com/pkg/errors"
 )
 
-// RenumberLocks reassigns lock numbers for all containers, pods, and volumes in
-// the state.
+// renumberLocks reassigns lock numbers for all containers and pods in the
+// state.
 // It renders the runtime it is called on, and all container/pod/volume structs
 // from that runtime, unusable, and requires that a new runtime be initialized
 // after it is called.
@@ -18,24 +15,7 @@ import (
 // lock as read, renumber attempting to take a write lock?
 // The alternative is some sort of session tracking, and I don't know how
 // reliable that can be.
-func (r *Runtime) RenumberLocks() error {
-	r.lock.Lock()
-	locked := true
-	defer func() {
-		if locked {
-			r.lock.Unlock()
-		}
-	}()
-
-	runtimeAliveLock := filepath.Join(r.config.TmpDir, "alive.lck")
-	aliveLock, err := storage.GetLockfile(runtimeAliveLock)
-	if err != nil {
-		return errors.Wrapf(err, "error acquiring runtime init lock")
-	}
-	aliveLock.Lock()
-	// It's OK to defer until Shutdown() has run, so no need to check locked
-	defer aliveLock.Unlock()
-
+func (r *Runtime) renumberLocks() error {
 	// Start off by deallocating all locks
 	if err := r.lockManager.FreeAllLocks(); err != nil {
 		return err
@@ -75,9 +55,6 @@ func (r *Runtime) RenumberLocks() error {
 			return err
 		}
 	}
-
-	r.lock.Unlock()
-	locked = false
 
 	return r.Shutdown(false)
 }

--- a/libpod/runtime_renumber.go
+++ b/libpod/runtime_renumber.go
@@ -12,6 +12,12 @@ import (
 // It renders the runtime it is called on, and all container/pod/volume structs
 // from that runtime, unusable, and requires that a new runtime be initialized
 // after it is called.
+// TODO: It would be desirable to make it impossible to call this until all
+// other libpod sessions are dead.
+// Possibly use a read-write file lock, with all non-renumber podmans owning the
+// lock as read, renumber attempting to take a write lock?
+// The alternative is some sort of session tracking, and I don't know how
+// reliable that can be.
 func (r *Runtime) RenumberLocks() error {
 	r.lock.Lock()
 	locked := true

--- a/libpod/runtime_renumber.go
+++ b/libpod/runtime_renumber.go
@@ -52,6 +52,23 @@ func (r *Runtime) RenumberLocks() error {
 			return err
 		}
 	}
+	allPods, err := r.state.AllPods()
+	if err != nil {
+		return err
+	}
+	for _, pod := range allPods {
+		lock, err := r.lockManager.AllocateLock()
+		if err != nil {
+			return errors.Wrapf(err, "error allocating lock for pod %s", pod.ID())
+		}
+
+		pod.config.LockID = lock.ID()
+
+		// Write the new lock ID
+		if err := r.state.RewritePodConfig(pod, pod.config); err != nil {
+			return err
+		}
+	}
 
 	r.lock.Unlock()
 	locked = false

--- a/libpod/runtime_renumber.go
+++ b/libpod/runtime_renumber.go
@@ -1,0 +1,60 @@
+package libpod
+
+import (
+	"path/filepath"
+
+	"github.com/containers/storage"
+	"github.com/pkg/errors"
+)
+
+// RenumberLocks reassigns lock numbers for all containers, pods, and volumes in
+// the state.
+// It renders the runtime it is called on, and all container/pod/volume structs
+// from that runtime, unusable, and requires that a new runtime be initialized
+// after it is called.
+func (r *Runtime) RenumberLocks() error {
+	r.lock.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			r.lock.Unlock()
+		}
+	}()
+
+	runtimeAliveLock := filepath.Join(r.config.TmpDir, "alive.lck")
+	aliveLock, err := storage.GetLockfile(runtimeAliveLock)
+	if err != nil {
+		return errors.Wrapf(err, "error acquiring runtime init lock")
+	}
+	aliveLock.Lock()
+	// It's OK to defer until Shutdown() has run, so no need to check locked
+	defer aliveLock.Unlock()
+
+	// Start off by deallocating all locks
+	if err := r.lockManager.FreeAllLocks(); err != nil {
+		return err
+	}
+
+	allCtrs, err := r.state.AllContainers()
+	if err != nil {
+		return err
+	}
+	for _, ctr := range allCtrs {
+		lock, err := r.lockManager.AllocateLock()
+		if err != nil {
+			return errors.Wrapf(err, "error allocating lock for container %s", ctr.ID())
+		}
+
+		ctr.config.LockID = lock.ID()
+
+		// Write the new lock ID
+		if err := r.state.RewriteContainerConfig(ctr, ctr.config); err != nil {
+			return err
+		}
+	}
+
+	r.lock.Unlock()
+	locked = false
+
+	return r.Shutdown(false)
+}

--- a/libpod/runtime_renumber.go
+++ b/libpod/runtime_renumber.go
@@ -6,9 +6,6 @@ import (
 
 // renumberLocks reassigns lock numbers for all containers and pods in the
 // state.
-// It renders the runtime it is called on, and all container/pod/volume structs
-// from that runtime, unusable, and requires that a new runtime be initialized
-// after it is called.
 // TODO: It would be desirable to make it impossible to call this until all
 // other libpod sessions are dead.
 // Possibly use a read-write file lock, with all non-renumber podmans owning the
@@ -56,5 +53,5 @@ func (r *Runtime) renumberLocks() error {
 		}
 	}
 
-	return r.Shutdown(false)
+	return nil
 }

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -97,6 +97,21 @@ type State interface {
 	// returned.
 	AllContainers() ([]*Container, error)
 
+	// PLEASE READ FULL DESCRIPTION BEFORE USING.
+	// Rewrite a container's configuration.
+	// This function breaks libpod's normal prohibition on a read-only
+	// configuration, and as such should be used EXTREMELY SPARINGLY and
+	// only in very specific circumstances.
+	// Specifically, it is ONLY safe to use thing function to make changes
+	// that result in a functionally identical configuration (migrating to
+	// newer, but identical, configuration fields), or during libpod init
+	// WHILE HOLDING THE ALIVE LOCK (to prevent other libpod instances from
+	// being initialized).
+	// There are a lot of capital letters and conditions here, but the short
+	// answer is this: use this only very sparingly, and only if you really
+	// know what you're doing.
+	RewriteContainerConfig(ctr *Container, newCfg *ContainerConfig) error
+
 	// Accepts full ID of pod.
 	// If the pod given is not in the set namespace, an error will be
 	// returned.

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -107,10 +107,19 @@ type State interface {
 	// newer, but identical, configuration fields), or during libpod init
 	// WHILE HOLDING THE ALIVE LOCK (to prevent other libpod instances from
 	// being initialized).
+	// Most things in config can be changed by this, but container ID and
+	// name ABSOLUTELY CANNOT BE ALTERED. If you do so, there is a high
+	// potential for database corruption.
 	// There are a lot of capital letters and conditions here, but the short
 	// answer is this: use this only very sparingly, and only if you really
 	// know what you're doing.
 	RewriteContainerConfig(ctr *Container, newCfg *ContainerConfig) error
+	// PLEASE READ THE ABOVE DESCRIPTION BEFORE USING.
+	// This function is identical to RewriteContainerConfig, save for the
+	// fact that it is used with pods instead.
+	// It is subject to the same conditions as RewriteContainerConfig.
+	// Please do not use this unless you know what you're doing.
+	RewritePodConfig(pod *Pod, newCfg *PodConfig) error
 
 	// Accepts full ID of pod.
 	// If the pod given is not in the set namespace, an error will be

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -1298,6 +1298,42 @@ func TestCannotUseBadIDAsGenericDependency(t *testing.T) {
 	})
 }
 
+func TestRewriteContainerConfigDoesNotExist(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+		err := state.RewriteContainerConfig(&Container{}, &ContainerConfig{})
+		assert.Error(t, err)
+	})
+}
+
+func TestRewriteContainerConfigNotInState(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+		testCtr, err := getTestCtr1(manager)
+		assert.NoError(t, err)
+		err = state.RewriteContainerConfig(testCtr, &ContainerConfig{})
+		assert.Error(t, err)
+	})
+}
+
+func TestRewriteContainerConfigRewritesConfig(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+		testCtr, err := getTestCtr1(manager)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		testCtr.config.LogPath = "/another/path/"
+
+		err = state.RewriteContainerConfig(testCtr, testCtr.config)
+		assert.NoError(t, err)
+
+		testCtrFromState, err := state.Container(testCtr.ID())
+		assert.NoError(t, err)
+
+		testContainersEqual(t, testCtrFromState, testCtr, true)
+	})
+}
+
 func TestGetPodDoesNotExist(t *testing.T) {
 	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
 		_, err := state.Pod("doesnotexist")

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -1,7 +1,5 @@
 package libpod
 
-import "github.com/containers/libpod/libpod/lock"
-
 // Volume is the type used to create named volumes
 // TODO: all volumes should be created using this and the Volume API
 type Volume struct {
@@ -9,7 +7,6 @@ type Volume struct {
 
 	valid   bool
 	runtime *Runtime
-	lock    lock.Locker
 }
 
 // VolumeConfig holds the volume's config information
@@ -17,8 +14,6 @@ type Volume struct {
 type VolumeConfig struct {
 	// Name of the volume
 	Name string `json:"name"`
-	// ID of this volume's lock
-	LockID uint32 `json:"lockID"`
 
 	Labels     map[string]string `json:"labels"`
 	MountPoint string            `json:"mountPoint"`

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -18,8 +18,5 @@ func newVolume(runtime *Runtime) (*Volume, error) {
 
 // teardownStorage deletes the volume from volumePath
 func (v *Volume) teardownStorage() error {
-	if !v.valid {
-		return ErrNoSuchVolume
-	}
 	return os.RemoveAll(filepath.Join(v.runtime.config.VolumePath, v.Name()))
 }


### PR DESCRIPTION
Still needs Podman frontend, plus a bit more lock code.

Needed for a 1.1 release. We also need to modify RPM postinstall to call this for any 1.0->1.1 upgrades to ensure all containers get migrated properly to SHM locks.

Still messy but feel free to review while I hack the last bits into place.