### PR TITLE
podman-remote pod inspect|exists

### DIFF
--- a/API.md
+++ b/API.md
@@ -89,11 +89,15 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func ListPods() ListPodData](#ListPods)
 
+[func LoadImage(name: string, inputFile: string, quiet: bool, deleteFile: bool) MoreResponse](#LoadImage)
+
 [func MountContainer(name: string) string](#MountContainer)
 
 [func PauseContainer(name: string) string](#PauseContainer)
 
 [func PausePod(name: string) string](#PausePod)
+
+[func PodStateData(name: string) string](#PodStateData)
 
 [func PullImage(name: string, certDir: string, creds: string, signaturePolicy: string, tlsVerify: ) MoreResponse](#PullImage)
 
@@ -535,7 +539,9 @@ $ varlink call unix:/run/podman/io.podman/io.podman.GetPodStats '{"name": "7f62b
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
 method GetPodsByContext(all: [bool](https://godoc.org/builtin#bool), latest: [bool](https://godoc.org/builtin#bool), args: [[]string](#[]string)) [[]string](#[]string)</div>
-
+GetPodsByContext allows you to get a list pod ids depending on all, latest, or a list of
+pod names.  The definition of latest pod means the latest by creation date.  In a multi-
+user environment, results might differ from what you expect.
 ### <a name="GetVersion"></a>func GetVersion
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -571,7 +577,7 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.ImageExists '{"name": "im
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
 method ImageSave(options: [ImageSaveOptions](#ImageSaveOptions)) [MoreResponse](#MoreResponse)</div>
-
+ImageSave allows you to save an image from the local image storage to a tarball
 ### <a name="ImagesPrune"></a>func ImagesPrune
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -732,6 +738,11 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.ListPods
   ]
 }
 ~~~
+### <a name="LoadImage"></a>func LoadImage
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method LoadImage(name: [string](https://godoc.org/builtin#string), inputFile: [string](https://godoc.org/builtin#string), quiet: [bool](https://godoc.org/builtin#bool), deleteFile: [bool](https://godoc.org/builtin#bool)) [MoreResponse](#MoreResponse)</div>
+LoadImage allows you to load an image into local storage from a tarball.
 ### <a name="MountContainer"></a>func MountContainer
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -768,6 +779,12 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.PausePod '{"name": "fooba
   "pod": "1840835294cf076a822e4e12ba4152411f131bd869e7f6a4e8b16df9b0ea5c7f"
 }
 ~~~
+### <a name="PodStateData"></a>func PodStateData
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method PodStateData(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+PodStateData returns inspectr level information of a given pod in string form.  This call is for
+development of Podman only and generally should not be used.
 ### <a name="PullImage"></a>func PullImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 

--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -92,8 +92,6 @@ func getContainerSubCommands() []*cobra.Command {
 func getPodSubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		_podCreateCommand,
-		_podExistsCommand,
-		_podInspectCommand,
 		_podKillCommand,
 		_podPauseCommand,
 		_podPsCommand,

--- a/cmd/podman/exists.go
+++ b/cmd/podman/exists.go
@@ -5,7 +5,6 @@ import (
 	"github.com/spf13/cobra"
 	"os"
 
-	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/adapter"
 	"github.com/containers/libpod/libpod/image"
@@ -124,14 +123,14 @@ func podExistsCmd(c *cliconfig.PodExistsValues) error {
 	if len(args) > 1 || len(args) < 1 {
 		return errors.New("you may only check for the existence of one pod at a time")
 	}
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}
 	defer runtime.Shutdown(false)
 
 	if _, err := runtime.LookupPod(args[0]); err != nil {
-		if errors.Cause(err) == libpod.ErrNoSuchPod {
+		if errors.Cause(err) == libpod.ErrNoSuchPod || err.Error() == "io.podman.PodNotFound" {
 			os.Exit(1)
 		}
 		return err

--- a/cmd/podman/pod.go
+++ b/cmd/podman/pod.go
@@ -20,6 +20,8 @@ var podCommand = cliconfig.PodmanCommand{
 
 //podSubCommands are implemented both in local and remote clients
 var podSubCommands = []*cobra.Command{
+	_podExistsCommand,
+	_podInspectCommand,
 	_podRmCommand,
 }
 

--- a/cmd/podman/pod_inspect.go
+++ b/cmd/podman/pod_inspect.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/cmd/podman/libpodruntime"
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/adapter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -37,13 +36,13 @@ func init() {
 
 func podInspectCmd(c *cliconfig.PodInspectValues) error {
 	var (
-		pod *libpod.Pod
+		pod *adapter.Pod
 	)
 	if err := checkMutuallyExclusiveFlags(&c.PodmanCommand); err != nil {
 		return err
 	}
 	args := c.InputArgs
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -1082,6 +1082,10 @@ method ContainerInspectData(name: string) -> (config: string)
 # development of Podman only and generally should not be used.
 method ContainerStateData(name: string) -> (config: string)
 
+# PodStateData returns inspectr level information of a given pod in string form.  This call is for
+# development of Podman only and generally should not be used.
+method PodStateData(name: string) -> (config: string)
+
 # Sendfile allows a remote client to send a file to the host
 method SendFile(type: string, length: int) -> (file_handle: string)
 
@@ -1100,11 +1104,15 @@ method GetVolumes(args: []string, all: bool) -> (volumes: []Volume)
 # VolumesPrune removes unused volumes on the host
 method VolumesPrune() -> (prunedNames: []string, prunedErrors: []string)
 
+# ImageSave allows you to save an image from the local image storage to a tarball
 method ImageSave(options: ImageSaveOptions) -> (reply: MoreResponse)
 
-
+# GetPodsByContext allows you to get a list pod ids depending on all, latest, or a list of
+# pod names.  The definition of latest pod means the latest by creation date.  In a multi-
+# user environment, results might differ from what you expect.
 method GetPodsByContext(all: bool, latest: bool, args: []string) -> (pods: []string)
 
+# LoadImage allows you to load an image into local storage from a tarball.
 method LoadImage(name: string, inputFile: string, quiet: bool, deleteFile: bool) -> (reply: MoreResponse)
 
 # ImageNotFound means the image could not be found by the provided name or ID in local storage.

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -19,7 +19,7 @@ case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
     ubuntu-18)
         make install PREFIX=/usr ETCDIR=/etc
         make test-binaries
-        SKIP_USERNS=1 make localintegration
+        SKIP_USERNS=1 make localintegration GINKGOTIMEOUT=90m
         ;;
     fedora-29) ;&  # Continue to the next item
     fedora-28) ;&

--- a/libpod/adapter/pods.go
+++ b/libpod/adapter/pods.go
@@ -36,3 +36,19 @@ func (r *LocalRuntime) RemovePods(ctx context.Context, cli *cliconfig.PodRmValue
 	}
 	return podids, errs
 }
+
+// GetLatestPod gets the latest pod and wraps it in an adapter pod
+func (r *LocalRuntime) GetLatestPod() (*Pod, error) {
+	pod := Pod{}
+	p, err := r.Runtime.GetLatestPod()
+	pod.Pod = p
+	return &pod, err
+}
+
+// LookupPod gets a pod by name or id and wraps it in an adapter pod
+func (r *LocalRuntime) LookupPod(nameOrID string) (*Pod, error) {
+	pod := Pod{}
+	p, err := r.Runtime.LookupPod(nameOrID)
+	pod.Pod = p
+	return &pod, err
+}

--- a/libpod/adapter/pods_remote.go
+++ b/libpod/adapter/pods_remote.go
@@ -4,10 +4,13 @@ package adapter
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
+	"github.com/pkg/errors"
+	"github.com/ulule/deepcopier"
 )
 
 // Pod ...
@@ -16,11 +19,13 @@ type Pod struct {
 }
 
 type remotepod struct {
-	config  *libpod.PodConfig
-	state   *libpod.PodInspectState
-	Runtime *LocalRuntime
+	config     *libpod.PodConfig
+	state      *libpod.PodInspectState
+	containers []libpod.PodContainerInfo
+	Runtime    *LocalRuntime
 }
 
+// RemovePods removes one or more based on the cli context.
 func (r *LocalRuntime) RemovePods(ctx context.Context, cli *cliconfig.PodRmValues) ([]string, []error) {
 	var (
 		rmErrs []error
@@ -41,4 +46,53 @@ func (r *LocalRuntime) RemovePods(ctx context.Context, cli *cliconfig.PodRmValue
 		}
 	}
 	return rmPods, rmErrs
+}
+
+// Inspect looks up a pod by name or id and embeds its data into a remote pod
+// object.
+func (r *LocalRuntime) Inspect(nameOrID string) (*Pod, error) {
+	reply, err := iopodman.PodStateData().Call(r.Conn, nameOrID)
+	if err != nil {
+		return nil, err
+	}
+	data := libpod.PodInspect{}
+	if err := json.Unmarshal([]byte(reply), &data); err != nil {
+		return nil, err
+	}
+	pod := Pod{}
+	pod.Runtime = r
+	pod.config = data.Config
+	pod.state = data.State
+	pod.containers = data.Containers
+	return &pod, nil
+}
+
+// GetLatestPod gets the latest pod and wraps it in an adapter pod
+func (r *LocalRuntime) GetLatestPod() (*Pod, error) {
+	reply, err := iopodman.GetPodsByContext().Call(r.Conn, false, true, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(reply) > 0 {
+		return r.Inspect(reply[0])
+	}
+	return nil, errors.New("no pods exist")
+}
+
+// LookupPod gets a pod by name or ID and wraps it in an adapter pod
+func (r *LocalRuntime) LookupPod(nameOrID string) (*Pod, error) {
+	return r.Inspect(nameOrID)
+}
+
+// Inspect, like libpod pod inspect, returns a libpod.PodInspect object from
+// the data of a remotepod data struct
+func (p *Pod) Inspect() (*libpod.PodInspect, error) {
+	config := new(libpod.PodConfig)
+	deepcopier.Copy(p.remotepod.config).To(config)
+	inspectData := libpod.PodInspect{
+		Config:     config,
+		State:      p.remotepod.state,
+		Containers: p.containers,
+	}
+	return &inspectData, nil
 }

--- a/pkg/varlinkapi/pods.go
+++ b/pkg/varlinkapi/pods.go
@@ -286,3 +286,20 @@ func (i *LibpodAPI) GetPodsByContext(call iopodman.VarlinkCall, all, latest bool
 	}
 	return call.ReplyGetPodsByContext(podids)
 }
+
+// PodStateData returns a container's state data in string format
+func (i *LibpodAPI) PodStateData(call iopodman.VarlinkCall, name string) error {
+	pod, err := i.Runtime.LookupPod(name)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	data, err := pod.Inspect()
+	if err != nil {
+		return call.ReplyErrorOccurred("unable to obtain pod state")
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return call.ReplyErrorOccurred("unable to serialize pod inspect data")
+	}
+	return call.ReplyPodStateData(string(b))
+}


### PR DESCRIPTION
enable the remote client to be able to inspect a pod.  also, bonus of
enabling the podman pod exists command which returns a 0 or 1 depending
on whether the given pod exists.

Signed-off-by: baude <bbaude@redhat.com>