### PR TITLE
Change exit code to 1 on podman rm nosuch container

### DIFF
--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -1,9 +1,11 @@
-% podman-rm(1)
+% podman-container-rm(1)
 
 ## NAME
-podman\-rm - Remove one or more containers
+podman\-container\-rm (podman\-rm) - Remove one or more containers
 
 ## SYNOPSIS
+**podman container rm** [*options*] *container*
+
 **podman rm** [*options*] *container*
 
 ## DESCRIPTION
@@ -57,8 +59,13 @@ Forcibly remove the latest container created.
 podman rm -f --latest
 ```
 
+## Exit Status
+**_0_** if all specified containers removed
+**_1_** if one of the specified containers did not exist, and no other failures
+**_125_** if command fails for a reason other then an container did not exist
+
 ## SEE ALSO
-podman(1), podman-rmi(1)
+podman(1), podman-image-rm(1)
 
 ## HISTORY
 August 2017, Originally compiled by Ryan Cole <rycole@redhat.com>

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -128,4 +128,9 @@ var _ = Describe("Podman rm", func() {
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 
 	})
+	It("podman rm bogus container", func() {
+		session := podmanTest.Podman([]string{"rm", "bogus"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(1))
+	})
 })


### PR DESCRIPTION
Make it easy for scripts to determine if a container removal
fails versus the container did not exist.

If only errors were no such container exit with 1 versus 125.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>