### PR TITLE
Make 'podman rm' exit with 125 if it had a bogus & a running container

### DIFF
--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -195,5 +195,10 @@ func rmCmd(c *cliconfig.RmValues) error {
 			exitCode = 1
 		}
 	}
+
+	if failureCnt > 0 {
+		exitCode = 125
+	}
+
 	return err
 }

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -139,9 +139,23 @@ var _ = Describe("Podman rm", func() {
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 
 	})
+
 	It("podman rm bogus container", func() {
 		session := podmanTest.Podman([]string{"rm", "bogus"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(1))
+	})
+	It("podman rm bogus container and a running container", func() {
+		session := podmanTest.RunTopContainer("test1")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"rm", "bogus", "test1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
+
+		session = podmanTest.Podman([]string{"rm", "test1", "bogus"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
 	})
 })


### PR DESCRIPTION
Getting a list of containers, and then deleting them are two separate
fallible steps that can run into different sets of errors. eg., in the
case of a bogus missing container and a container that's running or
paused, the first step will only trigger libpod.ErrNoSuchCtr. At this
point it might appear that the exit code ought to be 1. However, when
attempting the deletion, it will fail once more due to the status of
the running or paused container. Since libpod.ErrNoSuchCtr is no longer
the only error encountered, the exit code should be reset to 125.

This problem is currently masked for rootless usage due to commit
35432ecaae4a8372 ("rootless: fix rm when uid in the container != 0").

Fixes: 85db895012bead6b ("rm: set exit code to 1 if a specified ...")
       e41279b902a334e5 ("Change exit code to 1 on podman rm ...")

Signed-off-by: Debarshi Ray <rishi@fedoraproject.org>