### PR TITLE
Cirrus: Notify on some post-merge failures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -217,14 +217,9 @@ testing_task:
 
     # Every *_script runs in sequence, for each task. The name prefix is for
     # WebUI reference.  The values may be strings...
-    setup_environment_script: $SCRIPT_BASE/setup_environment.sh
-
-    # ...or lists of strings
-    unit_test_script:
-        - go version
-        - $SCRIPT_BASE/unit_test.sh
-
-    integration_test_script: $SCRIPT_BASE/integration_test.sh
+    setup_environment_script: $SCRIPT_BASE/notice_master_failure.sh $SCRIPT_BASE/setup_environment.sh
+    unit_test_script: $SCRIPT_BASE/notice_master_failure.sh $SCRIPT_BASE/unit_test.sh
+    integration_test_script: $SCRIPT_BASE/notice_master_failure.sh $SCRIPT_BASE/integration_test.sh
 
 
 # This task executes tests as a regular user on a system
@@ -250,9 +245,9 @@ rootless_testing_task:
 
     timeout_in: 120m
 
-    setup_environment_script: $SCRIPT_BASE/setup_environment.sh
+    setup_environment_script: $SCRIPT_BASE/notice_master_failure.sh $SCRIPT_BASE/setup_environment.sh
     rootless_test_script: >-
-        ssh $ROOTLESS_USER@localhost
+        $SCRIPT_BASE/notice_master_failure.sh ssh $ROOTLESS_USER@localhost
         -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o CheckHostIP=no
         $CIRRUS_WORKING_DIR/$SCRIPT_BASE/rootless_test.sh
 

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -103,6 +103,15 @@ clean_env() {
     unset -v UNSET_ENV_VARS $UNSET_ENV_VARS || true  # don't fail on read-only
 }
 
+die() {
+    req_env_var "
+        1 $1
+        2 $2
+    "
+    echo "$2"
+    exit $1
+}
+
 # Return a GCE image-name compatible string representation of distribution name
 os_release_id() {
     eval "$(egrep -m 1 '^ID=' /etc/os-release | tr -d \' | tr -d \")"

--- a/contrib/cirrus/notice_master_failure.sh
+++ b/contrib/cirrus/notice_master_failure.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+source $(dirname $0)/lib.sh
+
+ETX="$(echo -n -e '\x03')"
+RED="${ETX}4"
+NOR="$(echo -n -e '\x0f')"
+
+[[ -n "$1" ]] || die 46 "Required command and arguments to wrap"
+
+if [[ "$CIRRUS_BRANCH" =~ "master" ]]
+then
+    # TURL="https://cirrus-ci.com/task/$CIRRUS_TASK_ID"
+    BURL="https://cirrus-ci.com/build/$CIRRUS_BUILD_ID"
+    echo "Monitoring execution of $1 and notifying on failure"
+    set +e
+    "$@"
+    RET=$?
+    MSG="Action Required: Post-merge testing on $(os_release_id) $(os_release_ver), $(basename $1) failed (exit $RET): $BURL"
+    ((RET)) && echo "$MSG"
+    ((RET)) && ircmsg "${RED}$MSG"
+    exit $RET
+else
+    "$@"
+fi


### PR DESCRIPTION
There is currently no simple way in Cirrus to perform actions when a
build or task has failed.  However, this means it's easily possible for
a flaking test or conflict to become part of master.  Add a
wrapper-script to monitor for some of these conditions, and post a
notice on IRC if/when it happens.

***Note:*** This is temporary.  An upstream RFE, marked "Comming Soon" will provide a
complete solution when it's released.  https://github.com/cirruslabs/cirrus-ci-docs/issues/55

Signed-off-by: Chris Evich <cevich@redhat.com>