### PR TITLE
start pod containers recursively

### DIFF
--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -153,7 +153,7 @@ func playKubeYAMLCmd(c *cliconfig.KubePlayValues) error {
 
 	// start the containers
 	for _, ctr := range containers {
-		if err := ctr.Start(ctx, false); err != nil {
+		if err := ctr.Start(ctx, true); err != nil {
 			// Making this a hard failure here to avoid a mess
 			// the other containers are in created status
 			return err


### PR DESCRIPTION
when using the play kube command, we need to make sure that containers
with dependancies are started in proper order.  in this case, the infra
container must be started first.

Signed-off-by: baude <bbaude@redhat.com>