### PR TITLE
fix up a number of misplace commands

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -18,7 +18,7 @@ func getMainCommands() []*cobra.Command {
 		_execCommand,
 		_generateCommand,
 		_playCommand,
-		_psCommand,
+		&_psCommand,
 		_loginCommand,
 		_logoutCommand,
 		_logsCommand,
@@ -54,6 +54,10 @@ func getImageSubCommands() []*cobra.Command {
 
 // Commands that the local client implements
 func getContainerSubCommands() []*cobra.Command {
+
+	var _listSubCommand = _psCommand
+	_listSubCommand.Use = "list"
+
 	return []*cobra.Command{
 		_attachCommand,
 		_checkpointCommand,
@@ -64,8 +68,8 @@ func getContainerSubCommands() []*cobra.Command {
 		_execCommand,
 		_exportCommand,
 		_killCommand,
+		&_listSubCommand,
 		_logsCommand,
-		_psCommand,
 		_mountCommand,
 		_pauseCommand,
 		_portCommand,

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -18,11 +18,13 @@ var containerCommand = cliconfig.PodmanCommand{
 // Commands that are universally implemented.
 var containerCommands = []*cobra.Command{
 	_containerExistsCommand,
+	_inspectCommand,
 }
 
 func init() {
 	containerCommand.AddCommand(containerCommands...)
 	containerCommand.AddCommand(getContainerSubCommands()...)
 	containerCommand.SetUsageTemplate(UsageTemplate())
+
 	rootCmd.AddCommand(containerCommand.Command)
 }

--- a/cmd/podman/image.go
+++ b/cmd/podman/image.go
@@ -15,6 +15,7 @@ var (
 		},
 	}
 	_imagesSubCommand = _imagesCommand
+	_rmSubCommand     = _rmiCommand
 )
 
 //imageSubCommands are implemented both in local and remote clients
@@ -28,7 +29,6 @@ var imageSubCommands = []*cobra.Command{
 	_pruneImagesCommand,
 	_pullCommand,
 	_pushCommand,
-	_rmiCommand,
 	_saveCommand,
 	_tagCommand,
 }
@@ -38,7 +38,12 @@ func init() {
 	imageCommand.AddCommand(imageSubCommands...)
 	imageCommand.AddCommand(getImageSubCommands()...)
 
-	_imagesSubCommand.Aliases = []string{"ls", "list"}
+	// Setup of "images" to appear as "list"
+	_imagesSubCommand.Use = "list"
+	_imagesSubCommand.Aliases = []string{"ls"}
 	imageCommand.AddCommand(&_imagesSubCommand)
 
+	// Setup of "rmi" to appears as "rm"
+	_rmSubCommand.Use = "rm"
+	imageCommand.AddCommand(&_rmSubCommand)
 }

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -47,7 +47,7 @@ var mainCommands = []*cobra.Command{
 	podCommand.Command,
 	_pullCommand,
 	_pushCommand,
-	_rmiCommand,
+	&_rmiCommand,
 	_saveCommand,
 	_tagCommand,
 	_versionCommand,

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -157,7 +157,7 @@ func (a psSortedSize) Less(i, j int) bool {
 var (
 	psCommand     cliconfig.PsValues
 	psDescription = "Prints out information about the containers"
-	_psCommand    = &cobra.Command{
+	_psCommand    = cobra.Command{
 		Use:   "ps",
 		Short: "List containers",
 		Long:  psDescription,
@@ -173,7 +173,7 @@ var (
 )
 
 func init() {
-	psCommand.Command = _psCommand
+	psCommand.Command = &_psCommand
 	psCommand.SetUsageTemplate(UsageTemplate())
 	flags := psCommand.Flags()
 	flags.BoolVarP(&psCommand.All, "all", "a", false, "Show all the containers, default is only running containers")

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -14,7 +14,7 @@ import (
 var (
 	rmiCommand     cliconfig.RmiValues
 	rmiDescription = "Removes one or more locally stored images."
-	_rmiCommand    = &cobra.Command{
+	_rmiCommand    = cobra.Command{
 		Use:   "rmi [flags] IMAGE [IMAGE...]",
 		Short: "Removes one or more images from local storage",
 		Long:  rmiDescription,
@@ -30,7 +30,7 @@ var (
 )
 
 func init() {
-	rmiCommand.Command = _rmiCommand
+	rmiCommand.Command = &_rmiCommand
 	rmiCommand.SetUsageTemplate(UsageTemplate())
 	flags := rmiCommand.Flags()
 	flags.BoolVarP(&rmiCommand.All, "all", "a", false, "Remove all images")


### PR DESCRIPTION
* ps now on main command
* sign is no longer on main commmand
* ls, list no longer are valid main aliases for images
* ls, list does work for podman image

Signed-off-by: baude <bbaude@redhat.com>