### PR TITLE
container: check containerInfo.Config before accessing it

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -337,11 +337,13 @@ func (c *Container) setupStorage(ctx context.Context) error {
 	}
 
 	// Set the default Entrypoint and Command
-	if c.config.Entrypoint == nil {
-		c.config.Entrypoint = containerInfo.Config.Config.Entrypoint
-	}
-	if c.config.Command == nil {
-		c.config.Command = containerInfo.Config.Config.Cmd
+	if containerInfo.Config != nil {
+		if c.config.Entrypoint == nil {
+			c.config.Entrypoint = containerInfo.Config.Config.Entrypoint
+		}
+		if c.config.Command == nil {
+			c.config.Command = containerInfo.Config.Config.Cmd
+		}
 	}
 
 	artifacts := filepath.Join(c.config.StaticDir, artifactsDir)


### PR DESCRIPTION
check that containerInfo.Config is not nil before trying to access
it.

Closes: https://github.com/containers/libpod/issues/2654

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>