### PR TITLE
Cirrus: Fix post-merge failure notice

### DIFF
--- a/contrib/cirrus/notice_master_failure.sh
+++ b/contrib/cirrus/notice_master_failure.sh
@@ -12,8 +12,7 @@ NOR="$(echo -n -e '\x0f')"
 if [[ "$CIRRUS_BRANCH" =~ "master" ]]
 then
     BURL="https://cirrus-ci.com/build/$CIRRUS_BUILD_ID"
-    echo "Monitoring execution of $CIRRUS_TASK_NAME and notifying on failure"
-    MSG="${RED}[Action Recommended]: ${NOR}Post-merge testing ${RED}$CIRRUS_BRANCH failed${NOR} in $CIRRUS_TASK_NAME on $(os_release_id)-$(os_release_ver): $BURL.  Please investigate, and re-run if appropriate."
+    ircmsg "${RED}[Action Recommended]: ${NOR}Post-merge testing ${RED}$CIRRUS_BRANCH failed${NOR} in $CIRRUS_TASK_NAME on $(os_release_id)-$(os_release_ver): $BURL.  Please investigate, and re-run if appropriate."
 fi
 
 # This script assumed to be executed on failure

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -89,4 +89,6 @@ then
     fi
 fi
 
+show_env_vars
+
 record_timestamp "env. setup end"


### PR DESCRIPTION
Likely caused by rebase typos after removing test-commit.  This fixes
notifications to actually get sent.  Also show env. vars after setting
up the environment - helps debugging.

Signed-off-by: Chris Evich <cevich@redhat.com>