### PR TITLE
podman logs on created container should exit

### DIFF
--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -132,4 +132,14 @@ var _ = Describe("Podman logs", func() {
 		Expect(len(output)).To(Equal(6))
 		Expect(strings.Contains(output[0], cid1[:12]) || strings.Contains(output[0], cid2[:12])).To(BeTrue())
 	})
+
+	It("podman logs on a created container should result in 0 exit code", func() {
+		session := podmanTest.Podman([]string{"create", "-dt", "--name", "log", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(BeZero())
+
+		results := podmanTest.Podman([]string{"logs", "log"})
+		results.WaitWithDefaultTimeout()
+		Expect(results.ExitCode()).To(BeZero())
+	})
 })


### PR DESCRIPTION
when running podman logs on a created container (which has no logs),
podman should return gracefully (like docker) with a 0 return code. if
multiple containers are provided and one is only in the created state
(and no follow is used), we still display the logs for the other ids.

fixes issue #2677 

Signed-off-by: baude <bbaude@redhat.com>