### PR TITLE
fix bug in podman images list all images with same name

### DIFF
--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -112,6 +112,18 @@ var _ = Describe("Podman images", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(1))
+
+		session = podmanTest.Podman([]string{"tag", ALPINE, "foo:a"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"tag", BB, "foo:b"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"images", "-q", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(2))
 	})
 
 	It("podman images filter reference", func() {

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Podman load", func() {
 		load.WaitWithDefaultTimeout()
 		Expect(load.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"images", "-f", "label", "hello:world"})
+		result := podmanTest.Podman([]string{"images", "hello:world"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.LineInOutputContains("docker")).To(Not(BeTrue()))
 		Expect(result.LineInOutputContains("localhost")).To(BeTrue())
@@ -216,7 +216,7 @@ var _ = Describe("Podman load", func() {
 		load.WaitWithDefaultTimeout()
 		Expect(load.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"images", "-f", "label", "hello:latest"})
+		result := podmanTest.Podman([]string{"images", "hello:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.LineInOutputContains("docker")).To(Not(BeTrue()))
 		Expect(result.LineInOutputContains("localhost")).To(BeTrue())
@@ -241,7 +241,7 @@ var _ = Describe("Podman load", func() {
 		load.WaitWithDefaultTimeout()
 		Expect(load.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"images", "-f", "label", "load:latest"})
+		result := podmanTest.Podman([]string{"images", "load:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.LineInOutputContains("docker")).To(Not(BeTrue()))
 		Expect(result.LineInOutputContains("localhost")).To(BeTrue())


### PR DESCRIPTION
fix #2241 
`podman images [image name]` can list all images with different tags has the given image name.
In order to match docker, passing the argument to podman images has the same result as using `podman images --filter reference=[argument]`
Signed-off-by: Qi Wang <qiwan@redhat.com>