### PR TITLE
add podman-healthcheck(1) to podman(1)

### DIFF
--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -137,6 +137,7 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-exec(1)](podman-exec.1.md)        | Execute a command in a running container.                                      |
 | [podman-export(1)](podman-export.1.md)    | Export a container's filesystem contents as a tar archive.                     |
 | [podman-generate(1)](podman-generate.1.md)| Generate structured data based for a containers and pods.                      |
+| [podman-healthcheck(1)](podman-healthcheck.1.md)| Manage healthchecks for containers                                       |
 | [podman-history(1)](podman-history.1.md)  | Show the history of an image.                                                  |
 | [podman-image(1)](podman-image.1.md)      | Manage Images.                                                                 |
 | [podman-images(1)](podman-images.1.md)    | List images in local storage.                                                  |

--- a/hack/podman-commands.sh
+++ b/hack/podman-commands.sh
@@ -35,6 +35,9 @@ function podman_man() {
         #   | [podman-cmd(1)\[(podman-cmd.1.md)   | Description ... |
         # For all such, print the 'cmd' portion (the one in brackets).
         sed -ne 's/^|\s\+\[podman-\([a-z]\+\)(1.*/\1/p' <docs/$1.1.md
+
+        # Special case: there is no podman-help man page, nor need for such.
+        echo "help"
     elif [ "$@" = "podman-image-trust" ]; then
         # Special case: set and show aren't actually in a table in the man page
         echo set


### PR DESCRIPTION
...caught by hack/podman-commands.sh script. Which had a little
buglet, which I fixed: add a special case for 'help', which
neither has nor needs a man page.

I believe the podman-commands.sh script is ready to be run in CI,
hint hint.

Signed-off-by: Ed Santiago <santiago@redhat.com>