### PR TITLE
support GO template {{ json . }}

### DIFF
--- a/cmd/podman/version.go
+++ b/cmd/podman/version.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -43,6 +44,9 @@ func versionCmd(c *cliconfig.VersionValues) error {
 
 	versionOutputFormat := c.Format
 	if versionOutputFormat != "" {
+		if strings.Join(strings.Fields(versionOutputFormat), "") == "{{json.}}" {
+			versionOutputFormat = formats.JSONString
+		}
 		var out formats.Writer
 		switch versionOutputFormat {
 		case formats.JSONString:

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -36,4 +36,24 @@ var _ = Describe("Podman version", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 2))
 	})
+
+	It("podman version --format json", func() {
+		session := podmanTest.Podman([]string{"version", "--format", "json"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.IsJSONOutputValid()).To(BeTrue())
+	})
+
+	It("podman version --format json", func() {
+		session := podmanTest.Podman([]string{"version", "--format", "{{ json .}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.IsJSONOutputValid()).To(BeTrue())
+	})
+
+	It("podman version --format GO template", func() {
+		session := podmanTest.Podman([]string{"version", "--format", "{{ .Version }}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
for podman version, we now support a GO template for json output.

fixes #2671

Signed-off-by: baude <bbaude@redhat.com>