### PR TITLE
Set blob cache directory based on GraphDriver

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containers/image/pkg/docker/config"
 	"github.com/containers/image/types"
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod/common"
+	"github.com/containers/libpod/libpod/image"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
@@ -64,7 +64,7 @@ func loginCmd(c *cliconfig.LoginValues) error {
 	server := registryFromFullName(scrubServer(args[0]))
 	authfile := getAuthFile(c.Authfile)
 
-	sc := common.GetSystemContext("", authfile, false)
+	sc := image.GetSystemContext("", authfile, false)
 	if c.Flag("tls-verify").Changed {
 		sc.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!c.TlsVerify)
 	}

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/containers/image/pkg/docker/config"
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod/common"
+	"github.com/containers/libpod/libpod/image"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -54,7 +54,7 @@ func logoutCmd(c *cliconfig.LogoutValues) error {
 	}
 	authfile := getAuthFile(c.Authfile)
 
-	sc := common.GetSystemContext("", authfile, false)
+	sc := image.GetSystemContext("", authfile, false)
 
 	if c.All {
 		if err := config.RemoveAllAuthentication(sc); err != nil {

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -13,7 +13,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/libpod"
-	image2 "github.com/containers/libpod/libpod/image"
+	"github.com/containers/libpod/libpod/image"
 	ns "github.com/containers/libpod/pkg/namespaces"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/spec"
@@ -145,7 +145,7 @@ func playKubeYAMLCmd(c *cliconfig.KubePlayValues) error {
 		writer = os.Stderr
 	}
 
-	dockerRegistryOptions := image2.DockerRegistryOptions{
+	dockerRegistryOptions := image.DockerRegistryOptions{
 		DockerRegistryCreds: registryCreds,
 		DockerCertPath:      c.CertDir,
 	}
@@ -183,7 +183,7 @@ func playKubeYAMLCmd(c *cliconfig.KubePlayValues) error {
 	}
 
 	for _, container := range podYAML.Spec.Containers {
-		newImage, err := runtime.ImageRuntime().New(ctx, container.Image, c.SignaturePolicy, c.Authfile, writer, &dockerRegistryOptions, image2.SigningOptions{}, false, nil)
+		newImage, err := runtime.ImageRuntime().New(ctx, container.Image, c.SignaturePolicy, c.Authfile, writer, &dockerRegistryOptions, image.SigningOptions{}, false, nil)
 		if err != nil {
 			return err
 		}
@@ -232,7 +232,7 @@ func getPodPorts(containers []v1.Container) []ocicni.PortMapping {
 }
 
 // kubeContainerToCreateConfig takes a v1.Container and returns a createconfig describing a container
-func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container, runtime *libpod.Runtime, newImage *image2.Image, namespaces map[string]string, volumes map[string]string) (*createconfig.CreateConfig, error) {
+func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container, runtime *libpod.Runtime, newImage *image.Image, namespaces map[string]string, volumes map[string]string) (*createconfig.CreateConfig, error) {
 	var (
 		containerConfig createconfig.CreateConfig
 		envs            map[string]string

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod/common"
 	image2 "github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/containers/libpod/pkg/util"
@@ -127,7 +126,7 @@ func pullCmd(c *cliconfig.PullValues) error {
 	} else {
 		authfile := getAuthFile(c.String("authfile"))
 		spec := image
-		systemContext := common.GetSystemContext("", authfile, false)
+		systemContext := image2.GetSystemContext("", authfile, false)
 		srcRef, err := alltransports.ParseImageName(spec)
 		if err != nil {
 			dockerTransport := "docker://"

--- a/libpod/common/common.go
+++ b/libpod/common/common.go
@@ -1,20 +1,5 @@
 package common
 
-import (
-	"github.com/containers/image/types"
-)
-
-// GetSystemContext Constructs a new containers/image/types.SystemContext{} struct from the given signaturePolicy path
-func GetSystemContext(signaturePolicyPath, authFilePath string, forceCompress bool) *types.SystemContext {
-	sc := &types.SystemContext{}
-	if signaturePolicyPath != "" {
-		sc.SignaturePolicyPath = signaturePolicyPath
-	}
-	sc.AuthFilePath = authFilePath
-	sc.DirForceCompress = forceCompress
-	return sc
-}
-
 // IsTrue determines whether the given string equals "true"
 func IsTrue(str string) bool {
 	return str == "true"

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -22,7 +23,6 @@ import (
 	"github.com/containers/image/transports"
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
-	"github.com/containers/libpod/libpod/common"
 	"github.com/containers/libpod/libpod/driver"
 	"github.com/containers/libpod/libpod/events"
 	"github.com/containers/libpod/pkg/inspect"
@@ -548,6 +548,7 @@ func (i *Image) PushImageToHeuristicDestination(ctx context.Context, destination
 // PushImageToReference pushes the given image to a location described by the given path
 func (i *Image) PushImageToReference(ctx context.Context, dest types.ImageReference, manifestMIMEType, authFile, signaturePolicyPath string, writer io.Writer, forceCompress bool, signingOptions SigningOptions, dockerRegistryOptions *DockerRegistryOptions, additionalDockerArchiveTags []reference.NamedTagged) error {
 	sc := GetSystemContext(signaturePolicyPath, authFile, forceCompress)
+	sc.BlobInfoCacheDir = filepath.Join(i.imageruntime.store.GraphRoot(), "cache")
 
 	policyContext, err := getPolicyContext(sc)
 	if err != nil {
@@ -909,7 +910,7 @@ func (ir *Runtime) Import(ctx context.Context, path, reference string, writer io
 		return nil, errors.Wrapf(err, "error updating image config")
 	}
 
-	sc := common.GetSystemContext("", "", false)
+	sc := GetSystemContext("", "", false)
 
 	// if reference not given, get the image digest
 	if reference == "" {

--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 
 	cp "github.com/containers/image/copy"
@@ -204,6 +205,7 @@ func (ir *Runtime) pullImageFromHeuristicSource(ctx context.Context, inputName s
 
 	var goal *pullGoal
 	sc := GetSystemContext(signaturePolicyPath, authfile, false)
+	sc.BlobInfoCacheDir = filepath.Join(ir.store.GraphRoot(), "cache")
 	srcRef, err := alltransports.ParseImageName(inputName)
 	if err != nil {
 		// could be trying to pull from registry with short name

--- a/libpod/image/search.go
+++ b/libpod/image/search.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/containers/image/docker"
 	"github.com/containers/image/types"
-	"github.com/containers/libpod/libpod/common"
 	sysreg "github.com/containers/libpod/pkg/registries"
 	"github.com/fatih/camelcase"
 	"github.com/pkg/errors"
@@ -157,7 +156,7 @@ func searchImageInRegistry(term string, registry string, options SearchOptions) 
 		limit = options.Limit
 	}
 
-	sc := common.GetSystemContext("", options.Authfile, false)
+	sc := GetSystemContext("", options.Authfile, false)
 	sc.DockerInsecureSkipTLSVerify = options.InsecureSkipTLSVerify
 	// FIXME: Set this more globally.  Probably no reason not to have it in
 	// every types.SystemContext, and to compute the value just once in one


### PR DESCRIPTION
Currently in rootless containers, we end up not using the blob cache.
We also don't store the blob cache based on the users specified graph
storage.  This change will cause the cache directory to be stored with
the rest of the containe images.

While doing this patch, I found that we had duplicated GetSystemContext in
two places in libpod. I cleaned this up.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>