### PR TITLE
Add a task to Cirrus gating to build w/o Varlink

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -118,6 +118,11 @@ gating_task:
         - '/usr/local/bin/entrypoint.sh vendor'
         - 'cd /go/src/github.com/containers/libpod && ./hack/tree_status.sh'
 
+    # This task builds Podman with different buildtags to ensure the build does
+    # not break.
+    build_script:
+        - '/usr/local/bin/entrypoint.sh clean podman BUILDTAGS="exclude_graphdriver_devicemapper selinux seccomp"'
+
 
 build_each_commit_task:
 

--- a/contrib/gate/Dockerfile
+++ b/contrib/gate/Dockerfile
@@ -49,8 +49,6 @@ WORKDIR $GOSRC
 
 # Install dependencies
 RUN set -x && \
-    go get -u github.com/mailru/easyjson/... && \
-    install -D -m 755 "$GOPATH"/bin/easyjson /usr/bin/ && \
     make install.tools && \
     install -D -m 755 $GOSRC/contrib/gate/entrypoint.sh /usr/local/bin/ && \
     rm -rf "$GOSRC"


### PR DESCRIPTION
We had a regression on master where we broke the build for non-Varlink builds. Catch this in CI in the future.