### PR TITLE
label parsing in non-quoted field

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 	"strings"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/containers/storage"
 	"github.com/fatih/camelcase"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -311,7 +311,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"kernel-memory", "",
 		"Kernel memory limit (format: `<number>[<unit>]`, where unit = b, k, m or g)",
 	)
-	createFlags.StringSliceP(
+	createFlags.StringArrayP(
 		"label", "l", []string{},
 		"Set metadata on container (default [])",
 	)

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -592,7 +592,7 @@ func parseCreateOpts(ctx context.Context, c *cliconfig.PodmanCommand, runtime *l
 	}
 
 	// LABEL VARIABLES
-	labels, err := getAllLabels(c.StringSlice("label-file"), c.StringSlice("label"))
+	labels, err := getAllLabels(c.StringSlice("label-file"), c.StringArray("label"))
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to process labels")
 	}


### PR DESCRIPTION
switch from a stringslice to a stringarray for labels to handle quoted
input.

fixes issue #2574

Signed-off-by: baude <bbaude@redhat.com>