### PR TITLE
rootless: change default path for conmon.pid

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -171,7 +171,7 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 	}()
 
 	if rootless.IsRootless() && ctr.config.ConmonPidFile == "" {
-		ctr.config.ConmonPidFile = filepath.Join(ctr.state.RunDir, "conmon.pid")
+		ctr.config.ConmonPidFile = filepath.Join(ctr.config.StaticDir, "conmon.pid")
 	}
 
 	// Go through the volume mounts and check for named volumes


### PR DESCRIPTION
We cannot use the RunDir for writing the conmon.pid file as we might
not be able to read it before we join a namespace, since it is owned
by the root in the container which can be a different uid when using
uidmap.  To avoid completely the issue, we will just write it to the
static dir which is always readable by the unprivileged user.

Closes: https://github.com/containers/libpod/issues/2673

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>