### PR TITLE
podman-search: run in parallel

### DIFF
--- a/API.md
+++ b/API.md
@@ -107,7 +107,7 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func RestartPod(name: string) string](#RestartPod)
 
-[func SearchImages(query: string, limit: , tlsVerify: ) ImageSearchResult](#SearchImages)
+[func SearchImages(query: string, limit: int, tlsVerify: ?bool, filter: []string) ImageSearchResult](#SearchImages)
 
 [func SendFile(type: string, length: int) string](#SendFile)
 

--- a/API.md
+++ b/API.md
@@ -107,7 +107,7 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func RestartPod(name: string) string](#RestartPod)
 
-[func SearchImages(query: string, limit: int, tlsVerify: ?bool, filter: []string) ImageSearchResult](#SearchImages)
+[func SearchImages(query: string, limit: int, tlsVerify: ?bool, filter: ImageSearchFilter) ImageSearchResult](#SearchImages)
 
 [func SendFile(type: string, length: int) string](#SendFile)
 
@@ -162,6 +162,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 [type Image](#Image)
 
 [type ImageHistory](#ImageHistory)
+
+[type ImageSearchFilter](#ImageSearchFilter)
 
 [type ImageSearchResult](#ImageSearchResult)
 
@@ -1408,6 +1410,15 @@ tags [[]string](#[]string)
 size [int](https://godoc.org/builtin#int)
 
 comment [string](https://godoc.org/builtin#string)
+### <a name="ImageSearchFilter"></a>type ImageSearchFilter
+
+Represents a filter for SearchImages
+
+is_official [bool](https://godoc.org/builtin#bool)
+
+is_automated [bool](https://godoc.org/builtin#bool)
+
+star_count [int](https://godoc.org/builtin#int)
 ### <a name="ImageSearchResult"></a>type ImageSearchResult
 
 Represents a single search result from SearchImages

--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -1,22 +1,14 @@
 package main
 
 import (
-	"context"
-	"reflect"
-	"strconv"
 	"strings"
-	"sync"
 
-	"github.com/containers/image/docker"
 	"github.com/containers/image/types"
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/formats"
-	"github.com/containers/libpod/libpod/common"
-	sysreg "github.com/containers/libpod/pkg/registries"
+	"github.com/containers/libpod/libpod/image"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -56,30 +48,6 @@ func init() {
 	flags.BoolVar(&searchCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
 }
 
-type searchParams struct {
-	Index       string
-	Name        string
-	Description string
-	Stars       int
-	Official    string
-	Automated   string
-}
-
-type searchOpts struct {
-	filter                []string
-	limit                 int
-	noTrunc               bool
-	format                string
-	authfile              string
-	insecureSkipTLSVerify types.OptionalBool
-}
-
-type searchFilterParams struct {
-	stars       int
-	isAutomated *bool
-	isOfficial  *bool
-}
-
 func searchCmd(c *cliconfig.SearchValues) error {
 	args := c.InputArgs
 	if len(args) > 1 {
@@ -90,37 +58,24 @@ func searchCmd(c *cliconfig.SearchValues) error {
 	}
 	term := args[0]
 
-	// Check if search term has a registry in it
-	registry, err := sysreg.GetRegistry(term)
-	if err != nil {
-		return errors.Wrapf(err, "error getting registry from %q", term)
-	}
-	if registry != "" {
-		term = term[len(registry)+1:]
-	}
-
-	format := genSearchFormat(c.Format)
-	opts := searchOpts{
-		format:   format,
-		noTrunc:  c.NoTrunc,
-		limit:    c.Limit,
-		filter:   c.Filter,
-		authfile: getAuthFile(c.Authfile),
+	searchOptions := image.SearchOptions{
+		NoTrunc:  c.NoTrunc,
+		Limit:    c.Limit,
+		Filter:   c.Filter,
+		Authfile: getAuthFile(c.Authfile),
 	}
 	if c.Flag("tls-verify").Changed {
-		opts.insecureSkipTLSVerify = types.NewOptionalBool(!c.TlsVerify)
+		searchOptions.InsecureSkipTLSVerify = types.NewOptionalBool(!c.TlsVerify)
 	}
-	registries, err := getRegistries(registry)
+
+	results, err := image.SearchImages(term, searchOptions)
 	if err != nil {
 		return err
 	}
-
-	filter, err := parseSearchFilter(&opts)
-	if err != nil {
-		return err
-	}
-
-	return generateSearchOutput(term, registries, opts, *filter)
+	format := genSearchFormat(c.Format)
+	out := formats.StdoutTemplateArray{Output: searchToGeneric(results), Template: format, Fields: results[0].HeaderMap()}
+	formats.Writer(out).Out()
+	return nil
 }
 
 func genSearchFormat(format string) string {
@@ -132,205 +87,9 @@ func genSearchFormat(format string) string {
 	return "table {{.Index}}\t{{.Name}}\t{{.Description}}\t{{.Stars}}\t{{.Official}}\t{{.Automated}}\t"
 }
 
-func searchToGeneric(params []searchParams) (genericParams []interface{}) {
+func searchToGeneric(params []image.SearchResult) (genericParams []interface{}) {
 	for _, v := range params {
 		genericParams = append(genericParams, interface{}(v))
 	}
 	return genericParams
-}
-
-func (s *searchParams) headerMap() map[string]string {
-	v := reflect.Indirect(reflect.ValueOf(s))
-	values := make(map[string]string, v.NumField())
-
-	for i := 0; i < v.NumField(); i++ {
-		key := v.Type().Field(i).Name
-		value := key
-		values[key] = strings.ToUpper(splitCamelCase(value))
-	}
-	return values
-}
-
-// getRegistries returns the list of registries to search, depending on an optional registry specification
-func getRegistries(registry string) ([]string, error) {
-	var registries []string
-	if registry != "" {
-		registries = append(registries, registry)
-	} else {
-		var err error
-		registries, err = sysreg.GetRegistries()
-		if err != nil {
-			return nil, errors.Wrapf(err, "error getting registries to search")
-		}
-	}
-	return registries, nil
-}
-
-func getSearchOutput(term string, registry string, opts searchOpts, filter searchFilterParams) ([]searchParams, error) {
-	// Max number of queries by default is 25
-	limit := maxQueries
-	if opts.limit != 0 {
-		limit = opts.limit
-	}
-
-	sc := common.GetSystemContext("", opts.authfile, false)
-	sc.DockerInsecureSkipTLSVerify = opts.insecureSkipTLSVerify
-	// FIXME: Set this more globally.  Probably no reason not to have it in
-	// every types.SystemContext, and to compute the value just once in one
-	// place.
-	sc.SystemRegistriesConfPath = sysreg.SystemRegistriesConfPath()
-	results, err := docker.SearchRegistry(context.TODO(), sc, registry, term, limit)
-	if err != nil {
-		logrus.Errorf("error searching registry %q: %v", registry, err)
-		return []searchParams{}, nil
-	}
-	index := registry
-	arr := strings.Split(registry, ".")
-	if len(arr) > 2 {
-		index = strings.Join(arr[len(arr)-2:], ".")
-	}
-
-	// limit is the number of results to output
-	// if the total number of results is less than the limit, output all
-	// if the limit has been set by the user, output those number of queries
-	limit = maxQueries
-	if len(results) < limit {
-		limit = len(results)
-	}
-	if opts.limit != 0 && opts.limit < len(results) {
-		limit = opts.limit
-	}
-
-	paramsArr := []searchParams{}
-	for i := 0; i < limit; i++ {
-		if len(opts.filter) > 0 {
-			// Check whether query matches filters
-			if !(matchesAutomatedFilter(filter, results[i]) && matchesOfficialFilter(filter, results[i]) && matchesStarFilter(filter, results[i])) {
-				continue
-			}
-		}
-		official := ""
-		if results[i].IsOfficial {
-			official = "[OK]"
-		}
-		automated := ""
-		if results[i].IsAutomated {
-			automated = "[OK]"
-		}
-		description := strings.Replace(results[i].Description, "\n", " ", -1)
-		if len(description) > 44 && !opts.noTrunc {
-			description = description[:descriptionTruncLength] + "..."
-		}
-		name := registry + "/" + results[i].Name
-		if index == "docker.io" && !strings.Contains(results[i].Name, "/") {
-			name = index + "/library/" + results[i].Name
-		}
-		params := searchParams{
-			Index:       index,
-			Name:        name,
-			Description: description,
-			Official:    official,
-			Automated:   automated,
-			Stars:       results[i].StarCount,
-		}
-		paramsArr = append(paramsArr, params)
-	}
-	return paramsArr, nil
-}
-
-func generateSearchOutput(term string, registries []string, opts searchOpts, filter searchFilterParams) error {
-	// searchOutputData is used as a return value for searching in parallel.
-	type searchOutputData struct {
-		data []searchParams
-		err  error
-	}
-
-	// Let's follow Firefox by limiting parallel downloads to 6.
-	sem := semaphore.NewWeighted(6)
-	wg := sync.WaitGroup{}
-	wg.Add(len(registries))
-	data := make([]searchOutputData, len(registries))
-
-	getSearchOutputHelper := func(index int, registry string) {
-		defer sem.Release(1)
-		defer wg.Done()
-		searchOutput, err := getSearchOutput(term, registry, opts, filter)
-		data[index] = searchOutputData{data: searchOutput, err: err}
-	}
-
-	ctx := context.Background()
-	for i := range registries {
-		sem.Acquire(ctx, 1)
-		go getSearchOutputHelper(i, registries[i])
-	}
-
-	wg.Wait()
-	searchOutput := []searchParams{}
-	for _, d := range data {
-		if d.err != nil {
-			return d.err
-		}
-		searchOutput = append(searchOutput, d.data...)
-	}
-	if len(searchOutput) == 0 {
-		return nil
-	}
-	out := formats.StdoutTemplateArray{Output: searchToGeneric(searchOutput), Template: opts.format, Fields: searchOutput[0].headerMap()}
-	return formats.Writer(out).Out()
-}
-
-func parseSearchFilter(opts *searchOpts) (*searchFilterParams, error) {
-	filterParams := &searchFilterParams{}
-	ptrTrue := true
-	ptrFalse := false
-	for _, filter := range opts.filter {
-		arr := strings.Split(filter, "=")
-		switch arr[0] {
-		case "stars":
-			if len(arr) < 2 {
-				return nil, errors.Errorf("invalid `stars` filter %q, should be stars=<value>", filter)
-			}
-			stars, err := strconv.Atoi(arr[1])
-			if err != nil {
-				return nil, errors.Wrapf(err, "incorrect value type for stars filter")
-			}
-			filterParams.stars = stars
-			break
-		case "is-automated":
-			if len(arr) == 2 && arr[1] == "false" {
-				filterParams.isAutomated = &ptrFalse
-			} else {
-				filterParams.isAutomated = &ptrTrue
-			}
-			break
-		case "is-official":
-			if len(arr) == 2 && arr[1] == "false" {
-				filterParams.isOfficial = &ptrFalse
-			} else {
-				filterParams.isOfficial = &ptrTrue
-			}
-			break
-		default:
-			return nil, errors.Errorf("invalid filter type %q", filter)
-		}
-	}
-	return filterParams, nil
-}
-
-func matchesStarFilter(filter searchFilterParams, result docker.SearchResult) bool {
-	return result.StarCount >= filter.stars
-}
-
-func matchesAutomatedFilter(filter searchFilterParams, result docker.SearchResult) bool {
-	if filter.isAutomated != nil {
-		return result.IsAutomated == *filter.isAutomated
-	}
-	return true
-}
-
-func matchesOfficialFilter(filter searchFilterParams, result docker.SearchResult) bool {
-	if filter.isOfficial != nil {
-		return result.IsOfficial == *filter.isOfficial
-	}
-	return true
 }

--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -58,10 +58,15 @@ func searchCmd(c *cliconfig.SearchValues) error {
 	}
 	term := args[0]
 
+	filter, err := image.ParseSearchFilter(c.Filter)
+	if err != nil {
+		return err
+	}
+
 	searchOptions := image.SearchOptions{
 		NoTrunc:  c.NoTrunc,
 		Limit:    c.Limit,
-		Filter:   c.Filter,
+		Filter:   *filter,
 		Authfile: getAuthFile(c.Authfile),
 	}
 	if c.Flag("tls-verify").Changed {

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -72,6 +72,12 @@ type ImageSearchResult (
     star_count: int
 )
 
+type ImageSearchFilter (
+    is_official: ?bool,
+    is_automated: ?bool,
+    star_count: int
+)
+
 type Container (
     id: string,
     image: string,
@@ -681,7 +687,7 @@ method RemoveImage(name: string, force: bool) -> (image: string)
 # SearchImages searches available registries for images that contain the
 # contents of "query" in their name. If "limit" is given, limits the amount of
 # search results per registry.
-method SearchImages(query: string, limit: ?int, tlsVerify: ?bool, filter: []string) -> (results: []ImageSearchResult)
+method SearchImages(query: string, limit: ?int, tlsVerify: ?bool, filter: ImageSearchFilter) -> (results: []ImageSearchResult)
 
 # DeleteUnusedImages deletes any images not associated with a container.  The IDs of the deleted images are returned
 # in a string array.

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -681,7 +681,7 @@ method RemoveImage(name: string, force: bool) -> (image: string)
 # SearchImages searches available registries for images that contain the
 # contents of "query" in their name. If "limit" is given, limits the amount of
 # search results per registry.
-method SearchImages(query: string, limit: ?int, tlsVerify: ?bool) -> (results: []ImageSearchResult)
+method SearchImages(query: string, limit: ?int, tlsVerify: ?bool, filter: []string) -> (results: []ImageSearchResult)
 
 # DeleteUnusedImages deletes any images not associated with a container.  The IDs of the deleted images are returned
 # in a string array.

--- a/libpod/image/search.go
+++ b/libpod/image/search.go
@@ -1,0 +1,280 @@
+package image
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/containers/image/docker"
+	"github.com/containers/image/types"
+	"github.com/containers/libpod/libpod/common"
+	sysreg "github.com/containers/libpod/pkg/registries"
+	"github.com/fatih/camelcase"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	descriptionTruncLength = 44
+	maxQueries             = 25
+	maxParallelSearches    = int64(6)
+)
+
+// SearchResult is holding image-search related data.
+type SearchResult struct {
+	// Index is the image index (e.g., "docker.io" or "quay.io")
+	Index string
+	// Name is the canoncical name of the image (e.g., "docker.io/library/alpine").
+	Name string
+	// Description of the image.
+	Description string
+	// Stars is the number of stars of the image.
+	Stars int
+	// Official indicates if it's an official image.
+	Official string
+	// Automated indicates if the image was created by an automated build.
+	Automated string
+}
+
+// SearchOptions are used to control the behaviour of SearchImages.
+type SearchOptions struct {
+	// Filter allows to filter the results.
+	Filter []string
+	// Limit limits the number of queries per index (default: 25). Must be
+	// greater than 0 to overwrite the default value.
+	Limit int
+	// NoTrunc avoids the output to be truncated.
+	NoTrunc bool
+	// Authfile is the path to the authentication file.
+	Authfile string
+	// InsecureSkipTLSVerify allows to skip TLS verification.
+	InsecureSkipTLSVerify types.OptionalBool
+}
+
+type searchFilterParams struct {
+	stars       int
+	isAutomated *bool
+	isOfficial  *bool
+}
+
+func splitCamelCase(src string) string {
+	entries := camelcase.Split(src)
+	return strings.Join(entries, " ")
+}
+
+// HeaderMap returns the headers of a SearchResult.
+func (s *SearchResult) HeaderMap() map[string]string {
+	v := reflect.Indirect(reflect.ValueOf(s))
+	values := make(map[string]string, v.NumField())
+
+	for i := 0; i < v.NumField(); i++ {
+		key := v.Type().Field(i).Name
+		value := key
+		values[key] = strings.ToUpper(splitCamelCase(value))
+	}
+	return values
+}
+
+// SearchImages searches images based on term and the specified SearchOptions
+// in all registries.
+func SearchImages(term string, options SearchOptions) ([]SearchResult, error) {
+	filter, err := parseSearchFilter(&options)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if search term has a registry in it
+	registry, err := sysreg.GetRegistry(term)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting registry from %q", term)
+	}
+	if registry != "" {
+		term = term[len(registry)+1:]
+	}
+
+	registries, err := getRegistries(registry)
+	if err != nil {
+		return nil, err
+	}
+
+	// searchOutputData is used as a return value for searching in parallel.
+	type searchOutputData struct {
+		data []SearchResult
+		err  error
+	}
+
+	// Let's follow Firefox by limiting parallel downloads to 6.
+	sem := semaphore.NewWeighted(maxParallelSearches)
+	wg := sync.WaitGroup{}
+	wg.Add(len(registries))
+	data := make([]searchOutputData, len(registries))
+
+	searchImageInRegistryHelper := func(index int, registry string) {
+		defer sem.Release(1)
+		defer wg.Done()
+		searchOutput, err := searchImageInRegistry(term, registry, options, filter)
+		data[index] = searchOutputData{data: searchOutput, err: err}
+	}
+
+	ctx := context.Background()
+	for i := range registries {
+		sem.Acquire(ctx, 1)
+		go searchImageInRegistryHelper(i, registries[i])
+	}
+
+	wg.Wait()
+	results := []SearchResult{}
+	for _, d := range data {
+		if d.err != nil {
+			return nil, d.err
+		}
+		results = append(results, d.data...)
+	}
+	return results, nil
+}
+
+// getRegistries returns the list of registries to search, depending on an optional registry specification
+func getRegistries(registry string) ([]string, error) {
+	var registries []string
+	if registry != "" {
+		registries = append(registries, registry)
+	} else {
+		var err error
+		registries, err = sysreg.GetRegistries()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error getting registries to search")
+		}
+	}
+	return registries, nil
+}
+
+func searchImageInRegistry(term string, registry string, options SearchOptions, filter *searchFilterParams) ([]SearchResult, error) {
+	// Max number of queries by default is 25
+	limit := maxQueries
+	if options.Limit > 0 {
+		limit = options.Limit
+	}
+
+	sc := common.GetSystemContext("", options.Authfile, false)
+	sc.DockerInsecureSkipTLSVerify = options.InsecureSkipTLSVerify
+	// FIXME: Set this more globally.  Probably no reason not to have it in
+	// every types.SystemContext, and to compute the value just once in one
+	// place.
+	sc.SystemRegistriesConfPath = sysreg.SystemRegistriesConfPath()
+	results, err := docker.SearchRegistry(context.TODO(), sc, registry, term, limit)
+	if err != nil {
+		logrus.Errorf("error searching registry %q: %v", registry, err)
+		return []SearchResult{}, nil
+	}
+	index := registry
+	arr := strings.Split(registry, ".")
+	if len(arr) > 2 {
+		index = strings.Join(arr[len(arr)-2:], ".")
+	}
+
+	// limit is the number of results to output
+	// if the total number of results is less than the limit, output all
+	// if the limit has been set by the user, output those number of queries
+	limit = maxQueries
+	if len(results) < limit {
+		limit = len(results)
+	}
+	if options.Limit != 0 && options.Limit < len(results) {
+		limit = options.Limit
+	}
+
+	paramsArr := []SearchResult{}
+	for i := 0; i < limit; i++ {
+		if len(options.Filter) > 0 {
+			// Check whether query matches filters
+			if !(matchesAutomatedFilter(filter, results[i]) && matchesOfficialFilter(filter, results[i]) && matchesStarFilter(filter, results[i])) {
+				continue
+			}
+		}
+		official := ""
+		if results[i].IsOfficial {
+			official = "[OK]"
+		}
+		automated := ""
+		if results[i].IsAutomated {
+			automated = "[OK]"
+		}
+		description := strings.Replace(results[i].Description, "\n", " ", -1)
+		if len(description) > 44 && !options.NoTrunc {
+			description = description[:descriptionTruncLength] + "..."
+		}
+		name := registry + "/" + results[i].Name
+		if index == "docker.io" && !strings.Contains(results[i].Name, "/") {
+			name = index + "/library/" + results[i].Name
+		}
+		params := SearchResult{
+			Index:       index,
+			Name:        name,
+			Description: description,
+			Official:    official,
+			Automated:   automated,
+			Stars:       results[i].StarCount,
+		}
+		paramsArr = append(paramsArr, params)
+	}
+	return paramsArr, nil
+}
+
+func parseSearchFilter(options *SearchOptions) (*searchFilterParams, error) {
+	filterParams := &searchFilterParams{}
+	ptrTrue := true
+	ptrFalse := false
+	for _, filter := range options.Filter {
+		arr := strings.Split(filter, "=")
+		switch arr[0] {
+		case "stars":
+			if len(arr) < 2 {
+				return nil, errors.Errorf("invalid `stars` filter %q, should be stars=<value>", filter)
+			}
+			stars, err := strconv.Atoi(arr[1])
+			if err != nil {
+				return nil, errors.Wrapf(err, "incorrect value type for stars filter")
+			}
+			filterParams.stars = stars
+			break
+		case "is-automated":
+			if len(arr) == 2 && arr[1] == "false" {
+				filterParams.isAutomated = &ptrFalse
+			} else {
+				filterParams.isAutomated = &ptrTrue
+			}
+			break
+		case "is-official":
+			if len(arr) == 2 && arr[1] == "false" {
+				filterParams.isOfficial = &ptrFalse
+			} else {
+				filterParams.isOfficial = &ptrTrue
+			}
+			break
+		default:
+			return nil, errors.Errorf("invalid filter type %q", filter)
+		}
+	}
+	return filterParams, nil
+}
+
+func matchesStarFilter(filter *searchFilterParams, result docker.SearchResult) bool {
+	return result.StarCount >= filter.stars
+}
+
+func matchesAutomatedFilter(filter *searchFilterParams, result docker.SearchResult) bool {
+	if filter.isAutomated != nil {
+		return result.IsAutomated == *filter.isAutomated
+	}
+	return true
+}
+
+func matchesOfficialFilter(filter *searchFilterParams, result docker.SearchResult) bool {
+	if filter.isOfficial != nil {
+		return result.IsOfficial == *filter.isOfficial
+	}
+	return true
+}

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -435,9 +435,14 @@ func (i *LibpodAPI) RemoveImage(call iopodman.VarlinkCall, name string, force bo
 // SearchImages searches all registries configured in /etc/containers/registries.conf for an image
 // Requires an image name and a search limit as int
 func (i *LibpodAPI) SearchImages(call iopodman.VarlinkCall, query string, limit *int64, tlsVerify *bool, filter []string) error {
+	sFilter, err := image.ParseSearchFilter(filter)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+
 	searchOptions := image.SearchOptions{
 		Limit:                 1000,
-		Filter:                filter,
+		Filter:                *sFilter,
 		InsecureSkipTLSVerify: types.NewOptionalBool(!*tlsVerify),
 	}
 	results, err := image.SearchImages(query, searchOptions)

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -434,9 +434,10 @@ func (i *LibpodAPI) RemoveImage(call iopodman.VarlinkCall, name string, force bo
 
 // SearchImages searches all registries configured in /etc/containers/registries.conf for an image
 // Requires an image name and a search limit as int
-func (i *LibpodAPI) SearchImages(call iopodman.VarlinkCall, query string, limit *int64, tlsVerify *bool) error {
+func (i *LibpodAPI) SearchImages(call iopodman.VarlinkCall, query string, limit *int64, tlsVerify *bool, filter []string) error {
 	searchOptions := image.SearchOptions{
 		Limit:                 1000,
+		Filter:                filter,
 		InsecureSkipTLSVerify: types.NewOptionalBool(!*tlsVerify),
 	}
 	results, err := image.SearchImages(query, searchOptions)


### PR DESCRIPTION
* Run image searches in parallel.
* Refactor code to be used by podman and the varlink API.
* Extend varlink API with an image search filter.

Fixes: #2345