### PR TITLE
slirp4netns: set mtu to 65520

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -162,9 +162,9 @@ func (r *Runtime) setupRootlessNetNS(ctr *Container) (err error) {
 	var cmd *exec.Cmd
 	if havePortMapping {
 		// if we need ports to be mapped from the host, create a API socket to use for communicating with slirp4netns.
-		cmd = exec.Command(path, "-c", "-e", "3", "-r", "4", "--api-socket", apiSocket, fmt.Sprintf("%d", ctr.state.PID), "tap0")
+		cmd = exec.Command(path, "--mtu", "65520", "-c", "-e", "3", "-r", "4", "--api-socket", apiSocket, fmt.Sprintf("%d", ctr.state.PID), "tap0")
 	} else {
-		cmd = exec.Command(path, "-c", "-e", "3", "-r", "4", fmt.Sprintf("%d", ctr.state.PID), "tap0")
+		cmd = exec.Command(path, "--mtu", "65520", "-c", "-e", "3", "-r", "4", fmt.Sprintf("%d", ctr.state.PID), "tap0")
 	}
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{


### PR DESCRIPTION
it improves significantly the performance of the slirp4netns network:

https://github.com/rootless-containers/slirp4netns/tree/777bdccceffa5bee38dbfd9eefc06628cc160ff6#iperf3-netns---host

Closes: https://github.com/containers/libpod/issues/1732

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>