### PR TITLE
Verify that used OCI runtime supports checkpoint

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -890,3 +890,16 @@ func (r *OCIRuntime) checkpointContainer(ctr *Container, options ContainerCheckp
 	args = append(args, ctr.ID())
 	return utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, nil, r.path, args...)
 }
+
+func (r *OCIRuntime) featureCheckCheckpointing() bool {
+	// Check if the runtime implements checkpointing. Currently only
+	// runc's checkpoint/restore implementation is supported.
+	cmd := exec.Command(r.path, "checkpoint", "-h")
+	if err := cmd.Start(); err != nil {
+		return false
+	}
+	if err := cmd.Wait(); err == nil {
+		return true
+	}
+	return false
+}

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 
 	"github.com/containers/libpod/pkg/criu"
 	. "github.com/containers/libpod/test/utils"
@@ -27,6 +28,16 @@ var _ = Describe("Podman checkpoint", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.RestoreAllArtifacts()
+		// Check if the runtime implements checkpointing. Currently only
+		// runc's checkpoint/restore implementation is supported.
+		cmd := exec.Command(podmanTest.OCIRuntime, "checkpoint", "-h")
+		if err := cmd.Start(); err != nil {
+			Skip("OCI runtime does not support checkpoint/restore")
+		}
+		if err := cmd.Wait(); err != nil {
+			Skip("OCI runtime does not support checkpoint/restore")
+		}
+
 		if !criu.CheckForCriu() {
 			Skip("CRIU is missing or too old.")
 		}


### PR DESCRIPTION
To be able to use OCI runtimes which do not implement checkpoint/restore
this adds a check to the checkpoint code path and the checkpoint/restore
tests to see if it knows about the checkpoint subcommand. If the used
OCI runtime does not implement checkpoint/restore the tests are skipped
and the actual 'podman container checkpoint' returns an error.

Signed-off-by: Adrian Reber <areber@redhat.com>