### PR TITLE
rootless, new[ug]idmap: on failure add output

### DIFF
--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -93,7 +93,8 @@ func tryMappingTool(tool string, pid int, hostID int, mappings []idtools.IDMap) 
 		Args: args,
 	}
 
-	if err := cmd.Run(); err != nil {
+	if output, err := cmd.CombinedOutput(); err != nil {
+		logrus.Debugf("error from %s: %s", tool, output)
 		return errors.Wrapf(err, "cannot setup namespace using %s", tool)
 	}
 	return nil


### PR DESCRIPTION
if any of the mapping tools for setting up the user namespace fail,
then include their output in the error message.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>