### PR TITLE
rootless: propagate errors from info

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -971,9 +971,12 @@ func (r *Runtime) refreshRootless() error {
 	// Take advantage of a command that requires a new userns
 	// so that we are running as the root user and able to use refresh()
 	cmd := exec.Command(os.Args[0], "info")
-	err := cmd.Run()
-	if err != nil {
-		return errors.Wrapf(err, "Error running %s info while refreshing state", os.Args[0])
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		if _, ok := err.(*exec.ExitError); !ok {
+			return errors.Wrapf(err, "Error waiting for info while refreshing state: %s", os.Args[0])
+		}
+		return errors.Wrapf(err, "Error running %s info while refreshing state: %s", os.Args[0], output)
 	}
 	return nil
 }

--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -277,6 +277,8 @@ reexec_in_user_namespace (int ready)
       _exit (EXIT_FAILURE);
     }
   close (ready);
+  if (b != '1')
+    _exit (EXIT_FAILURE);
 
   if (syscall_setresgid (0, 0, 0) < 0)
     {

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -229,6 +229,7 @@ func BecomeRootInUserNS() (bool, int, error) {
 	}
 	defer r.Close()
 	defer w.Close()
+	defer w.Write([]byte("0"))
 
 	pidC := C.reexec_in_user_namespace(C.int(r.Fd()))
 	pid := int(pidC)


### PR DESCRIPTION
we use "podman info" to reconfigure the runtime after a reboot, but we
don't propagate the error message back if something goes wrong.

Closes: https://github.com/containers/libpod/issues/2584

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>