### PR TITLE
Fix pod create failure

### DIFF
--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -95,8 +95,11 @@ func (r *Runtime) NewPod(ctx context.Context, options ...PodCreateOption) (*Pod,
 	if pod.config.UsePodCgroup {
 		logrus.Debugf("Got pod cgroup as %s", pod.state.CgroupPath)
 	}
-	if pod.HasInfraContainer() != pod.SharesNamespaces() {
+	if !pod.HasInfraContainer() && pod.SharesNamespaces() {
 		return nil, errors.Errorf("Pods must have an infra container to share namespaces")
+	}
+	if pod.HasInfraContainer() && !pod.SharesNamespaces() {
+		logrus.Warnf("Pod has an infra container, but shares no namespaces")
 	}
 
 	if err := r.state.AddPod(pod); err != nil {


### PR DESCRIPTION
Before, a pod create would fail if it was set to share no namespaces, but had an infra container. While inefficient (you add a container for no reason), it shouldn't be a fatal failure. Fix this by only failing if the pod was set to share namespaces, but had no infra container.

Signed-off-by: Peter Hunt <pehunt@redhat.com>