### PR TITLE
Add --update and --pull-always flags to run/create

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -426,6 +426,10 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"publish-all", "P", false,
 		"Publish all exposed ports to random ports on the host interface",
 	)
+	createFlags.Bool(
+		"pull", false,
+		"Update the image if it exists in storage but is older than its source (default false)",
+	)
 	createFlags.BoolP(
 		"quiet", "q", false,
 		"Suppress output information when pulling images",

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -505,7 +505,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.Bool(
 		"update", false,
-		"Update the image if it exists in storage but is older than its source (default false)",
+		"Update the image from registries if a newer version is available",
 	)
 	createFlags.StringP(
 		"user", "u", "",

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -427,6 +427,10 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"Publish all exposed ports to random ports on the host interface",
 	)
 	createFlags.Bool(
+		"pull-always", false,
+		"Pull the image, even if a version is present",
+	)
+	createFlags.Bool(
 		"pull", false,
 		"Update the image if it exists in storage but is older than its source (default false)",
 	)

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -430,10 +430,6 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"pull-always", false,
 		"Pull the image, even if a version is present",
 	)
-	createFlags.Bool(
-		"pull", false,
-		"Update the image if it exists in storage but is older than its source (default false)",
-	)
 	createFlags.BoolP(
 		"quiet", "q", false,
 		"Suppress output information when pulling images",
@@ -506,6 +502,10 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	createFlags.StringSlice(
 		"ulimit", []string{},
 		"Ulimit options (default [])",
+	)
+	createFlags.Bool(
+		"update", false,
+		"Update the image if it exists in storage but is older than its source (default false)",
 	)
 	createFlags.StringP(
 		"user", "u", "",

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -184,7 +184,7 @@ func playKubeYAMLCmd(c *cliconfig.KubePlayValues) error {
 	}
 
 	for _, container := range podYAML.Spec.Containers {
-		newImage, err := runtime.ImageRuntime().New(ctx, container.Image, c.SignaturePolicy, c.Authfile, writer, &dockerRegistryOptions, image.SigningOptions{}, false, nil)
+		newImage, err := runtime.ImageRuntime().New(ctx, container.Image, c.SignaturePolicy, c.Authfile, writer, &dockerRegistryOptions, image.SigningOptions{}, false, nil, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -183,8 +183,15 @@ func playKubeYAMLCmd(c *cliconfig.KubePlayValues) error {
 		volumes[volume.Name] = hostPath.Path
 	}
 
+	imageConfig := runtime.ImageRuntime().DefaultPullConfig("")
+	imageConfig.SignaturePolicyPath = c.SignaturePolicy
+	imageConfig.Authfile = c.Authfile
+	imageConfig.Writer = writer
+	imageConfig.DockerOptions = &dockerRegistryOptions
+	imageConfig.SigningOptions = image.SigningOptions{}
 	for _, container := range podYAML.Spec.Containers {
-		newImage, err := runtime.ImageRuntime().New(ctx, container.Image, c.SignaturePolicy, c.Authfile, writer, &dockerRegistryOptions, image.SigningOptions{}, false, nil, false)
+		imageConfig.Name = container.Image
+		newImage, err := runtime.ImageRuntime().New(ctx, imageConfig, false, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -693,7 +693,7 @@ func GetRunlabel(label string, runlabelImage string, ctx context.Context, runtim
 			registryCreds = creds
 		}
 		dockerRegistryOptions.DockerRegistryCreds = registryCreds
-		newImage, err = runtime.ImageRuntime().New(ctx, runlabelImage, signaturePolicyPath, authfile, output, &dockerRegistryOptions, image.SigningOptions{}, false, &label)
+		newImage, err = runtime.ImageRuntime().New(ctx, runlabelImage, signaturePolicyPath, authfile, output, &dockerRegistryOptions, image.SigningOptions{}, false, &label, false)
 	} else {
 		newImage, err = runtime.ImageRuntime().NewFromLocal(runlabelImage)
 	}

--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -693,7 +693,15 @@ func GetRunlabel(label string, runlabelImage string, ctx context.Context, runtim
 			registryCreds = creds
 		}
 		dockerRegistryOptions.DockerRegistryCreds = registryCreds
-		newImage, err = runtime.ImageRuntime().New(ctx, runlabelImage, signaturePolicyPath, authfile, output, &dockerRegistryOptions, image.SigningOptions{}, false, &label, false)
+
+		config := runtime.ImageRuntime().DefaultPullConfig(runlabelImage)
+		config.SignaturePolicyPath = signaturePolicyPath
+		config.Authfile = authfile
+		config.Writer = output
+		config.DockerOptions = &dockerRegistryOptions
+		config.Label = &label
+
+		newImage, err = runtime.ImageRuntime().New(ctx, config, false, false)
 	} else {
 		newImage, err = runtime.ImageRuntime().NewFromLocal(runlabelImage)
 	}

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -75,7 +75,7 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 			writer = os.Stderr
 		}
 
-		newImage, err := runtime.ImageRuntime().New(ctx, c.InputArgs[0], rtc.SignaturePolicyPath, "", writer, nil, image.SigningOptions{}, false, nil, c.Bool("pull"))
+		newImage, err := runtime.ImageRuntime().New(ctx, c.InputArgs[0], rtc.SignaturePolicyPath, "", writer, nil, image.SigningOptions{}, c.Bool("pull-always"), nil, c.Bool("pull"))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/image/manifest"
 	"github.com/containers/libpod/cmd/podman/shared/parse"
 	"github.com/containers/libpod/libpod"
-	"github.com/containers/libpod/libpod/image"
 	ann "github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/inspect"
 	ns "github.com/containers/libpod/pkg/namespaces"
@@ -75,7 +74,11 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 			writer = os.Stderr
 		}
 
-		newImage, err := runtime.ImageRuntime().New(ctx, c.InputArgs[0], rtc.SignaturePolicyPath, "", writer, nil, image.SigningOptions{}, c.Bool("pull-always"), nil, c.Bool("update"))
+		imageConfig := runtime.ImageRuntime().DefaultPullConfig(c.InputArgs[0])
+		imageConfig.SignaturePolicyPath = rtc.SignaturePolicyPath
+		imageConfig.Writer = writer
+
+		newImage, err := runtime.ImageRuntime().New(ctx, imageConfig, c.Bool("pull-always"), c.Bool("update"))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -75,7 +75,7 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 			writer = os.Stderr
 		}
 
-		newImage, err := runtime.ImageRuntime().New(ctx, c.InputArgs[0], rtc.SignaturePolicyPath, "", writer, nil, image.SigningOptions{}, false, nil)
+		newImage, err := runtime.ImageRuntime().New(ctx, c.InputArgs[0], rtc.SignaturePolicyPath, "", writer, nil, image.SigningOptions{}, false, nil, c.Bool("pull"))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -75,7 +75,7 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 			writer = os.Stderr
 		}
 
-		newImage, err := runtime.ImageRuntime().New(ctx, c.InputArgs[0], rtc.SignaturePolicyPath, "", writer, nil, image.SigningOptions{}, c.Bool("pull-always"), nil, c.Bool("pull"))
+		newImage, err := runtime.ImageRuntime().New(ctx, c.InputArgs[0], rtc.SignaturePolicyPath, "", writer, nil, image.SigningOptions{}, c.Bool("pull-always"), nil, c.Bool("update"))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/podman/sign.go
+++ b/cmd/podman/sign.go
@@ -112,7 +112,13 @@ func signCmd(c *cliconfig.SignValues) error {
 		if err != nil {
 			return err
 		}
-		newImage, err := runtime.ImageRuntime().New(getContext(), signimage, rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{SignBy: signby}, false, nil, false)
+
+		config := runtime.ImageRuntime().DefaultPullConfig(signimage)
+		config.SignaturePolicyPath = rtc.SignaturePolicyPath
+		config.Writer = os.Stderr
+		config.SigningOptions = image.SigningOptions{SignBy: signby}
+
+		newImage, err := runtime.ImageRuntime().New(getContext(), config, false, false)
 		if err != nil {
 			return errors.Wrapf(err, "error pulling image %s", signimage)
 		}

--- a/cmd/podman/sign.go
+++ b/cmd/podman/sign.go
@@ -112,7 +112,7 @@ func signCmd(c *cliconfig.SignValues) error {
 		if err != nil {
 			return err
 		}
-		newImage, err := runtime.ImageRuntime().New(getContext(), signimage, rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{SignBy: signby}, false, nil)
+		newImage, err := runtime.ImageRuntime().New(getContext(), signimage, rtc.SignaturePolicyPath, "", os.Stderr, nil, image.SigningOptions{SignBy: signby}, false, nil, false)
 		if err != nil {
 			return errors.Wrapf(err, "error pulling image %s", signimage)
 		}

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1734,7 +1734,6 @@ _podman_container_run() {
 		--pod
 		--publish -p
 		--pull-always
-		--pull
 		--runtime
 		--rootfs
 		--security-opt
@@ -1748,6 +1747,7 @@ _podman_container_run() {
 		--systemd
 		--uidmap
 		--ulimit
+		--update
 		--user -u
 		--userns
 		--uts

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1733,6 +1733,7 @@ _podman_container_run() {
 		--pids-limit
 		--pod
 		--publish -p
+		--pull-always
 		--pull
 		--runtime
 		--rootfs

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1733,6 +1733,7 @@ _podman_container_run() {
 		--pids-limit
 		--pod
 		--publish -p
+		--pull
 		--runtime
 		--rootfs
 		--security-opt

--- a/contrib/perftest/main.go
+++ b/contrib/perftest/main.go
@@ -103,7 +103,11 @@ func main() {
 		}
 		fmt.Printf("image %s not found locally, fetching from remote registry..\n", *testImageName)
 
-		testImage, err = client.ImageRuntime().New(ctx, *testImageName, "", "", writer, &dockerRegistryOptions, image2.SigningOptions{}, false, nil)
+		imageConfig := client.ImageRuntime().DefaultNewImageConfig(*testImageName)
+		imageConfig.Writer = writer
+		imageConfig.DockerOptions = &dockerRegistryOptions
+		imageConfig.SigningOptions = image2.SigningOptions{}
+		testImage, err = client.ImageRuntime().New(ctx, imageConfig, false, false)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -530,17 +530,6 @@ port to a random port on the host within an *ephemeral port range* defined by
 `/proc/sys/net/ipv4/ip_local_port_range`. To find the mapping between the host
 ports and the exposed ports, use `podman port`.
 
-**--pull**=*true*|*false*
-
-When the flag is enabled, attempt to pull the latest image from the registries listed
-in registries.conf if a local image does not exist or the image is newer than the one in storage.
-Raise an error if the image is not in any listed registry and is not present locally.
-
-If the flag is disabled (with --pull=false), do not pull the image from the registry,
-use only the local version.
-
-Default is *false*
-
 **--pull-always**=*true*|*false*
 
 Pull the image from the first registry it is found in as listed in registries.conf.
@@ -689,6 +678,14 @@ The following example maps uids 0-2000 in the container to the uids 30000-31999 
 **--ulimit**=[]
 
 Ulimit options
+
+**--update**=*true*|*false*
+
+When the flag is enabled, attempt to pull the latest image from the registries listed
+in registries.conf if a local image does not exist or the image is newer than the one in storage.
+Raise an error if the image is not in any listed registry and is not present locally.
+
+Default is *false*
 
 **--user**, **-u**=""
 

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -532,8 +532,19 @@ ports and the exposed ports, use `podman port`.
 
 **--pull**=*true*|*false*
 
-If an image already exists in the local storage, but it is out of date with the
-respective image in its source repository, update the image before creating the container.
+When the flag is enabled, attempt to pull the latest image from the registries listed
+in registries.conf if a local image does not exist or the image is newer than the one in storage.
+Raise an error if the image is not in any listed registry and is not present locally.
+
+If the flag is disabled (with --pull=false), do not pull the image from the registry,
+use only the local version.
+
+Default is *false*
+
+**--pull-always**=*true*|*false*
+
+Pull the image from the first registry it is found in as listed in registries.conf.
+Raise an error if not found in the registries, even if the image is present locally.
 
 **--quiet, -q**
 

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -530,6 +530,11 @@ port to a random port on the host within an *ephemeral port range* defined by
 `/proc/sys/net/ipv4/ip_local_port_range`. To find the mapping between the host
 ports and the exposed ports, use `podman port`.
 
+**--pull**=*true*|*false*
+
+If an image already exists in the local storage, but it is out of date with the
+respective image in its source repository, update the image before creating the container.
+
 **--quiet, -q**
 
 Suppress output information when pulling images

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -524,8 +524,19 @@ To find the mapping between the host ports and the exposed ports, use `podman po
 
 **--pull**=*true*|*false*
 
-If an image already exists in the local storage, but it is out of date with the
-respective image in its source repository, update the image before creating the container.
+When the flag is enabled, attempt to pull the latest image from the registries listed
+in registries.conf if a local image does not exist or the image is newer than the one in storage.
+Raise an error if the image is not in any listed registry and is not present locally.
+
+If the flag is disabled (with --pull=false), do not pull the image from the registry,
+use only the local version.
+
+Default is *false*
+
+**--pull-always**=*true*|*false*
+
+Pull the image from the first registry it is found in as listed in registries.conf.
+Raise an error if not found in the registries, even if the image is present locally.
 
 **--quiet, -q**
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -522,17 +522,6 @@ When using -P, podman will bind any exposed port to a random port on the host
 within an *ephemeral port range* defined by `/proc/sys/net/ipv4/ip_local_port_range`.
 To find the mapping between the host ports and the exposed ports, use `podman port`.
 
-**--pull**=*true*|*false*
-
-When the flag is enabled, attempt to pull the latest image from the registries listed
-in registries.conf if a local image does not exist or the image is newer than the one in storage.
-Raise an error if the image is not in any listed registry and is not present locally.
-
-If the flag is disabled (with --pull=false), do not pull the image from the registry,
-use only the local version.
-
-Default is *false*
-
 **--pull-always**=*true*|*false*
 
 Pull the image from the first registry it is found in as listed in registries.conf.
@@ -695,6 +684,14 @@ The example maps uids 0-2000 in the container to the uids 30000-31999 on the hos
 **--ulimit**=[]
 
 Ulimit options
+
+**--update**=*true*|*false*
+
+When the flag is enabled, attempt to pull the latest image from the registries listed
+in registries.conf if a local image does not exist or the image is newer than the one in storage.
+Raise an error if the image is not in any listed registry and is not present locally.
+
+Default is *false*
 
 **--user**, **-u**=""
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -522,6 +522,11 @@ When using -P, podman will bind any exposed port to a random port on the host
 within an *ephemeral port range* defined by `/proc/sys/net/ipv4/ip_local_port_range`.
 To find the mapping between the host ports and the exposed ports, use `podman port`.
 
+**--pull**=*true*|*false*
+
+If an image already exists in the local storage, but it is out of date with the
+respective image in its source repository, update the image before creating the container.
+
 **--quiet, -q**
 
 Suppress output information when pulling images

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -87,9 +87,9 @@ func TestImage_NewFromLocal(t *testing.T) {
 	// Need images to be present for this test
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
-	bb, err := ir.New(context.Background(), "docker.io/library/busybox:latest", "", "", writer, nil, SigningOptions{}, false, nil)
+	bb, err := ir.New(context.Background(), "docker.io/library/busybox:latest", "", "", writer, nil, SigningOptions{}, false, nil, false)
 	assert.NoError(t, err)
-	bbglibc, err := ir.New(context.Background(), "docker.io/library/busybox:glibc", "", "", writer, nil, SigningOptions{}, false, nil)
+	bbglibc, err := ir.New(context.Background(), "docker.io/library/busybox:glibc", "", "", writer, nil, SigningOptions{}, false, nil, false)
 	assert.NoError(t, err)
 
 	tm, err := makeLocalMatrix(bb, bbglibc)
@@ -136,7 +136,7 @@ func TestImage_New(t *testing.T) {
 	// Iterate over the names and delete the image
 	// after the pull
 	for _, img := range names {
-		newImage, err := ir.New(context.Background(), img, "", "", writer, nil, SigningOptions{}, false, nil)
+		newImage, err := ir.New(context.Background(), img, "", "", writer, nil, SigningOptions{}, false, nil, false)
 		assert.NoError(t, err)
 		assert.NotEqual(t, newImage.ID(), "")
 		err = newImage.Remove(false)
@@ -164,7 +164,7 @@ func TestImage_MatchRepoTag(t *testing.T) {
 	}
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
-	newImage, err := ir.New(context.Background(), "busybox", "", "", os.Stdout, nil, SigningOptions{}, false, nil)
+	newImage, err := ir.New(context.Background(), "busybox", "", "", os.Stdout, nil, SigningOptions{}, false, nil, false)
 	assert.NoError(t, err)
 	err = newImage.TagImage("foo:latest")
 	assert.NoError(t, err)

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -87,9 +87,14 @@ func TestImage_NewFromLocal(t *testing.T) {
 	// Need images to be present for this test
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
-	bb, err := ir.New(context.Background(), "docker.io/library/busybox:latest", "", "", writer, nil, SigningOptions{}, false, nil, false)
+	imageConfig := ir.DefaultNewImageConfig("docker.io/library/busybox:latest")
+	imageConfig.Writer = writer
+
+	bb, err := ir.New(context.Background(), imageConfig, false, false)
 	assert.NoError(t, err)
-	bbglibc, err := ir.New(context.Background(), "docker.io/library/busybox:glibc", "", "", writer, nil, SigningOptions{}, false, nil, false)
+
+	imageConfig.Name = "docker.io/library/busybox:glibc"
+	bbglibc, err := ir.New(context.Background(), imageConfig, false, false)
 	assert.NoError(t, err)
 
 	tm, err := makeLocalMatrix(bb, bbglibc)
@@ -136,7 +141,10 @@ func TestImage_New(t *testing.T) {
 	// Iterate over the names and delete the image
 	// after the pull
 	for _, img := range names {
-		newImage, err := ir.New(context.Background(), img, "", "", writer, nil, SigningOptions{}, false, nil, false)
+		imageConfig := ir.DefaultNewImageConfig(img)
+		imageConfig.Writer = writer
+
+		newImage, err := ir.New(context.Background(), imageConfig, false, false)
 		assert.NoError(t, err)
 		assert.NotEqual(t, newImage.ID(), "")
 		err = newImage.Remove(false)
@@ -164,7 +172,10 @@ func TestImage_MatchRepoTag(t *testing.T) {
 	}
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
-	newImage, err := ir.New(context.Background(), "busybox", "", "", os.Stdout, nil, SigningOptions{}, false, nil, false)
+	config := ir.DefaultNewImageConfig("busybox")
+	config.Writer = os.Stdout
+
+	newImage, err := ir.New(context.Background(), config, false, false)
 	assert.NoError(t, err)
 	err = newImage.TagImage("foo:latest")
 	assert.NoError(t, err)

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -87,7 +87,7 @@ func TestImage_NewFromLocal(t *testing.T) {
 	// Need images to be present for this test
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
-	imageConfig := ir.DefaultNewImageConfig("docker.io/library/busybox:latest")
+	imageConfig := ir.DefaultPullConfig("docker.io/library/busybox:latest")
 	imageConfig.Writer = writer
 
 	bb, err := ir.New(context.Background(), imageConfig, false, false)
@@ -141,7 +141,7 @@ func TestImage_New(t *testing.T) {
 	// Iterate over the names and delete the image
 	// after the pull
 	for _, img := range names {
-		imageConfig := ir.DefaultNewImageConfig(img)
+		imageConfig := ir.DefaultPullConfig(img)
 		imageConfig.Writer = writer
 
 		newImage, err := ir.New(context.Background(), imageConfig, false, false)
@@ -172,7 +172,7 @@ func TestImage_MatchRepoTag(t *testing.T) {
 	}
 	ir, err := NewImageRuntimeFromOptions(so)
 	assert.NoError(t, err)
-	config := ir.DefaultNewImageConfig("busybox")
+	config := ir.DefaultPullConfig("busybox")
 	config.Writer = os.Stdout
 
 	newImage, err := ir.New(context.Background(), config, false, false)

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/opencontainers/image-spec/specs-go/v1"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -107,7 +106,8 @@ func (r *Runtime) createInfraContainer(ctx context.Context, p *Pod) (*Container,
 		return nil, ErrRuntimeStopped
 	}
 
-	newImage, err := r.ImageRuntime().New(ctx, r.config.InfraImage, "", "", nil, nil, image.SigningOptions{}, false, nil, false)
+	imgConfig := r.ImageRuntime().DefaultPullConfig(r.config.InfraImage)
+	newImage, err := r.ImageRuntime().New(ctx, imgConfig, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -107,7 +107,7 @@ func (r *Runtime) createInfraContainer(ctx context.Context, p *Pod) (*Container,
 		return nil, ErrRuntimeStopped
 	}
 
-	newImage, err := r.ImageRuntime().New(ctx, r.config.InfraImage, "", "", nil, nil, image.SigningOptions{}, false, nil)
+	newImage, err := r.ImageRuntime().New(ctx, r.config.InfraImage, "", "", nil, nil, image.SigningOptions{}, false, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -100,7 +100,7 @@ func (r *LocalRuntime) LoadFromArchiveReference(ctx context.Context, srcRef type
 
 // New calls into local storage to look for an image in local storage or to pull it
 func (r *LocalRuntime) New(ctx context.Context, name, signaturePolicyPath, authfile string, writer io.Writer, dockeroptions *image.DockerRegistryOptions, signingoptions image.SigningOptions, forcePull bool, label *string) (*ContainerImage, error) {
-	img, err := r.Runtime.ImageRuntime().New(ctx, name, signaturePolicyPath, authfile, writer, dockeroptions, signingoptions, forcePull, label)
+	img, err := r.Runtime.ImageRuntime().New(ctx, name, signaturePolicyPath, authfile, writer, dockeroptions, signingoptions, forcePull, label, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -100,7 +100,17 @@ func (r *LocalRuntime) LoadFromArchiveReference(ctx context.Context, srcRef type
 
 // New calls into local storage to look for an image in local storage or to pull it
 func (r *LocalRuntime) New(ctx context.Context, name, signaturePolicyPath, authfile string, writer io.Writer, dockeroptions *image.DockerRegistryOptions, signingoptions image.SigningOptions, forcePull bool, label *string) (*ContainerImage, error) {
-	img, err := r.Runtime.ImageRuntime().New(ctx, name, signaturePolicyPath, authfile, writer, dockeroptions, signingoptions, forcePull, label, false)
+	imageConfig := r.Runtime.ImageRuntime().DefaultPullConfig(name)
+	if signaturePolicyPath != "" {
+		imageConfig.SignaturePolicyPath = signaturePolicyPath
+	}
+	imageConfig.Authfile = authfile
+	imageConfig.Writer = writer
+	imageConfig.DockerOptions = dockeroptions
+	imageConfig.SigningOptions = signingoptions
+	imageConfig.Label = label
+
+	img, err := r.Runtime.ImageRuntime().New(ctx, imageConfig, forcePull, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -640,7 +640,7 @@ func (i *LibpodAPI) PullImage(call iopodman.VarlinkCall, name string, certDir, c
 			}
 			imageID = newImage[0].ID()
 		} else {
-			newImage, err := i.Runtime.ImageRuntime().New(getContext(), name, signaturePolicy, "", output, &dockerRegistryOptions, so, false, nil)
+			newImage, err := i.Runtime.ImageRuntime().New(getContext(), name, signaturePolicy, "", output, &dockerRegistryOptions, so, false, nil, false)
 			if err != nil {
 				c <- errors.Wrapf(err, "unable to pull %s", name)
 			}

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -640,7 +640,13 @@ func (i *LibpodAPI) PullImage(call iopodman.VarlinkCall, name string, certDir, c
 			}
 			imageID = newImage[0].ID()
 		} else {
-			newImage, err := i.Runtime.ImageRuntime().New(getContext(), name, signaturePolicy, "", output, &dockerRegistryOptions, so, false, nil, false)
+			imageConfig := i.Runtime.ImageRuntime().DefaultPullConfig(name)
+			imageConfig.SignaturePolicyPath = signaturePolicy
+			imageConfig.Writer = output
+			imageConfig.DockerOptions = &dockerRegistryOptions
+			imageConfig.SigningOptions = so
+
+			newImage, err := i.Runtime.ImageRuntime().New(getContext(), imageConfig, false, false)
 			if err != nil {
 				c <- errors.Wrapf(err, "unable to pull %s", name)
 			}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -763,7 +763,7 @@ USER mail`
 		Expect(session.ExitCode()).ToNot(Equal(0))
 	})
 
-	It("podman run --pull from local registry", func() {
+	It("podman run --update from local registry", func() {
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
 		}
@@ -792,8 +792,8 @@ USER mail`
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Equal(0))
 
-		// run and pull updated image
-		run = podmanTest.Podman([]string{"run", "--pull", "true", "--rm", "localhost:5000/my-alpine", "ls"})
+		// run and update updated image
+		run = podmanTest.Podman([]string{"run", "--update", "true", "--rm", "localhost:5000/my-alpine", "ls"})
 		run.WaitWithDefaultTimeout()
 		Expect(run.ExitCode()).To(Equal(0))
 		Expect(run.LineInOutputContains("Yup")).To(BeTrue())


### PR DESCRIPTION
--update updates an image in storage if it exists and there is a newer version in its source registry
--pull-always always searches for the image in the registries

(edited to change pull to update)