### PR TITLE
WIP: Added Pod Restart policy

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -228,16 +228,17 @@ type KubePlayValues struct {
 
 type PodCreateValues struct {
 	PodmanCommand
-	CgroupParent string
-	Infra        bool
-	InfraImage   string
-	InfraCommand string
-	LabelFile    []string
-	Labels       []string
-	Name         string
-	PodIDFile    string
-	Publish      []string
-	Share        string
+	CgroupParent  string
+	Infra         bool
+	InfraImage    string
+	InfraCommand  string
+	LabelFile     []string
+	Labels        []string
+	Name          string
+	PodIDFile     string
+	Publish       []string
+	RestartPolicy string
+	Share         string
 }
 
 type PodInspectValues struct {

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -246,6 +246,10 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"Read in a file of environment variables",
 	)
 	createFlags.StringSlice(
+		"exit-command", []string{},
+		"Command to execute when container exits",
+	)
+	createFlags.StringSlice(
 		"expose", []string{},
 		"Expose a port or a range of ports (default [])",
 	)

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -711,6 +711,7 @@ func parseCreateOpts(ctx context.Context, c *cliconfig.PodmanCommand, runtime *l
 		DNSServers:        c.StringSlice("dns"),
 		Entrypoint:        entrypoint,
 		Env:               env,
+		ExitCommand:       exitCommand,
 		//ExposedPorts:   ports,
 		GroupAdd:       c.StringSlice("group-add"),
 		Hostname:       c.String("hostname"),

--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -52,6 +52,7 @@ func init() {
 	flags.StringVar(&podCreateCommand.PodIDFile, "pod-id-file", "", "Write the pod ID to the file")
 	flags.StringSliceVarP(&podCreateCommand.Publish, "publish", "p", []string{}, "Publish a container's port, or a range of ports, to the host (default [])")
 	flags.StringVar(&podCreateCommand.Share, "share", DefaultKernelNamespaces, "A comma delimited list of kernel namespaces the pod will share")
+	flags.StringVar(&podCreateCommand.RestartPolicy, "restart-policy", "never", "The restart policy for the pod")
 
 }
 
@@ -124,6 +125,8 @@ func podCreateCmd(c *cliconfig.PodCreateValues) error {
 	// always have containers use pod cgroups
 	// User Opt out is not yet supported
 	options = append(options, libpod.WithPodCgroups())
+
+	options = append(options, libpod.WithRestartPolicy(c.RestartPolicy))
 
 	ctx := getContext()
 	pod, err := runtime.NewPod(ctx, options...)

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -261,6 +261,7 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 	if ctr.config.ConmonPidFile != "" {
 		args = append(args, "--conmon-pidfile", ctr.config.ConmonPidFile)
 	}
+	// TODO exit command formatted here, maybe restart delay needs to go here?
 	if len(ctr.config.ExitCommand) > 0 {
 		args = append(args, "--exit-command", ctr.config.ExitCommand[0])
 		for _, arg := range ctr.config.ExitCommand[1:] {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1430,3 +1430,18 @@ func WithInfraContainerPorts(bindings []ocicni.PortMapping) PodCreateOption {
 		return nil
 	}
 }
+
+// WithRestartPolicy sets the pod restart policy
+func WithRestartPolicy(restartPolicy string) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return ErrPodFinalized
+		}
+		if restartPolicy == "never" {
+			pod.config.RestartPolicy = []string{}
+		} else if restartPolicy == "always" {
+			pod.config.RestartPolicy = []string{"start"}
+		}
+		return nil
+	}
+}

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -63,6 +63,9 @@ type PodConfig struct {
 
 	// ID of the pod's lock
 	LockID uint32 `json:"lockID"`
+
+	// Policy for restarting the containers in the pod. Options are currently: never, always
+	RestartPolicy []string `json:"restartPolicy"`
 }
 
 // podState represents a pod's state
@@ -191,6 +194,11 @@ func (p *Pod) CgroupPath() (string, error) {
 	}
 
 	return p.state.CgroupPath, nil
+}
+
+// RestartPolicy returns when a container will automatically restart in the pod
+func (p *Pod) RestartPolicy() []string {
+	return p.config.RestartPolicy
 }
 
 // HasContainer checks if a container is present in the pod

--- a/libpod/pod_internal.go
+++ b/libpod/pod_internal.go
@@ -18,6 +18,7 @@ func newPod(runtime *Runtime) (*Pod, error) {
 	pod.config.Labels = make(map[string]string)
 	pod.config.CreatedTime = time.Now()
 	pod.config.InfraContainer = new(InfraContainerConfig)
+	pod.config.RestartPolicy = []string{} // will result in default behavior of cleaning up container
 	pod.state = new(podState)
 	pod.runtime = runtime
 


### PR DESCRIPTION
Pod restart policies are defined in Kubernetes as operations that happen after a container exits. Lay groundwork for adding restart policies, and allow for containers to inherit restart policies from their pod if they are in one. Current restart policies are "never" (cleanup container after exit) and "always" (start the container after it exits).

Still TODO:
	onFailure - restart a container only when it doesn't exit with 0
	exponential backoff - allow for both always and onFailure to slow down on restarts if they continually exit. This is done in k8s

The TODO require some changes to conmon, so I'm putting this out there for folks to look at and begin to argue about while I look into that :) 
