### PR TITLE
add flag --extract tar file in podman cp

### DIFF
--- a/cmd/podman/cliconfig/create.go
+++ b/cmd/podman/cliconfig/create.go
@@ -23,4 +23,5 @@ type BuildValues struct {
 
 type CpValues struct {
 	PodmanCommand
+	Extract bool
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2308,6 +2308,15 @@ _podman_load() {
     _complete_ "$options_with_args" "$boolean_options"
 }
 
+_podman_cp() {
+	local boolean_options="
+	  --help
+	  -h
+	  --extract
+     "
+	_complete_ "$boolean_options"
+}
+
 _podman_login() {
      local options_with_args="
      --username
@@ -2974,6 +2983,7 @@ _podman_podman() {
     build
     commit
     container
+    cp
     create
     diff
     exec

--- a/docs/podman-cp.1.md
+++ b/docs/podman-cp.1.md
@@ -54,6 +54,11 @@ You can also use : when specifying paths to a **SRC_PATH** or **DEST_PATH** on a
 If you use a : in a local machine path, you must be explicit with a relative or absolute path, for example:
 	`/path/to/file:name.txt` or `./file:name.txt`
 
+## OPTIONS
+
+**--extract**
+
+Extract the tar file into the destination directory. If the destination directory is not provided, extract the tar file into the root directory.
 
 ## ALTERNATIVES
 
@@ -99,6 +104,8 @@ podman cp /home/myuser/myfiles.tar containerID:/tmp
 podman cp containerID:/myapp/ /myapp/
 
 podman cp containerID:/home/myuser/. /home/myuser/
+
+podman cp --extract /home/myuser/myfiles.tar.gz containerID:/myfiles
 
 ## SEE ALSO
 podman(1), podman-mount(1), podman-umount(1)


### PR DESCRIPTION
fix #2520 
Use `--extract` to extract tar file in source argument to the destination directory
Signed-off-by: Qi Wang <qiwan@redhat.com>