### PR TITLE
hack/tree_status.sh: preserve new lines

### DIFF
--- a/hack/tree_status.sh
+++ b/hack/tree_status.sh
@@ -8,6 +8,6 @@ then
 else
 	echo "tree is dirty, please commit all changes and sync the vendor.conf"
 	echo ""
-	echo $STATUS
+	echo "$STATUS"
 	exit 1
 fi


### PR DESCRIPTION
Quote the status output in echo to preserve the new lines.
Having the output in one line complicated debugging issues
and is not friendly to use.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>