### PR TITLE
Warn instead of fail on failure to validate against DB

### DIFF
--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -146,10 +146,11 @@ func validateDBAgainstConfig(bucket *bolt.Bucket, fieldName, runtimeValue string
 				return nil
 			}
 
-			// If DB value is the empty string, check that the
-			// runtime value is the default
-			if string(keyBytes) == "" && defaultValue != "" &&
-				runtimeValue == defaultValue {
+			// If DB value is the empty string, we ought to be fine.
+			// (Though I'm honestly not sure how we got this far
+			// with an empty-string DB config)
+			if string(keyBytes) == "" {
+				logrus.Warnf("Database stored empty configuration for %s - unable to validate", fieldName)
 				return nil
 			}
 

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -297,6 +297,9 @@ func GetDefaultStoreOptions() (storage.StoreOptions, error) {
 		err                      error
 	)
 	storageOpts := storage.DefaultStoreOptions
+	if !rootless.IsRootless() {
+		storageOpts = storage.StoreOptions{}
+	}
 	if rootless.IsRootless() {
 		storageOpts, err = GetRootlessStorageOpts()
 		if err != nil {


### PR DESCRIPTION
When the database has somehow stored the empty string for a field we wish to validate against, we cannot perform any reasonable validation. Instead of making this a hard failure, print a warning that we cannot validate, and bad things may happen.