### PR TITLE
Allow Exec API user to override streams

### DIFF
--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -105,5 +105,13 @@ func execCmd(c *cliconfig.ExecValues) error {
 		envs = append(envs, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	return ctr.Exec(c.Tty, c.Privileged, envs, cmd, c.User, c.Workdir)
+	streams := new(libpod.AttachStreams)
+	streams.OutputStream = os.Stdout
+	streams.ErrorStream = os.Stderr
+	streams.InputStream = os.Stdin
+	streams.AttachOutput = true
+	streams.AttachError = true
+	streams.AttachInput = true
+
+	return ctr.Exec(c.Tty, c.Privileged, envs, cmd, c.User, c.Workdir, streams)
 }

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -203,9 +203,8 @@ func (c *Container) Kill(signal uint) error {
 }
 
 // Exec starts a new process inside the container
-// TODO allow specifying streams to attach to
 // TODO investigate allowing exec without attaching
-func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir string) error {
+func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir string, streams *AttachStreams) error {
 	var capList []string
 
 	locked := false
@@ -267,7 +266,7 @@ func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir 
 
 	logrus.Debugf("Creating new exec session in container %s with session id %s", c.ID(), sessionID)
 
-	execCmd, err := c.runtime.ociRuntime.execContainer(c, cmd, capList, env, tty, workDir, hostUser, sessionID)
+	execCmd, err := c.runtime.ociRuntime.execContainer(c, cmd, capList, env, tty, workDir, hostUser, sessionID, streams)
 	if err != nil {
 		return errors.Wrapf(err, "error exec %s", c.ID())
 	}


### PR DESCRIPTION
Allow passing in of AttachStreams to libpod.Exec() for usage in podman healthcheck. An API caller can now specify different streams for stdout, stderr and stdin, or no streams at all.

Signed-off-by: Peter Hunt <pehunt@redhat.com>