### PR TITLE
WIP: Cirrus: Integration-test sub-sets

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -188,9 +188,8 @@ meta_task:
 
     script: /usr/local/bin/entrypoint.sh
 
-
 # This task does the unit and integration testing for every platform
-testing_task:
+unit_testing_task:
 
     depends_on:
         - "gating"
@@ -210,23 +209,44 @@ testing_task:
             image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
             image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
 
-            # TODO: Make these work (also optional_testing_task below)
-            # image_name: "${PRIOR_RHEL_CACHE_IMAGE_NAME}"
-            # image_name: "${RHEL_CACHE_IMAGE_NAME}"
-            # image_name: "${CENTOS_CACHE_IMAGE_NAME}"
+    timeout_in: 30m
+
+    setup_environment_script: '$SCRIPT_BASE/setup_environment.sh'
+    unit_test_script: '$SCRIPT_BASE/unit_test.sh'
+
+
+# This task does the unit and integration testing for every platform
+integration_testing_task:
+
+    depends_on:
+        - "gating"
+        - "build_each_commit"
+        - "unit_testing"
+
+    env:
+        matrix:
+            TEST_SET: '1_3'
+            TEST_SET: '2_3'
+            TEST_SET: '3_3'
+
+    gce_instance:
+        image_project: "libpod-218412"
+        zone: "us-central1-a"  # Required by Cirrus for the time being
+        cpu: 2
+        memory: "4Gb"
+        disk: 200  # see https://developers.google.com/compute/docs/disks#performance
+        # Generate multiple parallel tasks, covering all possible
+        # 'matrix' combinations.
+        matrix:
+            # Images are generated separately, from build_images_task (below)
+            image_name: "${FEDORA_CACHE_IMAGE_NAME}"
+            image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
+            image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
 
     timeout_in: 120m
 
-    # Every *_script runs in sequence, for each task. The name prefix is for
-    # WebUI reference.  The values may be strings...
-    setup_environment_script: $SCRIPT_BASE/setup_environment.sh
-
-    # ...or lists of strings
-    unit_test_script:
-        - go version
-        - $SCRIPT_BASE/unit_test.sh
-
-    integration_test_script: $SCRIPT_BASE/integration_test.sh
+    setup_environment_script: '$SCRIPT_BASE/setup_environment.sh'
+    integration_test_script: '$SCRIPT_BASE/integration_test.sh'
 
 
 # This task executes tests as a regular user on a system
@@ -338,7 +358,8 @@ success_task:
     depends_on:  # ignores any dependent task conditions
         - "gating"
         - "vendor_check"
-        - "testing"
+        - "unit_testing"
+        - "integration_testing"
         - "optional_testing"
         - "cache_images"
 

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ localunit: test/goecho/goecho varlink_generate
 	$(MAKE) -C contrib/cirrus/packer test
 
 ginkgo:
-	ginkgo -v -tags "$(BUILDTAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes 3 test/e2e/.
+	ginkgo -v -tags "$(BUILDTAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.
 
 ginkgo-remote:
 	ginkgo -v -tags "$(BUILDTAGS) remoteclient" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.

--- a/contrib/cirrus/e2e/1_3
+++ b/contrib/cirrus/e2e/1_3
@@ -1,0 +1,34 @@
+# This file specifies the *_test.go files to retain in addition to 'common'
+# FIXME: STUB: These should be properly divided up based on runtime
+attach_test.go
+checkpoint_test.go
+commit_test.go
+cp_test.go
+create_staticip_test.go
+create_test.go
+diff_test.go
+events_test.go
+exec_test.go
+exists_test.go
+export_test.go
+generate_kube_test.go
+healthcheck_run_test.go
+history_test.go
+images_test.go
+import_test.go
+info_test.go
+inspect_test.go
+kill_test.go
+load_test.go
+logs_test.go
+mount_test.go
+namespace_test.go
+pause_test.go
+pod_create_test.go
+pod_infra_container_test.go
+pod_inspect_test.go
+pod_kill_test.go
+pod_pause_test.go
+pod_ps_test.go
+pod_restart_test.go
+pod_rm_test.go

--- a/contrib/cirrus/e2e/2_3
+++ b/contrib/cirrus/e2e/2_3
@@ -1,0 +1,29 @@
+# This file specifies the *_test.go files to retain in addition to 'common'
+# FIXME: STUB: These should be properly divided up based on runtime
+pod_start_test.go
+pod_stats_test.go
+pod_stop_test.go
+pod_top_test.go
+port_test.go
+prune_test.go
+ps_test.go
+pull_test.go
+push_test.go
+refresh_test.go
+restart_test.go
+rmi_test.go
+rm_test.go
+rootless_test.go
+run_cgroup_parent_test.go
+run_cleanup_test.go
+run_cpu_test.go
+run_device_test.go
+run_dns_test.go
+run_entrypoint_test.go
+run_exit_test.go
+runlabel_test.go
+run_memory_test.go
+run_networking_test.go
+run_ns_test.go
+run_passwd_test.go
+run_privileged_test.go

--- a/contrib/cirrus/e2e/3_3
+++ b/contrib/cirrus/e2e/3_3
@@ -1,0 +1,2 @@
+# Note: This is a special-case, contents of this file are ignored.
+exclude what's in 1_3 and 2_3

--- a/contrib/cirrus/e2e/common
+++ b/contrib/cirrus/e2e/common
@@ -1,0 +1,4 @@
+# This file specifies the *_test.go files to retain for all stages
+common_test.go
+libpod_suite_test.go
+libpod_suite_remoteclient_test.go

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -4,17 +4,28 @@ set -e
 source $(dirname $0)/lib.sh
 
 req_env_var "
-GOSRC $GOSRC
-OS_RELEASE_ID $OS_RELEASE_ID
-OS_RELEASE_VER $OS_RELEASE_VER
+    GOSRC $GOSRC
+    OS_RELEASE_ID $OS_RELEASE_ID
+    OS_RELEASE_VER $OS_RELEASE_VER
+    TEST_SET $TEST_SET
 "
 
 record_timestamp "integration test start"
 
 clean_env
 
+cd $GOSRC
+case "$TEST_SET" in
+    1_3) ;&  #  Continue to the next item
+    2_3) include_ginkgo_tests ./test/e2e ./$SCRIPT_BASE/e2e/common ./$SCRIPT_BASE/e2e/$TEST_SET ;;
+    3_3) exclude_ginkgo_tests ./test/e2e ./$SCRIPT_BASE/e2e/1_3 ./$SCRIPT_BASE/e2e/2_3 ;;
+    *)
+        echo "Unable to handle \$TEST_SET \"$TEST_SET\""
+        exit 83
+        ;;
+esac
+
 set -x
-cd "$GOSRC"
 case "${OS_RELEASE_ID}-${OS_RELEASE_VER}" in
     ubuntu-18)
         make install PREFIX=/usr ETCDIR=/etc

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 source $(dirname $0)/lib.sh
 
 req_env_var "
@@ -14,7 +14,6 @@ record_timestamp "integration test start"
 
 clean_env
 
-cd $GOSRC
 case "$TEST_SET" in
     1_3) ;&  #  Continue to the next item
     2_3) include_ginkgo_tests ./test/e2e ./$SCRIPT_BASE/e2e/common ./$SCRIPT_BASE/e2e/$TEST_SET ;;


### PR DESCRIPTION
As tests are added, total runtime increases beyond (IMHO) optomal 45
minutes (more or less) for PR testing.  Fix this by utilizing an
additional matrix of VMs to divide up testing for parallel execution.

fixes #2649

Signed-off-by: Chris Evich <cevich@redhat.com>