### PR TITLE
rootless: fix clone syscall on s390 and cris archs

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -32,7 +32,11 @@ syscall_setresgid (gid_t rgid, gid_t egid, gid_t sgid)
 static int
 syscall_clone (unsigned long flags, void *child_stack)
 {
+#if defined(__s390__) || defined(__CRIS__)
+  return (int) syscall (__NR_clone, child_stack, flags);
+#else
   return (int) syscall (__NR_clone, flags, child_stack);
+#endif
 }
 
 static char **


### PR DESCRIPTION
from the clone man page:

  On the cris and s390 architectures, the order of the first two
  arguments is reversed:

           long clone(void *child_stack, unsigned long flags,
                      int *ptid, int *ctid,
                      unsigned long newtls);

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1672714

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>