### PR TITLE
 port grouping in ps command output 

### DIFF
--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -303,4 +303,18 @@ var _ = Describe("Podman ps", func() {
 		Expect(session.OutputToString()).To(ContainSubstring(podid))
 
 	})
+
+	It("podman ps test with port range", func() {
+		session := podmanTest.RunTopContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"run", "-dt", "-p", "1000-1006:1000-1006", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"ps", "--format", "{{.Ports}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.OutputToString()).To(ContainSubstring("0.0.0.0:1000-1006"))
+	})
 })


### PR DESCRIPTION
groups the continuous ports and display in readable format.

BugFix : https://github.com/containers/libpod/issues/1358

e.g. 
```
$ podman run -it -p 1000-1006:1000-1006 --rm --name manyports centos /bin/bash

$ podman ps
CONTAINER ID  IMAGE                            COMMAND    CREATED        STATUS            PORTS                             NAMES
ad7b4aa8c420  docker.io/library/centos:latest  /bin/bash  4 seconds ago  Up 4 seconds ago  0.0.0.0:1000-1006->1000-1006/tcp  manyports


```