### PR TITLE
podman container runlabel --replace

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -414,6 +414,7 @@ type RunlabelValues struct {
 	Opt2            string
 	Opt3            string
 	Quiet           bool
+	Replace         bool
 	SignaturePolicy string
 	TlsVerify       bool
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2453,6 +2453,7 @@ _podman_container_runlabel() {
 	 -h
 	 -q
 	 --quiet
+	 --replace
 	 --tls-verify
   "
 

--- a/docs/podman-container-runlabel.1.md
+++ b/docs/podman-container-runlabel.1.md
@@ -7,11 +7,15 @@ podman-container-runlabel - Execute Image Label Method
 # SYNOPSIS
 **podman container runlabel**
 [**-h**|**--help**]
+[**--authfile**]
+[**--cert-dir**]
+[**--creds**]
 [**--display**]
 [**-n**][**--name**[=*NAME*]]
-[**--rootfs**=*ROOTFS*]
-[**--set**=*NAME*=*VALUE*]
-[**--storage**]
+[**-q**][**--quiet**]
+[**--replace**]
+[**--signature-policy**]
+[**--tls-verify**]
 LABEL IMAGE [ARG...]
 
 # DESCRIPTION
@@ -84,6 +88,11 @@ Print usage statement
 **--quiet, -q**
 
 Suppress output information when pulling images
+
+**--replace**
+
+If a container with the same name exists in local storage, it will be removed prior
+to executing the label command.
 
 **--signature-policy="PATHNAME"**
 


### PR DESCRIPTION
in order to more closely mimic the atomic cli tool, we needed a
--replace option that would allow a container with a similar name to be
deleted prior to executing the new image label.

fixes: #1677908

Signed-off-by: baude <bbaude@redhat.com>