### PR TITLE
rootless: use /tmp/libpod-rundir-$EUID for fallback

### DIFF
--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -72,7 +72,7 @@ func GetRootlessUID() int {
 		u, _ := strconv.Atoi(uidEnv)
 		return u
 	}
-	return os.Getuid()
+	return os.Geteuid()
 }
 
 func tryMappingTool(tool string, pid int, hostID int, mappings []idtools.IDMap) error {

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -190,15 +190,15 @@ func GetRootlessRuntimeDir() (string, error) {
 		tmpDir := filepath.Join("/run", "user", uid)
 		os.MkdirAll(tmpDir, 0700)
 		st, err := os.Stat(tmpDir)
-		if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Getuid() && st.Mode().Perm() == 0700 {
+		if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && st.Mode().Perm() == 0700 {
 			runtimeDir = tmpDir
 		}
 	}
 	if runtimeDir == "" {
-		tmpDir := filepath.Join(os.TempDir(), "user", uid)
+		tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("libpod-rundir-%s", uid))
 		os.MkdirAll(tmpDir, 0700)
 		st, err := os.Stat(tmpDir)
-		if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Getuid() && st.Mode().Perm() == 0700 {
+		if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && st.Mode().Perm() == 0700 {
 			runtimeDir = tmpDir
 		}
 	}


### PR DESCRIPTION
when the fallback is in place, the first user creating /tmp/user/$EUID
prevents other users for creating other directories since /tmp/user is
created with mode 0700.

Since there is no way for an unprivileged user to initialize the
/tmp/user directory correctly (we would need it to be owned by root
with the sticky bit set), let's just use /tmp/libpod-rundir-$EUID.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>