### PR TITLE
output newline at end if not on a terminal

### DIFF
--- a/cmd/podman/formats/formats.go
+++ b/cmd/podman/formats/formats.go
@@ -172,3 +172,10 @@ func humanNewLine() {
 		fmt.Println()
 	}
 }
+
+// NonTermNewLine prints a new line at the end of the output only if stdout is the not a terminal
+func NonTermNewLine() {
+	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+		fmt.Println()
+	}
+}

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -174,7 +174,11 @@ func imagesCmd(c *cliconfig.ImagesValues) error {
 		filteredImages = images
 	}
 
-	return generateImagesOutput(ctx, filteredImages, opts)
+	if err = generateImagesOutput(ctx, filteredImages, opts); err != nil {
+		return err
+	}
+	formats.NonTermNewLine()
+	return nil
 }
 
 func (i imagesOptions) setOutputFormat() string {


### PR DESCRIPTION
When user redirects podman images, we do not output new lines
between data, so we want to make sure we print a new line at the
end of output.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>