### PR TITLE
Add registry name to fields returned by varlink image search

### DIFF
--- a/API.md
+++ b/API.md
@@ -107,7 +107,7 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func RestartPod(name: string) string](#RestartPod)
 
-[func SearchImages(quety: string, limit: int, tlsVerify: ?bool) ImageSearchResult](#SearchImages)
+[func SearchImages(query: string, limit: int, tlsVerify: ?bool) ImageSearchResult](#SearchImages)
 
 [func SendFile(type: string, length: int) string](#SendFile)
 
@@ -780,8 +780,9 @@ ReceiveFile allows the host to send a remote client a file
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
 method RemoveContainer(name: [string](https://godoc.org/builtin#string), force: [bool](https://godoc.org/builtin#bool), removeVolumes: [bool](https://godoc.org/builtin#bool)) [string](https://godoc.org/builtin#string)</div>
-RemoveContainer takes requires the name or ID of container as well a boolean representing whether a running
-container can be stopped and removed.  It also takes a flag on whether or not to remove builtin volumes. Upon successful removal of the container, its ID is returned.  If the
+RemoveContainer requires the name or ID of container as well a boolean representing whether a running container can be stopped and removed, and a boolean
+indicating whether to remove builtin volumes. Upon successful removal of the
+container, its ID is returned.  If the
 container cannot be found by name or ID, a [ContainerNotFound](#ContainerNotFound) error will be returned.
 #### Example
 ~~~
@@ -1422,6 +1423,8 @@ description [string](https://godoc.org/builtin#string)
 is_official [bool](https://godoc.org/builtin#bool)
 
 is_automated [bool](https://godoc.org/builtin#bool)
+
+registry [string](https://godoc.org/builtin#string)
 
 name [string](https://godoc.org/builtin#string)
 

--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/formats"
 	"github.com/containers/libpod/libpod/common"
 	sysreg "github.com/containers/libpod/pkg/registries"
-	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -88,7 +87,7 @@ func searchCmd(c *cliconfig.SearchValues) error {
 	term := args[0]
 
 	// Check if search term has a registry in it
-	registry, err := getRegistry(term)
+	registry, err := sysreg.GetRegistry(term)
 	if err != nil {
 		return errors.Wrapf(err, "error getting registry from %q", term)
 	}
@@ -300,17 +299,4 @@ func matchesOfficialFilter(filter searchFilterParams, result docker.SearchResult
 		return result.IsOfficial == *filter.isOfficial
 	}
 	return true
-}
-
-func getRegistry(image string) (string, error) {
-	// It is possible to only have the registry name in the format "myregistry/"
-	// if so, just trim the "/" from the end and return the registry name
-	if strings.HasSuffix(image, "/") {
-		return strings.TrimSuffix(image, "/"), nil
-	}
-	imgRef, err := reference.Parse(image)
-	if err != nil {
-		return "", err
-	}
-	return reference.Domain(imgRef.(reference.Named)), nil
 }

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -67,6 +67,7 @@ type ImageSearchResult (
     description: string,
     is_official: bool,
     is_automated: bool,
+    registry: string,
     name: string,
     star_count: int
 )
@@ -600,8 +601,9 @@ method GetAttachSockets(name: string) -> (sockets: Sockets)
 # a [ContainerNotFound](#ContainerNotFound) error is returned.
 method WaitContainer(name: string) -> (exitcode: int)
 
-# RemoveContainer takes requires the name or ID of container as well a boolean representing whether a running and a boolean indicating whether to remove builtin volumes
-# container can be stopped and removed.  Upon successful removal of the container, its ID is returned.  If the
+# RemoveContainer requires the name or ID of container as well a boolean representing whether a running container can be stopped and removed, and a boolean
+# indicating whether to remove builtin volumes. Upon successful removal of the
+# container, its ID is returned.  If the
 # container cannot be found by name or ID, a [ContainerNotFound](#ContainerNotFound) error will be returned.
 # #### Example
 # ~~~

--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -3,10 +3,12 @@ package registries
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/containers/image/pkg/sysregistries"
 	"github.com/containers/image/types"
 	"github.com/containers/libpod/pkg/rootless"
+	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 )
 
@@ -48,4 +50,18 @@ func GetInsecureRegistries() ([]string, error) {
 		return nil, errors.Wrapf(err, "unable to parse the registries.conf file")
 	}
 	return registries, nil
+}
+
+// GetRegistry returns the registry name from a string if specified
+func GetRegistry(image string) (string, error) {
+	// It is possible to only have the registry name in the format "myregistry/"
+	// if so, just trim the "/" from the end and return the registry name
+	if strings.HasSuffix(image, "/") {
+		return strings.TrimSuffix(image, "/"), nil
+	}
+	imgRef, err := reference.Parse(image)
+	if err != nil {
+		return "", err
+	}
+	return reference.Domain(imgRef.(reference.Named)), nil
 }


### PR DESCRIPTION
Cockpit team wants to list the registry name where the image was
found.

Also fix up SearchImages code to check if the user specified a registry
in his call to use that rather then all the registries, This matches
podman search command.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>