### PR TITLE
fix up a number of misplace commands

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -30,7 +30,6 @@ func getMainCommands() []*cobra.Command {
 		_rmCommand,
 		_runCommand,
 		_searchCommand,
-		_signCommand,
 		_startCommand,
 		_statsCommand,
 		_stopCommand,
@@ -49,7 +48,6 @@ func getMainCommands() []*cobra.Command {
 // Commands that the local client implements
 func getImageSubCommands() []*cobra.Command {
 	return []*cobra.Command{
-		_loadCommand,
 		_signCommand,
 	}
 }

--- a/cmd/podman/image.go
+++ b/cmd/podman/image.go
@@ -14,6 +14,7 @@ var (
 			Long:  imageDescription,
 		},
 	}
+	_imagesSubCommand = _imagesCommand
 )
 
 //imageSubCommands are implemented both in local and remote clients
@@ -21,7 +22,6 @@ var imageSubCommands = []*cobra.Command{
 	_buildCommand,
 	_historyCommand,
 	_imageExistsCommand,
-	_imagesCommand,
 	_importCommand,
 	_inspectCommand,
 	_loadCommand,
@@ -37,4 +37,8 @@ func init() {
 	imageCommand.SetUsageTemplate(UsageTemplate())
 	imageCommand.AddCommand(imageSubCommands...)
 	imageCommand.AddCommand(getImageSubCommands()...)
+
+	_imagesSubCommand.Aliases = []string{"ls", "list"}
+	imageCommand.AddCommand(&_imagesSubCommand)
+
 }

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -87,7 +87,7 @@ var (
 	imagesCommand     cliconfig.ImagesValues
 	imagesDescription = "lists locally stored images."
 
-	_imagesCommand = &cobra.Command{
+	_imagesCommand = cobra.Command{
 		Use:   "images",
 		Short: "List images in local storage",
 		Long:  imagesDescription,
@@ -103,8 +103,9 @@ var (
 )
 
 func init() {
-	imagesCommand.Command = _imagesCommand
+	imagesCommand.Command = &_imagesCommand
 	imagesCommand.SetUsageTemplate(UsageTemplate())
+
 	flags := imagesCommand.Flags()
 	flags.BoolVarP(&imagesCommand.All, "all", "a", false, "Show all images (default hides intermediate images)")
 	flags.BoolVar(&imagesCommand.Digests, "digests", false, "Show digests")

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -38,7 +38,7 @@ var mainCommands = []*cobra.Command{
 	_buildCommand,
 	_exportCommand,
 	_historyCommand,
-	_imagesCommand,
+	&_imagesCommand,
 	_importCommand,
 	_infoCommand,
 	_inspectCommand,

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -158,10 +158,9 @@ var (
 	psCommand     cliconfig.PsValues
 	psDescription = "Prints out information about the containers"
 	_psCommand    = &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls", "ps"},
-		Short:   "List containers",
-		Long:    psDescription,
+		Use:   "ps",
+		Short: "List containers",
+		Long:  psDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			psCommand.InputArgs = args
 			psCommand.GlobalFlags = MainGlobalOpts


### PR DESCRIPTION
* ps now on main command
* sign is no longer on main commmand
* ls, list no longer are valid main aliases for images
* ls, list does work for podman image

Signed-off-by: baude <bbaude@redhat.com>