### PR TITLE
runtime: fill the runtime config with sane defaults

### DIFF
--- a/libpod/events.go
+++ b/libpod/events.go
@@ -1,6 +1,8 @@
 package libpod
 
 import (
+	"os"
+
 	"github.com/containers/libpod/libpod/events"
 	"github.com/hpcloud/tail"
 	"github.com/pkg/errors"
@@ -85,7 +87,7 @@ func (r *Runtime) Events(fromStart, stream bool, options []events.EventFilter, e
 
 func (r *Runtime) getTail(fromStart, stream bool) (*tail.Tail, error) {
 	reopen := true
-	seek := tail.SeekInfo{Offset: 0, Whence: 2}
+	seek := tail.SeekInfo{Offset: 0, Whence: os.SEEK_END}
 	if fromStart || !stream {
 		seek.Whence = 0
 		reopen = false

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -241,6 +241,12 @@ type runtimeConfiguredFrom struct {
 	libpodStaticDirSet    bool
 	libpodTmpDirSet       bool
 	volPathSet            bool
+	conmonPath            bool
+	conmonEnvVars         bool
+	ociRuntimes           bool
+	runtimePath           bool
+	cniPluginDir          bool
+	noPivotRoot           bool
 }
 
 var (
@@ -434,6 +440,24 @@ func newRuntimeFromConfig(userConfigPath string, options ...RuntimeOption) (runt
 		if tmpConfig.VolumePath != "" {
 			runtime.configuredFrom.volPathSet = true
 		}
+		if tmpConfig.ConmonPath != nil {
+			runtime.configuredFrom.conmonPath = true
+		}
+		if tmpConfig.ConmonEnvVars != nil {
+			runtime.configuredFrom.conmonEnvVars = true
+		}
+		if tmpConfig.OCIRuntimes != nil {
+			runtime.configuredFrom.ociRuntimes = true
+		}
+		if tmpConfig.RuntimePath != nil {
+			runtime.configuredFrom.runtimePath = true
+		}
+		if tmpConfig.CNIPluginDir != nil {
+			runtime.configuredFrom.cniPluginDir = true
+		}
+		if tmpConfig.NoPivotRoot {
+			runtime.configuredFrom.noPivotRoot = true
+		}
 
 		if _, err := toml.Decode(string(contents), runtime.config); err != nil {
 			return nil, errors.Wrapf(err, "error decoding configuration file %s", configPath)
@@ -453,12 +477,24 @@ func newRuntimeFromConfig(userConfigPath string, options ...RuntimeOption) (runt
 			}
 
 			// Cherry pick the settings we want from the global configuration
-			runtime.config.ConmonPath = tmpConfig.ConmonPath
-			runtime.config.ConmonEnvVars = tmpConfig.ConmonEnvVars
-			runtime.config.OCIRuntimes = tmpConfig.OCIRuntimes
-			runtime.config.RuntimePath = tmpConfig.RuntimePath
-			runtime.config.CNIPluginDir = tmpConfig.CNIPluginDir
-			runtime.config.NoPivotRoot = tmpConfig.NoPivotRoot
+			if !runtime.configuredFrom.conmonPath {
+				runtime.config.ConmonPath = tmpConfig.ConmonPath
+			}
+			if !runtime.configuredFrom.conmonEnvVars {
+				runtime.config.ConmonEnvVars = tmpConfig.ConmonEnvVars
+			}
+			if !runtime.configuredFrom.ociRuntimes {
+				runtime.config.OCIRuntimes = tmpConfig.OCIRuntimes
+			}
+			if !runtime.configuredFrom.runtimePath {
+				runtime.config.RuntimePath = tmpConfig.RuntimePath
+			}
+			if !runtime.configuredFrom.cniPluginDir {
+				runtime.config.CNIPluginDir = tmpConfig.CNIPluginDir
+			}
+			if !runtime.configuredFrom.noPivotRoot {
+				runtime.config.NoPivotRoot = tmpConfig.NoPivotRoot
+			}
 			break
 		}
 	}


### PR DESCRIPTION
we cannot safely default to zeroed values.  It solves the error:

ERRO[0000] error creating libpod runtime: number of locks must be greater than 0: invalid argument

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>