### PR TITLE
Change exit code to 1 on podman rmi nosuch image

### DIFF
--- a/cmd/podman/errors.go
+++ b/cmd/podman/errors.go
@@ -6,8 +6,6 @@ import (
 	"os/exec"
 	"syscall"
 
-	"github.com/containers/libpod/cmd/podman/varlink"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -20,22 +18,6 @@ func outputError(err error) {
 				exitCode = status.ExitStatus()
 			}
 		}
-		var ne error
-		switch e := err.(type) {
-		// For some reason golang wont let me list them with commas so listing them all.
-		case *iopodman.ImageNotFound:
-			ne = errors.New(e.Reason)
-		case *iopodman.ContainerNotFound:
-			ne = errors.New(e.Reason)
-		case *iopodman.PodNotFound:
-			ne = errors.New(e.Reason)
-		case *iopodman.VolumeNotFound:
-			ne = errors.New(e.Reason)
-		case *iopodman.ErrorOccurred:
-			ne = errors.New(e.Reason)
-		default:
-			ne = err
-		}
-		fmt.Fprintln(os.Stderr, "Error:", ne.Error())
+		fmt.Fprintln(os.Stderr, "Error:", err.Error())
 	}
 }

--- a/docs/podman-container-cleanup.1.md
+++ b/docs/podman-container-cleanup.1.md
@@ -30,7 +30,7 @@ The latest option is not supported on the remote client.
 
 `podman container cleanup 860a4b23`
 
-`podman container-cleanup -a`
+`podman container cleanup -a`
 
 `podman container cleanup --latest`
 

--- a/docs/podman-rmi.1.md
+++ b/docs/podman-rmi.1.md
@@ -1,9 +1,11 @@
-% podman-rmi(1)
+% podman-image-rm(1)
 
 ## NAME
-podman\-rmi - Removes one or more images
+podman\-image\-rm (podman\-rmi) - Removes one or more images
 
 ## SYNOPSIS
+**podman image rm** *image* ...
+
 **podman rmi** *image* ...
 
 ## DESCRIPTION
@@ -38,6 +40,10 @@ Remove all images and containers.
 ```
 podman rmi -a -f
 ```
+## Exit Status
+**_0_** if all specified images removed
+**_1_** if one of the specified images did not exist, and no other failures
+**_125_** if command fails for a reason other then an image did not exist
 
 ## SEE ALSO
 podman(1)

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Podman rmi", func() {
 	It("podman rmi bogus image", func() {
 		session := podmanTest.Podman([]string{"rmi", "debian:6.0.10"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session.ExitCode()).To(Equal(1))
 
 	})
 


### PR DESCRIPTION
Make it easy for scripts to determine if an image removal
failure.   If only errors were no such image exit with 1
versus 125.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>