### PR TITLE
make remote-client error messaging more robust

### DIFF
--- a/API.md
+++ b/API.md
@@ -225,6 +225,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [error RuntimeError](#RuntimeError)
 
+[error VolumeNotFound](#VolumeNotFound)
+
 ## Methods
 ### <a name="BuildImage"></a>func BuildImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
@@ -1724,3 +1726,6 @@ PodNotFound means the pod could not be found by the provided name or ID in local
 ### <a name="RuntimeError"></a>type RuntimeError
 
 RuntimeErrors generally means a runtime could not be found or gotten.
+### <a name="VolumeNotFound"></a>type VolumeNotFound
+
+VolumeNotFound means the volume could not be found by the name or ID in local storage.

--- a/cmd/podman/errors.go
+++ b/cmd/podman/errors.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/containers/libpod/cmd/podman/varlink"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func outputError(err error) {
+	if MainGlobalOpts.LogLevel == "debug" {
+		logrus.Errorf(err.Error())
+	} else {
+		if ee, ok := err.(*exec.ExitError); ok {
+			if status, ok := ee.Sys().(syscall.WaitStatus); ok {
+				exitCode = status.ExitStatus()
+			}
+		}
+		var ne error
+		switch e := err.(type) {
+		// For some reason golang wont let me list them with commas so listing them all.
+		case *iopodman.ImageNotFound:
+			ne = errors.New(e.Reason)
+		case *iopodman.ContainerNotFound:
+			ne = errors.New(e.Reason)
+		case *iopodman.PodNotFound:
+			ne = errors.New(e.Reason)
+		case *iopodman.VolumeNotFound:
+			ne = errors.New(e.Reason)
+		case *iopodman.ErrorOccurred:
+			ne = errors.New(e.Reason)
+		default:
+			ne = err
+		}
+		fmt.Fprintln(os.Stderr, "Error:", ne.Error())
+	}
+}

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log/syslog"
 	"os"
-	"os/exec"
 	"runtime/pprof"
 	"strings"
 	"syscall"
@@ -18,7 +16,7 @@ import (
 	"github.com/containers/libpod/pkg/tracing"
 	"github.com/containers/libpod/version"
 	"github.com/containers/storage/pkg/reexec"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	lsyslog "github.com/sirupsen/logrus/hooks/syslog"
@@ -223,16 +221,7 @@ func main() {
 		return
 	}
 	if err := rootCmd.Execute(); err != nil {
-		if MainGlobalOpts.LogLevel == "debug" {
-			logrus.Errorf(err.Error())
-		} else {
-			if ee, ok := err.(*exec.ExitError); ok {
-				if status, ok := ee.Sys().(syscall.WaitStatus); ok {
-					exitCode = status.ExitStatus()
-				}
-			}
-			fmt.Fprintln(os.Stderr, "Error:", err.Error())
-		}
+		outputError(err)
 	} else {
 		// The exitCode modified from 125, indicates an application
 		// running inside of a container failed, as opposed to the

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -1108,16 +1108,19 @@ method GetPodsByContext(all: bool, latest: bool, args: []string) -> (pods: []str
 method LoadImage(name: string, inputFile: string, quiet: bool, deleteFile: bool) -> (reply: MoreResponse)
 
 # ImageNotFound means the image could not be found by the provided name or ID in local storage.
-error ImageNotFound (id: string)
+error ImageNotFound (id: string, reason: string)
 
 # ContainerNotFound means the container could not be found by the provided name or ID in local storage.
-error ContainerNotFound (id: string)
+error ContainerNotFound (id: string, reason: string)
 
 # NoContainerRunning means none of the containers requested are running in a command that requires a running container.
 error NoContainerRunning ()
 
 # PodNotFound means the pod could not be found by the provided name or ID in local storage.
-error PodNotFound (name: string)
+error PodNotFound (name: string, reason: string)
+
+# VolumeNotFound means the volume could not be found by the name or ID in local storage.
+error VolumeNotFound (id: string, reason: string)
 
 # PodContainerError means a container associated with a pod failed to preform an operation. It contains
 # a container ID of the container that failed.

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -47,7 +47,7 @@ func (i *LibpodAPI) ListContainers(call iopodman.VarlinkCall) error {
 func (i *LibpodAPI) GetContainer(call iopodman.VarlinkCall, id string) error {
 	ctr, err := i.Runtime.LookupContainer(id)
 	if err != nil {
-		return call.ReplyContainerNotFound(id)
+		return call.ReplyContainerNotFound(id, err.Error())
 	}
 	opts := shared.PsOptions{
 		Namespace: true,
@@ -64,7 +64,7 @@ func (i *LibpodAPI) GetContainer(call iopodman.VarlinkCall, id string) error {
 func (i *LibpodAPI) InspectContainer(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	inspectInfo, err := ctr.Inspect(true)
 	if err != nil {
@@ -90,7 +90,7 @@ func (i *LibpodAPI) InspectContainer(call iopodman.VarlinkCall, name string) err
 func (i *LibpodAPI) ListContainerProcesses(call iopodman.VarlinkCall, name string, opts []string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	containerState, err := ctr.State()
 	if err != nil {
@@ -118,7 +118,7 @@ func (i *LibpodAPI) GetContainerLogs(call iopodman.VarlinkCall, name string) err
 	var logs []string
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	logPath := ctr.LogPath()
 
@@ -198,7 +198,7 @@ func (i *LibpodAPI) ListContainerChanges(call iopodman.VarlinkCall, name string)
 func (i *LibpodAPI) ExportContainer(call iopodman.VarlinkCall, name, outPath string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	outputFile, err := ioutil.TempFile("", "varlink_recv")
 	if err != nil {
@@ -220,7 +220,7 @@ func (i *LibpodAPI) ExportContainer(call iopodman.VarlinkCall, name, outPath str
 func (i *LibpodAPI) GetContainerStats(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	containerStats, err := ctr.GetContainerStats(&libpod.ContainerStats{})
 	if err != nil {
@@ -251,7 +251,7 @@ func (i *LibpodAPI) GetContainerStats(call iopodman.VarlinkCall, name string) er
 func (i *LibpodAPI) StartContainer(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	state, err := ctr.State()
 	if err != nil {
@@ -270,7 +270,7 @@ func (i *LibpodAPI) StartContainer(call iopodman.VarlinkCall, name string) error
 func (i *LibpodAPI) StopContainer(call iopodman.VarlinkCall, name string, timeout int64) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	if err := ctr.StopWithTimeout(uint(timeout)); err != nil && err != libpod.ErrCtrStopped {
 		return call.ReplyErrorOccurred(err.Error())
@@ -282,7 +282,7 @@ func (i *LibpodAPI) StopContainer(call iopodman.VarlinkCall, name string, timeou
 func (i *LibpodAPI) RestartContainer(call iopodman.VarlinkCall, name string, timeout int64) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	if err := ctr.RestartWithTimeout(getContext(), uint(timeout)); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -311,7 +311,7 @@ func (i *LibpodAPI) KillContainer(call iopodman.VarlinkCall, name string, signal
 	}
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	if err := ctr.Kill(killSignal); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -323,7 +323,7 @@ func (i *LibpodAPI) KillContainer(call iopodman.VarlinkCall, name string, signal
 func (i *LibpodAPI) PauseContainer(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	if err := ctr.Pause(); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -335,7 +335,7 @@ func (i *LibpodAPI) PauseContainer(call iopodman.VarlinkCall, name string) error
 func (i *LibpodAPI) UnpauseContainer(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	if err := ctr.Unpause(); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -347,7 +347,7 @@ func (i *LibpodAPI) UnpauseContainer(call iopodman.VarlinkCall, name string) err
 func (i *LibpodAPI) WaitContainer(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	exitCode, err := ctr.Wait()
 	if err != nil {
@@ -362,7 +362,7 @@ func (i *LibpodAPI) RemoveContainer(call iopodman.VarlinkCall, name string, forc
 	ctx := getContext()
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	if err := i.Runtime.RemoveContainer(ctx, ctr, force, removeVolumes); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -398,7 +398,7 @@ func (i *LibpodAPI) DeleteStoppedContainers(call iopodman.VarlinkCall) error {
 func (i *LibpodAPI) GetAttachSockets(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 
 	status, err := ctr.State()
@@ -427,7 +427,7 @@ func (i *LibpodAPI) ContainerCheckpoint(call iopodman.VarlinkCall, name string, 
 	ctx := getContext()
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 
 	options := libpod.ContainerCheckpointOptions{
@@ -446,7 +446,7 @@ func (i *LibpodAPI) ContainerRestore(call iopodman.VarlinkCall, name string, kee
 	ctx := getContext()
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyContainerNotFound(name)
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 
 	options := libpod.ContainerCheckpointOptions{
@@ -475,7 +475,7 @@ func getArtifact(ctr *libpod.Container) (*cc.CreateConfig, error) {
 func (i *LibpodAPI) ContainerConfig(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyErrorOccurred(err.Error())
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	config := ctr.Config()
 	b, err := json.Marshal(config)
@@ -489,7 +489,7 @@ func (i *LibpodAPI) ContainerConfig(call iopodman.VarlinkCall, name string) erro
 func (i *LibpodAPI) ContainerArtifacts(call iopodman.VarlinkCall, name, artifactName string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyErrorOccurred(err.Error())
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	artifacts, err := ctr.GetArtifact(artifactName)
 	if err != nil {
@@ -506,7 +506,7 @@ func (i *LibpodAPI) ContainerArtifacts(call iopodman.VarlinkCall, name, artifact
 func (i *LibpodAPI) ContainerInspectData(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyErrorOccurred(err.Error())
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	data, err := ctr.Inspect(true)
 	if err != nil {
@@ -524,7 +524,7 @@ func (i *LibpodAPI) ContainerInspectData(call iopodman.VarlinkCall, name string)
 func (i *LibpodAPI) ContainerStateData(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
-		return call.ReplyErrorOccurred(err.Error())
+		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	data, err := ctr.ContainerState()
 	if err != nil {

--- a/pkg/varlinkapi/pods.go
+++ b/pkg/varlinkapi/pods.go
@@ -90,7 +90,7 @@ func (i *LibpodAPI) ListPods(call iopodman.VarlinkCall) error {
 func (i *LibpodAPI) GetPod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
-		return call.ReplyPodNotFound(name)
+		return call.ReplyPodNotFound(name, err.Error())
 	}
 	opts := shared.PsOptions{}
 
@@ -106,7 +106,7 @@ func (i *LibpodAPI) GetPod(call iopodman.VarlinkCall, name string) error {
 func (i *LibpodAPI) InspectPod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
-		return call.ReplyPodNotFound(name)
+		return call.ReplyPodNotFound(name, err.Error())
 	}
 	inspectData, err := pod.Inspect()
 	if err != nil {
@@ -123,7 +123,7 @@ func (i *LibpodAPI) InspectPod(call iopodman.VarlinkCall, name string) error {
 func (i *LibpodAPI) StartPod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
-		return call.ReplyPodNotFound(name)
+		return call.ReplyPodNotFound(name, err.Error())
 	}
 	ctnrs, err := pod.AllContainers()
 	if err != nil {
@@ -144,7 +144,7 @@ func (i *LibpodAPI) StartPod(call iopodman.VarlinkCall, name string) error {
 func (i *LibpodAPI) StopPod(call iopodman.VarlinkCall, name string, timeout int64) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
-		return call.ReplyPodNotFound(name)
+		return call.ReplyPodNotFound(name, err.Error())
 	}
 	ctrErrs, err := pod.StopWithTimeout(getContext(), true, int(timeout))
 	callErr := handlePodCall(call, pod, ctrErrs, err)
@@ -158,7 +158,7 @@ func (i *LibpodAPI) StopPod(call iopodman.VarlinkCall, name string, timeout int6
 func (i *LibpodAPI) RestartPod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
-		return call.ReplyPodNotFound(name)
+		return call.ReplyPodNotFound(name, err.Error())
 	}
 	ctnrs, err := pod.AllContainers()
 	if err != nil {
@@ -185,7 +185,7 @@ func (i *LibpodAPI) KillPod(call iopodman.VarlinkCall, name string, signal int64
 
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
-		return call.ReplyPodNotFound(name)
+		return call.ReplyPodNotFound(name, err.Error())
 	}
 	ctrErrs, err := pod.Kill(killSignal)
 	callErr := handlePodCall(call, pod, ctrErrs, err)
@@ -199,7 +199,7 @@ func (i *LibpodAPI) KillPod(call iopodman.VarlinkCall, name string, signal int64
 func (i *LibpodAPI) PausePod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
-		return call.ReplyPodNotFound(name)
+		return call.ReplyPodNotFound(name, err.Error())
 	}
 	ctrErrs, err := pod.Pause()
 	callErr := handlePodCall(call, pod, ctrErrs, err)
@@ -213,7 +213,7 @@ func (i *LibpodAPI) PausePod(call iopodman.VarlinkCall, name string) error {
 func (i *LibpodAPI) UnpausePod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
-		return call.ReplyPodNotFound(name)
+		return call.ReplyPodNotFound(name, err.Error())
 	}
 	ctrErrs, err := pod.Unpause()
 	callErr := handlePodCall(call, pod, ctrErrs, err)
@@ -228,7 +228,7 @@ func (i *LibpodAPI) RemovePod(call iopodman.VarlinkCall, name string, force bool
 	ctx := getContext()
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
-		return call.ReplyPodNotFound(name)
+		return call.ReplyPodNotFound(name, err.Error())
 	}
 	if err = i.Runtime.RemovePod(ctx, pod, force, force); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -241,7 +241,7 @@ func (i *LibpodAPI) RemovePod(call iopodman.VarlinkCall, name string, force bool
 func (i *LibpodAPI) GetPodStats(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
-		return call.ReplyPodNotFound(name)
+		return call.ReplyPodNotFound(name, err.Error())
 	}
 	prevStats := make(map[string]*libpod.ContainerStats)
 	podStats, err := pod.GetPodStats(prevStats)


### PR DESCRIPTION
the remote-client is currently weak for carrying error messages
over the varlink interface and displaying something useful to users
and developers for the purposes of debug.  this is a starting point
to improve that user experience.

Signed-off-by: baude <bbaude@redhat.com>