### PR TITLE
Fix SELinux on host shared systems in userns

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -454,10 +454,6 @@ func findMount(target string, mounts []*pmount.Info) (*pmount.Info, error) {
 }
 
 func blockAccessToKernelFilesystems(config *CreateConfig, g *generate.Generator) {
-	if config.PidMode.IsHost() && rootless.IsRootless() {
-		return
-	}
-
 	if !config.Privileged {
 		for _, mp := range []string{
 			"/proc/acpi",
@@ -469,8 +465,13 @@ func blockAccessToKernelFilesystems(config *CreateConfig, g *generate.Generator)
 			"/proc/sched_debug",
 			"/proc/scsi",
 			"/sys/firmware",
+			"/sys/fs/selinux",
 		} {
 			g.AddLinuxMaskedPaths(mp)
+		}
+
+		if config.PidMode.IsHost() && rootless.IsRootless() {
+			return
 		}
 
 		for _, rp := range []string{


### PR DESCRIPTION
Currently if you turn on --net=host on a rootless container
and have selinux-policy installed in the image, tools running with
SELinux will see that the system is SELinux enabled in rootless mode.

This patch mounts a tmpfs over /sys/fs/selinux blocking this behaviour.

This patch also fixes the fact that if you shared --pid=host we were not
masking over certin /proc paths.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>