### PR TITLE
remove duplicate commands in main

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -17,7 +17,6 @@ func getMainCommands() []*cobra.Command {
 		_diffCommand,
 		_execCommand,
 		_generateCommand,
-		_containerKubeCommand,
 		_playCommand,
 		_psCommand,
 		_loginCommand,
@@ -39,7 +38,6 @@ func getMainCommands() []*cobra.Command {
 		_topCommand,
 		_umountCommand,
 		_unpauseCommand,
-		volumeCommand.Command,
 		_waitCommand,
 	}
 

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -52,8 +52,6 @@ func init() {
 	flags.BoolVarP(&playKubeCommand.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
 	flags.StringVar(&playKubeCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
 	flags.BoolVar(&playKubeCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
-
-	rootCmd.AddCommand(playKubeCommand.Command)
 }
 
 func playKubeYAMLCmd(c *cliconfig.KubePlayValues) error {


### PR DESCRIPTION
kube was erronously being added as main subcommand multiple
times. it should not be a subcommand as it should live under
either play or generate.

also removing the addition of the volume command from the commands.go
to eliminate a duplicate.

Signed-off-by: baude <bbaude@redhat.com>