### PR TITLE
Replace skopeo-containers with containers-common

### DIFF
--- a/Dockerfile.CentOS
+++ b/Dockerfile.CentOS
@@ -15,7 +15,7 @@ RUN yum -y install btrfs-progs-devel \
               libassuan-devel \
               libseccomp-devel \
               libselinux-devel \
-              skopeo-containers \
+              containers-common \
               runc \
               make \
               ostree-devel \

--- a/Dockerfile.Fedora
+++ b/Dockerfile.Fedora
@@ -16,7 +16,7 @@ RUN dnf -y install btrfs-progs-devel \
               libassuan-devel \
               libseccomp-devel \
               libselinux-devel \
-              skopeo-containers \
+              containers-common \
               runc \
               make \
               ostree-devel \

--- a/contrib/gate/Dockerfile
+++ b/contrib/gate/Dockerfile
@@ -31,7 +31,7 @@ RUN dnf -y install \
       python3-pytoml \
       python3-pyyaml \
       python3-varlink \
-      skopeo-containers \
+      containers-common \
       slirp4netns \
       rsync \
       which \

--- a/docs/tutorials/podman_tutorial.md
+++ b/docs/tutorials/podman_tutorial.md
@@ -34,7 +34,7 @@ acquire the source, and build it.
 ```console
 sudo dnf install -y git runc libassuan-devel golang golang-github-cpuguy83-go-md2man glibc-static \
                                   gpgme-devel glib2-devel device-mapper-devel libseccomp-devel \
-                                  atomic-registries iptables skopeo-containers containernetworking-cni \
+                                  atomic-registries iptables containers-common containernetworking-cni \
                                   conmon ostree-devel
 ```
 ### Building and installing podman

--- a/install.md
+++ b/install.md
@@ -107,7 +107,7 @@ yum install -y \
   ostree-devel \
   pkgconfig \
   runc \
-  skopeo-containers
+  containers-common
 ```
 
 Debian, Ubuntu, and related distributions:

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -39,7 +39,7 @@ error pulling image "fedora": unable to pull fedora: error getting default regis
 
 #### Solution
 
-  * Verify that the `/etc/containers/registries.conf` file exists.  If not, verify that the skopeo-containers package is installed.
+  * Verify that the `/etc/containers/registries.conf` file exists.  If not, verify that the containers-common package is installed.
   * Verify that the entries in the `[registries.search]` section of the /etc/containers/registries.conf file are valid and reachable.
     *  i.e. `registries = ['registry.fedoraproject.org', 'quay.io', 'registry.access.redhat.com']`
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Replaces 'skopeo-containers' with 'containers-common' in the files that
I feel comfortable changing it in.  There are a number of rpm building
related files that still have it, but I was hesitant to do so.