### PR TITLE
Fix SystemExec completion race

### DIFF
--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Podman load", func() {
 		Expect(save.ExitCode()).To(Equal(0))
 
 		compress := SystemExec("gzip", []string{outfile})
-		compress.WaitWithDefaultTimeout()
+		Expect(compress.ExitCode()).To(Equal(0))
 		outfile = outfile + ".gz"
 
 		rmi := podmanTest.Podman([]string{"rmi", ALPINE})
@@ -174,7 +174,6 @@ var _ = Describe("Podman load", func() {
 
 	It("podman load localhost registry from scratch", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "load_test.tar.gz")
-
 		setup := podmanTest.Podman([]string{"tag", ALPINE, "hello:world"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
@@ -255,7 +254,6 @@ var _ = Describe("Podman load", func() {
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 		session := SystemExec("xz", []string{outfile})
-		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 		rmi := podmanTest.Podman([]string{"rmi", BB})

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -95,7 +95,6 @@ var _ = Describe("Podman pod create", func() {
 		Expect(webserver.ExitCode()).To(Equal(0))
 
 		check := SystemExec("nc", []string{"-z", "localhost", "80"})
-		check.WaitWithDefaultTimeout()
 		Expect(check.ExitCode()).To(Equal(1))
 	})
 
@@ -111,7 +110,6 @@ var _ = Describe("Podman pod create", func() {
 		Expect(webserver.ExitCode()).To(Equal(0))
 
 		check := SystemExec("nc", []string{"-z", "localhost", "80"})
-		check.WaitWithDefaultTimeout()
 		Expect(check.ExitCode()).To(Equal(0))
 	})
 

--- a/test/e2e/run_cleanup_test.go
+++ b/test/e2e/run_cleanup_test.go
@@ -36,14 +36,16 @@ var _ = Describe("Podman run exit", func() {
 
 	It("podman run -d mount cleanup test", func() {
 		mount := SystemExec("mount", nil)
-		mount.WaitWithDefaultTimeout()
+		Expect(mount.ExitCode()).To(Equal(0))
+
 		out1 := mount.OutputToString()
 		result := podmanTest.Podman([]string{"create", "-dt", ALPINE, "echo", "hello"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 
 		mount = SystemExec("mount", nil)
-		mount.WaitWithDefaultTimeout()
+		Expect(mount.ExitCode()).To(Equal(0))
+
 		out2 := mount.OutputToString()
 		Expect(out1).To(Equal(out2))
 	})

--- a/test/e2e/run_ns_test.go
+++ b/test/e2e/run_ns_test.go
@@ -53,7 +53,6 @@ var _ = Describe("Podman run ns", func() {
 
 	It("podman run ipcns test", func() {
 		setup := SystemExec("ls", []string{"--inode", "-d", "/dev/shm"})
-		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 		hostShm := setup.OutputToString()
 
@@ -65,7 +64,6 @@ var _ = Describe("Podman run ns", func() {
 
 	It("podman run ipcns ipcmk host test", func() {
 		setup := SystemExec("ipcmk", []string{"-M", "1024"})
-		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 		output := strings.Split(setup.OutputToString(), " ")
 		ipc := output[len(output)-1]
@@ -74,7 +72,6 @@ var _ = Describe("Podman run ns", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 
 		setup = SystemExec("ipcrm", []string{"-m", ipc})
-		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 	})
 

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -46,7 +46,6 @@ var _ = Describe("Podman privileged container tests", func() {
 
 	It("podman privileged CapEff", func() {
 		cap := SystemExec("grep", []string{"CapEff", "/proc/self/status"})
-		cap.WaitWithDefaultTimeout()
 		Expect(cap.ExitCode()).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"run", "--privileged", "busybox", "grep", "CapEff", "/proc/self/status"})
@@ -57,7 +56,6 @@ var _ = Describe("Podman privileged container tests", func() {
 
 	It("podman cap-add CapEff", func() {
 		cap := SystemExec("grep", []string{"CapEff", "/proc/self/status"})
-		cap.WaitWithDefaultTimeout()
 		Expect(cap.ExitCode()).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"run", "--cap-add", "all", "busybox", "grep", "CapEff", "/proc/self/status"})
@@ -97,7 +95,6 @@ var _ = Describe("Podman privileged container tests", func() {
 		}
 
 		cap := SystemExec("grep", []string{"NoNewPrivs", "/proc/self/status"})
-		cap.WaitWithDefaultTimeout()
 		if cap.ExitCode() != 0 {
 			Skip("Can't determine NoNewPrivs")
 		}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -387,7 +387,6 @@ var _ = Describe("Podman run", func() {
 		err = ioutil.WriteFile(keyFile, []byte(mountString), 0755)
 		Expect(err).To(BeNil())
 		execSession := SystemExec("ln", []string{"-s", targetDir, filepath.Join(secretsDir, "mysymlink")})
-		execSession.WaitWithDefaultTimeout()
 		Expect(execSession.ExitCode()).To(Equal(0))
 
 		session := podmanTest.Podman([]string{"--default-mounts-file=" + mountsFile, "run", "--rm", ALPINE, "cat", "/run/secrets/test.txt"})

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -326,6 +326,7 @@ func SystemExec(command string, args []string) *PodmanSession {
 	if err != nil {
 		Fail(fmt.Sprintf("unable to run command: %s %s", command, strings.Join(args, " ")))
 	}
+	session.Wait(defaultWaitTimeout)
 	return &PodmanSession{session}
 }
 


### PR DESCRIPTION
Some callers assume when SystemExec returns, the command has completed.
Other callers explicitly wait for completion (as required).  However,
forgetting to do that is an incredibly easy mistake to make.  Fix this
by adding an explicit parameter to the function.  This requires
every caller to deliberately state whether or not a completion-check
is required.

Also address **many** resource naming / cleanup completion-races.

Signed-off-by: Chris Evich <cevich@redhat.com>