### PR TITLE
Yet another seemingly minor tweak to usage message

### DIFF
--- a/cmd/podman/healthcheck_run.go
+++ b/cmd/podman/healthcheck_run.go
@@ -13,7 +13,7 @@ var (
 	healthcheckRunCommand     cliconfig.HealthCheckValues
 	healthcheckRunDescription = "run the health check of a container"
 	_healthcheckrunCommand    = &cobra.Command{
-		Use:     "run CONTAINER",
+		Use:     "run [flags] CONTAINER",
 		Short:   "run the health check of a container",
 		Long:    healthcheckRunDescription,
 		Example: `podman healthcheck run mywebapp`,


### PR DESCRIPTION
Add explicit [flags] to podman healthcheck run Use message.

Reason: Cobra checks for the string '[flags]' in the Use text.
If absent, and command has options, Cobra appends it. This
is misleading to humans, because the --help output looks like:

     podman healthcheck run CONTAINER [flags]

...when of course that won't work.

Signed-off-by: Ed Santiago <santiago@redhat.com>