### PR TITLE
Fix podman logs -l

### DIFF
--- a/cmd/podman/logs.go
+++ b/cmd/podman/logs.go
@@ -38,7 +38,7 @@ func init() {
 	flags := logsCommand.Flags()
 	flags.BoolVar(&logsCommand.Details, "details", false, "Show extra details provided to the logs")
 	flags.BoolVarP(&logsCommand.Follow, "follow", "f", false, "Follow log output.  The default is false")
-	flags.BoolVarP(&waitCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
+	flags.BoolVarP(&logsCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.StringVar(&logsCommand.Since, "since", "", "Show logs since TIMESTAMP")
 	flags.Uint64Var(&logsCommand.Tail, "tail", 0, "Output the specified number of LINES at the end of the logs.  Defaults to 0, which prints all lines")
 	flags.BoolVarP(&logsCommand.Timestamps, "timestamps", "t", false, "Output the timestamps in the log")


### PR DESCRIPTION
'podman logs -l' was no longer working. This fixes it by replacing
&waitCommand.Latest with &logsCommand.Latest.

Signed-off-by: Adrian Reber <areber@redhat.com>