### PR TITLE
Add all possible container status states to the podman-ps manual page.

### DIFF
--- a/docs/podman-ps.1.md
+++ b/docs/podman-ps.1.md
@@ -89,18 +89,18 @@ If multiple filters are given, only containers which match all of the given filt
 
 Valid filters are listed below:
 
-| **Filter**      | **Description**                                                     |
-| --------------- | ------------------------------------------------------------------- |
-| id              | [ID] Container's ID                                                 |
-| name            | [Name] Container's name                                             |
-| label           | [Key] or [Key=Value] Label assigned to a container                  |
-| exited          | [Int] Container's exit code                                         |
-| status          | [Status] Container's status, e.g *running*, *stopped*               |
-| ancestor        | [ImageName] Image or descendant used to create container            |
-| before          | [ID] or [Name] Containers created before this container             |
-| since           | [ID] or [Name] Containers created since this container              |
-| volume          | [VolumeName] or [MountpointDestination] Volume mounted in container |
-| health          | [Status] healthy or unhealthy                                       |
+| **Filter**      | **Description**                                                                  |
+| --------------- | -------------------------------------------------------------------------------- |
+| id              | [ID] Container's ID                                                              |
+| name            | [Name] Container's name                                                          |
+| label           | [Key] or [Key=Value] Label assigned to a container                               |
+| exited          | [Int] Container's exit code                                                      |
+| status          | [Status] Container's status: *created*, *exited*, *paused*, *running*, *unknown* |
+| ancestor        | [ImageName] Image or descendant used to create container                         |
+| before          | [ID] or [Name] Containers created before this container                          |
+| since           | [ID] or [Name] Containers created since this container                           |
+| volume          | [VolumeName] or [MountpointDestination] Volume mounted in container              |
+| health          | [Status] healthy or unhealthy                                                    |
 
 **--help**, **-h**
 


### PR DESCRIPTION
Also remove the invalid 'stopped' state that was listed.

I found the full list of states from docker [here](https://github.com/moby/moby/blob/b59ee9486fad5fa19f3d0af0eb6c5ce100eae0fc/container/state.go#L150). I could not find if they were all also defined in libpod somewhere and assumed they were since libpod aims to mirror docker in functionality.

This PR (1) documents all of the available status codes, which I found hard to find anywhere besides the source code, and (2) the originally suggested `stopped` state is not a real state that can be queried.

```
$ podman ps -f name=rhel7 -f "status=stopped"
invalid filter: stopped is not a valid status
```