### PR TITLE
Default to image entrypoint for infra container

### DIFF
--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -69,6 +69,18 @@ var _ = Describe("Podman pod create", func() {
 		Expect(len(check.OutputToStringArray())).To(Equal(1))
 	})
 
+	It("podman start infra container different image", func() {
+		session := podmanTest.Podman([]string{"pod", "create", "--infra-image", BB})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		podID := session.OutputToString()
+
+		session = podmanTest.Podman([]string{"pod", "start", podID})
+		session.WaitWithDefaultTimeout()
+		// If we use the default entry point, we should exit with no error
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman infra container namespaces", func() {
 		session := podmanTest.Podman([]string{"pod", "create"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
If the pod infra container is overriden, we want to run the entry point of the image, instead of the default infra command. This allows users to override the infra-image with greater ease.

Signed-off-by: Peter Hunt <pehunt@redhat.com>