### PR TITLE
Only remove image volumes when removing containers

### DIFF
--- a/cmd/podman/cleanup.go
+++ b/cmd/podman/cleanup.go
@@ -60,7 +60,7 @@ func cleanupCmd(c *cliconfig.CleanupValues) error {
 	for _, ctr := range cleanupContainers {
 		hadError := false
 		if c.Remove {
-			if err := runtime.RemoveContainer(ctx, ctr, false, false); err != nil {
+			if err := runtime.RemoveContainer(ctx, ctr, false, true); err != nil {
 				if lastError != nil {
 					fmt.Fprintln(os.Stderr, lastError)
 				}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1248,6 +1248,22 @@ func WithVolumeOptions(options map[string]string) VolumeCreateOption {
 	}
 }
 
+// withSetCtrSpecific sets a bool notifying libpod that a volume was created
+// specifically for a container.
+// These volumes will be removed when the container is removed and volumes are
+// also specified for removal.
+func withSetCtrSpecific() VolumeCreateOption {
+	return func(volume *Volume) error {
+		if volume.valid {
+			return ErrVolumeFinalized
+		}
+
+		volume.config.IsCtrSpecific = true
+
+		return nil
+	}
+}
+
 // Pod Creation Options
 
 // WithPodName sets the name of the pod.

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -180,7 +180,7 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 		if vol.Source[0] != '/' && isNamedVolume(vol.Source) {
 			volInfo, err := r.state.Volume(vol.Source)
 			if err != nil {
-				newVol, err := r.newVolume(ctx, WithVolumeName(vol.Source))
+				newVol, err := r.newVolume(ctx, WithVolumeName(vol.Source), withSetCtrSpecific())
 				if err != nil {
 					return nil, errors.Wrapf(err, "error creating named volume %q", vol.Source)
 				}
@@ -421,6 +421,9 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 
 	for _, v := range volumes {
 		if volume, err := runtime.state.Volume(v); err == nil {
+			if !volume.IsCtrSpecific() {
+				continue
+			}
 			if err := runtime.removeVolume(ctx, volume, false); err != nil && err != ErrNoSuchVolume && err != ErrVolumeBeingUsed {
 				logrus.Errorf("cleanup volume (%s): %v", v, err)
 			}

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -15,11 +15,12 @@ type VolumeConfig struct {
 	// Name of the volume
 	Name string `json:"name"`
 
-	Labels     map[string]string `json:"labels"`
-	MountPoint string            `json:"mountPoint"`
-	Driver     string            `json:"driver"`
-	Options    map[string]string `json:"options"`
-	Scope      string            `json:"scope"`
+	Labels        map[string]string `json:"labels"`
+	MountPoint    string            `json:"mountPoint"`
+	Driver        string            `json:"driver"`
+	Options       map[string]string `json:"options"`
+	Scope         string            `json:"scope"`
+	IsCtrSpecific bool              `json:"ctrSpecific"`
 }
 
 // Name retrieves the volume's name
@@ -59,4 +60,11 @@ func (v *Volume) Options() map[string]string {
 // Scope returns the scope of the volume
 func (v *Volume) Scope() string {
 	return v.config.Scope
+}
+
+// IsCtrSpecific returns whether this volume was created specifically for a
+// given container. Images with this set to true will be removed when the
+// container is removed with the Volumes parameter set to true.
+func (v *Volume) IsCtrSpecific() bool {
+	return v.config.IsCtrSpecific
 }


### PR DESCRIPTION
When removing volumes with rm --volumes we want to only remove volumes that were created with the container. Volumes created separately via 'podman volume create' should not be removed.

Also ensure that --rm implies volumes will be removed.

Fixes #2441