### PR TITLE
exec: support --preserve-fds

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -100,6 +100,7 @@ type ExecValues struct {
 	User         string
 	Latest       bool
 	Workdir      string
+	PreserveFDs  int
 }
 
 type ImageExistsValues struct {

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -869,7 +869,7 @@ func joinOrCreateRootlessUserNamespace(createConfig *cc.CreateConfig, runtime *l
 				}
 				return false, -1, errors.Errorf("dependency container %s is not running", ctr.ID())
 			}
-			return rootless.JoinNS(uint(pid))
+			return rootless.JoinNS(uint(pid), 0)
 		}
 	}
 	return rootless.BecomeRootInUserNS()

--- a/cmd/podman/top.go
+++ b/cmd/podman/top.go
@@ -108,7 +108,7 @@ func topCmd(c *cliconfig.TopValues) error {
 	if err != nil {
 		return err
 	}
-	became, ret, err := rootless.JoinNS(uint(pid))
+	became, ret, err := rootless.JoinNS(uint(pid), 0)
 	if err != nil {
 		return err
 	}

--- a/docs/podman-exec.1.md
+++ b/docs/podman-exec.1.md
@@ -26,6 +26,10 @@ to run containers such as CRI-O, the last started  container could be from eithe
 
 The latest option is not supported on the remote client.
 
+**--preserve-fds=N**
+
+Pass down to the process N additional file descriptors (in addition to 0, 1, 2).  The total FDs will be 3+N.
+
 **--privileged**
 
 Give the process extended Linux capabilities when running the command in container.

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -204,7 +204,7 @@ func (c *Container) Kill(signal uint) error {
 
 // Exec starts a new process inside the container
 // TODO investigate allowing exec without attaching
-func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir string, streams *AttachStreams) error {
+func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir string, streams *AttachStreams, preserveFDs int) error {
 	var capList []string
 
 	locked := false
@@ -266,7 +266,7 @@ func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir 
 
 	logrus.Debugf("Creating new exec session in container %s with session id %s", c.ID(), sessionID)
 
-	execCmd, err := c.runtime.ociRuntime.execContainer(c, cmd, capList, env, tty, workDir, hostUser, sessionID, streams)
+	execCmd, err := c.runtime.ociRuntime.execContainer(c, cmd, capList, env, tty, workDir, hostUser, sessionID, streams, preserveFDs)
 	if err != nil {
 		return errors.Wrapf(err, "error exec %s", c.ID())
 	}


### PR DESCRIPTION
Allow to pass additional FDs to the process being executed.

Closes: https://github.com/containers/libpod/issues/2372

Depends on: https://github.com/opencontainers/runc/pull/1995

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>