### PR TITLE
volume: do not create a volume if there is a bind

### DIFF
--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -240,7 +240,7 @@ func (c *CreateConfig) GetVolumeMounts(specMounts []spec.Mount) ([]spec.Mount, e
 	}
 
 	for vol := range c.BuiltinImgVolumes {
-		if libpod.MountExists(specMounts, vol) {
+		if libpod.MountExists(specMounts, vol) || libpod.MountExists(m, vol) {
 			continue
 		}
 


### PR DESCRIPTION
if there is already a bind mount specified for the target, do not
create a new volume.

Regression introduced by 52df1fa7e054d577e8416d1d46db1741ad324d4a

Closes: https://github.com/containers/libpod/issues/2441

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>