### PR TITLE
Ensure that userns is created for stopped rootless pods

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -868,6 +868,12 @@ func joinOrCreateRootlessUserNamespace(createConfig *cc.CreateConfig, runtime *l
 			if err != nil {
 				return false, -1, err
 			}
+			if pid == 0 {
+				if createConfig.Pod != "" {
+					continue
+				}
+				return false, -1, errors.Errorf("dependency container %s is not running", ctr.ID())
+			}
 			return rootless.JoinNS(uint(pid))
 		}
 	}


### PR DESCRIPTION
When starting a container in a stopped pod, we attempt to recursively start dependencies. Unfortunately, this presently causes an error when we try and join an appropriate user namespace, as we weren't checking whether the PID of the container we're joining was not 0. Fix that here.