### PR TITLE
Clean up man pages to match commands

### DIFF
--- a/docs/podman-container.1.md
+++ b/docs/podman-container.1.md
@@ -11,40 +11,41 @@ The container command allows you to manage containers
 
 ## COMMANDS
 
-| Command  | Man Page                                            | Description                                                                  |
-| -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
-| attach   | [podman-attach(1)](podman-attach.1.md)              | Attach to a running container.                                               |
+| Command    | Man Page                                            | Description                                                                  |
+| ---------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
+| attach     | [podman-attach(1)](podman-attach.1.md)              | Attach to a running container.                                               |
 | checkpoint | [podman-container-checkpoint(1)](podman-container-checkpoint.1.md)  | Checkpoints one or more containers.                        |
-| cleanup  | [podman-container-cleanup(1)](podman-container-cleanup.1.md)    | Cleanup containers network and mountpoints.                               |
-| commit   | [podman-commit(1)](podman-commit.1.md)              | Create new image based on the changed container.                             |
-| create   | [podman-create(1)](podman-create.1.md)              | Create a new container.                                                      |
-| diff     | [podman-diff(1)](podman-diff.1.md)                  | Inspect changes on a container or image's filesystem.                        |
-| exec     | [podman-exec(1)](podman-exec.1.md)                  | Execute a command in a running container.                                    |
-| exists   | [podman-exists(1)](podman-container-exists.1.md)    | Check if a container exists in local storage                                 |
-| export   | [podman-export(1)](podman-export.1.md)              | Export a container's filesystem contents as a tar archive.                   |
-| inspect  | [podman-inspect(1)](podman-inspect.1.md)            | Display a container or image's configuration.                                |
-| kill     | [podman-kill(1)](podman-kill.1.md)                  | Kill the main process in one or more containers.                             |
-| list     | [podman-ps(1)](podman-ps.1.md)                 | List the containers on the system.                                     |
-| logs     | [podman-logs(1)](podman-logs.1.md)                  | Display the logs of a container.                                             |
-| ls       | [podman-ps(1)](podman-ps.1.md)                 | List the containers on the system.                                     |
-| mount    | [podman-mount(1)](podman-mount.1.md)                | Mount a working container's root filesystem.                                 |
-| pause    | [podman-pause(1)](podman-pause.1.md)                | Pause one or more containers.                                                |
-| port     | [podman-port(1)](podman-port.1.md)                  | List port mappings for the container.                                        |
-| prune    | [podman-container-prune(1)](podman-container-prune.1.md)                  | Remove all stopped containers from local storage        |
-| ps       | [podman-ps(1)](podman-ps.1.md)                 | List the containers on the system.                                     |
-| refresh  | [podman-refresh(1)](podman-container-refresh.1.md)  | Refresh the state of all containers                                          |
-| restart  | [podman-restart(1)](podman-restart.1.md)            | Restart one or more containers.                                              |
-| restore  | [podman-container-restore(1)](podman-container-restore.1.md)  | Restores one or more containers from a checkpoint.                 |
-| rm       | [podman-rm(1)](podman-rm.1.md)                      | Remove one or more containers.                                               |
-| run      | [podman-run(1)](podman-run.1.md)                    | Run a command in a container.                                                |
-| start    | [podman-start(1)](podman-start.1.md)                | Starts one or more containers.                                               |
-| stats    | [podman-stats(1)](podman-stats.1.md)                | Display a live stream of one or more container's resource usage statistics.  |
-| stop     | [podman-stop(1)](podman-stop.1.md)                  | Stop one or more running containers.                                         |
-| top      | [podman-top(1)](podman-top.1.md)                    | Display the running processes of a container.                                |
-| umount   | [podman-umount(1)](podman-umount.1.md)              | Unmount a working container's root filesystem.                               |
-| unmount  | [podman-umount(1)](podman-umount.1.md)              | Unmount a working container's root filesystem.                               |
-| unpause  | [podman-unpause(1)](podman-unpause.1.md)            | Unpause one or more containers.                                              |
-| wait     | [podman-wait(1)](podman-wait.1.md)                  | Wait on one or more containers to stop and print their exit codes.           |
+| cleanup    | [podman-container-cleanup(1)](podman-container-cleanup.1.md)    | Cleanup containers network and mountpoints.                      |
+| commit     | [podman-commit(1)](podman-commit.1.md)              | Create new image based on the changed container.                             |
+| create     | [podman-create(1)](podman-create.1.md)              | Create a new container.                                                      |
+| diff       | [podman-diff(1)](podman-diff.1.md)                  | Inspect changes on a container or image's filesystem.                        |
+| exec       | [podman-exec(1)](podman-exec.1.md)                  | Execute a command in a running container.                                    |
+| exists     | [podman-exists(1)](podman-container-exists.1.md)    | Check if a container exists in local storage                                 |
+| export     | [podman-export(1)](podman-export.1.md)              | Export a container's filesystem contents as a tar archive.                   |
+| inspect    | [podman-inspect(1)](podman-inspect.1.md)            | Display a container or image's configuration.                                |
+| kill       | [podman-kill(1)](podman-kill.1.md)                  | Kill the main process in one or more containers.                             |
+| list       | [podman-ps(1)](podman-ps.1.md)                      | List the containers on the system.                                           |
+| logs       | [podman-logs(1)](podman-logs.1.md)                  | Display the logs of a container.                                             |
+| ls         | [podman-ps(1)](podman-ps.1.md)                      | List the containers on the system.                                           |
+| mount      | [podman-mount(1)](podman-mount.1.md)                | Mount a working container's root filesystem.                                 |
+| pause      | [podman-pause(1)](podman-pause.1.md)                | Pause one or more containers.                                                |
+| port       | [podman-port(1)](podman-port.1.md)                  | List port mappings for the container.                                        |
+| prune      | [podman-container-prune(1)](podman-container-prune.1.md)| Remove all stopped containers from local storage.                        |
+| ps         | [podman-ps(1)](podman-ps.1.md)                      | List the containers on the system.                                           |
+| refresh    | [podman-refresh(1)](podman-container-refresh.1.md)  | Refresh the state of all containers                                          |
+| restart    | [podman-restart(1)](podman-restart.1.md)            | Restart one or more containers.                                              |
+| restore    | [podman-container-restore(1)](podman-container-restore.1.md)  | Restores one or more containers from a checkpoint.                 |
+| rm         | [podman-rm(1)](podman-rm.1.md)                      | Remove one or more containers.                                               |
+| run        | [podman-run(1)](podman-run.1.md)                    | Run a command in a container.                                                |
+| runlabel   | [podman-container-runlabel(1)](podman-container-runlabel.1.md)  | Executes a command as described by a container image label.      |
+| start      | [podman-start(1)](podman-start.1.md)                | Starts one or more containers.                                               |
+| stats      | [podman-stats(1)](podman-stats.1.md)                | Display a live stream of one or more container's resource usage statistics.  |
+| stop       | [podman-stop(1)](podman-stop.1.md)                  | Stop one or more running containers.                                         |
+| top        | [podman-top(1)](podman-top.1.md)                    | Display the running processes of a container.                                |
+| umount     | [podman-umount(1)](podman-umount.1.md)              | Unmount a working container's root filesystem.                               |
+| unmount    | [podman-umount(1)](podman-umount.1.md)              | Unmount a working container's root filesystem.                               |
+| unpause    | [podman-unpause(1)](podman-unpause.1.md)            | Unpause one or more containers.                                              |
+| wait       | [podman-wait(1)](podman-wait.1.md)                  | Wait on one or more containers to stop and print their exit codes.           |
 
 ## SEE ALSO
 podman, podman-exec, podman-run

--- a/docs/podman-generate.1.md
+++ b/docs/podman-generate.1.md
@@ -13,7 +13,7 @@ The generate command will create structured output (like YAML) based on a contai
 
 | Command  | Man Page                                            | Description                                                                  |
 | -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
-| kube | [podman-generate-kube(1)](podman-generate-kube.1.md)              | Generate Kubernetes YAML based on a pod or container
+| kube     | [podman-generate-kube(1)](podman-generate-kube.1.md)| Generate Kubernetes YAML based on a pod or container.                        |
 
 ## SEE ALSO
 podman, podman-pod, podman-container

--- a/docs/podman-image.1.md
+++ b/docs/podman-image.1.md
@@ -11,24 +11,24 @@ The image command allows you to manage images
 
 ## COMMANDS
 
-| Command  | Man Page                                  | Description                                                                    |
-| -------- | ----------------------------------------- | ------------------------------------------------------------------------------ |
-| build    | [podman-build(1)](podman-build.1.md)      | Build a container using a Dockerfile.                                          |
-| exists   | [podman-exists(1)](podman-image-exists.1.md)      | Check if a image exists in local storage                                          |
-| history  | [podman-history(1)](podman-history.1.md)  | Show the history of an image.                                                  |
-| import   | [podman-import(1)](podman-import.1.md)    | Import a tarball and save it as a filesystem image.                            |
-| inspect  | [podman-inspect(1)](podman-inspect.1.md)  | Display a image or image's configuration.                                      |
-| list     | [podman-images(1)](podman-images.1.md)    | List the container images on the system.                                           |
-| load     | [podman-load(1)](podman-load.1.md)        | Load an image from the docker archive.                                         |
-| ls       | [podman-images(1)](podman-images.1.md)    | List the container images on the system.                                           |
-| pull     | [podman-pull(1)](podman-pull.1.md)        | Pull an image from a registry.                                                 |
-| prune| [podman-container-prune(1)](podman-container-prune.1.md)        | Removed all unused images from the local store                                 |
-| push     | [podman-push(1)](podman-push.1.md)        | Push an image from local storage to elsewhere.                                 |
-| rm       | [podman-rm(1)](podman-rmi.1.md)           | Removes one or more locally stored images.                                     |
-| save     | [podman-save(1)](podman-save.1.md)        | Save an image to docker-archive or oci.                                        |
-| tag      | [podman-tag(1)](podman-tag.1.md)          | Add an additional name to a local image.                                       |
-| trust    | [podman-image-trust(1)](podman-image-trust.1.md)  | Manage container image trust policy.                                   |
-| sign    | [podman-image-sign(1)](podman-image-sign.1.md)  | Sign an image.                                                            |
+| Command  | Man Page                                        | Description                                                                 |
+| -------- | ----------------------------------------------- | --------------------------------------------------------------------------- |
+| build    | [podman-build(1)](podman-build.1.md)            | Build a container using a Dockerfile.                                       |
+| exists   | [podman-exists(1)](podman-image-exists.1.md)    | Check if a image exists in local storage.                                   |
+| history  | [podman-history(1)](podman-history.1.md)        | Show the history of an image.                                               |
+| import   | [podman-import(1)](podman-import.1.md)          | Import a tarball and save it as a filesystem image.                         |
+| inspect  | [podman-inspect(1)](podman-inspect.1.md)        | Display a image or image's configuration.                                   |
+| list     | [podman-images(1)](podman-images.1.md)          | List the container images on the system.                                    |
+| load     | [podman-load(1)](podman-load.1.md)              | Load an image from the docker archive.                                      |
+| ls       | [podman-images(1)](podman-images.1.md)          | List the container images on the system.                                    |
+| prune    | [podman-image-prune(1)](podman-image-prune.1.md)| Removed all unused images from the local store.                             |
+| pull     | [podman-pull(1)](podman-pull.1.md)              | Pull an image from a registry.                                              |
+| push     | [podman-push(1)](podman-push.1.md)              | Push an image from local storage to elsewhere.                              |
+| rm       | [podman-rm(1)](podman-rmi.1.md)                 | Removes one or more locally stored images.                                  |
+| save     | [podman-save(1)](podman-save.1.md)              | Save an image to docker-archive or oci.                                     |
+| sign     | [podman-image-sign(1)](podman-image-sign.1.md)  | Sign an image.                                                              |
+| tag      | [podman-tag(1)](podman-tag.1.md)                | Add an additional name to a local image.                                    |
+| trust    | [podman-image-trust(1)](podman-image-trust.1.md)| Manage container image trust policy.                                        |
 
 ## SEE ALSO
 podman

--- a/docs/podman-play.1.md
+++ b/docs/podman-play.1.md
@@ -14,7 +14,7 @@ file input.  Containers will be automatically started.
 
 | Command  | Man Page                                            | Description                                                                  |
 | -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
-| kube | [podman-play-kube(1)](podman-play-kube.1.md)              | Recreate pods and containers based on Kubernetes YAML.
+| kube     | [podman-play-kube(1)](podman-play-kube.1.md)        | Recreate pods and containers based on Kubernetes YAML.                       |
 
 ## SEE ALSO
 podman, podman-pod(1), podman-container(1), podman-generate(1), podman-play(1), podman-play-kube(1)

--- a/docs/podman-pod-stats.1.md
+++ b/docs/podman-pod-stats.1.md
@@ -1,0 +1,92 @@
+% podman-pod-stats "1"
+
+## NAME
+podman\-pod\-stats - Display a live stream of resource usage statistics for the containers in one or more pods
+
+## SYNOPSIS
+**podman pod stats** [*options*] [*pod*]
+
+## DESCRIPTION
+Display a live stream of containers in one or more pods resource usage statistics
+
+## OPTIONS
+
+**--all, -a**
+
+Show all containers.  Only running containers are shown by default
+
+**--latest, -l**
+
+Instead of providing the pod name or ID, use the last created pod.
+
+The latest option is not supported on the remote client.
+
+**--no-reset**
+
+Do not clear the terminal/screen in between reporting intervals
+
+**--no-stream**
+
+Disable streaming pod stats and only pull the first result, default setting is false
+
+**--format="TEMPLATE"**
+
+Pretty-print container statistics to JSON or using a Go template
+
+Valid placeholders for the Go template are listed below:
+
+| **Placeholder** | **Description**   |
+| --------------- | ---------------   |
+| .Pod            | Pod ID      |
+| .CID            | Container ID      |
+| .Name           | Container Name    |
+| .CPU            | CPU percentage    |
+| .MemUsage       | Memory usage      |
+| .Mem            | Memory percentage |
+| .NetIO          | Network IO        |
+| .BlockIO        | Block IO          |
+| .PIDS           | Number of PIDs    |
+
+When using a GO template, you may preceed the format with `table` to print headers.
+## EXAMPLE
+
+```
+# podman pod stats -a --no-stream
+ID             NAME              CPU %   MEM USAGE / LIMIT   MEM %   NET IO    BLOCK IO   PIDS
+a9f807ffaacd   frosty_hodgkin    --      3.092MB / 16.7GB    0.02%   -- / --   -- / --    2
+3b33001239ee   sleepy_stallman   --      -- / --             --      -- / --   -- / --    --
+```
+
+```
+# podman pod stats --no-stream a9f80
+ID             NAME             CPU %   MEM USAGE / LIMIT   MEM %   NET IO    BLOCK IO   PIDS
+a9f807ffaacd   frosty_hodgkin   --      3.092MB / 16.7GB    0.02%   -- / --   -- / --    2
+```
+
+```
+# podman pod stats --no-stream --format=json a9f80
+[
+    {
+        "id": "a9f807ffaacd",
+        "name": "frosty_hodgkin",
+        "cpu_percent": "--",
+        "mem_usage": "3.092MB / 16.7GB",
+        "mem_percent": "0.02%",
+        "netio": "-- / --",
+        "blocki": "-- / --",
+        "pids": "2"
+    }
+]
+```
+
+```
+# podman pod-stats --no-stream --format "table {{.ID}} {{.Name}} {{.MemUsage}}" 6eae
+ID             NAME           MEM USAGE / LIMIT
+6eae9e25a564   clever_bassi   3.031MB / 16.7GB
+```
+
+## SEE ALSO
+podman-pod(1), podman(1)
+
+## HISTORY
+February 2019, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/docs/podman-pod.1.md
+++ b/docs/podman-pod.1.md
@@ -11,16 +11,24 @@ podman pod is a set of subcommands that manage pods, or groups of containers.
 
 ## SUBCOMMANDS
 
-| Subcommand                                        | Description                                                                    |
-| ------------------------------------------------- | ------------------------------------------------------------------------------ |
-| [podman-pod-create(1)](podman-pod-create.1.md)    | Create a new pod.                                                              |
-| [podman-pod-kill(1)](podman-pod-kill.1.md)        | Kill the main process of each container in pod.                                |
-| [podman-pod-pause(1)](podman-pod-pause.1.md)      | Pause one or more pods.                                                        |
-| [podman-pod-ps(1)](podman-pod-ps.1.md)            | Prints out information about pods.                                             |
-| [podman-pod-rm(1)](podman-pod-rm.1.md)            | Remove one or more pods.                                                       |
-| [podman-pod-start(1)](podman-pod-start.1.md)      | Start one or more pods.                                                        |
-| [podman-pod-stop(1)](podman-pod-stop.1.md)        | Stop one or more pods.                                                         |
-| [podman-pod-unpause(1)](podman-pod-unpause.1.md)  | Unpause one or more pods.                                                      |
+| Command | Man Page                                          | Description                                                                    |
+| ------- | ------------------------------------------------- | ------------------------------------------------------------------------------ |
+| create  | [podman-pod-create(1)](podman-pod-create.1.md)    | Create a new pod.                                                              |
+| exists  | [podman-pod-exists(1)](podman-pod-exists.1.md)    | Check if a pod exists in local storage.                                        |
+| inspect | [podman-pod-inspect(1)](podman-pod-inspect.1.md)  | Displays information describing a pod.                                         |
+| kill    | [podman-pod-kill(1)](podman-pod-kill.1.md)        | Kill the main process of each container in pod.                                |
+| pause   | [podman-pod-pause(1)](podman-pod-pause.1.md)      | Pause one or more pods.                                                        |
+| ps      | [podman-pod-ps(1)](podman-pod-ps.1.md)            | Prints out information about pods.                                             |
+| restart | [podman-pod-restart(1)](podman-pod-restart.1.md)  | Restart one or mode pods.                                                      |
+| rm      | [podman-pod-rm(1)](podman-pod-rm.1.md)            | Remove one or more pods.                                                       |
+| start   | [podman-pod-start(1)](podman-pod-start.1.md)      | Start one or more pods.                                                        |
+| stats   | [podman-pod-stats(1)](podman-pod-stats.1.md)      | Display live stream resource usage stats for containers in one or more pods.   |
+| stop    | [podman-pod-stop(1)](podman-pod-stop.1.md)        | Stop one or more pods.                                                         |
+| top     | [podman-pod-top(1)](podman-pod-top.1.md)          | Display the running processes of containers in a pod.                          |
+| unpause | [podman-pod-unpause(1)](podman-pod-unpause.1.md)  | Unpause one or more pods.                                                      |
+
+## SEE ALSO
+podman(1)
 
 ## HISTORY
 July 2018, Originally compiled by Peter Hunt <pehunt@redhat.com>

--- a/docs/podman-system.1.md
+++ b/docs/podman-system.1.md
@@ -15,6 +15,7 @@ The system command allows you to manage the podman systems
 | -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
 | info     | [podman-system-info(1)](podman-info.1.md)           | Displays Podman related system information.                                  |
 | prune    | [podman-system-prune(1)](podman-system-prune.1.md)  | Remove all unused data                                                       |
+| renumber | [podman-system-renumber(1)](podman-system-renumber.1.md)| Migrate lock numbers to handle a change in maximum number of locks.      |
 
 ## SEE ALSO
-podman
+podman(1)

--- a/docs/podman-volume.1.md
+++ b/docs/podman-volume.1.md
@@ -11,13 +11,16 @@ podman volume is a set of subcommands that manage volumes.
 
 ## SUBCOMMANDS
 
-| Subcommand                                             | Description                                                                    |
-| -------------------------------------------------      | ------------------------------------------------------------------------------ |
-| [podman-volume-create(1)](podman-volume-create.1.md)   | Create a new volume.                                                           |
-| [podman-volume-inspect(1)](podman-volume-inspect.1.md) | Get detailed information on one or more volumes.                               |
-| [podman-volume-ls(1)](podman-volume-ls.1.md)           | List all the available volumes.                                                |
-| [podman-volume-rm(1)](podman-volume-rm.1.md)           | Remove one or more volumes.                                                    |
-| [podman-volume-prune(1)](podman-volume-prune.1.md)     | Remove all unused volumes.                                                     |
+| Command | Man Page                                               | Description                                                                    |
+| ------- | ------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| create  | [podman-volume-create(1)](podman-volume-create.1.md)   | Create a new volume.                                                           |
+| inspect | [podman-volume-inspect(1)](podman-volume-inspect.1.md) | Get detailed information on one or more volumes.                               |
+| ls      | [podman-volume-ls(1)](podman-volume-ls.1.md)           | List all the available volumes.                                                |
+| prune   | [podman-volume-prune(1)](podman-volume-prune.1.md)     | Remove all unused volumes.                                                     |
+| rm      | [podman-volume-rm(1)](podman-volume-rm.1.md)           | Remove one or more volumes.                                                    |
+
+## SEE ALSO
+podman(1)
 
 ## HISTORY
 November 2018, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -72,7 +72,7 @@ Default state dir is configured in /etc/containers/storage.conf.
 
 Name of the OCI runtime as specified in libpod.conf or absolute path to the OCI compatible binary used to run containers.
 
-**--storage-driver, -s**=**value**
+**--storage-driver**=**value**
 
 Storage driver.  The default storage driver for UID 0 is configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode), and is *vfs* for non-root users when *fuse-overlayfs* is not available.  The `STORAGE_DRIVER` environment variable overrides the default.  The --storage-driver specified driver overrides all.
 
@@ -136,6 +136,8 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-diff(1)](podman-diff.1.md)        | Inspect changes on a container or image's filesystem.                          |
 | [podman-exec(1)](podman-exec.1.md)        | Execute a command in a running container.                                      |
 | [podman-export(1)](podman-export.1.md)    | Export a container's filesystem contents as a tar archive.                     |
+| [podman-generate(1)](podman-generate.1.md)| Generate structured data based for a containers and pods.                      |
+| [podman-help(1)](podman-history.1.md)     | Show help information on podman.                                               |
 | [podman-history(1)](podman-history.1.md)  | Show the history of an image.                                                  |
 | [podman-image(1)](podman-image.1.md)      | Manage Images.                                                                 |
 | [podman-images(1)](podman-images.1.md)    | List images in local storage.                                                  |
@@ -149,10 +151,13 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-logs(1)](podman-logs.1.md)        | Display the logs of a container.                                               |
 | [podman-mount(1)](podman-mount.1.md)      | Mount a working container's root filesystem.                                   |
 | [podman-pause(1)](podman-pause.1.md)      | Pause one or more containers.                                                  |
+| [podman-play(1)](podman-play.1.md)        | Play pods and containers based on a structured input file.                     |
+| [podman-pod(1)](podman-pod.1.md)          | Management tool for groups of containers, called pods.                         |
 | [podman-port(1)](podman-port.1.md)        | List port mappings for the container.                                          |
 | [podman-ps(1)](podman-ps.1.md)            | Prints out information about containers.                                       |
 | [podman-pull(1)](podman-pull.1.md)        | Pull an image from a registry.                                                 |
 | [podman-push(1)](podman-push.1.md)        | Push an image from local storage to elsewhere.                                 |
+| [podman-refresh(1)](podman-refresh.1.md)  | Refresh state of all containers to handle database changes.                    |
 | [podman-restart(1)](podman-restart.1.md)  | Restart one or more containers.                                                |
 | [podman-rm(1)](podman-rm.1.md)            | Remove one or more containers.                                                 |
 | [podman-rmi(1)](podman-rmi.1.md)          | Removes one or more locally stored images.                                     |
@@ -167,8 +172,9 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-top(1)](podman-top.1.md)          | Display the running processes of a container.                                  |
 | [podman-umount(1)](podman-umount.1.md)    | Unmount a working container's root filesystem.                                 |
 | [podman-unpause(1)](podman-unpause.1.md)  | Unpause one or more containers.                                                |
-| [podman-version(1)](podman-version.1.md)  | Display the Podman version information.                                        |
-| [podman-volume(1)](podman-volume.1.md)    | Manage Volumes.                                                                 |
+| [podman-varlink(1)](podman-varlink.1.md)  | Display the Podman version information.                                        |
+| [podman-version(1)](podman-version.1.md)  | Runs the varlink backend interface.                                            |
+| [podman-volume(1)](podman-volume.1.md)    | Manage Volumes.                                                                |
 | [podman-wait(1)](podman-wait.1.md)        | Wait on one or more containers to stop and print their exit codes.             |
 
 ## FILES

--- a/hack/podman-commands.sh
+++ b/hack/podman-commands.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+./bin/podman --help | sed -n -Ee '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman.cmd
+man ./docs/podman.1 | sed -n -e '0,/COMMANDS/d' -e '/^FILES/q;p' | grep podman | cut -f2 -d- | cut -f1 -d\( > /tmp/podman.man
+echo diff -B -u /tmp/podman.cmd /tmp/podman.man
+diff -B -u /tmp/podman.cmd /tmp/podman.man
+
+./bin/podman image --help | sed -n -e '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman-image.cmd
+man ./docs/podman-image.1 | sed -n -Ee '0,/COMMANDS/d'  -e 's/^[[:space:]]*//' -e '/^SEE ALSO/q;p' | grep podman | cut -f1 -d' ' | sed 's/^.//' > /tmp/podman-image.man
+echo diff -B -u /tmp/podman-image.cmd /tmp/podman-image.man
+diff -B -u /tmp/podman-image.cmd /tmp/podman-image.man
+
+./bin/podman container --help | sed -n -e '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman-container.cmd
+man docs/podman-container.1 | sed -n -Ee '0,/COMMANDS/d'  -e 's/^[[:space:]]*//' -e '/^SEE ALSO/q;p' | grep podman | cut -f1 -d' ' | sed 's/^.//' > /tmp/podman-container.man
+echo diff -B -u /tmp/podman-container.cmd /tmp/podman-container.man
+diff -B -u /tmp/podman-container.cmd /tmp/podman-container.man
+
+./bin/podman system --help | sed -n -e '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman-system.cmd
+man docs/podman-system.1 | sed -n -Ee '0,/COMMANDS/d'  -e 's/^[[:space:]]*//' -e '/^SEE ALSO/q;p' | grep podman | cut -f1 -d' ' | sed 's/^.//' > /tmp/podman-system.man
+echo diff -B -u /tmp/podman-system.cmd /tmp/podman-system.man
+diff -B -u /tmp/podman-system.cmd /tmp/podman-system.man
+
+./bin/podman play --help | sed -n -e '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman-play.cmd
+man docs/podman-play.1 | sed -n -Ee '0,/COMMANDS/d'  -e 's/^[[:space:]]*//' -e '/^SEE ALSO/q;p' | grep podman | cut -f1 -d' ' | sed 's/^.//' > /tmp/podman-play.man
+echo diff -B -u /tmp/podman-play.cmd /tmp/podman-play.man
+diff -B -u /tmp/podman-play.cmd /tmp/podman-play.man
+
+./bin/podman generate --help | sed -n -e '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman-generate.cmd
+man docs/podman-generate.1 | sed -n -Ee '0,/COMMANDS/d'  -e 's/^[[:space:]]*//' -e '/^SEE ALSO/q;p' | grep podman | cut -f1 -d' ' | sed 's/^.//' > /tmp/podman-generate.man
+echo diff -B -u /tmp/podman-generate.cmd /tmp/podman-generate.man
+diff -B -u /tmp/podman-generate.cmd /tmp/podman-generate.man
+
+./bin/podman pod --help | sed -n -e '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman-pod.cmd
+man docs/podman-pod.1 | sed -n -Ee '0,/COMMANDS/d'  -e 's/^[[:space:]]*//' -e '/^SEE ALSO/q;p' | grep podman | cut -f1 -d' ' | sed 's/^.//' > /tmp/podman-pod.man
+echo diff -B -u /tmp/podman-pod.cmd /tmp/podman-pod.man
+diff -B -u /tmp/podman-pod.cmd /tmp/podman-pod.man
+
+./bin/podman volume --help | sed -n -e '0,/Available Commands/d' -e '/^Flags/q;p' | sed '/^$/d' | awk '{ print $1 }' > /tmp/podman-volume.cmd
+man docs/podman-volume.1 | sed -n -Ee '0,/COMMANDS/d'  -e 's/^[[:space:]]*//' -e '/^SEE ALSO/q;p' | grep podman | cut -f1 -d' ' | sed 's/^.//' > /tmp/podman-volume.man
+echo diff -B -u /tmp/podman-volume.cmd /tmp/podman-volume.man
+diff -B -u /tmp/podman-volume.cmd /tmp/podman-volume.man


### PR DESCRIPTION
Also add podman-commands.sh to compare man pages to commands.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>