### PR TITLE
cmd: support rootless mode for cp command

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -61,6 +61,7 @@ var cmdsNotRequiringRootless = map[*cobra.Command]bool{
 	_versionCommand: true,
 	_createCommand:  true,
 	_execCommand:    true,
+	_cpCommand:      true,
 	_exportCommand:  true,
 	//// `info` must be executed in an user namespace.
 	//// If this change, please also update libpod.refreshRootless()


### PR DESCRIPTION
I'll add tests once https://github.com/containers/libpod/pull/2393 lands as it includes few changes to the rootless tests

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>