### PR TITLE
Move all storage configuration defaults into libpod

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -331,16 +331,13 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 	deepcopier.Copy(defaultRuntimeConfig).To(runtime.config)
 	runtime.config.TmpDir = tmpDir
 
-	if rootless.IsRootless() {
-		// If we're rootless, override the default storage config
-		storageConf, volumePath, err := util.GetDefaultStoreOptions()
-		if err != nil {
-			return nil, errors.Wrapf(err, "error retrieving rootless storage config")
-		}
-		runtime.config.StorageConfig = storageConf
-		runtime.config.StaticDir = filepath.Join(storageConf.GraphRoot, "libpod")
-		runtime.config.VolumePath = volumePath
+	storageConf, volumePath, err := util.GetDefaultStoreOptions()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error retrieving rootless storage config")
 	}
+	runtime.config.StorageConfig = storageConf
+	runtime.config.StaticDir = filepath.Join(storageConf.GraphRoot, "libpod")
+	runtime.config.VolumePath = volumePath
 
 	configPath := ConfigPath
 	foundConfig := true

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -331,13 +331,13 @@ func NewRuntime(options ...RuntimeOption) (runtime *Runtime, err error) {
 	deepcopier.Copy(defaultRuntimeConfig).To(runtime.config)
 	runtime.config.TmpDir = tmpDir
 
-	storageConf, volumePath, err := util.GetDefaultStoreOptions()
+	storageConf, err := util.GetDefaultStoreOptions()
 	if err != nil {
 		return nil, errors.Wrapf(err, "error retrieving rootless storage config")
 	}
 	runtime.config.StorageConfig = storageConf
 	runtime.config.StaticDir = filepath.Join(storageConf.GraphRoot, "libpod")
-	runtime.config.VolumePath = volumePath
+	runtime.config.VolumePath = filepath.Join(storageConf.GraphRoot, "volumes")
 
 	configPath := ConfigPath
 	foundConfig := true

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -325,6 +325,7 @@ func GetDefaultStoreOptions() (storage.StoreOptions, string, error) {
 		defaultRootlessGraphRoot = storageOpts.GraphRoot
 		storageOpts = storage.StoreOptions{}
 		storage.ReloadConfigurationFile(storageConf, &storageOpts)
+		volumePath = filepath.Join(storageOpts.GraphRoot, "volumes")
 	}
 
 	if rootless.IsRootless() {
@@ -351,6 +352,7 @@ func GetDefaultStoreOptions() (storage.StoreOptions, string, error) {
 			if storageOpts.GraphRoot == "" {
 				storageOpts.GraphRoot = defaultRootlessGraphRoot
 			}
+			volumePath = filepath.Join(storageOpts.GraphRoot, "volumes")
 		}
 	}
 	return storageOpts, volumePath, nil

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -259,15 +259,6 @@ func GetRootlessStorageOpts() (storage.StoreOptions, error) {
 	return opts, nil
 }
 
-// GetRootlessVolumePath returns where all the name volumes will be created in rootless mode
-func GetRootlessVolumePath() (string, error) {
-	dataDir, _, err := GetRootlessDirInfo()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dataDir, "containers", "storage", "volumes"), nil
-}
-
 type tomlOptionsConfig struct {
 	MountProgram string `toml:"mount_program"`
 }
@@ -297,25 +288,18 @@ func getTomlStorage(storeOptions *storage.StoreOptions) *tomlConfig {
 	return config
 }
 
-// GetDefaultStoreOptions returns the storage ops for containers and the volume path
-// for the volume API
-// It also returns the path where all named volumes will be created using the volume API
-func GetDefaultStoreOptions() (storage.StoreOptions, string, error) {
+// GetDefaultStoreOptions returns the default storage ops for containers
+func GetDefaultStoreOptions() (storage.StoreOptions, error) {
 	var (
 		defaultRootlessRunRoot   string
 		defaultRootlessGraphRoot string
 		err                      error
 	)
 	storageOpts := storage.DefaultStoreOptions
-	volumePath := filepath.Join(storageOpts.GraphRoot, "volumes")
 	if rootless.IsRootless() {
 		storageOpts, err = GetRootlessStorageOpts()
 		if err != nil {
-			return storageOpts, volumePath, err
-		}
-		volumePath, err = GetRootlessVolumePath()
-		if err != nil {
-			return storageOpts, volumePath, err
+			return storageOpts, err
 		}
 	}
 
@@ -325,7 +309,6 @@ func GetDefaultStoreOptions() (storage.StoreOptions, string, error) {
 		defaultRootlessGraphRoot = storageOpts.GraphRoot
 		storageOpts = storage.StoreOptions{}
 		storage.ReloadConfigurationFile(storageConf, &storageOpts)
-		volumePath = filepath.Join(storageOpts.GraphRoot, "volumes")
 	}
 
 	if rootless.IsRootless() {
@@ -333,7 +316,7 @@ func GetDefaultStoreOptions() (storage.StoreOptions, string, error) {
 			os.MkdirAll(filepath.Dir(storageConf), 0755)
 			file, err := os.OpenFile(storageConf, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 			if err != nil {
-				return storageOpts, volumePath, errors.Wrapf(err, "cannot open %s", storageConf)
+				return storageOpts, errors.Wrapf(err, "cannot open %s", storageConf)
 			}
 
 			tomlConfiguration := getTomlStorage(&storageOpts)
@@ -352,10 +335,9 @@ func GetDefaultStoreOptions() (storage.StoreOptions, string, error) {
 			if storageOpts.GraphRoot == "" {
 				storageOpts.GraphRoot = defaultRootlessGraphRoot
 			}
-			volumePath = filepath.Join(storageOpts.GraphRoot, "volumes")
 		}
 	}
-	return storageOpts, volumePath, nil
+	return storageOpts, nil
 }
 
 // StorageConfigFile returns the path to the storage config file used


### PR DESCRIPTION
Instead of passing in defaults via WithStorageConfig after computing them in cmd/podman/libpodruntime, do all defaults in libpod itself.

This can alleviate ordering issues which caused settings in the libpod config (most notably, volume path) to be ignored.

This ended up being a lot simpler than I thought it would be, and un-breaks `volume_path` in the libpod config.