### PR TITLE
podman log needs to fail if the log file does not exists.

### DIFF
--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -111,7 +111,7 @@ func getLogFile(path string, options *LogOptions) (*tail.Tail, []*LogLine, error
 		Whence: whence,
 	}
 
-	t, err := tail.TailFile(path, tail.Config{Poll: true, Follow: options.Follow, Location: &seek, Logger: tail.DiscardingLogger})
+	t, err := tail.TailFile(path, tail.Config{Poll: true, Follow: options.Follow, MustExist: true, Location: &seek, Logger: tail.DiscardingLogger})
 	return t, logTail, err
 }
 


### PR DESCRIPTION
Currently if you create a container and then do a podman log on it, it just
hangs.  This change will get the container to exit with an error saying the
log file does not exists.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>