### PR TITLE
podman-commands script: refactor

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -519,7 +519,6 @@ func scrubServer(server string) string {
 func UsageTemplate() string {
 	return `Usage:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:


### PR DESCRIPTION
Make more general-purpose: instead of hardcoding a list
of known subcommands, and duplicating sed pipelines for
each, rely on 'podman help' itself to tell us which
podman commands have subcommands; and examine each
in turn. Should there ever be new subcommands, this
will identify and test them.

A special case is needed for 'podman image trust', whose
documentation format doesn't match the others.

The change to `common.go` fixes an inconsistency: the
Usage message for commands with subcommands had an
unnecessary blank line, making it harder to parse
automatically. This simply produces consistent
Usage messages for all podman commands.

This script will not pass until #2480 is merged.
After that, the goal is to add this as a CI hook.

Signed-off-by: Ed Santiago <santiago@redhat.com>