### PR TITLE
Default to SELinux private label for play kube mounts 

### DIFF
--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -168,7 +168,13 @@ func playKubeYAMLCmd(c *cliconfig.KubePlayValues) error {
 						return errors.Errorf("Error creating HostPath %s at %s", volume.Name, hostPath.Path)
 					}
 				}
+				// unconditionally label a newly created volume as private
+				if err := libpod.LabelVolumePath(hostPath.Path, false); err != nil {
+					return errors.Wrapf(err, "Error giving %s a label", hostPath.Path)
+				}
+				break
 			case v1.HostPathDirectory:
+			case v1.HostPathUnset:
 				// do nothing here because we will verify the path exists in validateVolumeHostDir
 				break
 			default:
@@ -178,7 +184,6 @@ func playKubeYAMLCmd(c *cliconfig.KubePlayValues) error {
 		if err := shared.ValidateVolumeHostDir(hostPath.Path); err != nil {
 			return errors.Wrapf(err, "Error in parsing HostPath in YAML")
 		}
-		fmt.Println(volume.Name)
 		volumes[volume.Name] = hostPath.Path
 	}
 

--- a/docs/podman-play-kube.1.md
+++ b/docs/podman-play-kube.1.md
@@ -22,6 +22,8 @@ the ID of the new Pod is output.
 
 Ideally the input file would be one created by Podman (see podman-generate-kube(1)).  This would guarantee a smooth import and expected results.
 
+Note: HostPath volume types created by play kube will be given an SELinux private label (Z)
+
 # OPTIONS:
 
 **--authfile**

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/containers/libpod/libpod/events"
 	"github.com/containers/storage/pkg/stringid"
-	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -56,15 +55,8 @@ func (r *Runtime) newVolume(ctx context.Context, options ...VolumeCreateOption) 
 	if err := os.MkdirAll(fullVolPath, 0755); err != nil {
 		return nil, errors.Wrapf(err, "error creating volume directory %q", fullVolPath)
 	}
-	_, mountLabel, err := label.InitLabels([]string{})
-	if err != nil {
-		return nil, errors.Wrapf(err, "error getting default mountlabels")
-	}
-	if err := label.ReleaseLabel(mountLabel); err != nil {
-		return nil, errors.Wrapf(err, "error releasing label %q", mountLabel)
-	}
-	if err := label.Relabel(fullVolPath, mountLabel, true); err != nil {
-		return nil, errors.Wrapf(err, "error setting selinux label to %q", fullVolPath)
+	if err := LabelVolumePath(fullVolPath, true); err != nil {
+		return nil, err
 	}
 	volume.config.MountPoint = fullVolPath
 

--- a/libpod/util_unsupported.go
+++ b/libpod/util_unsupported.go
@@ -21,3 +21,9 @@ func deleteSystemdCgroup(path string) error {
 func assembleSystemdCgroupName(baseSlice, newSlice string) (string, error) {
 	return "", errors.Wrapf(ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
 }
+
+// LabelVolumePath takes a mount path for a volume and gives it an
+// selinux label of either shared or not
+func LabelVolumePath(path string, shared bool) error {
+	return ErrNotImplemented
+}


### PR DESCRIPTION
Before, there were SELinux denials when a volume was mounted podman play kube. Fix this by hardcoding a shared label into the Volume.
