### PR TITLE
Usability cleanup for 'inspect'

### DIFF
--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -19,6 +19,20 @@ var (
 		},
 	}
 
+	contInspectSubCommand  cliconfig.InspectValues
+	_contInspectSubCommand = &cobra.Command{
+		Use:   strings.Replace(_inspectCommand.Use, "| IMAGE", "", 1),
+		Short: "Display the configuration of a container",
+		Long:  `Displays the low-level information on a container identified by name or ID.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			contInspectSubCommand.InputArgs = args
+			contInspectSubCommand.GlobalFlags = MainGlobalOpts
+			return inspectCmd(&contInspectSubCommand)
+		},
+		Example: `podman container inspect myCtr
+  podman container inspect -l --format '{{.Id}} {{.Config.Labels}}'`,
+	}
+
 	listSubCommand  cliconfig.PsValues
 	_listSubCommand = &cobra.Command{
 		Use:     strings.Replace(_psCommand.Use, "ps", "list", 1),
@@ -37,12 +51,15 @@ var (
 	// Commands that are universally implemented.
 	containerCommands = []*cobra.Command{
 		_containerExistsCommand,
-		_inspectCommand,
+		_contInspectSubCommand,
 		_listSubCommand,
 	}
 )
 
 func init() {
+	contInspectSubCommand.Command = _contInspectSubCommand
+	inspectInit(&contInspectSubCommand)
+
 	listSubCommand.Command = _listSubCommand
 	psInit(&listSubCommand)
 

--- a/cmd/podman/image.go
+++ b/cmd/podman/image.go
@@ -31,6 +31,19 @@ var (
 		Example: strings.Replace(_imagesCommand.Example, "podman images", "podman image list", -1),
 	}
 
+	inspectSubCommand  cliconfig.InspectValues
+	_inspectSubCommand = &cobra.Command{
+		Use:   strings.Replace(_inspectCommand.Use, "CONTAINER | ", "", 1),
+		Short: "Display the configuration of an image",
+		Long:  `Displays the low-level information on an image identified by name or ID.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inspectSubCommand.InputArgs = args
+			inspectSubCommand.GlobalFlags = MainGlobalOpts
+			return inspectCmd(&inspectSubCommand)
+		},
+		Example: `podman image inspect alpine`,
+	}
+
 	rmSubCommand  cliconfig.RmiValues
 	_rmSubCommand = &cobra.Command{
 		Use:   strings.Replace(_rmiCommand.Use, "rmi", "rm", 1),
@@ -52,7 +65,7 @@ var imageSubCommands = []*cobra.Command{
 	_imagesSubCommand,
 	_imageExistsCommand,
 	_importCommand,
-	_inspectCommand,
+	_inspectSubCommand,
 	_loadCommand,
 	_pruneImagesCommand,
 	_pullCommand,
@@ -68,6 +81,9 @@ func init() {
 
 	imagesSubCommand.Command = _imagesSubCommand
 	imagesInit(&imagesSubCommand)
+
+	inspectSubCommand.Command = _inspectSubCommand
+	inspectInit(&inspectSubCommand)
 
 	imageCommand.SetUsageTemplate(UsageTemplate())
 	imageCommand.AddCommand(imageSubCommands...)

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -42,7 +42,7 @@ var mainCommands = []*cobra.Command{
 	&_imagesCommand,
 	_importCommand,
 	_infoCommand,
-	_inspectCommand,
+	&_inspectCommand,
 	_killCommand,
 	_loadCommand,
 	podCommand.Command,

--- a/docs/podman-inspect.1.md
+++ b/docs/podman-inspect.1.md
@@ -6,6 +6,10 @@ podman\-inspect - Display a container or image's configuration
 ## SYNOPSIS
 **podman inspect** [*options*] *name* ...
 
+**podman image inspect** [*options*] *image*
+
+**podman container inspect** [*options*] *container*
+
 ## DESCRIPTION
 This displays the low-level information on containers and images identified by name or ID. By default, this will render
 all results in a JSON array. If the container and image have the same name, this will return container JSON for
@@ -16,6 +20,7 @@ unspecified type. If a format is specified, the given template will be executed 
 **--type, t="TYPE"**
 
 Return JSON for the specified type.  Type can be 'container', 'image' or 'all' (default: all)
+(Only meaningful when invoked as *podman inspect*)
 
 **--format, -f="FORMAT"**
 
@@ -27,7 +32,7 @@ The keys of the returned JSON can be used as the values for the --format flag (s
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
 to run containers such as CRI-O, the last started container could be from either of those methods.
 
-The latest option is not supported on the remote client.
+The latest option is not supported on the remote client or when invoked as *podman image inspect*.
 
 **--size, -s**
 
@@ -94,12 +99,12 @@ overlay
 ```
 
 ```
-# podman inspect --format "size: {{.Size}}" alpine
+# podman image inspect --format "size: {{.Size}}" alpine
 size:   4405240
 ```
 
 ```
-podman inspect --latest --format {{.EffectiveCaps}}
+podman container inspect --latest --format {{.EffectiveCaps}}
 [CAP_CHOWN CAP_DAC_OVERRIDE CAP_FSETID CAP_FOWNER CAP_MKNOD CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SETFCAP CAP_SETPCAP CAP_NET_BIND_SERVICE CAP_SYS_CHROOT CAP_KILL CAP_AUDIT_WRITE]
 ```
 

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Podman commit", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		check := podmanTest.Podman([]string{"container", "inspect", "foobar.com/test1-image:latest"})
+		check := podmanTest.Podman([]string{"image", "inspect", "foobar.com/test1-image:latest"})
 		check.WaitWithDefaultTimeout()
 		data := check.InspectImageJSON()
 		Expect(StringInSlice("foobar.com/test1-image:latest", data[0].RepoTags)).To(BeTrue())


### PR DESCRIPTION
Make the usage messages (and options) different between
podman inspect, podman image inspect, and podman container inspect.

Disable inapplicable options (-l, -s) for podman image inspect

Disable -t (type) when the type is implicit through the subcommand.

Uglier than desirable due to Go and Cobra limitations

Signed-off-by: Ed Santiago <santiago@redhat.com>