### PR TITLE
vendor containers/image v1.5

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -15,7 +15,7 @@ github.com/containerd/cgroups 39b18af02c4120960f517a3a4c2588fabb61d02c
 github.com/containerd/continuity 004b46473808b3e7a4a3049c20e4376c91eb966d
 github.com/containernetworking/cni v0.7.0-alpha1
 github.com/containernetworking/plugins v0.7.4
-github.com/containers/image v1.4
+github.com/containers/image v1.5
 github.com/vbauerster/mpb v3.3.4
 github.com/mattn/go-isatty v0.0.4
 github.com/VividCortex/ewma v1.1.1

--- a/vendor/github.com/containers/image/version/version.go
+++ b/vendor/github.com/containers/image/version/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 5
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
Fixes are race condition in the blobinfocache when copying images
leading to a panic().

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>