### PR TITLE
rootless: allow single ID mappings

### DIFF
--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -267,7 +267,7 @@ func (ir *Runtime) doPullImage(ctx context.Context, sc *types.SystemContext, goa
 		_, err = cp.Image(ctx, policyContext, imageInfo.dstRef, imageInfo.srcRef, copyOptions)
 		if err != nil {
 			pullErrors = multierror.Append(pullErrors, err)
-			logrus.Debugf("Error pulling image ref %s: %v", imageInfo.srcRef.StringWithinTransport(), err)
+			logrus.Errorf("Error pulling image ref %s: %v", imageInfo.srcRef.StringWithinTransport(), err)
 			if writer != nil {
 				io.WriteString(writer, "Failed\n")
 			}

--- a/test/e2e/rootless_test.go
+++ b/test/e2e/rootless_test.go
@@ -126,7 +126,6 @@ var _ = Describe("Podman rootless", func() {
 			env := os.Environ()
 			env = append(env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", xdgRuntimeDir))
 			env = append(env, fmt.Sprintf("HOME=%s", home))
-			env = append(env, "PODMAN_ALLOW_SINGLE_ID_MAPPING_IN_USERNS=1")
 			env = append(env, "USER=foo")
 
 			cmd := rootlessTest.PodmanAsUser([]string{"pod", "create", "--infra=false"}, 1000, 1000, "", env)
@@ -171,7 +170,6 @@ var _ = Describe("Podman rootless", func() {
 			env := os.Environ()
 			env = append(env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", xdgRuntimeDir))
 			env = append(env, fmt.Sprintf("HOME=%s", home))
-			env = append(env, "PODMAN_ALLOW_SINGLE_ID_MAPPING_IN_USERNS=1")
 			env = append(env, "USER=foo")
 
 			allArgs := append([]string{"run"}, args...)


### PR DESCRIPTION
we were playing safe and not allowed any container to have less than 65536 mappings.  There are a couple of reasons to change it:

- it blocked libpod to work in an environment where newuidmap/newgidmap are not available, or not configured.

- not allowed to use different partitions of subuids, where each user has less than 65536 ids available.

Hopefully this change in containers/storage:

https://github.com/containers/storage/pull/303

will make error clearers if there are not enough IDs for the image that is being used.

Closes: https://github.com/containers/libpod/issues/1651

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>