### PR TITLE
Enable specifying directory as device on container with --device

### DIFF
--- a/pkg/spec/config_linux.go
+++ b/pkg/spec/config_linux.go
@@ -46,19 +46,32 @@ func devicesFromPath(g *generate.Generator, devicePath string) error {
 		return errors.Wrapf(err, "cannot stat %s", devicePath)
 	}
 	if st.IsDir() {
-		if len(devs) > 2 {
-			return errors.Wrapf(unix.EINVAL, "not allowed to specify destination with a directory %s", devicePath)
-		}
 		found := false
+		src := resolvedDevicePath
+		dest := src
+		var devmode string
+		if len(devs) > 1 {
+			if len(devs[1]) > 0 && devs[1][0] == '/' {
+				dest = devs[1]
+			} else {
+				devmode = devs[1]
+			}
+		}
+		if len(devs) > 2 {
+			if devmode != "" {
+				return errors.Wrapf(unix.EINVAL, "invalid device specification %s", devicePath)
+			}
+			devmode = devs[2]
+		}
+
 		// mount the internal devices recursively
 		if err := filepath.Walk(resolvedDevicePath, func(dpath string, f os.FileInfo, e error) error {
 
 			if f.Mode()&os.ModeDevice == os.ModeDevice {
 				found = true
-				device := dpath
-
-				if len(devs) > 1 {
-					device = fmt.Sprintf("%s:%s", dpath, devs[1])
+				device := fmt.Sprintf("%s:%s", dpath, filepath.Join(dest, strings.TrimPrefix(dpath, src)))
+				if devmode != "" {
+					device = fmt.Sprintf("%s:%s", device, devmode)
 				}
 				if err := addDevice(g, device); err != nil {
 					return errors.Wrapf(err, "failed to add %s device", dpath)

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -72,4 +72,12 @@ var _ = Describe("Podman run device", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
+
+	It("podman run device host device and container device parameter are directories", func() {
+		SystemExec("mkdir", []string{"/dev/foodevdir"})
+		SystemExec("mknod", []string{"/dev/foodevdir/null", "c", "1", "3"})
+		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/foodevdir:/dev/bar", ALPINE, "ls", "/dev/bar/null"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
If device on host is specified a directory, enable user to specify the directory on container. 
`$ sudo podman run --device /dev/snd:/dev/snd:rmw localhost/qi`
fix #2380 
Signed-off-by: Qi Wang <qiwan@redhat.com>