### PR TITLE
More cleanup for failures on missing commands.

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"strings"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/fatih/camelcase"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -65,6 +65,16 @@ func noSubArgs(c *cobra.Command, args []string) error {
 		return errors.Errorf("`%s` takes no arguments", c.CommandPath())
 	}
 	return nil
+}
+
+func commandRunE() func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return errors.Errorf("unrecognized command `%s %s`\nTry '%s --help' for more information.", cmd.CommandPath(), args[0], cmd.CommandPath())
+		} else {
+			return errors.Errorf("missing command '%s COMMAND'\nTry '%s --help' for more information.", cmd.CommandPath(), cmd.CommandPath())
+		}
+	}
 }
 
 // getAllOrLatestContainers tries to return the correct list of containers
@@ -537,7 +547,7 @@ Description:
 // This blocks the desplaying of the global options. The main podman
 // command should not use this.
 func UsageTemplate() string {
-	return `Usage:{{if .Runnable}}
+	return `Usage:{{if (and .Runnable (not .HasAvailableSubCommands))}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -15,6 +15,7 @@ var (
 			Short:            "Manage Containers",
 			Long:             containerDescription,
 			TraverseChildren: true,
+			RunE:             commandRunE(),
 		},
 	}
 

--- a/cmd/podman/generate.go
+++ b/cmd/podman/generate.go
@@ -12,6 +12,7 @@ var (
 		Use:   "generate",
 		Short: "Generated structured data",
 		Long:  generateDescription,
+		RunE:  commandRunE(),
 	}
 )
 

--- a/cmd/podman/healthcheck.go
+++ b/cmd/podman/healthcheck.go
@@ -11,6 +11,7 @@ var healthcheckCommand = cliconfig.PodmanCommand{
 		Use:   "healthcheck",
 		Short: "Manage Healthcheck",
 		Long:  healthcheckDescription,
+		RunE:  commandRunE(),
 	},
 }
 

--- a/cmd/podman/image.go
+++ b/cmd/podman/image.go
@@ -14,6 +14,7 @@ var (
 			Use:   "image",
 			Short: "Manage images",
 			Long:  imageDescription,
+			RunE:  commandRunE(),
 		},
 	}
 	imagesSubCommand  cliconfig.ImagesValues

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -82,9 +82,7 @@ var cmdsNotRequiringRootless = map[*cobra.Command]bool{
 var rootCmd = &cobra.Command{
 	Use:  "podman",
 	Long: "manage pods and images",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cmd.Help()
-	},
+	RunE: commandRunE(),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return before(cmd, args)
 	},

--- a/cmd/podman/play.go
+++ b/cmd/podman/play.go
@@ -12,6 +12,7 @@ var (
 		Use:   "play",
 		Short: "Play a pod",
 		Long:  playDescription,
+		RunE:  commandRunE(),
 	}
 )
 

--- a/cmd/podman/pod.go
+++ b/cmd/podman/pod.go
@@ -13,6 +13,7 @@ var podCommand = cliconfig.PodmanCommand{
 		Use:   "pod",
 		Short: "Manage pods",
 		Long:  podDescription,
+		RunE:  commandRunE(),
 	},
 }
 

--- a/cmd/podman/system.go
+++ b/cmd/podman/system.go
@@ -13,6 +13,7 @@ var (
 			Use:   "system",
 			Short: "Manage podman",
 			Long:  systemDescription,
+			RunE:  commandRunE(),
 		},
 	}
 )

--- a/cmd/podman/trust.go
+++ b/cmd/podman/trust.go
@@ -14,6 +14,7 @@ var (
 			Use:   "trust",
 			Short: "Manage container image trust policy",
 			Long:  trustDescription,
+			RunE:  commandRunE(),
 		},
 	}
 )

--- a/cmd/podman/volume.go
+++ b/cmd/podman/volume.go
@@ -12,6 +12,7 @@ var volumeCommand = cliconfig.PodmanCommand{
 		Use:   "volume",
 		Short: "Manage volumes",
 		Long:  volumeDescription,
+		RunE:  commandRunE(),
 	},
 }
 var volumeSubcommands = []*cobra.Command{


### PR DESCRIPTION
Currently in podman if a user specifies a command that does not exist
the tool shows the help information.  This patch changes it to show
information like:

$ ./bin/podman foobar
Error: unrecognized command 'podman foobar'
Try 'podman --help' for more information.
$ ./bin/podman volume foobar
Error: unrecognized command `podman volume foobar`
Try 'podman volume --help' for more information.
$ ./bin/podman container foobar
Error: unrecognized command `podman container foobar`
Try 'podman container --help' for more information.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>