### PR TITLE
podman create: disable interspersed opts

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -67,7 +67,7 @@ func init() {
 
 	getCreateFlags(&createCommand.PodmanCommand)
 	flags := createCommand.Flags()
-	flags.SetInterspersed(true)
+	flags.SetInterspersed(false)
 
 }
 


### PR DESCRIPTION
With the change to cobra, the following command fails:

   # podman create alpine sh -c /bin/true
   Error: unknown shorthand flag: 'c' in -c

(Correct behavior is to pass '-c' to the container command)

This PR corrects that.

Signed-off-by: Ed Santiago <santiago@redhat.com>