### PR TITLE
remove duplicate kill from `podman --help`

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -14,7 +14,6 @@ func getMainCommands() []*cobra.Command {
 		_createCommand,
 		_diffCommand,
 		_execCommand,
-		_killCommand,
 		generateCommand.Command,
 		podCommand.Command,
 		_containerKubeCommand,


### PR DESCRIPTION
Remove the duplicate kill command and only keep it in the
`mainCommands` containing commands that are implemented by
the native client and the remote one.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>