### PR TITLE
podman image tree: fix usage message

### DIFF
--- a/cmd/podman/tree.go
+++ b/cmd/podman/tree.go
@@ -23,7 +23,7 @@ var (
 
 	treeDescription = "Prints layer hierarchy of an image in a tree format"
 	_treeCommand    = &cobra.Command{
-		Use:   "tree",
+		Use:   "tree [flags] IMAGE",
 		Short: treeDescription,
 		Long:  treeDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/podman-image.1.md
+++ b/docs/podman-image.1.md
@@ -27,8 +27,8 @@ The image command allows you to manage images
 | save     | [podman-save(1)](podman-save.1.md)              | Save an image to docker-archive or oci.                                     |
 | sign     | [podman-image-sign(1)](podman-image-sign.1.md)  | Sign an image.                                                              |
 | tag      | [podman-tag(1)](podman-tag.1.md)                | Add an additional name to a local image.                                    |
+| tree     | [podman-image-tree(1)](podman-image-tree.1.md)  | Prints layer hierarchy of an image in a tree format.                        |
 | trust    | [podman-image-trust(1)](podman-image-trust.1.md)| Manage container image trust policy.                                        |
-| tree     | [podman-image-tree(1)](podman-image-tree.1.md)  | Prints layer hierarchy of an image in a tree format                          |
 
 ## SEE ALSO
 podman


### PR DESCRIPTION
Minor fix to Use message: add IMAGE argument. (I'm a stickler
for this because my zsh completion is self-generating, from
the --help messages).

Also, sort 'tree' before 'trust' in man page.

Signed-off-by: Ed Santiago <santiago@redhat.com>