### PR TITLE
Append hosts to dependency container's /etc/hosts file

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1231,6 +1231,23 @@ func (c *Container) writeStringToRundir(destFile, output string) (string, error)
 	return filepath.Join(c.state.DestinationRunDir, destFile), nil
 }
 
+// appendStringToRundir appends the provided string to the runtimedir file
+func (c *Container) appendStringToRundir(destFile, output string) (string, error) {
+	destFileName := filepath.Join(c.state.RunDir, destFile)
+
+	f, err := os.OpenFile(destFileName, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to open %s", destFileName)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(output); err != nil {
+		return "", errors.Wrapf(err, "unable to write %s", destFileName)
+	}
+
+	return filepath.Join(c.state.DestinationRunDir, destFile), nil
+}
+
 // Save OCI spec to disk, replacing any existing specs for the container
 func (c *Container) saveSpec(spec *spec.Spec) error {
 	// If the OCI spec already exists, we need to replace it

--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -360,4 +360,21 @@ var _ = Describe("Podman pod create", func() {
 
 		Expect(result.OutputToString()).To(ContainSubstring(infraID))
 	})
+
+	It("podman run --add-host in pod", func() {
+		session := podmanTest.Podman([]string{"pod", "create"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		podID := session.OutputToString()
+
+		// verify we can add a host to the infra's /etc/hosts
+		session = podmanTest.Podman([]string{"run", "--pod", podID, "--add-host", "foobar:127.0.0.1", BB, "ping", "-c", "1", "foobar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		// verify we can see the other hosts of infra's /etc/hosts
+		session = podmanTest.Podman([]string{"run", "--pod", podID, BB, "ping", "-c", "1", "foobar"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
Before, any container with a netNS dependency simply used its dependency container's hosts file, and didn't abide its configuration (mainly --add-host). Fix this by always appending to the dependency container's hosts file, creating one if necessary.

fixes: #2504 

Note: there will be a different PR for a similar action with resolv.conf, but considering resolv.conf is more complex, and this fixes the issue, I decided to file this first.