### PR TITLE
runtime: fill a proper default tmpdir when --config is used

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -477,6 +477,12 @@ func NewRuntimeFromConfig(configPath string, options ...RuntimeOption) (runtime 
 	runtime.config.OCIRuntime = defaultRuntimeConfig.OCIRuntime
 	runtime.config.StorageConfig = storage.StoreOptions{}
 
+	tmpDir, err := getDefaultTmpDir()
+	if err != nil {
+		return nil, err
+	}
+	runtime.config.TmpDir = tmpDir
+
 	// Check to see if the given configuration file exists
 	if _, err := os.Stat(configPath); err != nil {
 		return nil, errors.Wrapf(err, "error checking existence of configuration file %s", configPath)


### PR DESCRIPTION
Closes: https://github.com/containers/libpod/issues/2408

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>