### PR TITLE
Cirrus: Install Go 1.11 on Ubuntu VMs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,7 @@ env:
     ###
     FEDORA_CACHE_IMAGE_NAME: "fedora-29-libpod-7f4cd1f7"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-28-libpod-7f4cd1f7"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-18-libpod-7f4cd1f7"
+    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-18-libpod-84514d8b"
     # RHEL_CACHE_IMAGE_NAME: "rhel-8-notready"
     PRIOR_RHEL_CACHE_IMAGE_NAME: "rhel-7-libpod-7f4cd1f7"
     # CENTOS_CACHE_IMAGE_NAME: "centos-7-notready"

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -19,7 +19,7 @@ case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
     ubuntu-18)
         make install PREFIX=/usr ETCDIR=/etc
         make test-binaries
-        SKIP_USERNS=1 make localintegration
+        SKIP_USERNS=1 make localintegration GINKGOTIMEOUT=90m
         ;;
     fedora-29) ;&  # Continue to the next item
     fedora-28) ;&

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -325,7 +325,7 @@ install_packer_copied_files(){
                            /etc/containers/registries.d/registry.access.redhat.com.yaml
 }
 
-install_varlink(){
+install_varlink() {
     echo "Installing varlink from the cheese-factory"
     ooe.sh sudo -H pip3 install varlink
 }

--- a/contrib/cirrus/packer/ubuntu_setup.sh
+++ b/contrib/cirrus/packer/ubuntu_setup.sh
@@ -28,7 +28,13 @@ export DEBIAN_FRONTEND=noninteractive
 echo "Updating system and installing package dependencies"
 ooe.sh sudo -E apt-get -qq update || sudo -E apt-get -qq update
 ooe.sh sudo -E apt-get -qq upgrade || sudo -E apt-get -qq upgrade
-ooe.sh sudo -E apt-get -qq install --no-install-recommends \
+ooe.sh sudo -E apt-get -qq install software-properties-common
+
+# Required to have Go 1.11 on Ubuntu 18.0.4
+ooe.sh sudo -E add-apt-repository --yes ppa:longsleep/golang-backports
+ooe.sh sudo -E apt-get -qq update || sudo -E apt-get -qq update
+
+ooe.sh sudo -E apt-get -qq install \
     apparmor \
     autoconf \
     automake \

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -79,8 +79,9 @@ then
     cd "${GOSRC}/"
     source "$SCRIPT_BASE/lib.sh"
 
-    # Only testing-VMs need deps installed
-    [[ -n "$PACKER_BUILDS" ]] || install_testing_dependencies  # must exist in $GOPATH
+    # Only testing-VMs need deps installed, not image-builder VM
+    echo "$CIRRUS_TASK_NAME" | grep -q 'image' || \
+       install_testing_dependencies  # must exist in $GOPATH
 fi
 
 record_timestamp "env. setup end"


### PR DESCRIPTION
There is no native package for this, so the packaged version must also
be installed, otherwise all the support/dependencies would be removed
also (like go-md2man).  Fix this by installing from the google released
tarball, into /usr/local/go and set $GOROOT to point there.

Also, include a small fix for hack/get_ci_vm.sh not installing
testing dependencies because of an old assumption.

Signed-off-by: Chris Evich <cevich@redhat.com>