### PR TITLE
podman port fix output

### DIFF
--- a/cmd/podman/port.go
+++ b/cmd/podman/port.go
@@ -128,9 +128,6 @@ func portCmd(c *cliconfig.PortValues) error {
 		if state, _ := con.State(); state != libpod.ContainerStateRunning {
 			continue
 		}
-		if c.All {
-			fmt.Println(con.ID())
-		}
 
 		portmappings, err := con.PortMappings()
 		if err != nil {
@@ -142,6 +139,9 @@ func portCmd(c *cliconfig.PortValues) error {
 			// Set host IP to 0.0.0.0 if blank
 			if hostIP == "" {
 				hostIP = "0.0.0.0"
+			}
+			if c.All {
+				fmt.Printf("%s\t", con.ID()[:12])
 			}
 			// If not searching by port or port/proto, then dump what we see
 			if port == "" {


### PR DESCRIPTION
list a portion of the container id and the ports exposed on the same
line. when using all, if no ports are exposed, do not list the container
id.  Also, shorten the container id to a len of 12 like other container
commands.

Fixes bugzilla #1683734
Signed-off-by: baude <bbaude@redhat.com>