### PR TITLE
Skip checkpoint/restore tests on Fedora for now

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -30,6 +30,13 @@ var _ = Describe("Podman checkpoint", func() {
 		if !criu.CheckForCriu() {
 			Skip("CRIU is missing or too old.")
 		}
+		// TODO: Remove the skip when the current CRIU SELinux problem is solved.
+		// See: https://github.com/containers/libpod/issues/2334
+		hostInfo := podmanTest.Host
+		if hostInfo.Distribution == "fedora" {
+			Skip("Checkpointing containers on Fedora currently broken.")
+		}
+
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
There is currently still one SELinux related checkpoint/restore problem:
https://github.com/containers/libpod/issues/2334

To avoid unnecessary CI failures the checkpoint/restore tests are
temporarily disabled on Fedora.

It is not necessary to disable the tests on Ubuntu as it is running
without SELinux and it is also not necessary to disable the RHEL 7 tests
as RHEL's CRIU is too old to run the checkpoint/restore tests at all.

Signed-off-by: Adrian Reber <areber@redhat.com>