### PR TITLE
add newline to images output

### DIFF
--- a/cmd/podman/formats/formats.go
+++ b/cmd/podman/formats/formats.go
@@ -125,6 +125,7 @@ func (t StdoutTemplateArray) Out() error {
 			fmt.Fprintln(w, "")
 		}
 	}
+	fmt.Fprintln(w, "")
 	return w.Flush()
 }
 


### PR DESCRIPTION
ensure a final newline is always added to images output.

fixes #2388

Signed-off-by: baude <bbaude@redhat.com>