### PR TITLE
Usage messages: deduplicate '(default true)' et al

### DIFF
--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -35,7 +35,7 @@ func init() {
 	flags := attachCommand.Flags()
 	flags.StringVar(&attachCommand.DetachKeys, "detach-keys", "", "Override the key sequence for detaching a container. Format is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _")
 	flags.BoolVar(&attachCommand.NoStdin, "no-stdin", false, "Do not attach STDIN. The default is false")
-	flags.BoolVar(&attachCommand.SigProxy, "sig-proxy", true, "Proxy received signals to the process (default true)")
+	flags.BoolVar(&attachCommand.SigProxy, "sig-proxy", true, "Proxy received signals to the process")
 	flags.BoolVarP(&attachCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	markFlagHiddenForRemoteClient("latest", flags)
 }

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -313,7 +313,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.String(
 		"image-volume", "bind",
-		"Tells podman how to handle the builtin image volumes. The options are: 'bind', 'tmpfs', or 'ignore' (default 'bind')",
+		"Tells podman how to handle the builtin image volumes. The options are: 'bind', 'tmpfs', or 'ignore'",
 	)
 	createFlags.Bool(
 		"init", false,
@@ -374,7 +374,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.Int64(
 		"memory-swappiness", -1,
-		"Tune container memory swappiness (0 to 100) (default -1)",
+		"Tune container memory swappiness (0 to 100, or -1 for system default)",
 	)
 	createFlags.String(
 		"name", "",

--- a/cmd/podman/export.go
+++ b/cmd/podman/export.go
@@ -36,7 +36,7 @@ func init() {
 	exportCommand.SetHelpTemplate(HelpTemplate())
 	exportCommand.SetUsageTemplate(UsageTemplate())
 	flags := exportCommand.Flags()
-	flags.StringVarP(&exportCommand.Output, "output", "o", "/dev/stdout", "Write to a file instead of terminal")
+	flags.StringVarP(&exportCommand.Output, "output", "o", "", "Write to a specified file (default: stdout, which must be redirected)")
 }
 
 // exportCmd saves a container to a tarball on disk
@@ -60,15 +60,16 @@ func exportCmd(c *cliconfig.ExportValues) error {
 	}
 
 	output := c.Output
-	if runtime.Remote && (output == "/dev/stdout" || len(output) == 0) {
+	if runtime.Remote && len(output) == 0 {
 		return errors.New("remote client usage must specify an output file (-o)")
 	}
 
-	if output == "/dev/stdout" {
+	if len(output) == 0 {
 		file := os.Stdout
 		if logrus.IsTerminal(file) {
 			return errors.Errorf("refusing to export to terminal. Use -o flag or redirect")
 		}
+		output = "/dev/stdout"
 	}
 
 	if err := parse.ValidateFileName(output); err != nil {

--- a/cmd/podman/export.go
+++ b/cmd/podman/export.go
@@ -36,7 +36,7 @@ func init() {
 	exportCommand.SetHelpTemplate(HelpTemplate())
 	exportCommand.SetUsageTemplate(UsageTemplate())
 	flags := exportCommand.Flags()
-	flags.StringVarP(&exportCommand.Output, "output", "o", "/dev/stdout", "Write to a file, default is STDOUT")
+	flags.StringVarP(&exportCommand.Output, "output", "o", "/dev/stdout", "Write to a file instead of terminal")
 }
 
 // exportCmd saves a container to a tarball on disk

--- a/cmd/podman/load.go
+++ b/cmd/podman/load.go
@@ -34,7 +34,7 @@ func init() {
 	loadCommand.SetHelpTemplate(HelpTemplate())
 	loadCommand.SetUsageTemplate(UsageTemplate())
 	flags := loadCommand.Flags()
-	flags.StringVarP(&loadCommand.Input, "input", "i", "/dev/stdin", "Read from archive file, default is STDIN")
+	flags.StringVarP(&loadCommand.Input, "input", "i", "/dev/stdin", "Read from archive file instead of from terminal")
 	flags.BoolVarP(&loadCommand.Quiet, "quiet", "q", false, "Suppress the output")
 	flags.StringVar(&loadCommand.SignaturePolicy, "signature-policy", "", "Pathname of signature policy file (not usually used)")
 

--- a/cmd/podman/load.go
+++ b/cmd/podman/load.go
@@ -34,7 +34,7 @@ func init() {
 	loadCommand.SetHelpTemplate(HelpTemplate())
 	loadCommand.SetUsageTemplate(UsageTemplate())
 	flags := loadCommand.Flags()
-	flags.StringVarP(&loadCommand.Input, "input", "i", "/dev/stdin", "Read from archive file instead of from terminal")
+	flags.StringVarP(&loadCommand.Input, "input", "i", "", "Read from specified archive file (default: stdin)")
 	flags.BoolVarP(&loadCommand.Quiet, "quiet", "q", false, "Suppress the output")
 	flags.StringVar(&loadCommand.SignaturePolicy, "signature-policy", "", "Pathname of signature policy file (not usually used)")
 
@@ -64,7 +64,10 @@ func loadCmd(c *cliconfig.LoadValues) error {
 	if runtime.Remote && len(input) == 0 {
 		return errors.New("the remote client requires you to load via -i and a tarball")
 	}
-	if input == "/dev/stdin" {
+	if len(input) == 0 {
+		input = "/dev/stdin"
+		c.Input = input
+
 		fi, err := os.Stdin.Stat()
 		if err != nil {
 			return err

--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -45,7 +45,7 @@ func init() {
 	flags.StringVar(&loginCommand.CertDir, "cert-dir", "", "Pathname of a directory containing TLS certificates and keys used to connect to the registry")
 	flags.BoolVar(&loginCommand.GetLogin, "get-login", true, "Return the current login user for the registry")
 	flags.StringVarP(&loginCommand.Password, "password", "p", "", "Password for registry")
-	flags.BoolVar(&loginCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
+	flags.BoolVar(&loginCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 	flags.StringVarP(&loginCommand.Username, "username", "u", "", "Username for registry")
 	flags.BoolVar(&loginCommand.StdinPassword, "password-stdin", false, "Take the password from stdin")
 

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -115,7 +115,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.DefaultMountsFile, "default-mounts-file", "", "Path to default mounts file")
 	rootCmd.PersistentFlags().MarkHidden("defaults-mount-file")
 	rootCmd.PersistentFlags().StringSliceVar(&MainGlobalOpts.HooksDir, "hooks-dir", []string{}, "Set the OCI hooks directory path (may be set multiple times)")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.LogLevel, "log-level", "error", "Log messages above specified level: debug, info, warn, error (default), fatal or panic")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.LogLevel, "log-level", "error", "Log messages above specified level: debug, info, warn, error, fatal or panic")
 	rootCmd.PersistentFlags().IntVar(&MainGlobalOpts.MaxWorks, "max-workers", 0, "The maximum number of workers for parallel operations")
 	rootCmd.PersistentFlags().MarkHidden("max-workers")
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Namespace, "namespace", "", "Set the libpod namespace, used to create separate views of the containers and pods on the system")

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -59,7 +59,7 @@ func init() {
 	flags.StringVar(&playKubeCommand.Creds, "creds", "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
 	flags.BoolVarP(&playKubeCommand.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
 	flags.StringVar(&playKubeCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
-	flags.BoolVar(&playKubeCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
+	flags.BoolVar(&playKubeCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 }
 
 func playKubeYAMLCmd(c *cliconfig.KubePlayValues) error {

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -52,7 +52,7 @@ func init() {
 	flags.StringVar(&pullCommand.Creds, "creds", "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
 	flags.BoolVarP(&pullCommand.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
 	flags.StringVar(&pullCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
-	flags.BoolVar(&pullCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
+	flags.BoolVar(&pullCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 
 }
 

--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -54,7 +54,7 @@ func init() {
 	flags.BoolVar(&pushCommand.RemoveSignatures, "remove-signatures", false, "Discard any pre-existing signatures in the image")
 	flags.StringVar(&pushCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
 	flags.StringVar(&pushCommand.SignBy, "sign-by", "", "Add a signature at the destination using the specified key")
-	flags.BoolVar(&pushCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
+	flags.BoolVar(&pushCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 }
 
 func pushCmd(c *cliconfig.PushValues) error {

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -44,7 +44,7 @@ func init() {
 	runCommand.SetUsageTemplate(UsageTemplate())
 	flags := runCommand.Flags()
 	flags.SetInterspersed(false)
-	flags.Bool("sig-proxy", true, "Proxy received signals to the process (default true)")
+	flags.Bool("sig-proxy", true, "Proxy received signals to the process")
 	getCreateFlags(&runCommand.PodmanCommand)
 }
 

--- a/cmd/podman/runlabel.go
+++ b/cmd/podman/runlabel.go
@@ -57,7 +57,7 @@ func init() {
 	flags.BoolP("pull", "p", false, "Pull the image if it does not exist locally prior to executing the label contents")
 	flags.BoolVarP(&runlabelCommand.Quiet, "quiet", "q", false, "Suppress output information when installing images")
 	flags.StringVar(&runlabelCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
-	flags.BoolVar(&runlabelCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
+	flags.BoolVar(&runlabelCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 
 	flags.MarkDeprecated("pull", "podman will pull if not found in local storage")
 }

--- a/cmd/podman/save.go
+++ b/cmd/podman/save.go
@@ -58,7 +58,7 @@ func init() {
 	flags := saveCommand.Flags()
 	flags.BoolVar(&saveCommand.Compress, "compress", false, "Compress tarball image layers when saving to a directory using the 'dir' transport. (default is same compression type as source)")
 	flags.StringVar(&saveCommand.Format, "format", v2s2Archive, "Save image to oci-archive, oci-dir (directory with oci manifest type), docker-archive, docker-dir (directory with v2s2 manifest type)")
-	flags.StringVarP(&saveCommand.Output, "output", "o", "/dev/stdout", "Write to a file, default is STDOUT")
+	flags.StringVarP(&saveCommand.Output, "output", "o", "/dev/stdout", "Write to a file instead of terminal")
 	flags.BoolVarP(&saveCommand.Quiet, "quiet", "q", false, "Suppress the output")
 }
 

--- a/cmd/podman/save.go
+++ b/cmd/podman/save.go
@@ -58,7 +58,7 @@ func init() {
 	flags := saveCommand.Flags()
 	flags.BoolVar(&saveCommand.Compress, "compress", false, "Compress tarball image layers when saving to a directory using the 'dir' transport. (default is same compression type as source)")
 	flags.StringVar(&saveCommand.Format, "format", v2s2Archive, "Save image to oci-archive, oci-dir (directory with oci manifest type), docker-archive, docker-dir (directory with v2s2 manifest type)")
-	flags.StringVarP(&saveCommand.Output, "output", "o", "/dev/stdout", "Write to a file instead of terminal")
+	flags.StringVarP(&saveCommand.Output, "output", "o", "", "Write to a specified file (default: stdout, which must be redirected)")
 	flags.BoolVarP(&saveCommand.Quiet, "quiet", "q", false, "Suppress the output")
 }
 
@@ -79,14 +79,14 @@ func saveCmd(c *cliconfig.SaveValues) error {
 		return errors.Errorf("--compress can only be set when --format is either 'oci-dir' or 'docker-dir'")
 	}
 
-	output := c.Output
-	if output == "/dev/stdout" {
+	if len(c.Output) == 0 {
 		fi := os.Stdout
 		if logrus.IsTerminal(fi) {
 			return errors.Errorf("refusing to save to terminal. Use -o flag or redirect")
 		}
+		c.Output = "/dev/stdout"
 	}
-	if err := parse.ValidateFileName(output); err != nil {
+	if err := parse.ValidateFileName(c.Output); err != nil {
 		return err
 	}
 	return runtime.SaveImage(getContext(), c)

--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -46,7 +46,7 @@ func init() {
 	flags.StringVar(&searchCommand.Format, "format", "", "Change the output format to a Go template")
 	flags.IntVar(&searchCommand.Limit, "limit", 0, "Limit the number of results")
 	flags.BoolVar(&searchCommand.NoTrunc, "no-trunc", false, "Do not truncate the output")
-	flags.BoolVar(&searchCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries (default: true)")
+	flags.BoolVar(&searchCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 }
 
 func searchCmd(c *cliconfig.SearchValues) error {

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -41,7 +41,7 @@ func init() {
 	flags.StringVar(&startCommand.DetachKeys, "detach-keys", "", "Override the key sequence for detaching a container. Format is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _")
 	flags.BoolVarP(&startCommand.Interactive, "interactive", "i", false, "Keep STDIN open even if not attached")
 	flags.BoolVarP(&startCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
-	flags.BoolVar(&startCommand.SigProxy, "sig-proxy", true, "Proxy received signals to the process (default true if attaching, false otherwise)")
+	flags.BoolVar(&startCommand.SigProxy, "sig-proxy", false, "Proxy received signals to the process (default true if attaching, false otherwise)")
 	markFlagHiddenForRemoteClient("latest", flags)
 }
 
@@ -62,14 +62,10 @@ func startCmd(c *cliconfig.StartValues) error {
 		return errors.Errorf("you cannot start and attach multiple containers at once")
 	}
 
-	sigProxy := c.SigProxy
+	sigProxy := c.SigProxy || attach
 
 	if sigProxy && !attach {
-		if c.Flag("sig-proxy").Changed {
-			return errors.Wrapf(libpod.ErrInvalidArg, "you cannot use sig-proxy without --attach")
-		} else {
-			sigProxy = false
-		}
+		return errors.Wrapf(libpod.ErrInvalidArg, "you cannot use sig-proxy without --attach")
 	}
 
 	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)


### PR DESCRIPTION
Remove hardcoded '(default: true)' strings from bool flags,
and '(default this-or-that)' from string flags.

First because it's unmaintainable duplication that would cause
confusion should someone ever change the default and not notice
the message.

Second, because cobra[1] already prints '(default XXXX)' for
all options with non-false non-nil default. So in each of
these cases, current podman help behavior is:

    $ podman login --help
    ...
       --tls-verify  Require HTTPS ... (default: true) (default true)

This PR eliminates that duplication.

 [1] actually spf13/pflag/flag.go

The only nontrivial one of these is start.go, where the default
for sigProxy depends on the --attach flag. Solution: change
the command-line default to false, and implement the new
conditional default in logic. Bonus: removed unnecessary
check, because now if sigProxy is set without --attach,
we can guarantee that it was done by the user. But please
pay close scrutiny to this particular section in case
there's something I missed.

Signed-off-by: Ed Santiago <santiago@redhat.com>