### PR TITLE
Add support for SCTP port forwarding

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -183,6 +183,7 @@ func waitPidsStop(pids []int, timeout time.Duration) error {
 
 func bindPorts(ports []ocicni.PortMapping) ([]*os.File, error) {
 	var files []*os.File
+	notifySCTP := false
 	for _, i := range ports {
 		switch i.Protocol {
 		case "udp":
@@ -217,6 +218,12 @@ func bindPorts(ports []ocicni.PortMapping) ([]*os.File, error) {
 				return nil, errors.Wrapf(err, "cannot get file for TCP socket")
 			}
 			files = append(files, f)
+			break
+		case "sctp":
+			if !notifySCTP {
+				notifySCTP = true
+				logrus.Warnf("port reservation for SCTP is not supported")
+			}
 			break
 		default:
 			return nil, fmt.Errorf("unknown protocol %s", i.Protocol)


### PR DESCRIPTION
SCTP is already present and enabled in the CNI plugins, so all we need to do to add support is not error on attempting to bind ports to reserve them.

I investigated adding this binding for SCTP, but support for SCTP in Go is honestly a mess - there's no widely-supported library for doing it that will do what we need.

For now, warn that port reservation for SCTP is not supported and forward the ports.