### PR TITLE
Allow dns settings with --net=host

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -646,11 +646,6 @@ func parseCreateOpts(ctx context.Context, c *cliconfig.PodmanCommand, runtime *l
 	if util.StringInSlice(".", c.StringSlice("dns-search")) && len(c.StringSlice("dns-search")) > 1 {
 		return nil, errors.Errorf("cannot pass additional search domains when also specifying '.'")
 	}
-	if !netMode.IsPrivate() {
-		if c.IsSet("dns-search") || c.IsSet("dns") || c.IsSet("dns-opt") {
-			return nil, errors.Errorf("specifying DNS flags when network mode is shared with the host or another container is not allowed")
-		}
-	}
 
 	// Validate domains are good
 	for _, dom := range c.StringSlice("dns-search") {


### PR DESCRIPTION
This seems to be a needless restriction.  We make a copy of the
hosts /etc/resolv.conf file, so these changes to not modify the
host.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>