### PR TITLE
rm: fix cleanup race

### DIFF
--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -166,6 +166,10 @@ func runCmd(c *cliconfig.RunValues) error {
 		exitCode = int(ecode)
 	}
 
+	if c.IsSet("rm") {
+		runtime.RemoveContainer(ctx, ctr, false, true)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
we fire the cleanup process asynchronously so we might race with a
command like: podman run --rm --name foo ... && podman run --rm --name foo

Fix it by ensuring the container is deleted before we exit.  This
will race with the "cleanup" process, but it is fine as one of the two
commands will fail with ErrNoSuchCtr while the other succeeds.

Closes: https://github.com/containers/libpod/issues/2619

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>