### PR TITLE
Remove restore as podman subcommand

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -27,7 +27,6 @@ func getMainCommands() []*cobra.Command {
 		_portCommand,
 		_refreshCommand,
 		_restartCommand,
-		_restoreCommand,
 		_rmCommand,
 		_runCommand,
 		_searchCommand,


### PR DESCRIPTION
The commands checkpoint and restore should only be available under
'podman container'. This is probably a result of the recent cobra
migration.

Signed-off-by: Adrian Reber <areber@redhat.com>