### PR TITLE
Add num_locks to the default libpod config

### DIFF
--- a/docs/libpod.conf.5.md
+++ b/docs/libpod.conf.5.md
@@ -82,6 +82,11 @@ libpod to manage containers.
 **label**="true|false"
   Indicates whether the containers should use label separation.
 
+**num_locks**=""
+  Number of locks available for containers and pods. Each created container or pod consumes one lock.
+  The default number available is 2048.
+  If this is changed, a lock renumbering must be performed, using the `podman system renumber` command.
+
 ## FILES
   `/usr/share/containers/libpod.conf`, default libpod configuration path
 

--- a/libpod.conf
+++ b/libpod.conf
@@ -88,6 +88,12 @@ pause_command = "/pause"
 # Default libpod support for container labeling
 # label=true
 
+# Number of locks available for containers and pods.
+# If this is changed, a lock renumber must be performed (e.g. with the
+# 'podman system renumber' command).
+num_locks = 2048
+
+# Default OCI runtime
 runtime = "runc"
 
 # Paths to look for a valid OCI runtime (runc, runv, etc)


### PR DESCRIPTION
Allow adjusting number of locks in libpod.conf via an already available knob we previously didn't expose in the default config file.

Sort of blocked by #2350 given the references to the unmerged renumber command