### PR TITLE
rm: set exit code to 1 if a specified container is not found

### DIFF
--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -80,6 +80,9 @@ func rmCmd(c *cliconfig.RmValues) error {
 			return err
 		}
 		if err != nil {
+			if errors.Cause(err) == libpod.ErrNoSuchCtr {
+				exitCode = 1
+			}
 			fmt.Println(err.Error())
 		}
 	}


### PR DESCRIPTION
Closes: https://github.com/containers/libpod/issues/2539

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>