### PR TITLE
Varlink proxy

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -483,6 +483,7 @@ type UnpauseValues struct {
 type VarlinkValues struct {
 	PodmanCommand
 	Timeout int64
+	Message string
 }
 
 type SetTrustValues struct {

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -75,6 +75,7 @@ var cmdsNotRequiringRootless = map[*cobra.Command]bool{
 	_statsCommand:   true,
 	_stopCommand:    true,
 	_topCommand:     true,
+	_varlinkCommand: true,
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/podman/varlink_dummy.go
+++ b/cmd/podman/varlink_dummy.go
@@ -1,4 +1,4 @@
-// +build !varlink
+// +build !varlink remoteclient
 
 package main
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -92,7 +92,7 @@ k8s.io/api kubernetes-1.10.13-beta.0 https://github.com/kubernetes/api
 k8s.io/apimachinery kubernetes-1.10.13-beta.0 https://github.com/kubernetes/apimachinery
 k8s.io/client-go kubernetes-1.10.13-beta.0 https://github.com/kubernetes/client-go
 github.com/mrunalp/fileutils 7d4729fb36185a7c1719923406c9d40e54fb93c7
-github.com/varlink/go 3ac79db6fd6aec70924193b090962f92985fe199
+github.com/varlink/go 0b25de1fc1a048a2ca5ea9f32e9c1c9b79fd4dea
 github.com/containers/buildah v1.7.1
 # TODO: Gotty has not been updated since 2012. Can we find replacement?
 github.com/Nvveen/Gotty cd527374f1e5bff4938207604a14f2e38a9cf512

--- a/vendor/github.com/varlink/go/varlink/varlink_test.go
+++ b/vendor/github.com/varlink/go/varlink/varlink_test.go
@@ -31,7 +31,7 @@ func TestService(t *testing.T) {
 		r := bufio.NewReader(&br)
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
-		if err := service.handleMessage(r, w, []byte{0}); err == nil {
+		if err := service.HandleMessage(nil, r, w, []byte{0}); err == nil {
 			t.Fatal("HandleMessage returned non-error")
 		}
 	})
@@ -42,7 +42,7 @@ func TestService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"foo.GetInterfaceDescription" fdgdfg}`)
-		if err := service.handleMessage(r, w, msg); err == nil {
+		if err := service.HandleMessage(nil, r, w, msg); err == nil {
 			t.Fatal("HandleMessage returned no error on invalid json")
 		}
 	})
@@ -53,7 +53,7 @@ func TestService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"foo.GetInterfaceDescription"}`)
-		if err := service.handleMessage(r, w, msg); err != nil {
+		if err := service.HandleMessage(nil, r, w, msg); err != nil {
 			t.Fatal("HandleMessage returned error on wrong interface")
 		}
 		expect(t, `{"parameters":{"interface":"foo"},"error":"org.varlink.service.InterfaceNotFound"}`+"\000",
@@ -66,7 +66,7 @@ func TestService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"InvalidMethod"}`)
-		if err := service.handleMessage(r, w, msg); err != nil {
+		if err := service.HandleMessage(nil, r, w, msg); err != nil {
 			t.Fatal("HandleMessage returned error on invalid method")
 		}
 		expect(t, `{"parameters":{"parameter":"method"},"error":"org.varlink.service.InvalidParameter"}`+"\000",
@@ -79,7 +79,7 @@ func TestService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"org.varlink.service.WrongMethod"}`)
-		if err := service.handleMessage(r, w, msg); err != nil {
+		if err := service.HandleMessage(nil, r, w, msg); err != nil {
 			t.Fatal("HandleMessage returned error on wrong method")
 		}
 		expect(t, `{"parameters":{"method":"WrongMethod"},"error":"org.varlink.service.MethodNotFound"}`+"\000",
@@ -92,7 +92,7 @@ func TestService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"org.varlink.service.GetInterfaceDescription","parameters": null}`)
-		if err := service.handleMessage(r, w, msg); err != nil {
+		if err := service.HandleMessage(nil, r, w, msg); err != nil {
 			t.Fatalf("HandleMessage returned error: %v", err)
 		}
 		expect(t, `{"parameters":{"parameter":"parameters"},"error":"org.varlink.service.InvalidParameter"}`+"\000",
@@ -105,7 +105,7 @@ func TestService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"org.varlink.service.GetInterfaceDescription","parameters":{}}`)
-		if err := service.handleMessage(r, w, msg); err != nil {
+		if err := service.HandleMessage(nil, r, w, msg); err != nil {
 			t.Fatalf("HandleMessage returned error: %v", err)
 		}
 		expect(t, `{"parameters":{"parameter":"interface"},"error":"org.varlink.service.InvalidParameter"}`+"\000",
@@ -118,7 +118,7 @@ func TestService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"org.varlink.service.GetInterfaceDescription","parameters":{"interface":"foo"}}`)
-		if err := service.handleMessage(r, w, msg); err != nil {
+		if err := service.HandleMessage(nil, r, w, msg); err != nil {
 			t.Fatalf("HandleMessage returned error: %v", err)
 		}
 		expect(t, `{"parameters":{"parameter":"interface"},"error":"org.varlink.service.InvalidParameter"}`+"\000",
@@ -131,7 +131,7 @@ func TestService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"org.varlink.service.GetInterfaceDescription","parameters":{"interface":"org.varlink.service"}}`)
-		if err := service.handleMessage(r, w, msg); err != nil {
+		if err := service.HandleMessage(nil, r, w, msg); err != nil {
 			t.Fatalf("HandleMessage returned error: %v", err)
 		}
 		expect(t, `{"parameters":{"description":"# The Varlink Service Interface is provided by every varlink service. It\n# describes the service and the interfaces it implements.\ninterface org.varlink.service\n\n# Get a list of all the interfaces a service provides and information\n# about the implementation.\nmethod GetInfo() -\u003e (\n  vendor: string,\n  product: string,\n  version: string,\n  url: string,\n  interfaces: []string\n)\n\n# Get the description of an interface that is implemented by this service.\nmethod GetInterfaceDescription(interface: string) -\u003e (description: string)\n\n# The requested interface was not found.\nerror InterfaceNotFound (interface: string)\n\n# The requested method was not found\nerror MethodNotFound (method: string)\n\n# The interface defines the requested method, but the service does not\n# implement it.\nerror MethodNotImplemented (method: string)\n\n# One of the passed parameters is invalid.\nerror InvalidParameter (parameter: string)"}}`+"\000",
@@ -144,7 +144,7 @@ func TestService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"org.varlink.service.GetInfo"}`)
-		if err := service.handleMessage(r, w, msg); err != nil {
+		if err := service.HandleMessage(nil, r, w, msg); err != nil {
 			t.Fatalf("HandleMessage returned error: %v", err)
 		}
 		expect(t, `{"parameters":{"vendor":"Varlink","product":"Varlink Test","version":"1","url":"https://github.com/varlink/go/varlink","interfaces":["org.varlink.service"]}}`+"\000",
@@ -224,7 +224,7 @@ func TestMoreService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"org.example.test.Pingf"}`)
-		if err := service.handleMessage(r, w, msg); err != nil {
+		if err := service.HandleMessage(nil, r, w, msg); err != nil {
 			t.Fatalf("HandleMessage returned error: %v", err)
 		}
 		expect(t, `{"parameters":{"method":"Pingf"},"error":"org.varlink.service.MethodNotImplemented"}`+"\000",
@@ -237,7 +237,7 @@ func TestMoreService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"org.example.test.PingError", "more" : true}`)
-		if err := service.handleMessage(r, w, msg); err != nil {
+		if err := service.HandleMessage(nil, r, w, msg); err != nil {
 			t.Fatalf("HandleMessage returned error: %v", err)
 		}
 		expect(t, `{"error":"org.example.test.PingError"}`+"\000",
@@ -249,7 +249,7 @@ func TestMoreService(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 		msg := []byte(`{"method":"org.example.test.Ping", "more" : true}`)
-		if err := service.handleMessage(r, w, msg); err != nil {
+		if err := service.HandleMessage(nil, r, w, msg); err != nil {
 			t.Fatalf("HandleMessage returned error: %v", err)
 		}
 		expect(t, `{"continues":true}`+"\000"+`{"continues":true}`+"\000"+`{}`+"\000",


### PR DESCRIPTION
One direct call without proxy
```
$ varlink  -A '/home/harald/podman --log-level debug varlink --timeout 1 \$VARLINK_ADDRESS' call io.podman.GetVersion
INFO[0000] running as rootless                          
DEBU[0000] Initializing boltdb state at /home/harald/.local/share/containers/storage/libpod/bolt_state.db 
DEBU[0000] Using graph driver overlay                   
DEBU[0000] Using graph root /home/harald/.local/share/containers/storage 
DEBU[0000] Using run root /run/user/1000                
DEBU[0000] Using static dir /home/harald/.local/share/containers/storage/libpod 
DEBU[0000] Using tmp dir /run/user/1000/libpod/tmp      
DEBU[0000] Using volume path /home/harald/.local/share/containers/storage/volumes 
DEBU[0000] Set libpod namespace to ""                   
DEBU[0000] Not configuring container store              
{
  "built": "2019-03-01T16:20:39+01:00",
  "git_commit": "bb45d844143b20c937e6eb742df06dc008911b5b",
  "go_version": "go1.11.5",
  "os_arch": "linux/amd64",
  "remote_api_version": 1,
  "version": "1.2.0-dev"
}
```

And one with reexec and proxy:
```
$ varlink  -A '/home/harald/podman --log-level debug varlink --timeout 1 \$VARLINK_ADDRESS' call io.podman.GetInfo
INFO[0000] running as rootless                          
DEBU[0000] Initializing boltdb state at /home/harald/.local/share/containers/storage/libpod/bolt_state.db 
DEBU[0000] Using graph driver overlay                   
DEBU[0000] Using graph root /home/harald/.local/share/containers/storage 
DEBU[0000] Using run root /run/user/1000                
DEBU[0000] Using static dir /home/harald/.local/share/containers/storage/libpod 
DEBU[0000] Using tmp dir /run/user/1000/libpod/tmp      
DEBU[0000] Using volume path /home/harald/.local/share/containers/storage/volumes 
DEBU[0000] Set libpod namespace to ""                   
DEBU[0000] Not configuring container store              
INFO[0000] running as rootless                          
WARN[0000] The configuration is using `runtime_path`, which is deprecated and will be removed in future.  Please use `runtimes` and `runtime` 
WARN[0000] If you are using both `runtime_path` and `runtime`, the configuration from `runtime_path` is used 
DEBU[0000] Initializing boltdb state at /home/harald/.local/share/containers/storage/libpod/bolt_state.db 
DEBU[0000] Using graph driver overlay                   
DEBU[0000] Using graph root /home/harald/.local/share/containers/storage 
DEBU[0000] Using run root /run/user/1000                
DEBU[0000] Using static dir /home/harald/.local/share/containers/storage/libpod 
DEBU[0000] Using tmp dir /run/user/1000/libpod/tmp      
DEBU[0000] Using volume path /home/harald/.local/share/containers/storage/volumes 
DEBU[0000] Set libpod namespace to ""                   
DEBU[0000] [graphdriver] trying provided driver "overlay" 
DEBU[0000] overlay: mount_program=/usr/bin/fuse-overlayfs 
DEBU[0000] backingFs=xfs, projectQuotaSupported=false, useNativeDiff=false, usingMetacopy=false 
{
  "info": {
    "host": {
      "arch": "amd64",
      "buildah_version": "1.7.1",
      "cpus": 2,
      "distribution": {
        "distribution": "fedora",
        "version": "29"
      },
      "hostname": "localhost.localdomain",
      "kernel": "4.18.16-300.fc29.x86_64",
      "mem_free": 1174843392,
      "mem_total": 2088931328,
      "os": "linux",
      "swap_free": 2147479552,
      "swap_total": 0,
      "uptime": "1h 47m 11.26s (Approximately 0.04 days)"
    },
    "insecure_registries": [],
    "podman": {
      "compiler": "gc",
      "git_commit": "bb45d844143b20c937e6eb742df06dc008911b5b",
      "go_version": "go1.11.5",
      "podman_version": "1.2.0-dev"
    },
    "registries": [
      "docker.io",
      "registry.fedoraproject.org",
      "quay.io",
      "registry.access.redhat.com",
      "registry.centos.org"
    ],
    "store": {
      "containers": 0,
      "graph_driver_name": "overlay",
      "graph_driver_options": "overlay.mount_program=/usr/bin/fuse-overlayfs",
      "graph_root": "/home/harald/.local/share/containers/storage",
      "graph_status": {
        "backing_filesystem": "xfs",
        "native_overlay_diff": "false",
        "supports_d_type": "true"
      },
      "images": 0,
      "run_root": "/run/user/1000"
    }
  }
}
INFO[0000] varlink service expired (use --timeout to increase session time beyond 1 ms, 0 means never timeout) 
```