### PR TITLE
Add tests to make sure podman container and podman image commands work

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -55,9 +55,6 @@ func getImageSubCommands() []*cobra.Command {
 // Commands that the local client implements
 func getContainerSubCommands() []*cobra.Command {
 
-	var _listSubCommand = _psCommand
-	_listSubCommand.Use = "list"
-
 	return []*cobra.Command{
 		_attachCommand,
 		_checkpointCommand,
@@ -68,7 +65,6 @@ func getContainerSubCommands() []*cobra.Command {
 		_execCommand,
 		_exportCommand,
 		_killCommand,
-		&_listSubCommand,
 		_logsCommand,
 		_mountCommand,
 		_pauseCommand,

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -1,27 +1,49 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/spf13/cobra"
 )
 
-var containerDescription = "Manage containers"
-var containerCommand = cliconfig.PodmanCommand{
-	Command: &cobra.Command{
-		Use:              "container",
-		Short:            "Manage Containers",
-		Long:             containerDescription,
-		TraverseChildren: true,
-	},
-}
+var (
+	containerDescription = "Manage containers"
+	containerCommand     = cliconfig.PodmanCommand{
+		Command: &cobra.Command{
+			Use:              "container",
+			Short:            "Manage Containers",
+			Long:             containerDescription,
+			TraverseChildren: true,
+		},
+	}
 
-// Commands that are universally implemented.
-var containerCommands = []*cobra.Command{
-	_containerExistsCommand,
-	_inspectCommand,
-}
+	listSubCommand  cliconfig.PsValues
+	_listSubCommand = &cobra.Command{
+		Use:     strings.Replace(_psCommand.Use, "ps", "list", 1),
+		Short:   _psCommand.Short,
+		Long:    _psCommand.Long,
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			listSubCommand.InputArgs = args
+			listSubCommand.GlobalFlags = MainGlobalOpts
+			return psCmd(&listSubCommand)
+		},
+		Example: strings.Replace(_psCommand.Example, "podman ps", "podman container list", -1),
+	}
+
+	// Commands that are universally implemented.
+	containerCommands = []*cobra.Command{
+		_containerExistsCommand,
+		_inspectCommand,
+		_listSubCommand,
+	}
+)
 
 func init() {
+	listSubCommand.Command = _listSubCommand
+	psInit(&listSubCommand)
+
 	containerCommand.AddCommand(containerCommands...)
 	containerCommand.AddCommand(getContainerSubCommands()...)
 	containerCommand.SetUsageTemplate(UsageTemplate())

--- a/cmd/podman/image.go
+++ b/cmd/podman/image.go
@@ -16,14 +16,39 @@ var (
 			Long:  imageDescription,
 		},
 	}
-	_imagesSubCommand = _imagesCommand
-	_rmSubCommand     = _rmiCommand
+	imagesSubCommand  cliconfig.ImagesValues
+	_imagesSubCommand = &cobra.Command{
+		Use:     strings.Replace(_imagesCommand.Use, "images", "list", 1),
+		Short:   _imagesCommand.Short,
+		Long:    _imagesCommand.Long,
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			imagesSubCommand.InputArgs = args
+			imagesSubCommand.GlobalFlags = MainGlobalOpts
+			return imagesCmd(&imagesSubCommand)
+		},
+		Example: strings.Replace(_imagesCommand.Example, "podman images", "podman image list", -1),
+	}
+
+	rmSubCommand  cliconfig.RmiValues
+	_rmSubCommand = &cobra.Command{
+		Use:   strings.Replace(_rmiCommand.Use, "rmi", "rm", 1),
+		Short: _rmiCommand.Short,
+		Long:  _rmiCommand.Long,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rmSubCommand.InputArgs = args
+			rmSubCommand.GlobalFlags = MainGlobalOpts
+			return rmiCmd(&rmSubCommand)
+		},
+		Example: strings.Replace(_rmiCommand.Example, "podman rmi", "podman image rm", -1),
+	}
 )
 
 //imageSubCommands are implemented both in local and remote clients
 var imageSubCommands = []*cobra.Command{
 	_buildCommand,
 	_historyCommand,
+	_imagesSubCommand,
 	_imageExistsCommand,
 	_importCommand,
 	_inspectCommand,
@@ -31,23 +56,20 @@ var imageSubCommands = []*cobra.Command{
 	_pruneImagesCommand,
 	_pullCommand,
 	_pushCommand,
+	_rmSubCommand,
 	_saveCommand,
 	_tagCommand,
 }
 
 func init() {
+	rmSubCommand.Command = _rmSubCommand
+	rmiInit(&rmSubCommand)
+
+	imagesSubCommand.Command = _imagesSubCommand
+	imagesInit(&imagesSubCommand)
+
 	imageCommand.SetUsageTemplate(UsageTemplate())
 	imageCommand.AddCommand(imageSubCommands...)
 	imageCommand.AddCommand(getImageSubCommands()...)
 
-	// Setup of "images" to appear as "list"
-	_imagesSubCommand.Use = strings.Replace(_imagesSubCommand.Use, "images", "list", 1)
-	_imagesSubCommand.Aliases = []string{"ls"}
-	_imagesSubCommand.Example = strings.Replace(_imagesSubCommand.Example, "podman images", "podman image list", -1)
-	imageCommand.AddCommand(&_imagesSubCommand)
-
-	// It makes no sense to keep 'podman images rmi'; just use 'rm'
-	_rmSubCommand.Use = strings.Replace(_rmSubCommand.Use, "rmi", "rm", 1)
-	_rmSubCommand.Example = strings.Replace(_rmSubCommand.Example, "podman rmi", "podman image rm", -1)
-	imageCommand.AddCommand(&_rmSubCommand)
 }

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -102,22 +102,26 @@ var (
 	}
 )
 
-func init() {
-	imagesCommand.Command = &_imagesCommand
-	imagesCommand.SetUsageTemplate(UsageTemplate())
+func imagesInit(command *cliconfig.ImagesValues) {
+	command.SetUsageTemplate(UsageTemplate())
 
-	flags := imagesCommand.Flags()
-	flags.BoolVarP(&imagesCommand.All, "all", "a", false, "Show all images (default hides intermediate images)")
-	flags.BoolVar(&imagesCommand.Digests, "digests", false, "Show digests")
-	flags.StringSliceVarP(&imagesCommand.Filter, "filter", "f", []string{}, "Filter output based on conditions provided (default [])")
-	flags.StringVar(&imagesCommand.Format, "format", "", "Change the output format to JSON or a Go template")
-	flags.BoolVarP(&imagesCommand.Noheading, "noheading", "n", false, "Do not print column headings")
+	flags := command.Flags()
+	flags.BoolVarP(&command.All, "all", "a", false, "Show all images (default hides intermediate images)")
+	flags.BoolVar(&command.Digests, "digests", false, "Show digests")
+	flags.StringSliceVarP(&command.Filter, "filter", "f", []string{}, "Filter output based on conditions provided (default [])")
+	flags.StringVar(&command.Format, "format", "", "Change the output format to JSON or a Go template")
+	flags.BoolVarP(&command.Noheading, "noheading", "n", false, "Do not print column headings")
 	// TODO Need to learn how to deal with second name being a string instead of a char.
 	// This needs to be "no-trunc, notruncate"
-	flags.BoolVar(&imagesCommand.NoTrunc, "no-trunc", false, "Do not truncate output")
-	flags.BoolVarP(&imagesCommand.Quiet, "quiet", "q", false, "Display only image IDs")
-	flags.StringVar(&imagesCommand.Sort, "sort", "created", "Sort by created, id, repository, size, or tag")
+	flags.BoolVar(&command.NoTrunc, "no-trunc", false, "Do not truncate output")
+	flags.BoolVarP(&command.Quiet, "quiet", "q", false, "Display only image IDs")
+	flags.StringVar(&command.Sort, "sort", "created", "Sort by created, id, repository, size, or tag")
 
+}
+
+func init() {
+	imagesCommand.Command = &_imagesCommand
+	imagesInit(&imagesCommand)
 }
 
 func imagesCmd(c *cliconfig.ImagesValues) error {

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -173,25 +173,29 @@ var (
 	}
 )
 
-func init() {
-	psCommand.Command = &_psCommand
-	psCommand.SetUsageTemplate(UsageTemplate())
-	flags := psCommand.Flags()
-	flags.BoolVarP(&psCommand.All, "all", "a", false, "Show all the containers, default is only running containers")
-	flags.StringSliceVarP(&psCommand.Filter, "filter", "f", []string{}, "Filter output based on conditions given")
-	flags.StringVar(&psCommand.Format, "format", "", "Pretty-print containers to JSON or using a Go template")
-	flags.IntVarP(&psCommand.Last, "last", "n", -1, "Print the n last created containers (all states)")
-	flags.BoolVarP(&psCommand.Latest, "latest", "l", false, "Show the latest container created (all states)")
-	flags.BoolVar(&psCommand.Namespace, "namespace", false, "Display namespace information")
-	flags.BoolVar(&psCommand.Namespace, "ns", false, "Display namespace information")
-	flags.BoolVar(&psCommand.NoTrunct, "no-trunc", false, "Display the extended information")
-	flags.BoolVarP(&psCommand.Pod, "pod", "p", false, "Print the ID and name of the pod the containers are associated with")
-	flags.BoolVarP(&psCommand.Quiet, "quiet", "q", false, "Print the numeric IDs of the containers only")
-	flags.BoolVarP(&psCommand.Size, "size", "s", false, "Display the total file sizes")
-	flags.StringVar(&psCommand.Sort, "sort", "created", "Sort output by command, created, id, image, names, runningfor, size, or status")
-	flags.BoolVar(&psCommand.Sync, "sync", false, "Sync container state with OCI runtime")
+func psInit(command *cliconfig.PsValues) {
+	command.SetUsageTemplate(UsageTemplate())
+	flags := command.Flags()
+	flags.BoolVarP(&command.All, "all", "a", false, "Show all the containers, default is only running containers")
+	flags.StringSliceVarP(&command.Filter, "filter", "f", []string{}, "Filter output based on conditions given")
+	flags.StringVar(&command.Format, "format", "", "Pretty-print containers to JSON or using a Go template")
+	flags.IntVarP(&command.Last, "last", "n", -1, "Print the n last created containers (all states)")
+	flags.BoolVarP(&command.Latest, "latest", "l", false, "Show the latest container created (all states)")
+	flags.BoolVar(&command.Namespace, "namespace", false, "Display namespace information")
+	flags.BoolVar(&command.Namespace, "ns", false, "Display namespace information")
+	flags.BoolVar(&command.NoTrunct, "no-trunc", false, "Display the extended information")
+	flags.BoolVarP(&command.Pod, "pod", "p", false, "Print the ID and name of the pod the containers are associated with")
+	flags.BoolVarP(&command.Quiet, "quiet", "q", false, "Print the numeric IDs of the containers only")
+	flags.BoolVarP(&command.Size, "size", "s", false, "Display the total file sizes")
+	flags.StringVar(&command.Sort, "sort", "created", "Sort output by command, created, id, image, names, runningfor, size, or status")
+	flags.BoolVar(&command.Sync, "sync", false, "Sync container state with OCI runtime")
 
 	markFlagHiddenForRemoteClient("latest", flags)
+}
+
+func init() {
+	psCommand.Command = &_psCommand
+	psInit(&psCommand)
 }
 
 func psCmd(c *cliconfig.PsValues) error {

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -29,12 +29,16 @@ var (
 	}
 )
 
+func rmiInit(command *cliconfig.RmiValues) {
+	command.SetUsageTemplate(UsageTemplate())
+	flags := command.Flags()
+	flags.BoolVarP(&command.All, "all", "a", false, "Remove all images")
+	flags.BoolVarP(&command.Force, "force", "f", false, "Force Removal of the image")
+}
+
 func init() {
 	rmiCommand.Command = &_rmiCommand
-	rmiCommand.SetUsageTemplate(UsageTemplate())
-	flags := rmiCommand.Flags()
-	flags.BoolVarP(&rmiCommand.All, "all", "a", false, "Remove all images")
-	flags.BoolVarP(&rmiCommand.Force, "force", "f", false, "Force Removal of the image")
+	rmiInit(&rmiCommand)
 }
 
 func rmiCmd(c *cliconfig.RmiValues) error {

--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -51,6 +51,16 @@ var _ = Describe("Podman attach", func() {
 		Expect(results.ExitCode()).To(Equal(125))
 	})
 
+	It("podman container attach to non-running container", func() {
+		session := podmanTest.Podman([]string{"container", "create", "--name", "test1", "-d", "-i", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		results := podmanTest.Podman([]string{"container", "attach", "test1"})
+		results.WaitWithDefaultTimeout()
+		Expect(results.ExitCode()).To(Equal(125))
+	})
+
 	It("podman attach to multiple containers", func() {
 		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -50,6 +50,21 @@ var _ = Describe("Podman commit", func() {
 		Expect(StringInSlice("foobar.com/test1-image:latest", data[0].RepoTags)).To(BeTrue())
 	})
 
+	It("podman container commit container", func() {
+		_, ec, _ := podmanTest.RunLsContainer("test1")
+		Expect(ec).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+
+		session := podmanTest.Podman([]string{"container", "commit", "test1", "foobar.com/test1-image:latest"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		check := podmanTest.Podman([]string{"container", "inspect", "foobar.com/test1-image:latest"})
+		check.WaitWithDefaultTimeout()
+		data := check.InspectImageJSON()
+		Expect(StringInSlice("foobar.com/test1-image:latest", data[0].RepoTags)).To(BeTrue())
+	})
+
 	It("podman commit container with message", func() {
 		_, ec, _ := podmanTest.RunLsContainer("test1")
 		Expect(ec).To(Equal(0))

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -56,6 +56,13 @@ var _ = Describe("Podman create", func() {
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 	})
 
+	It("podman container create container based on a remote image", func() {
+		session := podmanTest.Podman([]string{"container", "create", BB_GLIBC, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+	})
+
 	It("podman create using short options", func() {
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -43,6 +43,13 @@ var _ = Describe("Podman diff", func() {
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 0))
 	})
 
+	It("podman container diff of image", func() {
+		session := podmanTest.Podman([]string{"container", "diff", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 0))
+	})
+
 	It("podman diff bogus image", func() {
 		session := podmanTest.Podman([]string{"diff", "1234"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -57,6 +57,16 @@ var _ = Describe("Podman exec", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman container exec simple command", func() {
+		setup := podmanTest.RunTopContainer("test1")
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"container", "exec", "test1", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman exec simple command using latest", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()

--- a/test/e2e/export_test.go
+++ b/test/e2e/export_test.go
@@ -50,6 +50,22 @@ var _ = Describe("Podman export", func() {
 		Expect(err).To(BeNil())
 	})
 
+	It("podman container export output flag", func() {
+		SkipIfRemote()
+		_, ec, cid := podmanTest.RunLsContainer("")
+		Expect(ec).To(Equal(0))
+
+		outfile := filepath.Join(podmanTest.TempDir, "container.tar")
+		result := podmanTest.Podman([]string{"container", "export", "-o", outfile, cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		_, err := os.Stat(outfile)
+		Expect(err).To(BeNil())
+
+		err = os.Remove(outfile)
+		Expect(err).To(BeNil())
+	})
+
 	It("podman export bad filename", func() {
 		_, ec, cid := podmanTest.RunLsContainer("")
 		Expect(ec).To(Equal(0))

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -41,6 +41,19 @@ var _ = Describe("Podman kill", func() {
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
 
+	It("podman container kill a running container by id", func() {
+		session := podmanTest.RunTopContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"container", "kill", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+	})
+
 	It("podman kill a running container by id", func() {
 		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -49,6 +49,21 @@ var _ = Describe("Podman mount", func() {
 		Expect(umount.ExitCode()).To(Equal(0))
 	})
 
+	It("podman container mount", func() {
+		setup := podmanTest.Podman([]string{"container", "create", ALPINE, "ls"})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+		cid := setup.OutputToString()
+
+		mount := podmanTest.Podman([]string{"container", "mount", cid})
+		mount.WaitWithDefaultTimeout()
+		Expect(mount.ExitCode()).To(Equal(0))
+
+		umount := podmanTest.Podman([]string{"container", "umount", cid})
+		umount.WaitWithDefaultTimeout()
+		Expect(umount.ExitCode()).To(Equal(0))
+	})
+
 	It("podman mount with json format", func() {
 		setup := podmanTest.Podman([]string{"create", ALPINE, "ls"})
 		setup.WaitWithDefaultTimeout()

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -80,6 +80,23 @@ var _ = Describe("Podman pause", func() {
 		result.WaitWithDefaultTimeout()
 	})
 
+	It("podman container pause a running container by id", func() {
+		session := podmanTest.RunTopContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"container", "pause", cid})
+		result.WaitWithDefaultTimeout()
+
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
+		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring(pausedState))
+
+		result = podmanTest.Podman([]string{"container", "unpause", cid})
+		result.WaitWithDefaultTimeout()
+	})
+
 	It("podman unpause a running container by id", func() {
 		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/port_test.go
+++ b/test/e2e/port_test.go
@@ -60,6 +60,19 @@ var _ = Describe("Podman port", func() {
 		Expect(result.LineInOuputStartsWith(fmt.Sprintf("80/tcp -> 0.0.0.0:%s", port))).To(BeTrue())
 	})
 
+	It("podman container port  -l nginx", func() {
+		podmanTest.RestoreArtifact(nginx)
+		session := podmanTest.Podman([]string{"container", "run", "-dt", "-P", nginx})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"container", "port", "-l"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		port := strings.Split(result.OutputToStringArray()[0], ":")[1]
+		Expect(result.LineInOuputStartsWith(fmt.Sprintf("80/tcp -> 0.0.0.0:%s", port))).To(BeTrue())
+	})
+
 	It("podman port -l port nginx", func() {
 		podmanTest.RestoreArtifact(nginx)
 		session := podmanTest.Podman([]string{"run", "-dt", "-P", nginx})

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -88,17 +88,6 @@ var _ = Describe("Podman rm", func() {
 		Expect(len(images.OutputToStringArray())).To(Equal(0))
 	})
 
-	It("podman container image prune unused images", func() {
-		prune := podmanTest.Podman([]string{"container", "image", "prune", "-a"})
-		prune.WaitWithDefaultTimeout()
-		Expect(prune.ExitCode()).To(Equal(0))
-
-		images := podmanTest.Podman([]string{"image", "list", "-a"})
-		images.WaitWithDefaultTimeout()
-		// all images are unused, so they all should be deleted!
-		Expect(len(images.OutputToStringArray())).To(Equal(0))
-	})
-
 	It("podman system image prune unused images", func() {
 		SkipIfRemote()
 		podmanTest.BuildImage(pruneImage, "alpine_bash:latest", "true")

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -88,6 +88,17 @@ var _ = Describe("Podman rm", func() {
 		Expect(len(images.OutputToStringArray())).To(Equal(0))
 	})
 
+	It("podman container image prune unused images", func() {
+		prune := podmanTest.Podman([]string{"container", "image", "prune", "-a"})
+		prune.WaitWithDefaultTimeout()
+		Expect(prune.ExitCode()).To(Equal(0))
+
+		images := podmanTest.Podman([]string{"image", "list", "-a"})
+		images.WaitWithDefaultTimeout()
+		// all images are unused, so they all should be deleted!
+		Expect(len(images.OutputToStringArray())).To(Equal(0))
+	})
+
 	It("podman system image prune unused images", func() {
 		SkipIfRemote()
 		podmanTest.BuildImage(pruneImage, "alpine_bash:latest", "true")

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -65,6 +65,21 @@ var _ = Describe("Podman ps", func() {
 		Expect(len(result.OutputToStringArray())).Should(BeNumerically(">", 0))
 	})
 
+	It("podman container list all", func() {
+		_, ec, _ := podmanTest.RunLsContainer("")
+		Expect(ec).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"container", "list", "-a"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(len(result.OutputToStringArray())).Should(BeNumerically(">", 0))
+
+		result = podmanTest.Podman([]string{"container", "ls", "-a"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(len(result.OutputToStringArray())).Should(BeNumerically(">", 0))
+	})
+
 	It("podman ps size flag", func() {
 		_, ec, _ := podmanTest.RunLsContainer("")
 		Expect(ec).To(Equal(0))

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -90,6 +90,21 @@ var _ = Describe("Podman restart", func() {
 		Expect(restartTime.OutputToString()).To(Not(Equal(startTime.OutputToString())))
 	})
 
+	It("Podman container restart running container", func() {
+		_ = podmanTest.RunTopContainer("test1")
+		ok := WaitForContainer(podmanTest)
+		Expect(ok).To(BeTrue())
+		startTime := podmanTest.Podman([]string{"container", "inspect", "--format='{{.State.StartedAt}}'", "test1"})
+		startTime.WaitWithDefaultTimeout()
+
+		session := podmanTest.Podman([]string{"container", "restart", "test1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		restartTime := podmanTest.Podman([]string{"container", "inspect", "--format='{{.State.StartedAt}}'", "test1"})
+		restartTime.WaitWithDefaultTimeout()
+		Expect(restartTime.OutputToString()).To(Not(Equal(startTime.OutputToString())))
+	})
+
 	It("Podman restart multiple containers", func() {
 		_, exitCode, _ := podmanTest.RunLsContainer("test1")
 		Expect(exitCode).To(Equal(0))

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -65,6 +65,17 @@ var _ = Describe("Podman rm", func() {
 		Expect(result.ExitCode()).To(Equal(0))
 	})
 
+	It("podman container rm created container", func() {
+		session := podmanTest.Podman([]string{"container", "create", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"container", "rm", cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+	})
+
 	It("podman rm running container with -f", func() {
 		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Podman run", func() {
 
 	It("podman container run a container based on on a short name with localhost", func() {
 		podmanTest.RestoreArtifact(nginx)
-		tag := podmanTest.Podman([]string{"container", "tag", nginx, "localhost/libpod/alpine_nginx:latest"})
+		tag := podmanTest.Podman([]string{"image", "tag", nginx, "localhost/libpod/alpine_nginx:latest"})
 		tag.WaitWithDefaultTimeout()
 
 		rmi := podmanTest.Podman([]string{"image", "rm", nginx})

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -68,6 +68,20 @@ var _ = Describe("Podman run", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman container run a container based on on a short name with localhost", func() {
+		podmanTest.RestoreArtifact(nginx)
+		tag := podmanTest.Podman([]string{"container", "tag", nginx, "localhost/libpod/alpine_nginx:latest"})
+		tag.WaitWithDefaultTimeout()
+
+		rmi := podmanTest.Podman([]string{"image", "rm", nginx})
+		rmi.WaitWithDefaultTimeout()
+
+		session := podmanTest.Podman([]string{"container", "run", "libpod/alpine_nginx:latest", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ErrorToString()).ToNot(ContainSubstring("Trying to pull"))
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman run a container based on local image with short options", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -50,6 +50,16 @@ var _ = Describe("Podman start", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman container start single container by id", func() {
+		session := podmanTest.Podman([]string{"container", "create", "-d", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+		session = podmanTest.Podman([]string{"container", "start", cid})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman start single container by name", func() {
 		session := podmanTest.Podman([]string{"create", "-d", "--name", "foobar99", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -59,6 +59,15 @@ var _ = Describe("Podman stop", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman stop container by name", func() {
+		session := podmanTest.RunTopContainer("test1")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"container", "stop", "test1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman stop stopped container", func() {
 		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/top_test.go
+++ b/test/e2e/top_test.go
@@ -65,6 +65,17 @@ var _ = Describe("Podman top", func() {
 		Expect(len(result.OutputToStringArray())).To(BeNumerically(">", 1))
 	})
 
+	It("podman container top on container", func() {
+		session := podmanTest.Podman([]string{"container", "run", "-d", ALPINE, "top", "-d", "2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"container", "top", "-l"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(len(result.OutputToStringArray())).To(BeNumerically(">", 1))
+	})
+
 	It("podman top with options", func() {
 		session := podmanTest.Podman([]string{"run", "-d", ALPINE, "top", "-d", "2"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/wait_test.go
+++ b/test/e2e/wait_test.go
@@ -66,4 +66,11 @@ var _ = Describe("Podman wait", func() {
 		session = podmanTest.Podman([]string{"wait", "-l"})
 		session.Wait(20)
 	})
+	It("podman container wait on latest container", func() {
+		session := podmanTest.Podman([]string{"container", "run", "-d", ALPINE, "sleep", "1"})
+		session.Wait(20)
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"container", "wait", "-l"})
+		session.Wait(20)
+	})
 })


### PR DESCRIPTION
We have little to no testing to make sure we don't break podman image and
podman container commands that wrap traditional commands.

This PR adds tests for each of the commands.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>