### PR TITLE
Fix a potential segfault in podman search

### DIFF
--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -83,9 +83,23 @@ func searchCmd(c *cliconfig.SearchValues) error {
 	if len(results) == 0 {
 		return nil
 	}
-	out := formats.StdoutTemplateArray{Output: searchToGeneric(results), Template: format, Fields: genSearchOutputMap()}
+	out := formats.StdoutTemplateArray{Output: searchToGeneric(results), Template: format, Fields: searchHeaderMap()}
 	formats.Writer(out).Out()
 	return nil
+}
+
+// searchHeaderMap returns the headers of a SearchResult.
+func searchHeaderMap() map[string]string {
+	s := new(image.SearchResult)
+	v := reflect.Indirect(reflect.ValueOf(s))
+	values := make(map[string]string, v.NumField())
+
+	for i := 0; i < v.NumField(); i++ {
+		key := v.Type().Field(i).Name
+		value := key
+		values[key] = strings.ToUpper(splitCamelCase(value))
+	}
+	return values
 }
 
 func genSearchFormat(format string) string {

--- a/libpod/image/search.go
+++ b/libpod/image/search.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"context"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -10,7 +9,6 @@ import (
 	"github.com/containers/image/docker"
 	"github.com/containers/image/types"
 	sysreg "github.com/containers/libpod/pkg/registries"
-	"github.com/fatih/camelcase"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
@@ -61,24 +59,6 @@ type SearchFilter struct {
 	IsAutomated types.OptionalBool
 	// IsOfficial decides if only official images are displayed.
 	IsOfficial types.OptionalBool
-}
-
-func splitCamelCase(src string) string {
-	entries := camelcase.Split(src)
-	return strings.Join(entries, " ")
-}
-
-// HeaderMap returns the headers of a SearchResult.
-func (s *SearchResult) HeaderMap() map[string]string {
-	v := reflect.Indirect(reflect.ValueOf(s))
-	values := make(map[string]string, v.NumField())
-
-	for i := 0; i < v.NumField(); i++ {
-		key := v.Type().Field(i).Name
-		value := key
-		values[key] = strings.ToUpper(splitCamelCase(value))
-	}
-	return values
 }
 
 // SearchImages searches images based on term and the specified SearchOptions


### PR DESCRIPTION
When generating headers for search, we unconditionally access element 0 of an array, and I saw this segfault in our CI. There's no reason we have to do this, we're just going through it to get field names with reflect, so just make a new copy of the struct in question.

Also, move this code, which is only for CLI display, into cmd/podman from libpod/image.