### PR TITLE
WIP Support nfs local volume mounts

### DIFF
--- a/cmd/podman/volume_create.go
+++ b/cmd/podman/volume_create.go
@@ -25,8 +25,8 @@ var (
 			return volumeCreateCmd(&volumeCreateCommand)
 		},
 		Example: `podman volume create myvol
-  podman volume create
-  podman volume create --label foo=bar myvol`,
+  podman volume create --label foo=bar
+  podman volume create --opt type=nfs --opt o=addr=192.168.0.2,rw --opt device=:/nfsshare  mynfsvol`,
 	}
 )
 

--- a/docs/podman-volume-create.1.md
+++ b/docs/podman-volume-create.1.md
@@ -29,7 +29,13 @@ Set metadata for a volume (e.g., --label mykey=value).
 
 **-o**, **--opt**=[]
 
-Set driver specific options.
+Set driver specific options. To setup NFS volume you need to specify:
+
+    type: `-o type=nfs` To indicate the nfs mount.
+
+    o: `-o o=addr=nfsserver.example.com,rw` Options including the address of the nfs server.
+
+    device: `-o device=/nfsshare`, the remote nfs share.
 
 ## EXAMPLES
 
@@ -39,6 +45,8 @@ $ podman volume create myvol
 $ podman volume create
 
 $ podman volume create --label foo=bar myvol
+
+# podman volume create --opt type=nfs --opt o=addr=192.168.0.2,rw --opt device=/nfsshare  mynfsvol
 ```
 
 ## SEE ALSO

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -191,6 +191,13 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 			return nil, errors.Wrapf(err, "error creating named volume %q", vol.Name)
 		}
 
+		options := newVol.Options()
+		if len(options) > 0 {
+			if err := newVol.Mount(); err != nil {
+				return nil, err
+			}
+		}
+
 		if err := ctr.copyWithTarFromImage(vol.Dest, newVol.MountPoint()); err != nil && !os.IsNotExist(err) {
 			return nil, errors.Wrapf(err, "Failed to copy content into new volume mount %q", vol.Name)
 		}

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -18,5 +18,6 @@ func newVolume(runtime *Runtime) (*Volume, error) {
 
 // teardownStorage deletes the volume from volumePath
 func (v *Volume) teardownStorage() error {
+	v.Unmount()
 	return os.RemoveAll(filepath.Join(v.runtime.config.VolumePath, v.Name()))
 }


### PR DESCRIPTION
Allow users to create volumes with nfs shares.

These volumes will get mounted when the first container gets started
and then will remain mounted until the system reboots or the volume is
removed.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>