### PR TITLE
Fix up handling of user defined network namespaces

### DIFF
--- a/contrib/cirrus/packer/fedora_setup.sh
+++ b/contrib/cirrus/packer/fedora_setup.sh
@@ -40,6 +40,7 @@ ooe.sh sudo dnf install -y \
     golang-github-cpuguy83-go-md2man \
     gpgme-devel \
     iptables \
+    iproute \
     libassuan-devel \
     libcap-devel \
     libnet \

--- a/contrib/cirrus/packer/ubuntu_setup.sh
+++ b/contrib/cirrus/packer/ubuntu_setup.sh
@@ -48,6 +48,7 @@ ooe.sh sudo -E apt-get -qq install \
     gettext \
     go-md2man \
     golang \
+    iproute \
     iptables \
     libaio-dev \
     libapparmor-dev \

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -28,6 +28,8 @@ servers in the created `resolv.conf`). Additionally, an empty file is created in
 each container to indicate to programs they are running in a container. This file
 is located at `/run/.containerenv`.
 
+When running from a user defined network namespace, the /etc/netns/NSNAME/resolv.conf will be used if it exists, otherwise /etc/resolv.conf will be used.
+
 ## OPTIONS
 **--add-host**=[]
 
@@ -694,21 +696,21 @@ Current supported mount TYPES are bind, and tmpfs.
 
        Common Options:
 
-              · src, source: mount source spec for bind and volume. Mandatory for bind.
+	      · src, source: mount source spec for bind and volume. Mandatory for bind.
 
-              · dst, destination, target: mount destination spec.
+	      · dst, destination, target: mount destination spec.
 
-              · ro, read-only: true or false (default).
+	      · ro, read-only: true or false (default).
 
        Options specific to bind:
 
-              · bind-propagation: Z, z, shared, slave, private, rshared, rslave, or rprivate(default). See also mount(2).
+	      · bind-propagation: Z, z, shared, slave, private, rshared, rslave, or rprivate(default). See also mount(2).
 
        Options specific to tmpfs:
 
-              · tmpfs-size: Size of the tmpfs mount in bytes. Unlimited by default in Linux.
+	      · tmpfs-size: Size of the tmpfs mount in bytes. Unlimited by default in Linux.
 
-              · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
+	      · tmpfs-mode: File mode of the tmpfs in octal. (e.g. 700 or 0700.) Defaults to 1777 in Linux.
 
 **--userns**=""
 

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -904,10 +904,10 @@ func WithNetNS(portMappings []ocicni.PortMapping, postConfigureNetNS bool, netmo
 		}
 
 		ctr.config.PostConfigureNetNS = postConfigureNetNS
-		ctr.config.CreateNetNS = true
+		ctr.config.NetMode = namespaces.NetworkMode(netmode)
+		ctr.config.CreateNetNS = !ctr.config.NetMode.IsUserDefined()
 		ctr.config.PortMappings = portMappings
 		ctr.config.Networks = networks
-		ctr.config.NetMode = namespaces.NetworkMode(netmode)
 
 		return nil
 	}

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -446,7 +446,15 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime, pod *l
 	}
 
 	if IsNS(string(c.NetMode)) {
-		// pass
+		split := strings.SplitN(string(c.NetMode), ":", 2)
+		if len(split[0]) != 2 {
+			return nil, errors.Errorf("invalid user defined network namespace %q", c.NetMode.UserDefined())
+		}
+		_, err := os.Stat(split[1])
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, libpod.WithNetNS(portBindings, false, string(c.NetMode), networks))
 	} else if c.NetMode.IsContainer() {
 		connectedCtr, err := c.Runtime.LookupContainer(c.NetMode.Container())
 		if err != nil {


### PR DESCRIPTION
If user specifies network namespace and the /etc/netns/XXX/resolv.conf
exists, we should use this rather then /etc/resolv.conf

Also fail cleaner if the user specifies an invalid Network Namespace.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>