### PR TITLE
rootless: force same cwd when re-execing

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -109,6 +109,13 @@ reexec_userns_join (int userns, int mountns)
   char uid[16];
   char **argv;
   int pid;
+  char *cwd = getcwd (NULL, 0);
+
+  if (cwd == NULL)
+    {
+      fprintf (stderr, "error getting current working directory: %s\n", strerror (errno));
+      _exit (EXIT_FAILURE);
+    }
 
   sprintf (uid, "%d", geteuid ());
 
@@ -154,6 +161,13 @@ reexec_userns_join (int userns, int mountns)
       _exit (EXIT_FAILURE);
     }
 
+  if (chdir (cwd) < 0)
+    {
+      fprintf (stderr, "cannot chdir: %s\n", strerror (errno));
+      _exit (EXIT_FAILURE);
+    }
+  free (cwd);
+
   execvp (argv[0], argv);
 
   _exit (EXIT_FAILURE);
@@ -190,6 +204,13 @@ reexec_in_user_namespace (int ready)
   char *listen_fds = NULL;
   char *listen_pid = NULL;
   bool do_socket_activation = false;
+  char *cwd = getcwd (NULL, 0);
+
+  if (cwd == NULL)
+    {
+      fprintf (stderr, "error getting current working directory: %s\n", strerror (errno));
+      _exit (EXIT_FAILURE);
+    }
 
   listen_pid = getenv("LISTEN_PID");
   listen_fds = getenv("LISTEN_FDS");
@@ -264,6 +285,13 @@ reexec_in_user_namespace (int ready)
       fprintf (stderr, "cannot setresuid: %s\n", strerror (errno));
       _exit (EXIT_FAILURE);
     }
+
+  if (chdir (cwd) < 0)
+    {
+      fprintf (stderr, "cannot chdir: %s\n", strerror (errno));
+      _exit (EXIT_FAILURE);
+    }
+  free (cwd);
 
   execvp (argv[0], argv);
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -28,8 +28,8 @@ func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration 
 }
 
 // PodmanAsUser is the exec call to podman on the filesystem with the specified uid/gid and environment
-func (p *PodmanTestIntegration) PodmanAsUser(args []string, uid, gid uint32, env []string) *PodmanSessionIntegration {
-	podmanSession := p.PodmanAsUserBase(args, uid, gid, env)
+func (p *PodmanTestIntegration) PodmanAsUser(args []string, uid, gid uint32, cwd string, env []string) *PodmanSessionIntegration {
+	podmanSession := p.PodmanAsUserBase(args, uid, gid, cwd, env)
 	return &PodmanSessionIntegration{podmanSession}
 }
 

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Podman rootless", func() {
 		for _, v := range commands {
 			env := os.Environ()
 			env = append(env, "USER=foo")
-			cmd := podmanTest.PodmanAsUser([]string{v}, 1000, 1000, env)
+			cmd := podmanTest.PodmanAsUser([]string{v}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 		}
@@ -128,13 +128,13 @@ var _ = Describe("Podman rootless", func() {
 			env = append(env, "PODMAN_ALLOW_SINGLE_ID_MAPPING_IN_USERNS=1")
 			env = append(env, "USER=foo")
 
-			cmd := rootlessTest.PodmanAsUser([]string{"pod", "create", "--infra=false"}, 1000, 1000, env)
+			cmd := rootlessTest.PodmanAsUser([]string{"pod", "create", "--infra=false"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 			podId := cmd.OutputToString()
 
 			args := []string{"run", "--pod", podId, "--rootfs", mountPath, "echo", "hello"}
-			cmd = rootlessTest.PodmanAsUser(args, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser(args, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 			Expect(cmd.LineInOutputContains("hello")).To(BeTrue())
@@ -158,7 +158,7 @@ var _ = Describe("Podman rootless", func() {
 		env = append(env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", xdgRuntimeDir))
 		env = append(env, fmt.Sprintf("HOME=%s", home))
 		env = append(env, "USER=foo")
-		cmd := podmanTest.PodmanAsUser([]string{"search", "docker.io/busybox"}, 1000, 1000, env)
+		cmd := podmanTest.PodmanAsUser([]string{"search", "docker.io/busybox"}, 1000, 1000, "", env)
 		cmd.WaitWithDefaultTimeout()
 		Expect(cmd.ExitCode()).To(Equal(0))
 	})
@@ -175,65 +175,65 @@ var _ = Describe("Podman rootless", func() {
 
 			allArgs := append([]string{"run"}, args...)
 			allArgs = append(allArgs, "--rootfs", mountPath, "echo", "hello")
-			cmd := rootlessTest.PodmanAsUser(allArgs, 1000, 1000, env)
+			cmd := rootlessTest.PodmanAsUser(allArgs, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 			Expect(cmd.LineInOutputContains("hello")).To(BeTrue())
 
-			cmd = rootlessTest.PodmanAsUser([]string{"rm", "-l", "-f"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"rm", "-l", "-f"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
 			allArgs = append([]string{"run", "-d"}, args...)
 			allArgs = append(allArgs, "--security-opt", "seccomp=unconfined", "--rootfs", mountPath, "top")
-			cmd = rootlessTest.PodmanAsUser(allArgs, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser(allArgs, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
-			cmd = rootlessTest.PodmanAsUser([]string{"restart", "-l", "-t", "0"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"restart", "-l", "-t", "0"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
 			canUseExec := canExec()
 
 			if canUseExec {
-				cmd = rootlessTest.PodmanAsUser([]string{"top", "-l"}, 1000, 1000, env)
+				cmd = rootlessTest.PodmanAsUser([]string{"top", "-l"}, 1000, 1000, "", env)
 				cmd.WaitWithDefaultTimeout()
 				Expect(cmd.ExitCode()).To(Equal(0))
 			}
 
-			cmd = rootlessTest.PodmanAsUser([]string{"rm", "-l", "-f"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"rm", "-l", "-f"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
 			allArgs = append([]string{"run", "-d"}, args...)
 			allArgs = append(allArgs, "--security-opt", "seccomp=unconfined", "--rootfs", mountPath, "unshare", "-r", "unshare", "-r", "top")
-			cmd = rootlessTest.PodmanAsUser(allArgs, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser(allArgs, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
-			cmd = rootlessTest.PodmanAsUser([]string{"stop", "-l", "-t", "0"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"stop", "-l", "-t", "0"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
-			cmd = rootlessTest.PodmanAsUser([]string{"inspect", "-l", "--type", "container", "--format", "{{ .State.Status }}"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"inspect", "-l", "--type", "container", "--format", "{{ .State.Status }}"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.LineInOutputContains("exited")).To(BeTrue())
 
-			cmd = rootlessTest.PodmanAsUser([]string{"start", "-l"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"start", "-l"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
-			cmd = rootlessTest.PodmanAsUser([]string{"stop", "-l", "-t", "0"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"stop", "-l", "-t", "0"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
-			cmd = rootlessTest.PodmanAsUser([]string{"start", "-l"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"start", "-l"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
 			if len(args) == 0 {
-				cmd = rootlessTest.PodmanAsUser([]string{"inspect", "-l"}, 1000, 1000, env)
+				cmd = rootlessTest.PodmanAsUser([]string{"inspect", "-l"}, 1000, 1000, "", env)
 				cmd.WaitWithDefaultTimeout()
 				Expect(cmd.ExitCode()).To(Equal(0))
 				data := cmd.InspectContainerToJSON()
@@ -244,24 +244,23 @@ var _ = Describe("Podman rootless", func() {
 				Skip("ioctl(NS_GET_PARENT) not supported.")
 			}
 
-			cmd = rootlessTest.PodmanAsUser([]string{"exec", "-l", "echo", "hello"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"exec", "-l", "echo", "hello"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 			Expect(cmd.LineInOutputContains("hello")).To(BeTrue())
 
-			cmd = rootlessTest.PodmanAsUser([]string{"ps", "-l", "-q"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"ps", "-l", "-q"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 			cid := cmd.OutputToString()
 
-			cmd = rootlessTest.PodmanAsUser([]string{"exec", "-l", "sh", "-c", "echo SeCreTMessage > /file"}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"exec", "-l", "sh", "-c", "echo SeCreTMessage > /file"}, 1000, 1000, "", env)
 			cmd.WaitWithDefaultTimeout()
 			Expect(cmd.ExitCode()).To(Equal(0))
 
-			path := filepath.Join(home, "export.tar")
-			cmd = rootlessTest.PodmanAsUser([]string{"export", "-o", path, cid}, 1000, 1000, env)
+			cmd = rootlessTest.PodmanAsUser([]string{"export", "-o", "export.tar", cid}, 1000, 1000, home, env)
 			cmd.WaitWithDefaultTimeout()
-			content, err := ioutil.ReadFile(path)
+			content, err := ioutil.ReadFile(filepath.Join(home, "export.tar"))
 			Expect(err).To(BeNil())
 			Expect(strings.Contains(string(content), "SeCreTMessage")).To(BeTrue())
 		}

--- a/test/utils/podmantest_test.go
+++ b/test/utils/podmantest_test.go
@@ -23,7 +23,7 @@ var _ = Describe("PodmanTest test", func() {
 		FakeOutputs["check"] = []string{"check"}
 		os.Setenv("HOOK_OPTION", "hook_option")
 		env := os.Environ()
-		session := podmanTest.PodmanAsUserBase([]string{"check"}, 1000, 1000, env)
+		session := podmanTest.PodmanAsUserBase([]string{"check"}, 1000, 1000, "", env)
 		os.Unsetenv("HOOK_OPTION")
 		session.WaitWithDefaultTimeout()
 		Expect(session.Command.Process).ShouldNot(BeNil())


### PR DESCRIPTION
when joining an existing namespace, we were not maintaining the current working directory, causing commands like export -o to fail when they weren't referring to absolute paths.

Closes: https://github.com/containers/libpod/issues/2381

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
