### PR TITLE
Exit with errors not just logging error

### DIFF
--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -74,19 +74,16 @@ func pullCmd(c *cliconfig.PullValues) error {
 
 	args := c.InputArgs
 	if len(args) == 0 {
-		logrus.Errorf("an image name must be specified")
-		return nil
+		return errors.Errorf("an image name must be specified")
 	}
 	if len(args) > 1 {
-		logrus.Errorf("too many arguments. Requires exactly 1")
-		return nil
+		return errors.Errorf("too many arguments. Requires exactly 1")
 	}
 
 	arr := strings.SplitN(args[0], ":", 2)
 	if len(arr) == 2 {
 		if c.Bool("all-tags") {
-			logrus.Errorf("tag can't be used with --all-tags")
-			return nil
+			return errors.Errorf("tag can't be used with --all-tags")
 		}
 	}
 	ctx := getContext()

--- a/cmd/podman/runlabel.go
+++ b/cmd/podman/runlabel.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/utils"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -87,8 +86,7 @@ func runlabelCmd(c *cliconfig.RunlabelValues) error {
 
 	args := c.InputArgs
 	if len(args) < 2 {
-		logrus.Errorf("the runlabel command requires at least 2 arguments: LABEL IMAGE")
-		return nil
+		return errors.Errorf("the runlabel command requires at least 2 arguments: LABEL IMAGE")
 	}
 	if c.Display && c.Quiet {
 		return errors.Errorf("the display and quiet flags cannot be used together.")


### PR DESCRIPTION
Several commands were logging errors but exiting with a 0
exit code.  This patch cleans these up.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>