### PR TITLE
Ensure that each log line is newline-terminated

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -312,6 +312,10 @@ func (w *logWriter) write(msg *logMessage) error {
 	if w.opts.Timestamps {
 		prefix := append([]byte(msg.timestamp.Format(timeFormat)), delimiter[0])
 		line = append(prefix, line...)
+		// Ensure that lines always end in a newline
+		if line[len(line)-1] != '\n' {
+			line = append(line, '\n')
+		}
 	}
 	// If the line is longer than the remaining bytes, cut it.
 	if int64(len(line)) > w.remain {

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -313,11 +313,11 @@ func (w *logWriter) write(msg *logMessage) error {
 	if w.opts.Timestamps && !w.doAppend {
 		prefix := append([]byte(msg.timestamp.Format(timeFormat)), delimiter[0])
 		line = append(prefix, line...)
-		if line[len(line)-1] != '\n' {
+		if len(line) > 0 && line[len(line)-1] != '\n' {
 			w.doAppend = true
 		}
 	}
-	if w.doAppend && line[len(line)-1] == '\n' {
+	if w.doAppend && len(line) > 0 && line[len(line)-1] == '\n' {
 		w.doAppend = false
 	}
 	// If the line is longer than the remaining bytes, cut it.

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -277,10 +277,11 @@ func readLog(reader *bufio.Reader, opts *LogOptions) []string {
 
 // logWriter controls the writing into the stream based on the log options.
 type logWriter struct {
-	stdout io.Writer
-	stderr io.Writer
-	opts   *LogOptions
-	remain int64
+	stdout   io.Writer
+	stderr   io.Writer
+	opts     *LogOptions
+	remain   int64
+	doAppend bool
 }
 
 // errMaximumWrite is returned when all bytes have been written.
@@ -309,13 +310,15 @@ func (w *logWriter) write(msg *logMessage) error {
 		return nil
 	}
 	line := msg.log
-	if w.opts.Timestamps {
+	if w.opts.Timestamps && !w.doAppend {
 		prefix := append([]byte(msg.timestamp.Format(timeFormat)), delimiter[0])
 		line = append(prefix, line...)
-		// Ensure that lines always end in a newline
 		if line[len(line)-1] != '\n' {
-			line = append(line, '\n')
+			w.doAppend = true
 		}
+	}
+	if w.doAppend && line[len(line)-1] == '\n' {
+		w.doAppend = false
 	}
 	// If the line is longer than the remaining bytes, cut it.
 	if int64(len(line)) > w.remain {


### PR DESCRIPTION
When writing logs with timestamps to the terminal, ensure that each line is newline-terminated, so we don't end up with an unreadable mess with timestamps interspersed with the actual content being displayed.

An partial fix of the (easy) part of the issue from #2500 