### PR TITLE
Make sure buildin volumes have the same ownership and permissions as …

### DIFF
--- a/docs/podman-load.1.md
+++ b/docs/podman-load.1.md
@@ -4,7 +4,7 @@
 podman\-load - Load an image from docker archive
 
 ## SYNOPSIS
-**podman load** *name*[:*tag*|@*digest*]
+**podman load** [ARCHIVE]
 
 ## DESCRIPTION
 **podman load** copies an image from either **docker-archive** or **oci-archive** stored

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1429,5 +1429,9 @@ func (c *Container) copyWithTarFromImage(src, dest string) error {
 	}
 	a := archive.NewDefaultArchiver()
 	source := filepath.Join(mountpoint, src)
+
+	if err = c.copyOwnerAndPerms(source, dest); err != nil {
+		return err
+	}
 	return a.CopyWithTar(source, dest)
 }

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -982,3 +982,20 @@ func (c *Container) generatePasswd() (string, error) {
 	}
 	return passwdFile, nil
 }
+
+func (c *Container) copyOwnerAndPerms(source, dest string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "cannot stat `%s`", dest)
+	}
+	if err := os.Chmod(dest, info.Mode()); err != nil {
+		return errors.Wrapf(err, "cannot chmod `%s`", dest)
+	}
+	if err := os.Chown(dest, int(info.Sys().(*syscall.Stat_t).Uid), int(info.Sys().(*syscall.Stat_t).Gid)); err != nil {
+		return errors.Wrapf(err, "cannot chown `%s`", dest)
+	}
+	return nil
+}

--- a/libpod/container_internal_unsupported.go
+++ b/libpod/container_internal_unsupported.go
@@ -35,3 +35,7 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 func (c *Container) restore(ctx context.Context, options ContainerCheckpointOptions) error {
 	return ErrNotImplemented
 }
+
+func (c *Container) copyOwnerAndPerms(source, dest string) error {
+	return nil
+}


### PR DESCRIPTION
…image

When creating a new image volume to be mounted into a container, we need to
make sure the new volume matches the Ownership and permissions of the path
that it will be mounted on.

For example if a volume inside of a containre image is owned by the database
UID, we want the volume to be mounted onto the image to be owned by the
database UID.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>