### PR TITLE
Podman pod create now errors on receiving CLI args

### DIFF
--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -59,6 +59,10 @@ func podCreateCmd(c *cliconfig.PodCreateValues) error {
 	var options []libpod.PodCreateOption
 	var err error
 
+	if len(c.InputArgs) > 0 {
+		return errors.New("podman pod create does not accept any arguments")
+	}
+
 	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")


### PR DESCRIPTION
It has never accepted arguments, so we should error when passed args we will never use.