### PR TITLE
Remove 'podman ps' restarting filter and fix stopped

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -419,7 +419,7 @@ func generateContainerFilterFuncs(filter, filterValue string, runtime *libpod.Ru
 			return false
 		}, nil
 	case "status":
-		if !util.StringInSlice(filterValue, []string{"created", "restarting", "running", "paused", "exited", "unknown"}) {
+		if !util.StringInSlice(filterValue, []string{"created", "running", "paused", "exited", "unknown"}) {
 			return nil, errors.Errorf("%s is not a valid status", filterValue)
 		}
 		return func(c *libpod.Container) bool {
@@ -430,6 +430,8 @@ func generateContainerFilterFuncs(filter, filterValue string, runtime *libpod.Ru
 			state := status.String()
 			if status == libpod.ContainerStateConfigured {
 				state = "created"
+			} else if status == libpod.ContainerStateStopped {
+				state = "exited"
 			}
 			return state == filterValue
 		}, nil


### PR DESCRIPTION
Podman has no concept of a "restarting" container - such a container is just transitioning from running to stopped and then back to running through our ordinary state machine.

As such, filtering "restarting" containers doesn't work and does nothing.

Also, make "stopped" containers show as exited - this is a momentary state we transition to before proper exited.