### PR TITLE
Pull image for runlabel if not local

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -409,7 +409,6 @@ type RunlabelValues struct {
 	Opt2            string
 	Opt3            string
 	Quiet           bool
-	Pull            bool
 	SignaturePolicy string
 	TlsVerify       bool
 }

--- a/cmd/podman/runlabel.go
+++ b/cmd/podman/runlabel.go
@@ -53,10 +53,12 @@ func init() {
 	flags.MarkHidden("opt2")
 	flags.MarkHidden("opt3")
 
-	flags.BoolVarP(&runlabelCommand.Pull, "pull", "p", false, "Pull the image if it does not exist locally prior to executing the label contents")
+	flags.BoolP("pull", "p", false, "Pull the image if it does not exist locally prior to executing the label contents")
 	flags.BoolVarP(&runlabelCommand.Quiet, "quiet", "q", false, "Suppress output information when installing images")
 	flags.StringVar(&runlabelCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
 	flags.BoolVar(&runlabelCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
+
+	flags.MarkDeprecated("pull", "podman will pull if not found in local storage")
 }
 
 // installCmd gets the data from the command line and calls installImage
@@ -95,7 +97,6 @@ func runlabelCmd(c *cliconfig.RunlabelValues) error {
 	if len(args) > 2 {
 		extraArgs = args[2:]
 	}
-	pull := c.Pull
 	label := args[0]
 
 	runlabelImage := args[1]
@@ -131,7 +132,7 @@ func runlabelCmd(c *cliconfig.RunlabelValues) error {
 	}
 
 	authfile := getAuthFile(c.Authfile)
-	runLabel, imageName, err := shared.GetRunlabel(label, runlabelImage, ctx, runtime, pull, c.Creds, dockerRegistryOptions, authfile, c.SignaturePolicy, stdOut)
+	runLabel, imageName, err := shared.GetRunlabel(label, runlabelImage, ctx, runtime, true, c.Creds, dockerRegistryOptions, authfile, c.SignaturePolicy, stdOut)
 	if err != nil {
 		return err
 	}

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2401,8 +2401,6 @@ _podman_container_runlabel() {
 	 --display
 	 --help
 	 -h
-	 -p
-	 --pull
 	 -q
 	 --quiet
 	 --tls-verify

--- a/docs/podman-container-runlabel.1.md
+++ b/docs/podman-container-runlabel.1.md
@@ -9,7 +9,6 @@ podman-container-runlabel - Execute Image Label Method
 [**-h**|**--help**]
 [**--display**]
 [**-n**][**--name**[=*NAME*]]
-[**-p**][[**--pull**]]
 [**--rootfs**=*ROOTFS*]
 [**--set**=*NAME*=*VALUE*]
 [**--storage**]
@@ -27,7 +26,7 @@ If the container image has a LABEL INSTALL instruction like the following:
 `podman container runlabel` will set the following environment variables for use in the command:
 
 If the container image does not have the desired label, an error message will be displayed along with a non-zero
-return code.
+return code.  If the image is not found in local storage, Podman will attempt to pull it first.
 
 Note: Podman will always ensure that `podman` is the first argument of the command being executed.
 
@@ -81,9 +80,6 @@ Print usage statement
 
 **-n** **--name**=""
  Use this name for creating content for the container. NAME will default to the IMAGENAME if it is not specified.
-
-**p** **--pull**
- Pull the image if it cannot be found in local storage.
 
 **--quiet, -q**
 


### PR DESCRIPTION
In cases where a user issues the podman container runlabel
command and the image is not local, we now default to pulling
the image automatically to mimic the atomic cli behavior.

Fixes: BZ #1677905

Signed-off-by: baude <bbaude@redhat.com>