### PR TITLE
rootless: exec join the user+mount namespace

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -894,7 +894,16 @@ func joinOrCreateRootlessUserNamespace(createConfig *cc.CreateConfig, runtime *l
 				}
 				return false, -1, errors.Errorf("dependency container %s is not running", ctr.ID())
 			}
-			return rootless.JoinNS(uint(pid), 0)
+
+			data, err := ioutil.ReadFile(ctr.Config().ConmonPidFile)
+			if err != nil {
+				return false, -1, errors.Wrapf(err, "cannot read conmon PID file %q", ctr.Config().ConmonPidFile)
+			}
+			conmonPid, err := strconv.Atoi(string(data))
+			if err != nil {
+				return false, -1, errors.Wrapf(err, "cannot parse PID %q", data)
+			}
+			return rootless.JoinDirectUserAndMountNS(uint(conmonPid))
 		}
 	}
 	return rootless.BecomeRootInUserNS()

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -108,16 +108,25 @@ func execCmd(c *cliconfig.ExecValues) error {
 
 	}
 
-	pid, err := ctr.PID()
-	if err != nil {
-		return err
-	}
-	became, ret, err := rootless.JoinNS(uint(pid), c.PreserveFDs)
-	if err != nil {
-		return err
-	}
-	if became {
-		os.Exit(ret)
+	if os.Geteuid() != 0 {
+		var became bool
+		var ret int
+
+		data, err := ioutil.ReadFile(ctr.Config().ConmonPidFile)
+		if err != nil {
+			return errors.Wrapf(err, "cannot read conmon PID file %q", ctr.Config().ConmonPidFile)
+		}
+		conmonPid, err := strconv.Atoi(string(data))
+		if err != nil {
+			return errors.Wrapf(err, "cannot parse PID %q", data)
+		}
+		became, ret, err = rootless.JoinDirectUserAndMountNS(uint(conmonPid))
+		if err != nil {
+			return err
+		}
+		if became {
+			os.Exit(ret)
+		}
 	}
 
 	// ENVIRONMENT VARIABLES


### PR DESCRIPTION
it is not enough to join the user namespace where the container is
running.  We also need to join the mount namespace so that we can
correctly look-up inside of the container rootfs.  This is necessary
to lookup the mounted /etc/passwd file when --user is specified.

Closes: https://github.com/containers/libpod/issues/2566

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>