### PR TITLE
Command-line input validation: reject unused args

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -59,6 +59,14 @@ func checkAllAndLatest(c *cobra.Command, args []string, ignoreArgLen bool) error
 	return nil
 }
 
+// noSubArgs checks that there are no further positional parameters
+func noSubArgs(c *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return errors.Errorf("`%s` takes no arguments", c.CommandPath())
+	}
+	return nil
+}
+
 // getAllOrLatestContainers tries to return the correct list of containers
 // depending if --all, --latest or <container-id> is used.
 // It requires the Context (c) and the Runtime (runtime). As different

--- a/cmd/podman/containers_prune.go
+++ b/cmd/podman/containers_prune.go
@@ -21,6 +21,7 @@ var (
 `
 	_pruneContainersCommand = &cobra.Command{
 		Use:   "prune",
+		Args:  noSubArgs,
 		Short: "Remove all stopped containers",
 		Long:  pruneContainersDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/images_prune.go
+++ b/cmd/podman/images_prune.go
@@ -18,6 +18,7 @@ var (
 `
 	_pruneImagesCommand = &cobra.Command{
 		Use:   "prune",
+		Args:  noSubArgs,
 		Short: "Remove unused images",
 		Long:  pruneImagesDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/info.go
+++ b/cmd/podman/info.go
@@ -19,6 +19,7 @@ var (
 	infoDescription = "Display podman system information"
 	_infoCommand    = &cobra.Command{
 		Use:   "info",
+		Args:  noSubArgs,
 		Long:  infoDescription,
 		Short: `Display information pertaining to the host, current storage stats, and build of podman. Useful for the user and when reporting issues.`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -24,6 +24,7 @@ var (
 
 	_podCreateCommand = &cobra.Command{
 		Use:   "create",
+		Args:  noSubArgs,
 		Short: "Create a new empty pod",
 		Long:  podCreateDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -59,9 +60,6 @@ func podCreateCmd(c *cliconfig.PodCreateValues) error {
 		podIdFile *os.File
 	)
 
-	if len(c.InputArgs) > 0 {
-		return errors.New("podman pod create does not accept any arguments")
-	}
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")

--- a/cmd/podman/pod_ps.go
+++ b/cmd/podman/pod_ps.go
@@ -121,6 +121,7 @@ var (
 	_podPsCommand    = &cobra.Command{
 		Use:     "ps",
 		Aliases: []string{"ls", "list"},
+		Args:    noSubArgs,
 		Short:   "List pods",
 		Long:    podPsDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -159,10 +160,6 @@ func podPsCmd(c *cliconfig.PodPsValues) error {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}
 	defer runtime.Shutdown(false)
-
-	if len(c.InputArgs) > 0 {
-		return errors.Errorf("too many arguments, ps takes no arguments")
-	}
 
 	opts := podPsOptions{
 		NoTrunc:            c.NoTrunc,

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -159,6 +159,7 @@ var (
 	psDescription = "Prints out information about the containers"
 	_psCommand    = &cobra.Command{
 		Use:   "ps",
+		Args:  noSubArgs,
 		Short: "List containers",
 		Long:  psDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -214,10 +215,6 @@ func psCmd(c *cliconfig.PsValues) error {
 	}
 
 	defer runtime.Shutdown(false)
-
-	if len(c.InputArgs) > 0 {
-		return errors.Errorf("too many arguments, ps takes no arguments")
-	}
 
 	opts := shared.PsOptions{
 		All:       c.All,

--- a/cmd/podman/refresh.go
+++ b/cmd/podman/refresh.go
@@ -15,6 +15,7 @@ var (
 	refreshDescription = "The refresh command resets the state of all containers to handle database changes after a Podman upgrade. All running containers will be restarted."
 	_refreshCommand    = &cobra.Command{
 		Use:   "refresh",
+		Args:  noSubArgs,
 		Short: "Refresh container state",
 		Long:  refreshDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -31,10 +32,6 @@ func init() {
 }
 
 func refreshCmd(c *cliconfig.RefreshValues) error {
-	if len(c.InputArgs) > 0 {
-		return errors.Errorf("refresh does not accept any arguments")
-	}
-
 	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")

--- a/cmd/podman/system_renumber.go
+++ b/cmd/podman/system_renumber.go
@@ -18,6 +18,7 @@ var (
 
 	_renumberCommand = &cobra.Command{
 		Use:   "renumber",
+		Args:  noSubArgs,
 		Short: "Migrate lock numbers",
 		Long:  renumberDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/varlink.go
+++ b/cmd/podman/varlink.go
@@ -49,6 +49,9 @@ func varlinkCmd(c *cliconfig.VarlinkValues) error {
 	if len(args) < 1 {
 		return errors.Errorf("you must provide a varlink URI")
 	}
+	if len(args) > 1 {
+		return errors.Errorf("too many arguments. Requires exactly 1")
+	}
 	timeout := time.Duration(c.Timeout) * time.Millisecond
 
 	// Create a single runtime for varlink

--- a/cmd/podman/version.go
+++ b/cmd/podman/version.go
@@ -17,6 +17,7 @@ var (
 	versionCommand  cliconfig.VersionValues
 	_versionCommand = &cobra.Command{
 		Use:   "version",
+		Args:  noSubArgs,
 		Short: "Display the Podman Version Information",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			versionCommand.InputArgs = args

--- a/cmd/podman/volume_ls.go
+++ b/cmd/podman/volume_ls.go
@@ -49,6 +49,7 @@ and the output format can be changed to JSON or a user specified Go template.
 	_volumeLsCommand = &cobra.Command{
 		Use:     "ls",
 		Aliases: []string{"list"},
+		Args:    noSubArgs,
 		Short:   "List volumes",
 		Long:    volumeLsDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -75,10 +76,6 @@ func volumeLsCmd(c *cliconfig.VolumeLsValues) error {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}
 	defer runtime.Shutdown(false)
-
-	if len(c.InputArgs) > 0 {
-		return errors.Errorf("too many arguments, ls takes no arguments")
-	}
 
 	opts := volumeLsOptions{
 		Quiet: c.Quiet,

--- a/cmd/podman/volume_prune.go
+++ b/cmd/podman/volume_prune.go
@@ -24,6 +24,7 @@ using force.
 `
 	_volumePruneCommand = &cobra.Command{
 		Use:   "prune",
+		Args:  noSubArgs,
 		Short: "Remove all unused volumes",
 		Long:  volumePruneDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Several podman commands accept no subcommands. Some
of those were not actually checking, though, which
could lead to user confusion. Added validation where
missing; and, refactored to minimize duplication.

(Side note: I decided against using cobra.NoArgs
because its error message, "unknown command",
misleadingly implies that there are known ones).

Also added validation to varlink

Signed-off-by: Ed Santiago <santiago@redhat.com>