### PR TITLE
Fix help commands to show short and long description.

### DIFF
--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -30,6 +30,7 @@ var (
 
 func init() {
 	attachCommand.Command = _attachCommand
+	attachCommand.SetHelpTemplate(HelpTemplate())
 	attachCommand.SetUsageTemplate(UsageTemplate())
 	flags := attachCommand.Flags()
 	flags.StringVar(&attachCommand.DetachKeys, "detach-keys", "", "Override the key sequence for detaching a container. Format is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _")

--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -18,8 +18,7 @@ import (
 
 var (
 	buildCommand     cliconfig.BuildValues
-	buildDescription = "Builds an OCI or Docker image using instructions from one\n" +
-		"or more Dockerfiles and a specified build context directory."
+	buildDescription = "Builds an OCI or Docker image using instructions from one or more Dockerfiles and a specified build context directory."
 	layerValues      buildahcli.LayerResults
 	budFlagsValues   buildahcli.BudResults
 	fromAndBudValues buildahcli.FromAndBudResults
@@ -48,6 +47,7 @@ var (
 
 func init() {
 	buildCommand.Command = _buildCommand
+	buildCommand.SetHelpTemplate(HelpTemplate())
 	buildCommand.SetUsageTemplate(UsageTemplate())
 	flags := buildCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/podman/checkpoint.go
+++ b/cmd/podman/checkpoint.go
@@ -40,6 +40,7 @@ var (
 
 func init() {
 	checkpointCommand.Command = _checkpointCommand
+	checkpointCommand.SetHelpTemplate(HelpTemplate())
 	checkpointCommand.SetUsageTemplate(UsageTemplate())
 
 	flags := checkpointCommand.Flags()

--- a/cmd/podman/cleanup.go
+++ b/cmd/podman/cleanup.go
@@ -37,6 +37,7 @@ var (
 
 func init() {
 	cleanupCommand.Command = _cleanupCommand
+	cleanupCommand.SetHelpTemplate(HelpTemplate())
 	cleanupCommand.SetUsageTemplate(UsageTemplate())
 	flags := cleanupCommand.Flags()
 

--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -19,10 +19,7 @@ import (
 
 var (
 	commitCommand     cliconfig.CommitValues
-	commitDescription = `Create an image from a container's changes.
-	 Optionally tag the image created, set the author with the --author flag,
-	 set the commit message with the --message flag,
-	 and make changes to the instructions with the --change flag.`
+	commitDescription = `Create an image from a container's changes. Optionally tag the image created, set the author with the --author flag, set the commit message with the --message flag, and make changes to the instructions with the --change flag.`
 
 	_commitCommand = &cobra.Command{
 		Use:   "commit [flags] CONTAINER IMAGE",
@@ -41,6 +38,7 @@ var (
 
 func init() {
 	commitCommand.Command = _commitCommand
+	commitCommand.SetHelpTemplate(HelpTemplate())
 	commitCommand.SetUsageTemplate(UsageTemplate())
 	flags := commitCommand.Flags()
 	flags.StringSliceVarP(&commitCommand.Change, "change", "c", []string{}, fmt.Sprintf("Apply the following possible instructions to the created image (default []): %s", strings.Join(libpod.ChangeCmds, " | ")))

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -521,6 +521,18 @@ func scrubServer(server string) string {
 	return strings.TrimPrefix(server, "http://")
 }
 
+// HelpTemplate returns the help template for podman commands
+// This uses the short and long options.
+// command should not use this.
+func HelpTemplate() string {
+	return `{{.Short}}
+
+Description:
+  {{.Long}}
+
+{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+}
+
 // UsageTemplate returns the usage template for podman commands
 // This blocks the desplaying of the global options. The main podman
 // command should not use this.

--- a/cmd/podman/containers_prune.go
+++ b/cmd/podman/containers_prune.go
@@ -34,6 +34,7 @@ var (
 
 func init() {
 	pruneContainersCommand.Command = _pruneContainersCommand
+	pruneContainersCommand.SetHelpTemplate(HelpTemplate())
 	pruneContainersCommand.SetUsageTemplate(UsageTemplate())
 	flags := pruneContainersCommand.Flags()
 	flags.BoolVarP(&pruneContainersCommand.Force, "force", "f", false, "Force removal of a running container.  The default is false")

--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -27,8 +27,11 @@ import (
 var (
 	cpCommand cliconfig.CpValues
 
-	cpDescription = "Copy files/folders between a container and the local filesystem"
-	_cpCommand    = &cobra.Command{
+	cpDescription = `Command copies the contents of SRC_PATH to the DEST_PATH.
+
+  You can copy from the container's file system to the local machine or the reverse, from the local filesystem to the container. If "-" is specified for either the SRC_PATH or DEST_PATH, you can also stream a tar archive from STDIN or to STDOUT. The CONTAINER can be a running or stopped container.  The SRC_PATH or DEST_PATH can be a file or directory.
+`
+	_cpCommand = &cobra.Command{
 		Use:   "cp [flags] SRC_PATH DEST_PATH",
 		Short: "Copy files/folders between a container and the local filesystem",
 		Long:  cpDescription,
@@ -45,6 +48,8 @@ func init() {
 	cpCommand.Command = _cpCommand
 	flags := cpCommand.Flags()
 	flags.BoolVar(&cpCommand.Extract, "extract", false, "Extract the tar file into the destination directory.")
+	cpCommand.SetHelpTemplate(HelpTemplate())
+	cpCommand.SetUsageTemplate(UsageTemplate())
 	rootCmd.AddCommand(cpCommand.Command)
 }
 

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -37,11 +37,9 @@ import (
 
 var (
 	createCommand     cliconfig.CreateValues
-	createDescription = "Creates a new container from the given image or" +
-		" storage and prepares it for running the specified command. The" +
-		" container ID is then printed to stdout. You can then start it at" +
-		" any time with the podman start <container_id> command. The container" +
-		" will be created with the initial state 'created'."
+	createDescription = `Creates a new container from the given image or storage and prepares it for running the specified command.
+
+  The container ID is then printed to stdout. You can then start it at any time with the podman start <container_id> command. The container will be created with the initial state 'created'.`
 	_createCommand = &cobra.Command{
 		Use:   "create [flags] IMAGE [COMMAND [ARG...]]",
 		Short: "Create but do not start a container",
@@ -64,6 +62,7 @@ var (
 
 func init() {
 	createCommand.PodmanCommand.Command = _createCommand
+	createCommand.SetHelpTemplate(HelpTemplate())
 	createCommand.SetUsageTemplate(UsageTemplate())
 
 	getCreateFlags(&createCommand.PodmanCommand)

--- a/cmd/podman/diff.go
+++ b/cmd/podman/diff.go
@@ -34,8 +34,7 @@ func (so stdoutStruct) Out() error {
 
 var (
 	diffCommand     cliconfig.DiffValues
-	diffDescription = fmt.Sprint(`Displays changes on a container or image's filesystem.  The
-	container or image will be compared to its parent layer`)
+	diffDescription = fmt.Sprint(`Displays changes on a container or image's filesystem.  The container or image will be compared to its parent layer.`)
 
 	_diffCommand = &cobra.Command{
 		Use:   "diff [flags] CONTAINER | IMAGE",
@@ -54,6 +53,7 @@ var (
 
 func init() {
 	diffCommand.Command = _diffCommand
+	diffCommand.SetHelpTemplate(HelpTemplate())
 	diffCommand.SetUsageTemplate(UsageTemplate())
 	flags := diffCommand.Flags()
 

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -17,10 +17,7 @@ import (
 var (
 	execCommand cliconfig.ExecValues
 
-	execDescription = `
-	podman exec
-
-	Run a command in a running container
+	execDescription = `Execute the specified command inside a running container.
 `
 	_execCommand = &cobra.Command{
 		Use:   "exec [flags] CONTAINER [COMMAND [ARG...]]",
@@ -39,6 +36,7 @@ var (
 
 func init() {
 	execCommand.Command = _execCommand
+	execCommand.SetHelpTemplate(HelpTemplate())
 	execCommand.SetUsageTemplate(UsageTemplate())
 	flags := execCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/podman/exists.go
+++ b/cmd/podman/exists.go
@@ -16,21 +16,12 @@ var (
 	containerExistsCommand cliconfig.ContainerExistsValues
 	podExistsCommand       cliconfig.PodExistsValues
 
-	imageExistsDescription = `
-	podman image exists
+	imageExistsDescription = `If the named image exists in local storage, podman image exists exits with 0, otherwise the exit code will be 1.`
 
-	Check if an image exists in local storage
-`
-	containerExistsDescription = `
-	podman container exists
+	containerExistsDescription = `If the named container exists in local storage, podman container exists exits with 0, otherwise the exit code will be 1.`
 
-	Check if a container exists in local storage
-`
-	podExistsDescription = `
-	podman pod exists
+	podExistsDescription = `If the named pod exists in local storage, podman pod exists exits with 0, otherwise the exit code will be 1.`
 
-	Check if a pod exists in local storage
-`
 	_imageExistsCommand = &cobra.Command{
 		Use:   "exists IMAGE",
 		Short: "Check if an image exists in local storage",
@@ -75,12 +66,15 @@ var (
 func init() {
 	imageExistsCommand.Command = _imageExistsCommand
 	imageExistsCommand.DisableFlagsInUseLine = true
+	imageExistsCommand.SetHelpTemplate(HelpTemplate())
 	imageExistsCommand.SetUsageTemplate(UsageTemplate())
 	containerExistsCommand.Command = _containerExistsCommand
 	containerExistsCommand.DisableFlagsInUseLine = true
+	containerExistsCommand.SetHelpTemplate(HelpTemplate())
 	containerExistsCommand.SetUsageTemplate(UsageTemplate())
 	podExistsCommand.Command = _podExistsCommand
 	podExistsCommand.DisableFlagsInUseLine = true
+	podExistsCommand.SetHelpTemplate(HelpTemplate())
 	podExistsCommand.SetUsageTemplate(UsageTemplate())
 }
 

--- a/cmd/podman/export.go
+++ b/cmd/podman/export.go
@@ -32,6 +32,7 @@ var (
 
 func init() {
 	exportCommand.Command = _exportCommand
+	exportCommand.SetHelpTemplate(HelpTemplate())
 	exportCommand.SetUsageTemplate(UsageTemplate())
 	flags := exportCommand.Flags()
 	flags.StringVarP(&exportCommand.Output, "output", "o", "/dev/stdout", "Write to a file, default is STDOUT")

--- a/cmd/podman/generate_kube.go
+++ b/cmd/podman/generate_kube.go
@@ -15,10 +15,12 @@ import (
 
 var (
 	containerKubeCommand     cliconfig.GenerateKubeValues
-	containerKubeDescription = "Generate Kubernetes Pod YAML"
-	_containerKubeCommand    = &cobra.Command{
+	containerKubeDescription = `Command generates Kubernetes Pod YAML (v1 specification) from a podman container or pod.
+
+  Whether the input is for a container or pod, Podman will always generate the specification as a Pod. The input may be in the form of a pod or container name or ID.`
+	_containerKubeCommand = &cobra.Command{
 		Use:   "kube [flags] CONTAINER | POD",
-		Short: "Generate Kubernetes pod YAML for a container or pod",
+		Short: "Generate Kubernetes pod YAML from a container or pod",
 		Long:  containerKubeDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			containerKubeCommand.InputArgs = args
@@ -33,6 +35,7 @@ var (
 
 func init() {
 	containerKubeCommand.Command = _containerKubeCommand
+	containerKubeCommand.SetHelpTemplate(HelpTemplate())
 	containerKubeCommand.SetUsageTemplate(UsageTemplate())
 	flags := containerKubeCommand.Flags()
 	flags.BoolVarP(&containerKubeCommand.Service, "service", "s", false, "Generate YAML for kubernetes service object")

--- a/cmd/podman/history.go
+++ b/cmd/podman/history.go
@@ -37,8 +37,9 @@ type historyOptions struct {
 var (
 	historyCommand cliconfig.HistoryValues
 
-	historyDescription = "Displays the history of an image. The information can be printed out in an easy to read, " +
-		"or user specified format, and can be truncated."
+	historyDescription = `Displays the history of an image.
+
+  The information can be printed out in an easy to read, or user specified format, and can be truncated.`
 	_historyCommand = &cobra.Command{
 		Use:   "history [flags] IMAGE",
 		Short: "Show history of a specified image",
@@ -53,6 +54,7 @@ var (
 
 func init() {
 	historyCommand.Command = _historyCommand
+	historyCommand.SetHelpTemplate(HelpTemplate())
 	historyCommand.SetUsageTemplate(UsageTemplate())
 	flags := historyCommand.Flags()
 	flags.StringVar(&historyCommand.Format, "format", "", "Change the output to JSON or a Go template")

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -85,7 +85,7 @@ func (a imagesSortedSize) Less(i, j int) bool {
 
 var (
 	imagesCommand     cliconfig.ImagesValues
-	imagesDescription = "lists locally stored images."
+	imagesDescription = "Lists images previously pulled to the system or created on the system."
 
 	_imagesCommand = cobra.Command{
 		Use:   "images [flags] [IMAGE]",
@@ -103,6 +103,7 @@ var (
 )
 
 func imagesInit(command *cliconfig.ImagesValues) {
+	command.SetHelpTemplate(HelpTemplate())
 	command.SetUsageTemplate(UsageTemplate())
 
 	flags := command.Flags()

--- a/cmd/podman/images_prune.go
+++ b/cmd/podman/images_prune.go
@@ -11,11 +11,9 @@ import (
 
 var (
 	pruneImagesCommand     cliconfig.PruneImagesValues
-	pruneImagesDescription = `
-	podman image prune
+	pruneImagesDescription = `Removes all unnamed images from local storage.
 
-	Removes all unnamed images from local storage
-`
+  If an image is not being used by a container, it will be removed from the system.`
 	_pruneImagesCommand = &cobra.Command{
 		Use:   "prune",
 		Args:  noSubArgs,
@@ -31,6 +29,7 @@ var (
 
 func init() {
 	pruneImagesCommand.Command = _pruneImagesCommand
+	pruneImagesCommand.SetHelpTemplate(HelpTemplate())
 	pruneImagesCommand.SetUsageTemplate(UsageTemplate())
 	flags := pruneImagesCommand.Flags()
 	flags.BoolVarP(&pruneImagesCommand.All, "all", "a", false, "Remove all unused images, not just dangling ones")

--- a/cmd/podman/import.go
+++ b/cmd/podman/import.go
@@ -13,9 +13,9 @@ var (
 	importCommand cliconfig.ImportValues
 
 	importDescription = `Create a container image from the contents of the specified tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz).
-	 Note remote tar balls can be specified, via web address.
-	 Optionally tag the image. You can specify the instructions using the --change option.
-	`
+
+  Note remote tar balls can be specified, via web address.
+  Optionally tag the image. You can specify the instructions using the --change option.`
 	_importCommand = &cobra.Command{
 		Use:   "import [flags] PATH [REFERENCE]",
 		Short: "Import a tarball to create a filesystem image",
@@ -33,6 +33,7 @@ var (
 
 func init() {
 	importCommand.Command = _importCommand
+	importCommand.SetHelpTemplate(HelpTemplate())
 	importCommand.SetUsageTemplate(UsageTemplate())
 	flags := importCommand.Flags()
 	flags.StringSliceVarP(&importCommand.Change, "change", "c", []string{}, "Apply the following possible instructions to the created image (default []): CMD | ENTRYPOINT | ENV | EXPOSE | LABEL | STOPSIGNAL | USER | VOLUME | WORKDIR")

--- a/cmd/podman/info.go
+++ b/cmd/podman/info.go
@@ -16,12 +16,15 @@ import (
 var (
 	infoCommand cliconfig.InfoValues
 
-	infoDescription = "Display podman system information"
-	_infoCommand    = &cobra.Command{
+	infoDescription = `Display information pertaining to the host, current storage stats, and build of podman.
+
+  Useful for the user and when reporting issues.
+`
+	_infoCommand = &cobra.Command{
 		Use:   "info",
 		Args:  noSubArgs,
 		Long:  infoDescription,
-		Short: `Display information pertaining to the host, current storage stats, and build of podman. Useful for the user and when reporting issues.`,
+		Short: "Display podman system information",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			infoCommand.InputArgs = args
 			infoCommand.GlobalFlags = MainGlobalOpts
@@ -33,6 +36,7 @@ var (
 
 func init() {
 	infoCommand.Command = _infoCommand
+	infoCommand.SetHelpTemplate(HelpTemplate())
 	infoCommand.SetUsageTemplate(UsageTemplate())
 	flags := infoCommand.Flags()
 

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -24,8 +24,10 @@ const (
 var (
 	inspectCommand cliconfig.InspectValues
 
-	inspectDescription = "This displays the low-level information on containers and images identified by name or ID. By default, this will render all results in a JSON array. If the container and image have the same name, this will return container JSON for unspecified type."
-	_inspectCommand    = &cobra.Command{
+	inspectDescription = `This displays the low-level information on containers and images identified by name or ID.
+
+  If given a name that matches both a container and an image, this command inspects the container.  By default, this will render all results in a JSON array.`
+	_inspectCommand = &cobra.Command{
 		Use:   "inspect [flags] CONTAINER | IMAGE",
 		Short: "Display the configuration of a container or image",
 		Long:  inspectDescription,
@@ -42,6 +44,7 @@ var (
 
 func init() {
 	inspectCommand.Command = _inspectCommand
+	inspectCommand.SetHelpTemplate(HelpTemplate())
 	inspectCommand.SetUsageTemplate(UsageTemplate())
 	flags := inspectCommand.Flags()
 	flags.StringVarP(&inspectCommand.TypeObject, "type", "t", inspectAll, "Return JSON for specified type, (e.g image, container or task)")

--- a/cmd/podman/kill.go
+++ b/cmd/podman/kill.go
@@ -38,6 +38,7 @@ var (
 
 func init() {
 	killCommand.Command = _killCommand
+	killCommand.SetHelpTemplate(HelpTemplate())
 	killCommand.SetUsageTemplate(UsageTemplate())
 	flags := killCommand.Flags()
 

--- a/cmd/podman/load.go
+++ b/cmd/podman/load.go
@@ -30,6 +30,7 @@ var (
 
 func init() {
 	loadCommand.Command = _loadCommand
+	loadCommand.SetHelpTemplate(HelpTemplate())
 	loadCommand.SetUsageTemplate(UsageTemplate())
 	flags := loadCommand.Flags()
 	flags.StringVarP(&loadCommand.Input, "input", "i", "/dev/stdin", "Read from archive file, default is STDIN")

--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -37,6 +37,7 @@ var (
 
 func init() {
 	loginCommand.Command = _loginCommand
+	loginCommand.SetHelpTemplate(HelpTemplate())
 	loginCommand.SetUsageTemplate(UsageTemplate())
 	flags := loginCommand.Flags()
 

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -30,6 +30,7 @@ var (
 
 func init() {
 	logoutCommand.Command = _logoutCommand
+	logoutCommand.SetHelpTemplate(HelpTemplate())
 	logoutCommand.SetUsageTemplate(UsageTemplate())
 	flags := logoutCommand.Flags()
 	flags.BoolVarP(&logoutCommand.All, "all", "a", false, "Remove the cached credentials for all registries in the auth file")

--- a/cmd/podman/logs.go
+++ b/cmd/podman/logs.go
@@ -15,8 +15,10 @@ import (
 
 var (
 	logsCommand     cliconfig.LogsValues
-	logsDescription = "The podman logs command batch-retrieves whatever logs are present for a container at the time of execution.  This does not guarantee execution" +
-		"order when combined with podman run (i.e. your run may not have generated any logs at the time you execute podman logs"
+	logsDescription = `Retrieves logs for a container.
+
+  This does not guarantee execution order when combined with podman run (i.e. your run may not have generated any logs at the time you execute podman logs.
+`
 	_logsCommand = &cobra.Command{
 		Use:   "logs [flags] CONTAINER",
 		Short: "Fetch the logs of a container",
@@ -34,6 +36,7 @@ var (
 
 func init() {
 	logsCommand.Command = _logsCommand
+	logsCommand.SetHelpTemplate(HelpTemplate())
 	logsCommand.SetUsageTemplate(UsageTemplate())
 	flags := logsCommand.Flags()
 	flags.BoolVar(&logsCommand.Details, "details", false, "Show extra details provided to the logs")

--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -17,12 +17,11 @@ import (
 var (
 	mountCommand cliconfig.MountValues
 
-	mountDescription = `
-   podman mount
-   Lists all mounted containers mount points
+	mountDescription = `podman mount
+    Lists all mounted containers mount points if no container is specified
 
-   podman mount CONTAINER-NAME-OR-ID
-   Mounts the specified container and outputs the mountpoint
+  podman mount CONTAINER-NAME-OR-ID
+    Mounts the specified container and outputs the mountpoint
 `
 
 	_mountCommand = &cobra.Command{
@@ -42,6 +41,7 @@ var (
 
 func init() {
 	mountCommand.Command = _mountCommand
+	mountCommand.SetHelpTemplate(HelpTemplate())
 	mountCommand.SetUsageTemplate(UsageTemplate())
 	flags := mountCommand.Flags()
 	flags.BoolVarP(&mountCommand.All, "all", "a", false, "Mount all containers")

--- a/cmd/podman/pause.go
+++ b/cmd/podman/pause.go
@@ -14,12 +14,8 @@ import (
 
 var (
 	pauseCommand     cliconfig.PauseValues
-	pauseDescription = `
-   podman pause
-
-   Pauses one or more running containers.  The container name or ID can be used.
-`
-	_pauseCommand = &cobra.Command{
+	pauseDescription = `Pauses one or more running containers.  The container name or ID can be used.`
+	_pauseCommand    = &cobra.Command{
 		Use:   "pause [flags] CONTAINER [CONTAINER...]",
 		Short: "Pause all the processes in one or more containers",
 		Long:  pauseDescription,
@@ -36,6 +32,7 @@ var (
 
 func init() {
 	pauseCommand.Command = _pauseCommand
+	pauseCommand.SetHelpTemplate(HelpTemplate())
 	pauseCommand.SetUsageTemplate(UsageTemplate())
 	flags := pauseCommand.Flags()
 	flags.BoolVarP(&pauseCommand.All, "all", "a", false, "Pause all running containers")

--- a/cmd/podman/play.go
+++ b/cmd/podman/play.go
@@ -17,6 +17,7 @@ var (
 
 func init() {
 	playCommand.Command = _playCommand
+	playCommand.SetHelpTemplate(HelpTemplate())
 	playCommand.SetUsageTemplate(UsageTemplate())
 	playCommand.AddCommand(getPlaySubCommands()...)
 }

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -32,8 +32,10 @@ const (
 
 var (
 	playKubeCommand     cliconfig.KubePlayValues
-	playKubeDescription = "Play a Pod and its containers based on a Kubrernetes YAML"
-	_playKubeCommand    = &cobra.Command{
+	playKubeDescription = `Command reads in a structured file of Kubernetes YAML.
+
+  It creates the pod and containers described in the YAML.  The containers within the pod are then started and the ID of the new Pod is output.`
+	_playKubeCommand = &cobra.Command{
 		Use:   "kube [flags] KUBEFILE",
 		Short: "Play a pod based on Kubernetes YAML",
 		Long:  playKubeDescription,
@@ -49,6 +51,7 @@ var (
 
 func init() {
 	playKubeCommand.Command = _playKubeCommand
+	playKubeCommand.SetHelpTemplate(HelpTemplate())
 	playKubeCommand.SetUsageTemplate(UsageTemplate())
 	flags := playKubeCommand.Flags()
 	flags.StringVar(&playKubeCommand.Authfile, "authfile", "", "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")

--- a/cmd/podman/pod.go
+++ b/cmd/podman/pod.go
@@ -6,9 +6,7 @@ import (
 )
 
 var (
-	podDescription = `Manage container pods.
-
-Pods are a group of one or more containers sharing the same network, pid and ipc namespaces.`
+	podDescription = `Pods are a group of one or more containers sharing the same network, pid and ipc namespaces.`
 )
 var podCommand = cliconfig.PodmanCommand{
 	Command: &cobra.Command{
@@ -37,5 +35,6 @@ var podSubCommands = []*cobra.Command{
 
 func init() {
 	podCommand.AddCommand(podSubCommands...)
+	podCommand.SetHelpTemplate(HelpTemplate())
 	podCommand.SetUsageTemplate(UsageTemplate())
 }

--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -17,10 +17,9 @@ var (
 	DefaultKernelNamespaces = "cgroup,ipc,net,uts"
 	podCreateCommand        cliconfig.PodCreateValues
 
-	podCreateDescription = "Creates a new empty pod. The pod ID is then" +
-		" printed to stdout. You can then start it at any time with the" +
-		" podman pod start <pod_id> command. The pod will be created with the" +
-		" initial state 'created'."
+	podCreateDescription = `After creating the pod, the pod ID is printed to stdout.
+
+  You can then start it at any time with the  podman pod start <pod_id> command. The pod will be created with the initial state 'created'.`
 
 	_podCreateCommand = &cobra.Command{
 		Use:   "create",
@@ -37,6 +36,7 @@ var (
 
 func init() {
 	podCreateCommand.Command = _podCreateCommand
+	podCreateCommand.SetHelpTemplate(HelpTemplate())
 	podCreateCommand.SetUsageTemplate(UsageTemplate())
 	flags := podCreateCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/podman/pod_inspect.go
+++ b/cmd/podman/pod_inspect.go
@@ -12,8 +12,11 @@ import (
 
 var (
 	podInspectCommand     cliconfig.PodInspectValues
-	podInspectDescription = "Display the configuration for a pod by name or id"
-	_podInspectCommand    = &cobra.Command{
+	podInspectDescription = `Display the configuration for a pod by name or id
+
+  By default, this will render all results in a JSON array. If the container and image have the same name, this command returns the container JSON.`
+
+	_podInspectCommand = &cobra.Command{
 		Use:   "inspect [flags] POD",
 		Short: "Displays a pod configuration",
 		Long:  podInspectDescription,
@@ -28,6 +31,7 @@ var (
 
 func init() {
 	podInspectCommand.Command = _podInspectCommand
+	podInspectCommand.SetHelpTemplate(HelpTemplate())
 	podInspectCommand.SetUsageTemplate(UsageTemplate())
 	flags := podInspectCommand.Flags()
 	flags.BoolVarP(&podInspectCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")

--- a/cmd/podman/pod_kill.go
+++ b/cmd/podman/pod_kill.go
@@ -14,8 +14,10 @@ import (
 
 var (
 	podKillCommand     cliconfig.PodKillValues
-	podKillDescription = "The main process of each container inside the specified pod will be sent SIGKILL, or any signal specified with option --signal."
-	_podKillCommand    = &cobra.Command{
+	podKillDescription = `Signals are sent to the main process of each container inside the specified pod.
+
+  The default signal is SIGKILL, or any signal specified with option --signal.`
+	_podKillCommand = &cobra.Command{
 		Use:   "kill [flags] POD [POD...]",
 		Short: "Send the specified signal or SIGKILL to containers in pod",
 		Long:  podKillDescription,
@@ -35,6 +37,7 @@ var (
 
 func init() {
 	podKillCommand.Command = _podKillCommand
+	podKillCommand.SetHelpTemplate(HelpTemplate())
 	podKillCommand.SetUsageTemplate(UsageTemplate())
 	flags := podKillCommand.Flags()
 	flags.BoolVarP(&podKillCommand.All, "all", "a", false, "Kill all containers in all pods")

--- a/cmd/podman/pod_pause.go
+++ b/cmd/podman/pod_pause.go
@@ -11,8 +11,10 @@ import (
 
 var (
 	podPauseCommand     cliconfig.PodPauseValues
-	podPauseDescription = `Pauses one or more pods.  The pod name or ID can be used.`
-	_podPauseCommand    = &cobra.Command{
+	podPauseDescription = `The pod name or ID can be used.
+
+  All running containers within each specified pod will then be paused.`
+	_podPauseCommand = &cobra.Command{
 		Use:   "pause [flags] POD [POD...]",
 		Short: "Pause one or more pods",
 		Long:  podPauseDescription,
@@ -32,6 +34,7 @@ var (
 
 func init() {
 	podPauseCommand.Command = _podPauseCommand
+	podPauseCommand.SetHelpTemplate(HelpTemplate())
 	podPauseCommand.SetUsageTemplate(UsageTemplate())
 	flags := podPauseCommand.Flags()
 	flags.BoolVarP(&podPauseCommand.All, "all", "a", false, "Pause all running pods")

--- a/cmd/podman/pod_ps.go
+++ b/cmd/podman/pod_ps.go
@@ -134,6 +134,7 @@ var (
 
 func init() {
 	podPsCommand.Command = _podPsCommand
+	podPsCommand.SetHelpTemplate(HelpTemplate())
 	podPsCommand.SetUsageTemplate(UsageTemplate())
 	flags := podPsCommand.Flags()
 	flags.BoolVar(&podPsCommand.CtrNames, "ctr-names", false, "Display the container names")

--- a/cmd/podman/pod_restart.go
+++ b/cmd/podman/pod_restart.go
@@ -12,8 +12,10 @@ import (
 
 var (
 	podRestartCommand     cliconfig.PodRestartValues
-	podRestartDescription = `Restarts one or more pods. The pod ID or name can be used.`
-	_podRestartCommand    = &cobra.Command{
+	podRestartDescription = `The pod ID or name can be used.
+
+  All of the containers within each of the specified pods will be restarted. If a container in a pod is not currently running it will be started.`
+	_podRestartCommand = &cobra.Command{
 		Use:   "restart [flags] POD [POD...]",
 		Short: "Restart one or more pods",
 		Long:  podRestartDescription,
@@ -33,6 +35,7 @@ var (
 
 func init() {
 	podRestartCommand.Command = _podRestartCommand
+	podRestartCommand.SetHelpTemplate(HelpTemplate())
 	podRestartCommand.SetUsageTemplate(UsageTemplate())
 	flags := podRestartCommand.Flags()
 	flags.BoolVarP(&podRestartCommand.All, "all", "a", false, "Restart all running pods")

--- a/cmd/podman/pod_rm.go
+++ b/cmd/podman/pod_rm.go
@@ -12,11 +12,9 @@ import (
 
 var (
 	podRmCommand     cliconfig.PodRmValues
-	podRmDescription = fmt.Sprintf(`
-podman rm will remove one or more pods from the host. The pod name or ID can
-be used.  A pod with containers will not be removed without --force.
-If --force is specified, all containers will be stopped, then removed.
-`)
+	podRmDescription = fmt.Sprintf(`podman rm will remove one or more pods from the host.
+
+  The pod name or ID can be used.  A pod with containers will not be removed without --force. If --force is specified, all containers will be stopped, then removed.`)
 	_podRmCommand = &cobra.Command{
 		Use:   "rm [flags] POD [POD...]",
 		Short: "Remove one or more pods",
@@ -37,6 +35,7 @@ If --force is specified, all containers will be stopped, then removed.
 
 func init() {
 	podRmCommand.Command = _podRmCommand
+	podRmCommand.SetHelpTemplate(HelpTemplate())
 	podRmCommand.SetUsageTemplate(UsageTemplate())
 	flags := podRmCommand.Flags()
 	flags.BoolVarP(&podRmCommand.All, "all", "a", false, "Remove all running pods")

--- a/cmd/podman/pod_start.go
+++ b/cmd/podman/pod_start.go
@@ -12,11 +12,9 @@ import (
 
 var (
 	podStartCommand     cliconfig.PodStartValues
-	podStartDescription = `
-   podman pod start
+	podStartDescription = `The pod name or ID can be used.
 
-   Starts one or more pods.  The pod name or ID can be used.
-`
+  All containers defined in the pod will be started.`
 	_podStartCommand = &cobra.Command{
 		Use:   "start [flags] POD [POD...]",
 		Short: "Start one or more pods",
@@ -37,6 +35,7 @@ var (
 
 func init() {
 	podStartCommand.Command = _podStartCommand
+	podStartCommand.SetHelpTemplate(HelpTemplate())
 	podStartCommand.SetUsageTemplate(UsageTemplate())
 	flags := podStartCommand.Flags()
 	flags.BoolVarP(&podStartCommand.All, "all", "a", false, "Start all pods")

--- a/cmd/podman/pod_stats.go
+++ b/cmd/podman/pod_stats.go
@@ -22,10 +22,11 @@ import (
 
 var (
 	podStatsCommand     cliconfig.PodStatsValues
-	podStatsDescription = "Display a live stream of resource usage statistics for the containers in or more pods"
-	_podStatsCommand    = &cobra.Command{
+	podStatsDescription = `For each specified pod this command will display percentage of CPU, memory, network I/O, block I/O and PIDs for containers in one the pods.`
+
+	_podStatsCommand = &cobra.Command{
 		Use:   "stats [flags] POD [POD...]",
-		Short: "Display percentage of CPU, memory, network I/O, block I/O and PIDs for containers in one or more pods",
+		Short: "Display a live stream of resource usage statistics for the containers in one or more pods",
 		Long:  podStatsDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podStatsCommand.InputArgs = args
@@ -40,6 +41,7 @@ var (
 
 func init() {
 	podStatsCommand.Command = _podStatsCommand
+	podStatsCommand.SetHelpTemplate(HelpTemplate())
 	podStatsCommand.SetUsageTemplate(UsageTemplate())
 	flags := podStatsCommand.Flags()
 	flags.BoolVarP(&podStatsCommand.All, "all", "a", false, "Provide stats for all running pods")

--- a/cmd/podman/pod_stop.go
+++ b/cmd/podman/pod_stop.go
@@ -12,11 +12,9 @@ import (
 
 var (
 	podStopCommand     cliconfig.PodStopValues
-	podStopDescription = `
-   podman pod stop
+	podStopDescription = `The pod name or ID can be used.
 
-   Stops one or more running pods.  The pod name or ID can be used.
-`
+  This command will stop all running containers in each of the specified pods.`
 
 	_podStopCommand = &cobra.Command{
 		Use:   "stop [flags] POD [POD...]",
@@ -38,6 +36,7 @@ var (
 
 func init() {
 	podStopCommand.Command = _podStopCommand
+	podStopCommand.SetHelpTemplate(HelpTemplate())
 	podStopCommand.SetUsageTemplate(UsageTemplate())
 	flags := podStopCommand.Flags()
 	flags.BoolVarP(&podStopCommand.All, "all", "a", false, "Stop all running pods")

--- a/cmd/podman/pod_top.go
+++ b/cmd/podman/pod_top.go
@@ -16,12 +16,10 @@ import (
 var (
 	podTopCommand cliconfig.PodTopValues
 
-	podTopDescription = fmt.Sprintf(`Display the running processes containers in a pod.  Specify format descriptors
-to alter the output.  You may run "podman pod top -l pid pcpu seccomp" to print
-the process ID, the CPU percentage and the seccomp mode of each process of
-the latest pod.
-%s
-`, getDescriptorString())
+	podTopDescription = fmt.Sprintf(`Specify format descriptors to alter the output.
+
+  You may run "podman pod top -l pid pcpu seccomp" to print the process ID, the CPU percentage and the seccomp mode of each process of the latest pod.
+%s`, getDescriptorString())
 
 	_podTopCommand = &cobra.Command{
 		Use:   "top [flags] CONTAINER [FORMAT-DESCRIPTORS]",
@@ -40,6 +38,7 @@ the latest pod.
 
 func init() {
 	podTopCommand.Command = _podTopCommand
+	podTopCommand.SetHelpTemplate(HelpTemplate())
 	podTopCommand.SetUsageTemplate(UsageTemplate())
 	flags := podTopCommand.Flags()
 	flags.BoolVarP(&podTopCommand.Latest, "latest,", "l", false, "Act on the latest pod podman is aware of")

--- a/cmd/podman/pod_unpause.go
+++ b/cmd/podman/pod_unpause.go
@@ -12,8 +12,10 @@ import (
 
 var (
 	podUnpauseCommand     cliconfig.PodUnpauseValues
-	podUnpauseDescription = `Unpauses one or more pods.  The pod name or ID can be used.`
-	_podUnpauseCommand    = &cobra.Command{
+	podUnpauseDescription = `The podman unpause command will unpause all "paused" containers assigned to the pod.
+
+  The pod name or ID can be used.`
+	_podUnpauseCommand = &cobra.Command{
 		Use:   "unpause [flags] POD [POD...]",
 		Short: "Unpause one or more pods",
 		Long:  podUnpauseDescription,
@@ -33,6 +35,7 @@ var (
 
 func init() {
 	podUnpauseCommand.Command = _podUnpauseCommand
+	podUnpauseCommand.SetHelpTemplate(HelpTemplate())
 	podUnpauseCommand.SetUsageTemplate(UsageTemplate())
 	flags := podUnpauseCommand.Flags()
 	flags.BoolVarP(&podUnpauseCommand.All, "all", "a", false, "Unpause all running pods")

--- a/cmd/podman/port.go
+++ b/cmd/podman/port.go
@@ -14,10 +14,7 @@ import (
 
 var (
 	portCommand     cliconfig.PortValues
-	portDescription = `
-   podman port
-
-	List port mappings for the CONTAINER, or lookup the public-facing port that is NAT-ed to the PRIVATE_PORT
+	portDescription = `List port mappings for the CONTAINER, or lookup the public-facing port that is NAT-ed to the PRIVATE_PORT
 `
 	_portCommand = &cobra.Command{
 		Use:   "port [flags] CONTAINER",
@@ -39,6 +36,7 @@ var (
 
 func init() {
 	portCommand.Command = _portCommand
+	portCommand.SetHelpTemplate(HelpTemplate())
 	portCommand.SetUsageTemplate(UsageTemplate())
 	flags := portCommand.Flags()
 

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -174,6 +174,7 @@ var (
 )
 
 func psInit(command *cliconfig.PsValues) {
+	command.SetHelpTemplate(HelpTemplate())
 	command.SetUsageTemplate(UsageTemplate())
 	flags := command.Flags()
 	flags.BoolVarP(&command.All, "all", "a", false, "Show all the containers, default is only running containers")

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -23,11 +23,9 @@ import (
 
 var (
 	pullCommand     cliconfig.PullValues
-	pullDescription = `
-Pulls an image from a registry and stores it locally.
-An image can be pulled using its tag or digest. If a tag is not
-specified, the image with the 'latest' tag (if it exists) is pulled
-`
+	pullDescription = `Pulls an image from a registry and stores it locally.
+
+  An image can be pulled using its tag or digest. If a tag is not specified, the image with the 'latest' tag (if it exists) is pulled.`
 	_pullCommand = &cobra.Command{
 		Use:   "pull [flags] IMAGE-PATH",
 		Short: "Pull an image from a registry",
@@ -45,6 +43,7 @@ specified, the image with the 'latest' tag (if it exists) is pulled
 
 func init() {
 	pullCommand.Command = _pullCommand
+	pullCommand.SetHelpTemplate(HelpTemplate())
 	pullCommand.SetUsageTemplate(UsageTemplate())
 	flags := pullCommand.Flags()
 	flags.BoolVar(&pullCommand.AllTags, "all-tags", false, "All tagged images inthe repository will be pulled")

--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -20,10 +20,9 @@ import (
 
 var (
 	pushCommand     cliconfig.PushValues
-	pushDescription = fmt.Sprintf(`
-   Pushes an image to a specified location.
-   The Image "DESTINATION" uses a "transport":"details" format.
-   See podman-push(1) section "DESTINATION" for the expected format`)
+	pushDescription = fmt.Sprintf(`Pushes an image to a specified location.
+
+  The Image "DESTINATION" uses a "transport":"details" format. See podman-push(1) section "DESTINATION" for the expected format.`)
 
 	_pushCommand = &cobra.Command{
 		Use:   "push [flags] IMAGE REGISTRY",
@@ -42,6 +41,7 @@ var (
 
 func init() {
 	pushCommand.Command = _pushCommand
+	pushCommand.SetHelpTemplate(HelpTemplate())
 	pushCommand.SetUsageTemplate(UsageTemplate())
 	flags := pushCommand.Flags()
 	flags.MarkHidden("signature-policy")

--- a/cmd/podman/refresh.go
+++ b/cmd/podman/refresh.go
@@ -12,8 +12,11 @@ import (
 
 var (
 	refreshCommand     cliconfig.RefreshValues
-	refreshDescription = "The refresh command resets the state of all containers to handle database changes after a Podman upgrade. All running containers will be restarted."
-	_refreshCommand    = &cobra.Command{
+	refreshDescription = `Resets the state of all containers to handle database changes after a Podman upgrade.
+
+  All running containers will be restarted.
+`
+	_refreshCommand = &cobra.Command{
 		Use:   "refresh",
 		Args:  noSubArgs,
 		Short: "Refresh container state",
@@ -29,6 +32,7 @@ var (
 func init() {
 	_refreshCommand.Hidden = true
 	refreshCommand.Command = _refreshCommand
+	refreshCommand.SetHelpTemplate(HelpTemplate())
 	refreshCommand.SetUsageTemplate(UsageTemplate())
 }
 

--- a/cmd/podman/restart.go
+++ b/cmd/podman/restart.go
@@ -16,8 +16,10 @@ import (
 
 var (
 	restartCommand     cliconfig.RestartValues
-	restartDescription = `Restarts one or more running containers. The container ID or name can be used. A timeout before forcibly stopping can be set, but defaults to 10 seconds`
-	_restartCommand    = &cobra.Command{
+	restartDescription = `Restarts one or more running containers. The container ID or name can be used.
+
+  A timeout before forcibly stopping can be set, but defaults to 10 seconds.`
+	_restartCommand = &cobra.Command{
 		Use:   "restart [flags] CONTAINER [CONTAINER...]",
 		Short: "Restart one or more containers",
 		Long:  restartDescription,
@@ -37,6 +39,7 @@ var (
 
 func init() {
 	restartCommand.Command = _restartCommand
+	restartCommand.SetHelpTemplate(HelpTemplate())
 	restartCommand.SetUsageTemplate(UsageTemplate())
 	flags := restartCommand.Flags()
 	flags.BoolVarP(&restartCommand.All, "all", "a", false, "Restart all non-running containers")

--- a/cmd/podman/restore.go
+++ b/cmd/podman/restore.go
@@ -40,6 +40,7 @@ var (
 
 func init() {
 	restoreCommand.Command = _restoreCommand
+	restoreCommand.SetHelpTemplate(HelpTemplate())
 	restoreCommand.SetUsageTemplate(UsageTemplate())
 	flags := restoreCommand.Flags()
 	flags.BoolVarP(&restoreCommand.All, "all", "a", false, "Restore all checkpointed containers")

--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -15,11 +15,9 @@ import (
 
 var (
 	rmCommand     cliconfig.RmValues
-	rmDescription = fmt.Sprintf(`
-Podman rm will remove one or more containers from the host.
-The container name or ID can be used. This does not remove images.
-Running containers will not be removed without the -f option.
-`)
+	rmDescription = fmt.Sprintf(`Removes one or more containers from the host. The container name or ID can be used.
+
+  Command does not remove images. Running containers will not be removed without the -f option.`)
 	_rmCommand = &cobra.Command{
 		Use:   "rm [flags] CONTAINER [CONTAINER...]",
 		Short: "Remove one or more containers",
@@ -40,6 +38,7 @@ Running containers will not be removed without the -f option.
 
 func init() {
 	rmCommand.Command = _rmCommand
+	rmCommand.SetHelpTemplate(HelpTemplate())
 	rmCommand.SetUsageTemplate(UsageTemplate())
 	flags := rmCommand.Flags()
 	flags.BoolVarP(&rmCommand.All, "all", "a", false, "Remove all containers")

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	rmiCommand     cliconfig.RmiValues
-	rmiDescription = "Removes one or more locally stored images."
+	rmiDescription = "Removes one or more previously pulled or locally created images."
 	_rmiCommand    = cobra.Command{
 		Use:   "rmi [flags] IMAGE [IMAGE...]",
 		Short: "Removes one or more images from local storage",
@@ -30,6 +30,7 @@ var (
 )
 
 func rmiInit(command *cliconfig.RmiValues) {
+	command.SetHelpTemplate(HelpTemplate())
 	command.SetUsageTemplate(UsageTemplate())
 	flags := command.Flags()
 	flags.BoolVarP(&command.All, "all", "a", false, "Remove all images")

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -39,6 +39,7 @@ var (
 
 func init() {
 	runCommand.Command = _runCommand
+	runCommand.SetHelpTemplate(HelpTemplate())
 	runCommand.SetUsageTemplate(UsageTemplate())
 	flags := runCommand.Flags()
 	flags.SetInterspersed(false)

--- a/cmd/podman/runlabel.go
+++ b/cmd/podman/runlabel.go
@@ -38,6 +38,7 @@ Executes a command as described by a container image label.
 
 func init() {
 	runlabelCommand.Command = _runlabelCommand
+	runlabelCommand.SetHelpTemplate(HelpTemplate())
 	runlabelCommand.SetUsageTemplate(UsageTemplate())
 	flags := runlabelCommand.Flags()
 	flags.StringVar(&runlabelCommand.Authfile, "authfile", "", "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")

--- a/cmd/podman/save.go
+++ b/cmd/podman/save.go
@@ -23,9 +23,7 @@ var validFormats = []string{ociManifestDir, ociArchive, v2s2ManifestDir, v2s2Arc
 
 var (
 	saveCommand     cliconfig.SaveValues
-	saveDescription = `
-	Save an image to docker-archive or oci-archive on the local machine.
-	Default is docker-archive`
+	saveDescription = `Save an image to docker-archive or oci-archive on the local machine. Default is docker-archive.`
 
 	_saveCommand = &cobra.Command{
 		Use:   "save [flags] IMAGE",
@@ -54,6 +52,7 @@ var (
 
 func init() {
 	saveCommand.Command = _saveCommand
+	saveCommand.SetHelpTemplate(HelpTemplate())
 	saveCommand.SetUsageTemplate(UsageTemplate())
 	flags := saveCommand.Flags()
 	flags.BoolVar(&saveCommand.Compress, "compress", false, "Compress tarball image layers when saving to a directory using the 'dir' transport. (default is same compression type as source)")

--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -18,9 +18,9 @@ const (
 
 var (
 	searchCommand     cliconfig.SearchValues
-	searchDescription = `
-	Search registries for a given image. Can search all the default registries or a specific registry.
-	Can limit the number of results, and filter the output based on certain conditions.`
+	searchDescription = `Search registries for a given image. Can search all the default registries or a specific registry.
+
+  Users can limit the number of results, and filter the output based on certain conditions.`
 	_searchCommand = &cobra.Command{
 		Use:   "search [flags] TERM",
 		Short: "Search registry for image",
@@ -38,6 +38,7 @@ var (
 
 func init() {
 	searchCommand.Command = _searchCommand
+	searchCommand.SetHelpTemplate(HelpTemplate())
 	searchCommand.SetUsageTemplate(UsageTemplate())
 	flags := searchCommand.Flags()
 	flags.StringVar(&searchCommand.Authfile, "authfile", "", "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")

--- a/cmd/podman/sign.go
+++ b/cmd/podman/sign.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	signCommand     cliconfig.SignValues
-	signDescription = "Create a signature file that can be used later to verify the image"
+	signDescription = "Create a signature file that can be used later to verify the image."
 	_signCommand    = &cobra.Command{
 		Use:   "sign [flags] IMAGE [IMAGE...]",
 		Short: "Sign an image",
@@ -39,6 +39,7 @@ var (
 
 func init() {
 	signCommand.Command = _signCommand
+	signCommand.SetHelpTemplate(HelpTemplate())
 	signCommand.SetUsageTemplate(UsageTemplate())
 	flags := signCommand.Flags()
 	flags.StringVarP(&signCommand.Directory, "directory", "d", "", "Define an alternate directory to store signatures")

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -15,11 +15,8 @@ import (
 
 var (
 	startCommand     cliconfig.StartValues
-	startDescription = `
-   podman start
+	startDescription = `Starts one or more containers.  The container name or ID can be used.`
 
-   Starts one or more containers.  The container name or ID can be used.
-`
 	_startCommand = &cobra.Command{
 		Use:   "start [flags] CONTAINER [CONTAINER...]",
 		Short: "Start one or more containers",
@@ -37,6 +34,7 @@ var (
 
 func init() {
 	startCommand.Command = _startCommand
+	startCommand.SetHelpTemplate(HelpTemplate())
 	startCommand.SetUsageTemplate(UsageTemplate())
 	flags := startCommand.Flags()
 	flags.BoolVarP(&startCommand.Attach, "attach", "a", false, "Attach container's STDOUT and STDERR")

--- a/cmd/podman/stats.go
+++ b/cmd/podman/stats.go
@@ -31,10 +31,10 @@ type statsOutputParams struct {
 var (
 	statsCommand cliconfig.StatsValues
 
-	statsDescription = "display a live stream of one or more containers' resource usage statistics"
+	statsDescription = "Display percentage of CPU, memory, network I/O, block I/O and PIDs for one or more containers."
 	_statsCommand    = &cobra.Command{
 		Use:   "stats [flags] CONTAINER [CONTAINER...]",
-		Short: "Display percentage of CPU, memory, network I/O, block I/O and PIDs for one or more containers",
+		Short: "Display a live stream of container resource usage statistics",
 		Long:  statsDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			statsCommand.InputArgs = args
@@ -52,6 +52,7 @@ var (
 
 func init() {
 	statsCommand.Command = _statsCommand
+	statsCommand.SetHelpTemplate(HelpTemplate())
 	statsCommand.SetUsageTemplate(UsageTemplate())
 	flags := statsCommand.Flags()
 	flags.BoolVarP(&statsCommand.All, "all", "a", false, "Show all containers. Only running containers are shown by default. The default is false")

--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -15,13 +15,9 @@ import (
 
 var (
 	stopCommand     cliconfig.StopValues
-	stopDescription = `
-   podman stop
+	stopDescription = `Stops one or more running containers.  The container name or ID can be used.
 
-   Stops one or more running containers.  The container name or ID can be used.
-   A timeout to forcibly stop the container can also be set but defaults to 10
-   seconds otherwise.
-`
+  A timeout to forcibly stop the container can also be set but defaults to 10 seconds otherwise.`
 	_stopCommand = &cobra.Command{
 		Use:   "stop [flags] CONTAINER [CONTAINER...]",
 		Short: "Stop one or more containers",
@@ -42,6 +38,7 @@ var (
 
 func init() {
 	stopCommand.Command = _stopCommand
+	stopCommand.SetHelpTemplate(HelpTemplate())
 	stopCommand.SetUsageTemplate(UsageTemplate())
 	flags := stopCommand.Flags()
 	flags.BoolVarP(&stopCommand.All, "all", "a", false, "Stop all running containers")

--- a/cmd/podman/system_prune.go
+++ b/cmd/podman/system_prune.go
@@ -36,6 +36,7 @@ var (
 
 func init() {
 	pruneSystemCommand.Command = _pruneSystemCommand
+	pruneSystemCommand.SetHelpTemplate(HelpTemplate())
 	pruneSystemCommand.SetUsageTemplate(UsageTemplate())
 	flags := pruneSystemCommand.Flags()
 	flags.BoolVarP(&pruneSystemCommand.All, "all", "a", false, "Remove all unused data")

--- a/cmd/podman/system_renumber.go
+++ b/cmd/podman/system_renumber.go
@@ -31,6 +31,7 @@ var (
 
 func init() {
 	renumberCommand.Command = _renumberCommand
+	renumberCommand.SetHelpTemplate(HelpTemplate())
 	renumberCommand.SetUsageTemplate(UsageTemplate())
 }
 

--- a/cmd/podman/tag.go
+++ b/cmd/podman/tag.go
@@ -10,7 +10,7 @@ import (
 var (
 	tagCommand cliconfig.TagValues
 
-	tagDescription = "Adds one or more additional names to locally-stored image"
+	tagDescription = "Adds one or more additional names to locally-stored image."
 	_tagCommand    = &cobra.Command{
 		Use:   "tag [flags] IMAGE TAG [TAG...]",
 		Short: "Add an additional name to a local image",
@@ -28,6 +28,7 @@ var (
 
 func init() {
 	tagCommand.Command = _tagCommand
+	tagCommand.SetHelpTemplate(HelpTemplate())
 	tagCommand.SetUsageTemplate(UsageTemplate())
 }
 

--- a/cmd/podman/top.go
+++ b/cmd/podman/top.go
@@ -18,20 +18,20 @@ func getDescriptorString() string {
 	descriptors, err := libpod.GetContainerPidInformationDescriptors()
 	if err == nil {
 		return fmt.Sprintf(`
-Format Descriptors:
-%s`, strings.Join(descriptors, ","))
+  Format Descriptors:
+    %s`, strings.Join(descriptors, ","))
 	}
 	return ""
 }
 
 var (
 	topCommand     cliconfig.TopValues
-	topDescription = fmt.Sprintf(`Display the running processes of the container.  Specify format descriptors
-to alter the output.  You may run "podman top -l pid pcpu seccomp" to print
-the process ID, the CPU percentage and the seccomp mode of each process of
-the latest container.
-%s
-`, getDescriptorString())
+	topDescription = fmt.Sprintf(`Similar to system "top" command.
+
+  Specify format descriptors to alter the output.
+
+  Running "podman top -l pid pcpu seccomp" will print the process ID, the CPU percentage and the seccomp mode of each process of the latest container.
+%s`, getDescriptorString())
 
 	_topCommand = &cobra.Command{
 		Use:   "top [flags] CONTAINER [FORMAT-DESCRIPTIOS]",
@@ -50,6 +50,7 @@ the latest container.
 
 func init() {
 	topCommand.Command = _topCommand
+	topCommand.SetHelpTemplate(HelpTemplate())
 	topCommand.SetUsageTemplate(UsageTemplate())
 	flags := topCommand.Flags()
 	flags.BoolVar(&topCommand.ListDescriptors, "list-descriptors", false, "")

--- a/cmd/podman/trust.go
+++ b/cmd/podman/trust.go
@@ -6,16 +6,20 @@ import (
 )
 
 var (
+	trustDescription = `Manages which registries you trust as a source of container images based on its location.
+
+  The location is determined by the transport and the registry host of the image.  Using this container image docker://docker.io/library/busybox as an example, docker is the transport and docker.io is the registry host.`
 	trustCommand = cliconfig.PodmanCommand{
 		Command: &cobra.Command{
 			Use:   "trust",
 			Short: "Manage container image trust policy",
-			Long:  "podman image trust command",
+			Long:  trustDescription,
 		},
 	}
 )
 
 func init() {
+	trustCommand.SetHelpTemplate(HelpTemplate())
 	trustCommand.SetUsageTemplate(UsageTemplate())
 	trustCommand.AddCommand(getTrustSubCommands()...)
 	imageCommand.AddCommand(trustCommand.Command)

--- a/cmd/podman/trust_set_show.go
+++ b/cmd/podman/trust_set_show.go
@@ -50,8 +50,10 @@ var (
 
 func init() {
 	setTrustCommand.Command = _setTrustCommand
+	setTrustCommand.SetHelpTemplate(HelpTemplate())
 	setTrustCommand.SetUsageTemplate(UsageTemplate())
 	showTrustCommand.Command = _showTrustCommand
+	showTrustCommand.SetHelpTemplate(HelpTemplate())
 	showTrustCommand.SetUsageTemplate(UsageTemplate())
 	setFlags := setTrustCommand.Flags()
 	setFlags.StringVar(&setTrustCommand.PolicyPath, "policypath", "", "")

--- a/cmd/podman/umount.go
+++ b/cmd/podman/umount.go
@@ -14,12 +14,11 @@ import (
 
 var (
 	umountCommand cliconfig.UmountValues
-	description   = `
-Container storage increments a mount counter each time a container is mounted.
-When a container is unmounted, the mount counter is decremented and the
-container's root filesystem is physically unmounted only when the mount
-counter reaches zero indicating no other processes are using the mount.
-An unmount can be forced with the --force flag.
+	description   = `Container storage increments a mount counter each time a container is mounted.
+
+  When a container is unmounted, the mount counter is decremented. The container's root filesystem is physically unmounted only when the mount counter reaches zero indicating no other processes are using the mount.
+
+  An unmount can be forced with the --force flag.
 `
 	_umountCommand = &cobra.Command{
 		Use:     "umount [flags] CONTAINER [CONTAINER...]",
@@ -42,6 +41,7 @@ An unmount can be forced with the --force flag.
 
 func init() {
 	umountCommand.Command = _umountCommand
+	umountCommand.SetHelpTemplate(HelpTemplate())
 	umountCommand.SetUsageTemplate(UsageTemplate())
 	flags := umountCommand.Flags()
 	flags.BoolVarP(&umountCommand.All, "all", "a", false, "Umount all of the currently mounted containers")

--- a/cmd/podman/unpause.go
+++ b/cmd/podman/unpause.go
@@ -15,12 +15,8 @@ import (
 var (
 	unpauseCommand cliconfig.UnpauseValues
 
-	unpauseDescription = `
-   podman unpause
-
-   Unpauses one or more running containers.  The container name or ID can be used.
-`
-	_unpauseCommand = &cobra.Command{
+	unpauseDescription = `Unpauses one or more previously paused containers.  The container name or ID can be used.`
+	_unpauseCommand    = &cobra.Command{
 		Use:   "unpause [flags] CONTAINER [CONTAINER...]",
 		Short: "Unpause the processes in one or more containers",
 		Long:  unpauseDescription,
@@ -36,6 +32,7 @@ var (
 
 func init() {
 	unpauseCommand.Command = _unpauseCommand
+	unpauseCommand.SetHelpTemplate(HelpTemplate())
 	unpauseCommand.SetUsageTemplate(UsageTemplate())
 	flags := unpauseCommand.Flags()
 	flags.BoolVarP(&unpauseCommand.All, "all", "a", false, "Unpause all paused containers")

--- a/cmd/podman/varlink.go
+++ b/cmd/podman/varlink.go
@@ -18,10 +18,9 @@ import (
 
 var (
 	varlinkCommand     cliconfig.VarlinkValues
-	varlinkDescription = `
-	podman varlink
+	varlinkDescription = `Run varlink interface.  Podman varlink listens on the specified unix domain socket for incoming connects.
 
-	run varlink interface
+  Tools speaking varlink protocol can remotely manage pods, containers and images.
 `
 	_varlinkCommand = &cobra.Command{
 		Use:   "varlink [flags] URI",
@@ -39,6 +38,7 @@ var (
 
 func init() {
 	varlinkCommand.Command = _varlinkCommand
+	varlinkCommand.SetHelpTemplate(HelpTemplate())
 	varlinkCommand.SetUsageTemplate(UsageTemplate())
 	flags := varlinkCommand.Flags()
 	flags.Int64VarP(&varlinkCommand.Timeout, "timeout", "t", 1000, "Time until the varlink session expires in milliseconds.  Use 0 to disable the timeout")

--- a/cmd/podman/volume.go
+++ b/cmd/podman/volume.go
@@ -5,9 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var volumeDescription = `Manage volumes.
-
-Volumes are created in and can be shared between containers.`
+var volumeDescription = `Volumes are created in and can be shared between containers.`
 
 var volumeCommand = cliconfig.PodmanCommand{
 	Command: &cobra.Command{

--- a/cmd/podman/volume_create.go
+++ b/cmd/podman/volume_create.go
@@ -11,11 +11,7 @@ import (
 
 var (
 	volumeCreateCommand     cliconfig.VolumeCreateValues
-	volumeCreateDescription = `
-podman volume create
-
-Creates a new volume. If using the default driver, "local", the volume will
-be created at.`
+	volumeCreateDescription = `If using the default driver, "local", the volume will be created on the host in the volumes directory under container storage.`
 
 	_volumeCreateCommand = &cobra.Command{
 		Use:   "create [flags] [NAME]",
@@ -34,6 +30,7 @@ be created at.`
 
 func init() {
 	volumeCreateCommand.Command = _volumeCreateCommand
+	volumeCommand.SetHelpTemplate(HelpTemplate())
 	volumeCreateCommand.SetUsageTemplate(UsageTemplate())
 	flags := volumeCreateCommand.Flags()
 	flags.StringVar(&volumeCreateCommand.Driver, "driver", "", "Specify volume driver name (default local)")

--- a/cmd/podman/volume_inspect.go
+++ b/cmd/podman/volume_inspect.go
@@ -9,12 +9,9 @@ import (
 
 var (
 	volumeInspectCommand     cliconfig.VolumeInspectValues
-	volumeInspectDescription = `
-podman volume inspect
+	volumeInspectDescription = `Display detailed information on one or more volumes.
 
-Display detailed information on one or more volumes. Can change the format
-from JSON to a Go template.
-`
+  Use a Go template to change the format from JSON.`
 	_volumeInspectCommand = &cobra.Command{
 		Use:   "inspect [flags] VOLUME [VOLUME...]",
 		Short: "Display detailed information on one or more volumes",
@@ -32,6 +29,7 @@ from JSON to a Go template.
 
 func init() {
 	volumeInspectCommand.Command = _volumeInspectCommand
+	volumeInspectCommand.SetHelpTemplate(HelpTemplate())
 	volumeInspectCommand.SetUsageTemplate(UsageTemplate())
 	flags := volumeInspectCommand.Flags()
 	flags.BoolVarP(&volumeInspectCommand.All, "all", "a", false, "Inspect all volumes")

--- a/cmd/podman/volume_ls.go
+++ b/cmd/podman/volume_ls.go
@@ -44,8 +44,7 @@ var (
 podman volume ls
 
 List all available volumes. The output of the volumes can be filtered
-and the output format can be changed to JSON or a user specified Go template.
-`
+and the output format can be changed to JSON or a user specified Go template.`
 	_volumeLsCommand = &cobra.Command{
 		Use:     "ls",
 		Aliases: []string{"list"},
@@ -62,6 +61,7 @@ and the output format can be changed to JSON or a user specified Go template.
 
 func init() {
 	volumeLsCommand.Command = _volumeLsCommand
+	volumeLsCommand.SetHelpTemplate(HelpTemplate())
 	volumeLsCommand.SetUsageTemplate(UsageTemplate())
 	flags := volumeLsCommand.Flags()
 

--- a/cmd/podman/volume_prune.go
+++ b/cmd/podman/volume_prune.go
@@ -16,12 +16,10 @@ import (
 
 var (
 	volumePruneCommand     cliconfig.VolumePruneValues
-	volumePruneDescription = `
-podman volume prune
+	volumePruneDescription = `Volumes that are not currently owned by a container will be removed.
 
-Remove all unused volumes. Will prompt for confirmation if not
-using force.
-`
+  The command prompts for confirmation which can be overridden with the --force flag.
+  Note all data will be destroyed.`
 	_volumePruneCommand = &cobra.Command{
 		Use:   "prune",
 		Args:  noSubArgs,
@@ -37,6 +35,7 @@ using force.
 
 func init() {
 	volumePruneCommand.Command = _volumePruneCommand
+	volumePruneCommand.SetHelpTemplate(HelpTemplate())
 	volumePruneCommand.SetUsageTemplate(UsageTemplate())
 	flags := volumePruneCommand.Flags()
 

--- a/cmd/podman/volume_rm.go
+++ b/cmd/podman/volume_rm.go
@@ -11,13 +11,9 @@ import (
 
 var (
 	volumeRmCommand     cliconfig.VolumeRmValues
-	volumeRmDescription = `
-podman volume rm
+	volumeRmDescription = `Remove one or more existing volumes.
 
-Remove one or more existing volumes. Will only remove volumes that are
-not being used by any containers. To remove the volumes anyways, use the
---force flag.
-`
+  By default only volumes that are not being used by any containers will be removed. To remove the volumes anyways, use the --force flag.`
 	_volumeRmCommand = &cobra.Command{
 		Use:     "rm [flags] VOLUME [VOLUME...]",
 		Aliases: []string{"remove"},
@@ -36,6 +32,7 @@ not being used by any containers. To remove the volumes anyways, use the
 
 func init() {
 	volumeRmCommand.Command = _volumeRmCommand
+	volumeRmCommand.SetHelpTemplate(HelpTemplate())
 	volumeRmCommand.SetUsageTemplate(UsageTemplate())
 	flags := volumeRmCommand.Flags()
 	flags.BoolVarP(&volumeRmCommand.All, "all", "a", false, "Remove all volumes")

--- a/cmd/podman/wait.go
+++ b/cmd/podman/wait.go
@@ -14,10 +14,7 @@ import (
 var (
 	waitCommand cliconfig.WaitValues
 
-	waitDescription = `
-	podman wait
-
-	Block until one or more containers stop and then print their exit codes
+	waitDescription = `Block until one or more containers stop and then print their exit codes.
 `
 	_waitCommand = &cobra.Command{
 		Use:   "wait [flags] CONTAINER [CONTAINER...]",
@@ -36,6 +33,7 @@ var (
 
 func init() {
 	waitCommand.Command = _waitCommand
+	waitCommand.SetHelpTemplate(HelpTemplate())
 	waitCommand.SetUsageTemplate(UsageTemplate())
 	flags := waitCommand.Flags()
 	flags.UintVarP(&waitCommand.Interval, "interval", "i", 250, "Milliseconds to wait before polling for completion")


### PR DESCRIPTION
Cleanup lots of help information to look good when displayed.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

Examples added by @TomSweeneyRedHat 
```
[root@localhost ~]# podman build --help
Builds an OCI or Docker image using instructions from one
or more Dockerfiles and a specified build context directory.

Usage:
  podman build [flags] CONTEXT

Examples:
  podman build .
  podman build --cert-dir ~/auth --creds=username:password -t imageName -f Dockerfile.simple .
  podman build --layers --force-rm --tag imageName .

Flags:
      --add-host host:ip                           add a custom host-to-IP mapping (host:ip) (default [])
      --annotation strings                         Set metadata for an image (default [])
      --authfile string                            path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
      --build-arg argument=value                   argument=value to supply to the builder
      --cache-from string                          Images to utilise as potential cache sources. The build process does not currently support caching so this is a NOOP.
      --cap-add strings                            add the specified capability when running (default [])
      --cap-drop strings                           drop the specified capability when running (default [])
      --cert-dir string                            use certificates at the specified path to access the registry
      --cgroup-parent string                       optional parent cgroup for the container
      --cni-plugin-path path                       path of CNI network plugins (default "/usr/libexec/cni:/opt/cni/bin")
      --compress                                   This is legacy option, which has no effect on the image
      --cpu-period uint                            limit the CPU CFS (Completely Fair Scheduler) period
      --cpu-quota int                              limit the CPU CFS (Completely Fair Scheduler) quota
  -c, --cpu-shares uint                            CPU shares (relative weight)
      --cpuset-cpus string                         CPUs in which to allow execution (0-3, 0,1)

```
Podman build help after: 

```
# podman build --help
Build an image using instructions from Dockerfiles

Description:

Builds an OCI or Docker image using instructions from one or more Dockerfiles and a specified build context directory.

Usage:
  podman build [flags] CONTEXT

Examples:
  podman build .
  podman build --cert-dir ~/auth --creds=username:password -t imageName -f Dockerfile.simple .
  podman build --layers --force-rm --tag imageName .

Flags:
      --add-host host:ip                           add a custom host-to-IP mapping (host:ip) (default [])
      --annotation strings                         Set metadata for an image (default [])
      --authfile string                            path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
      --build-arg argument=value                   argument=value to supply to the builder
      --cache-from string                          Images to utilise as potential cache sources. The build process does not currently support caching so this is a NOOP.
      --cap-add strings                            add the specified capability when running (default [])
      --cap-drop strings                           drop the specified capability when running (default [])
      --cert-dir string                            use certificates at the specified path to access the registry
      --cgroup-parent string                       optional parent cgroup for the container
      --cni-plugin-path path                       path of CNI network plugins (default "/usr/libexec/cni:/opt/cni/bin")
      --compress                                   This is legacy option, which has no effect on the image
      --cpu-period uint                            limit the CPU CFS (Completely Fair Scheduler) period
      --cpu-quota int                              limit the CPU CFS (Completely Fair Scheduler) quota
  -c, --cpu-shares uint                            CPU shares (relative weight)
```

Podman diff help before:

```
# podman diff --help
Displays changes on a container or image's filesystem.  The
	container or image will be compared to its parent layer

Usage:
  podman diff [flags] CONTAINER | IMAGE

Examples:
  podman diff imageID
  podman diff ctrID
  podman diff --format json redis:alpine

Flags:
      --format string   Change the output format
  -h, --help            help for diff
```

Podman diff help after:

```
# podman diff --help
Inspect changes on container's file systems

Description:

Displays changes on a container or image's filesystem.  The container or image will be compared to its parent layer.

Usage:
  podman diff [flags] CONTAINER | IMAGE

Examples:
  podman diff imageID
  podman diff ctrID
  podman diff --format json redis:alpine

Flags:
      --format string   Change the output format
  -h, --help            help for diff
```