### PR TITLE
Fix usage messages for podman image list, rm

### DIFF
--- a/cmd/podman/image.go
+++ b/cmd/podman/image.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/spf13/cobra"
 )
@@ -39,11 +41,13 @@ func init() {
 	imageCommand.AddCommand(getImageSubCommands()...)
 
 	// Setup of "images" to appear as "list"
-	_imagesSubCommand.Use = "list"
+	_imagesSubCommand.Use = strings.Replace(_imagesSubCommand.Use, "images", "list", 1)
 	_imagesSubCommand.Aliases = []string{"ls"}
+	_imagesSubCommand.Example = strings.Replace(_imagesSubCommand.Example, "podman images", "podman image list", -1)
 	imageCommand.AddCommand(&_imagesSubCommand)
 
-	// Setup of "rmi" to appears as "rm"
-	_rmSubCommand.Use = "rm"
+	// It makes no sense to keep 'podman images rmi'; just use 'rm'
+	_rmSubCommand.Use = strings.Replace(_rmSubCommand.Use, "rmi", "rm", 1)
+	_rmSubCommand.Example = strings.Replace(_rmSubCommand.Example, "podman rmi", "podman image rm", -1)
 	imageCommand.AddCommand(&_rmSubCommand)
 }

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -275,4 +275,13 @@ RUN find $LOCAL
 		Expect(images.ExitCode()).To(Equal(0))
 		Expect(len(images.OutputToStringArray())).To(Equal(0))
 	})
+
+	// Don't rerun all tests; just assume that if we get that diagnostic,
+	// we're getting rmi
+	It("podman image rm is the same as rmi", func() {
+		session := podmanTest.Podman([]string{"image", "rm"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session.LineInOutputContains("image name or ID must be specified"))
+	})
 })


### PR DESCRIPTION
The command documented in podman-image(1) is 'rm'. This is also
the human-friendly and expected subcommand name. Due to a
limitation in Cobra, it was implemented as 'rmi'.

This PR applies a variation of the hackery in #2471: instead of
enabling an alias, we change the command name from 'rmi' to 'rm'
but only within the 'podman image' subcommand. As a usability
bonus we also amend the examples.

Signed-off-by: Ed Santiago <santiago@redhat.com>