### PR TITLE
libpod: allow to configure path to the slirp4netns binary

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -25,6 +25,7 @@ type MainFlags struct {
 	StorageOpts       []string
 	Syslog            bool
 	Trace             bool
+	NetworkCmdPath    string
 
 	Config     string
 	CpuProfile string

--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -86,6 +86,9 @@ func getRuntime(c *cliconfig.PodmanCommand, renumber bool) (*libpod.Runtime, err
 	if c.Flags().Changed("tmpdir") {
 		options = append(options, libpod.WithTmpDir(c.GlobalFlags.TmpDir))
 	}
+	if c.Flags().Changed("network-cmd-path") {
+		options = append(options, libpod.WithNetworkCmdPath(c.GlobalFlags.NetworkCmdPath))
+	}
 
 	if c.Flags().Changed("cgroup-manager") {
 		options = append(options, libpod.WithCgroupManager(c.GlobalFlags.CGroupManager))

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -104,6 +104,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.CpuProfile, "cpu-profile", "", "Path for the cpu profiling results")
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Config, "config", "", "Path of a libpod config file detailing container server configuration options")
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.ConmonPath, "conmon", "", "Path of the conmon binary")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.NetworkCmdPath, "network-cmd-path", "", "Path to the command for configuring the network")
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.CniConfigDir, "cni-config-dir", "", "Path of the configuration directory for CNI networks")
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.DefaultMountsFile, "default-mounts-file", "", "Path to default mounts file")
 	rootCmd.PersistentFlags().MarkHidden("defaults-mount-file")

--- a/docs/libpod.conf.5.md
+++ b/docs/libpod.conf.5.md
@@ -91,6 +91,10 @@ libpod to manage containers.
   Directory where named volumes will be created in using the default volume driver.
   By default this will be configured relative to where containers/storage stores containers.
 
+**network_cmd_path**=""
+  Path to the command binary to use for setting up a network.  It is currently only used for setting up
+  a slirp4netns network.  If "" is used then the binary is looked up using the $PATH environment variable.
+
 ## FILES
   `/usr/share/containers/libpod.conf`, default libpod configuration path
 

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -72,6 +72,9 @@ Default state dir is configured in /etc/containers/storage.conf.
 
 Name of the OCI runtime as specified in libpod.conf or absolute path to the OCI compatible binary used to run containers.
 
+**--network-cmd-path**=**path**
+Path to the command binary to use for setting up a network.  It is currently only used for setting up a slirp4netns network.  If "" is used then the binary is looked up using the $PATH environment variable.
+
 **--storage-driver**=**value**
 
 Storage driver.  The default storage driver for UID 0 is configured in /etc/containers/storage.conf (`$HOME/.config/containers/storage.conf` in rootless mode), and is *vfs* for non-root users when *fuse-overlayfs* is not available.  The `STORAGE_DRIVER` environment variable overrides the default.  The --storage-driver specified driver overrides all.

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -139,10 +139,15 @@ func (r *Runtime) setupRootlessNetNS(ctr *Container) (err error) {
 	defer ctr.rootlessSlirpSyncR.Close()
 	defer ctr.rootlessSlirpSyncW.Close()
 
-	path, err := exec.LookPath("slirp4netns")
-	if err != nil {
-		logrus.Errorf("could not find slirp4netns, the network namespace won't be configured: %v", err)
-		return nil
+	path := r.config.NetworkCmdPath
+
+	if path == "" {
+		var err error
+		path, err = exec.LookPath("slirp4netns")
+		if err != nil {
+			logrus.Errorf("could not find slirp4netns, the network namespace won't be configured: %v", err)
+			return nil
+		}
 	}
 
 	syncR, syncW, err := os.Pipe()

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -193,6 +193,20 @@ func WithConmonEnv(environment []string) RuntimeOption {
 	}
 }
 
+// WithNetworkCmdPath specifies the path to the slirp4netns binary which manages the
+// runtime.
+func WithNetworkCmdPath(path string) RuntimeOption {
+	return func(rt *Runtime) error {
+		if rt.valid {
+			return ErrRuntimeFinalized
+		}
+
+		rt.config.NetworkCmdPath = path
+
+		return nil
+	}
+}
+
 // WithCgroupManager specifies the manager implementation name which is used to
 // handle cgroups for containers.
 // Current valid values are "cgroupfs" and "systemd".

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -217,6 +217,8 @@ type RuntimeConfig struct {
 	EnablePortReservation bool `toml:"enable_port_reservation"`
 	// EnableLabeling indicates wether libpod will support container labeling
 	EnableLabeling bool `toml:"label"`
+	// NetworkCmdPath is the path to the slirp4netns binary
+	NetworkCmdPath string `toml:"network_cmd_path"`
 
 	// NumLocks is the number of locks to make available for containers and
 	// pods.


### PR DESCRIPTION
allow to configure the path to the slirp4netns binary, either via an
option flag --slirp4netns or through the libpod.conf configuration
file.

Closes: https://github.com/containers/libpod/issues/2506

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>