### PR TITLE
cirrus: Drop ginkgo, gomega, easyjson install

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -169,9 +169,9 @@ testing_task:
             image_name: "${FEDORA_CACHE_IMAGE_NAME}"
             image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
             image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
-            image_name: "${PRIOR_RHEL_CACHE_IMAGE_NAME}"
 
-            # TODO: tests fail
+            # TODO: Make these work (also optional_testing_task below)
+            # image_name: "${PRIOR_RHEL_CACHE_IMAGE_NAME}"
             # image_name: "${RHEL_CACHE_IMAGE_NAME}"
             # image_name: "${CENTOS_CACHE_IMAGE_NAME}"
 
@@ -206,9 +206,9 @@ optional_testing_task:
             image_name: "${FEDORA_CACHE_IMAGE_NAME}"
             image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
             image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
-            image_name: "${PRIOR_RHEL_CACHE_IMAGE_NAME}"
-            # TODO: Make these work (also build_images_task below)
+            # TODO: Make these work (also testing_task above)
             # image_name: "${RHEL_CACHE_IMAGE_NAME}"
+            # image_name: "${PRIOR_RHEL_CACHE_IMAGE_NAME}"
             # image_name: "${CENTOS_CACHE_IMAGE_NAME}"
 
     timeout_in: 60m

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -300,21 +300,6 @@ EOF
     fi
 }
 
-# Runs in testing VM, not image building
-install_testing_dependencies() {
-    echo "Installing ginkgo, gomega, and easyjson into \$GOPATH=$GOPATH"
-    req_env_var "
-        GOPATH $GOPATH
-        GOSRC $GOSRC
-    "
-    cd "$GOSRC"
-    ooe.sh go get -u github.com/onsi/ginkgo/ginkgo
-    ooe.sh install -D -m 755 "$GOPATH"/bin/ginkgo /usr/bin/
-    ooe.sh go get github.com/onsi/gomega/...
-    ooe.sh go get -u github.com/mailru/easyjson/...
-    sudo install -D -m 755 "$GOPATH"/bin/easyjson /usr/bin/
-}
-
 install_packer_copied_files(){
     # Install cni config, policy and registry config
     sudo install -D -m 755 /tmp/libpod/cni/87-podman-bridge.conflist \

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -78,10 +78,6 @@ then
 
     cd "${GOSRC}/"
     source "$SCRIPT_BASE/lib.sh"
-
-    # Only testing-VMs need deps installed, not image-builder VM
-    echo "$CIRRUS_TASK_NAME" | grep -q 'image' || \
-       install_testing_dependencies  # must exist in $GOPATH
 fi
 
 record_timestamp "env. setup end"


### PR DESCRIPTION
This is potentially harmful, since ginkgo and it's dependencies are now
vendored and installed by `make .install.ginkgo`, and may not agree with
installed 'go get' code under `$GOPATH`.  Prune this (and easyjson
install) from automation scripts.

***NOTE:*** THIS PR DISABLES TESTING ON RHEL

Signed-off-by: Chris Evich <cevich@redhat.com>