### PR TITLE
podman: --runtime has higher priority on runtime_path

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -149,6 +149,7 @@ func WithOCIRuntime(runtime string) RuntimeOption {
 		}
 
 		rt.config.OCIRuntime = runtime
+		rt.config.RuntimePath = nil
 
 		return nil
 	}


### PR DESCRIPTION
if --runtime is specified, then it has higher priority on the
runtime_path option, which was added for backward compatibility.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>