### PR TITLE
podman-remote pod pause|unpause|restart

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -92,11 +92,8 @@ func getContainerSubCommands() []*cobra.Command {
 // Commands that the local client implements
 func getPodSubCommands() []*cobra.Command {
 	return []*cobra.Command{
-		_podPauseCommand,
-		_podRestartCommand,
 		_podStatsCommand,
 		_podTopCommand,
-		_podUnpauseCommand,
 	}
 }
 

--- a/cmd/podman/pod.go
+++ b/cmd/podman/pod.go
@@ -24,10 +24,13 @@ var podSubCommands = []*cobra.Command{
 	_podExistsCommand,
 	_podInspectCommand,
 	_podKillCommand,
+	_podPauseCommand,
 	_podPsCommand,
+	_podRestartCommand,
 	_podRmCommand,
 	_podStartCommand,
 	_podStopCommand,
+	_podUnpauseCommand,
 }
 
 func init() {

--- a/cmd/podman/pod_pause.go
+++ b/cmd/podman/pod_pause.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/cmd/podman/libpodruntime"
+	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -40,37 +40,33 @@ func init() {
 }
 
 func podPauseCmd(c *cliconfig.PodPauseValues) error {
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	var lastError error
+	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}
 	defer runtime.Shutdown(false)
 
-	// getPodsFromContext returns an error when a requested pod
-	// isn't found. The only fatal error scenerio is when there are no pods
-	// in which case the following loop will be skipped.
-	pods, lastError := getPodsFromContext(&c.PodmanCommand, runtime)
+	pauseIDs, conErrors, pauseErrors := runtime.PausePods(c)
 
-	for _, pod := range pods {
-		ctr_errs, err := pod.Pause()
-		if ctr_errs != nil {
-			for ctr, err := range ctr_errs {
-				if lastError != nil {
-					logrus.Errorf("%q", lastError)
-				}
-				lastError = errors.Wrapf(err, "unable to pause container %q on pod %q", ctr, pod.ID())
-			}
-			continue
-		}
-		if err != nil {
+	for _, p := range pauseIDs {
+		fmt.Println(p)
+	}
+	if conErrors != nil && len(conErrors) > 0 {
+		for ctr, err := range conErrors {
 			if lastError != nil {
 				logrus.Errorf("%q", lastError)
 			}
-			lastError = errors.Wrapf(err, "unable to pause pod %q", pod.ID())
-			continue
+			lastError = errors.Wrapf(err, "unable to pause container %s", ctr)
 		}
-		fmt.Println(pod.ID())
 	}
-
+	if len(pauseErrors) > 0 {
+		lastError = pauseErrors[len(pauseErrors)-1]
+		// Remove the last error from the error slice
+		pauseErrors = pauseErrors[:len(pauseErrors)-1]
+	}
+	for _, err := range pauseErrors {
+		logrus.Errorf("%q", err)
+	}
 	return lastError
 }

--- a/cmd/podman/pod_restart.go
+++ b/cmd/podman/pod_restart.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/cmd/podman/libpodruntime"
+	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -42,37 +42,33 @@ func init() {
 }
 
 func podRestartCmd(c *cliconfig.PodRestartValues) error {
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	var lastError error
+	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}
 	defer runtime.Shutdown(false)
 
-	// getPodsFromContext returns an error when a requested pod
-	// isn't found. The only fatal error scenerio is when there are no pods
-	// in which case the following loop will be skipped.
-	pods, lastError := getPodsFromContext(&c.PodmanCommand, runtime)
+	restartIDs, conErrors, restartErrors := runtime.RestartPods(getContext(), c)
 
-	ctx := getContext()
-	for _, pod := range pods {
-		ctr_errs, err := pod.Restart(ctx)
-		if ctr_errs != nil {
-			for ctr, err := range ctr_errs {
-				if lastError != nil {
-					logrus.Errorf("%q", lastError)
-				}
-				lastError = errors.Wrapf(err, "unable to restart container %q on pod %q", ctr, pod.ID())
-			}
-			continue
-		}
-		if err != nil {
+	for _, p := range restartIDs {
+		fmt.Println(p)
+	}
+	if conErrors != nil && len(conErrors) > 0 {
+		for ctr, err := range conErrors {
 			if lastError != nil {
 				logrus.Errorf("%q", lastError)
 			}
-			lastError = errors.Wrapf(err, "unable to restart pod %q", pod.ID())
-			continue
+			lastError = errors.Wrapf(err, "unable to pause container %s", ctr)
 		}
-		fmt.Println(pod.ID())
+	}
+	if len(restartErrors) > 0 {
+		lastError = restartErrors[len(restartErrors)-1]
+		// Remove the last error from the error slice
+		restartErrors = restartErrors[:len(restartErrors)-1]
+	}
+	for _, err := range restartErrors {
+		logrus.Errorf("%q", err)
 	}
 	return lastError
 }

--- a/pkg/adapter/pods.go
+++ b/pkg/adapter/pods.go
@@ -224,3 +224,100 @@ func (p *Pod) GetPodStatus() (string, error) {
 func BatchContainerOp(ctr *libpod.Container, opts shared.PsOptions) (shared.BatchContainerStruct, error) {
 	return shared.BatchContainerOp(ctr, opts)
 }
+
+// PausePods is a wrapper for pausing pods via libpod
+func (r *LocalRuntime) PausePods(c *cliconfig.PodPauseValues) ([]string, map[string]error, []error) {
+	var (
+		pauseIDs    []string
+		pauseErrors []error
+	)
+	containerErrors := make(map[string]error)
+
+	pods, err := shortcuts.GetPodsByContext(c.All, c.Latest, c.InputArgs, r.Runtime)
+	if err != nil {
+		pauseErrors = append(pauseErrors, err)
+		return nil, containerErrors, pauseErrors
+	}
+
+	for _, pod := range pods {
+		ctrErrs, err := pod.Pause()
+		if err != nil {
+			pauseErrors = append(pauseErrors, err)
+			continue
+		}
+		if ctrErrs != nil {
+			for ctr, err := range ctrErrs {
+				containerErrors[ctr] = err
+			}
+			continue
+		}
+		pauseIDs = append(pauseIDs, pod.ID())
+
+	}
+	return pauseIDs, containerErrors, pauseErrors
+}
+
+// UnpausePods is a wrapper for unpausing pods via libpod
+func (r *LocalRuntime) UnpausePods(c *cliconfig.PodUnpauseValues) ([]string, map[string]error, []error) {
+	var (
+		unpauseIDs    []string
+		unpauseErrors []error
+	)
+	containerErrors := make(map[string]error)
+
+	pods, err := shortcuts.GetPodsByContext(c.All, c.Latest, c.InputArgs, r.Runtime)
+	if err != nil {
+		unpauseErrors = append(unpauseErrors, err)
+		return nil, containerErrors, unpauseErrors
+	}
+
+	for _, pod := range pods {
+		ctrErrs, err := pod.Unpause()
+		if err != nil {
+			unpauseErrors = append(unpauseErrors, err)
+			continue
+		}
+		if ctrErrs != nil {
+			for ctr, err := range ctrErrs {
+				containerErrors[ctr] = err
+			}
+			continue
+		}
+		unpauseIDs = append(unpauseIDs, pod.ID())
+
+	}
+	return unpauseIDs, containerErrors, unpauseErrors
+}
+
+// RestartPods is a wrapper to restart pods via libpod
+func (r *LocalRuntime) RestartPods(ctx context.Context, c *cliconfig.PodRestartValues) ([]string, map[string]error, []error) {
+	var (
+		restartIDs    []string
+		restartErrors []error
+	)
+	containerErrors := make(map[string]error)
+
+	pods, err := shortcuts.GetPodsByContext(c.All, c.Latest, c.InputArgs, r.Runtime)
+	if err != nil {
+		restartErrors = append(restartErrors, err)
+		return nil, containerErrors, restartErrors
+	}
+
+	for _, pod := range pods {
+		ctrErrs, err := pod.Restart(ctx)
+		if err != nil {
+			restartErrors = append(restartErrors, err)
+			continue
+		}
+		if ctrErrs != nil {
+			for ctr, err := range ctrErrs {
+				containerErrors[ctr] = err
+			}
+			continue
+		}
+		restartIDs = append(restartIDs, pod.ID())
+
+	}
+	return restartIDs, containerErrors, restartErrors
+
+}

--- a/pkg/adapter/pods_remote.go
+++ b/pkg/adapter/pods_remote.go
@@ -327,3 +327,75 @@ func (p *Pod) SharesCgroup() bool {
 func (p *Pod) CgroupParent() string {
 	return p.config.CgroupParent
 }
+
+// PausePods pauses a pod using varlink and the remote client
+func (r *LocalRuntime) PausePods(c *cliconfig.PodPauseValues) ([]string, map[string]error, []error) {
+	var (
+		pauseIDs    []string
+		pauseErrors []error
+	)
+	containerErrors := make(map[string]error)
+
+	pods, err := iopodman.GetPodsByContext().Call(r.Conn, c.All, c.Latest, c.InputArgs)
+	if err != nil {
+		pauseErrors = append(pauseErrors, err)
+		return nil, containerErrors, pauseErrors
+	}
+	for _, pod := range pods {
+		reply, err := iopodman.PausePod().Call(r.Conn, pod)
+		if err != nil {
+			pauseErrors = append(pauseErrors, err)
+			continue
+		}
+		pauseIDs = append(pauseIDs, reply)
+	}
+	return pauseIDs, nil, pauseErrors
+}
+
+// UnpausePods unpauses a pod using varlink and the remote client
+func (r *LocalRuntime) UnpausePods(c *cliconfig.PodUnpauseValues) ([]string, map[string]error, []error) {
+	var (
+		unpauseIDs    []string
+		unpauseErrors []error
+	)
+	containerErrors := make(map[string]error)
+
+	pods, err := iopodman.GetPodsByContext().Call(r.Conn, c.All, c.Latest, c.InputArgs)
+	if err != nil {
+		unpauseErrors = append(unpauseErrors, err)
+		return nil, containerErrors, unpauseErrors
+	}
+	for _, pod := range pods {
+		reply, err := iopodman.UnpausePod().Call(r.Conn, pod)
+		if err != nil {
+			unpauseErrors = append(unpauseErrors, err)
+			continue
+		}
+		unpauseIDs = append(unpauseIDs, reply)
+	}
+	return unpauseIDs, nil, unpauseErrors
+}
+
+// RestartPods restarts pods using varlink and the remote client
+func (r *LocalRuntime) RestartPods(ctx context.Context, c *cliconfig.PodRestartValues) ([]string, map[string]error, []error) {
+	var (
+		restartIDs    []string
+		restartErrors []error
+	)
+	containerErrors := make(map[string]error)
+
+	pods, err := iopodman.GetPodsByContext().Call(r.Conn, c.All, c.Latest, c.InputArgs)
+	if err != nil {
+		restartErrors = append(restartErrors, err)
+		return nil, containerErrors, restartErrors
+	}
+	for _, pod := range pods {
+		reply, err := iopodman.RestartPod().Call(r.Conn, pod)
+		if err != nil {
+			restartErrors = append(restartErrors, err)
+			continue
+		}
+		restartIDs = append(restartIDs, reply)
+	}
+	return restartIDs, nil, restartErrors
+}


### PR DESCRIPTION
enable the ability for the remote client to pause, unpause, and
restart pods.

Signed-off-by: baude <bbaude@redhat.com>