### PR TITLE
podman health check phase3

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -293,7 +293,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.String(
 		"healthcheck-interval", "30s",
-		"set an interval for the healthchecks",
+		"set an interval for the healthchecks (a value of disable results in no automatic timer setup)",
 	)
 	createFlags.Uint(
 		"healthcheck-retries", 3,

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -494,6 +494,14 @@ func generateContainerFilterFuncs(filter, filterValue string, runtime *libpod.Ru
 			}
 			return false
 		}, nil
+	case "health":
+		return func(c *libpod.Container) bool {
+			hcStatus, err := c.HealthCheckStatus()
+			if err != nil {
+				return false
+			}
+			return hcStatus == filterValue
+		}, nil
 	}
 	return nil, errors.Errorf("%s is an invalid filter", filter)
 }

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -868,13 +868,13 @@ func makeHealthCheckFromCli(c *cliconfig.PodmanCommand) (*manifest.Schema2Health
 	hc := manifest.Schema2HealthConfig{
 		Test: cmd,
 	}
+
+	if inInterval == "disable" {
+		inInterval = "0"
+	}
 	intervalDuration, err := time.ParseDuration(inInterval)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid healthcheck-interval %s ", inInterval)
-	}
-
-	if intervalDuration < time.Duration(time.Second*1) {
-		return nil, errors.New("healthcheck-interval must be at least 1 second")
 	}
 
 	hc.Interval = intervalDuration
@@ -882,7 +882,7 @@ func makeHealthCheckFromCli(c *cliconfig.PodmanCommand) (*manifest.Schema2Health
 	if inRetries < 1 {
 		return nil, errors.New("healthcheck-retries must be greater than 0.")
 	}
-
+	hc.Retries = int(inRetries)
 	timeoutDuration, err := time.ParseDuration(inTimeout)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid healthcheck-timeout %s", inTimeout)

--- a/docs/podman-ps.1.md
+++ b/docs/podman-ps.1.md
@@ -100,6 +100,7 @@ Valid filters are listed below:
 | before          | [ID] or [Name] Containers created before this container             |
 | since           | [ID] or [Name] Containers created since this container              |
 | volume          | [VolumeName] or [MountpointDestination] Volume mounted in container |
+| health          | [Status] healthy or unhealthy                                       |
 
 **--help**, **-h**
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -239,7 +239,7 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 			ociRuntime = "/usr/bin/runc"
 		}
 	}
-
+	os.Setenv("DISABLE_HC_SYSTEMD", "true")
 	CNIConfigDir := "/etc/cni/net.d"
 
 	p := &PodmanTestIntegration{
@@ -312,6 +312,14 @@ func (s *PodmanSessionIntegration) InspectImageJSON() []inspect.ImageData {
 	err := json.Unmarshal(s.Out.Contents(), &i)
 	Expect(err).To(BeNil())
 	return i
+}
+
+// InspectContainer returns a container's inspect data in JSON format
+func (p *PodmanTestIntegration) InspectContainer(name string) []inspect.ContainerData {
+	cmd := []string{"inspect", name}
+	session := p.Podman(cmd)
+	session.WaitWithDefaultTimeout()
+	return session.InspectContainerToJSON()
 }
 
 func processTestResult(f GinkgoTestDescription) {

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -83,4 +83,98 @@ var _ = Describe("Podman healthcheck run", func() {
 		hc.WaitWithDefaultTimeout()
 		Expect(hc.ExitCode()).To(Equal(125))
 	})
+
+	It("podman healthcheck should be starting", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--healthcheck-retries", "2", "--healthcheck-command", "\"CMD-SHELL ls /foo || exit 1\"", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		inspect := podmanTest.InspectContainer("hc")
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal("starting"))
+	})
+
+	It("podman healthcheck failed checks in start-period should not change status", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--healthcheck-start-period", "2m", "--healthcheck-retries", "2", "--healthcheck-command", "\"CMD-SHELL ls /foo || exit 1\"", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(1))
+
+		hc = podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(1))
+
+		hc = podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(1))
+
+		inspect := podmanTest.InspectContainer("hc")
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal("starting"))
+	})
+
+	It("podman healthcheck failed checks must reach retries before unhealthy ", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--healthcheck-retries", "2", "--healthcheck-command", "\"CMD-SHELL ls /foo || exit 1\"", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(1))
+
+		inspect := podmanTest.InspectContainer("hc")
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal("starting"))
+
+		hc = podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(1))
+
+		inspect = podmanTest.InspectContainer("hc")
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal("unhealthy"))
+
+	})
+
+	It("podman healthcheck good check results in healthy even in start-period", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--healthcheck-start-period", "2m", "--healthcheck-retries", "2", "--healthcheck-command", "\"CMD-SHELL\" \"ls\" \"||\" \"exit\" \"1\"", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.InspectContainer("hc")
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal("healthy"))
+	})
+
+	It("podman healthcheck single healthy result changes failed to healthy", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", "--healthcheck-retries", "2", "--healthcheck-command", "\"CMD-SHELL\" \"ls\" \"/foo\" \"||\" \"exit\" \"1\"", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(1))
+
+		inspect := podmanTest.InspectContainer("hc")
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal("starting"))
+
+		hc = podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(1))
+
+		inspect = podmanTest.InspectContainer("hc")
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal("unhealthy"))
+
+		foo := podmanTest.Podman([]string{"exec", "hc", "touch", "/foo"})
+		foo.WaitWithDefaultTimeout()
+		Expect(foo.ExitCode()).To(BeZero())
+
+		hc = podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(0))
+
+		inspect = podmanTest.InspectContainer("hc")
+		Expect(inspect[0].State.Healthcheck.Status).To(Equal("healthy"))
+	})
 })


### PR DESCRIPTION
podman will not start a transient service and timer for healthchecks.
this handles the tracking of the timing for health checks.

added the 'started' status which represents the time that a container is
in its start-period.

the systemd timing can be disabled with an env variable of
DISABLE_HC_SYSTEMD="true".

added filter for ps where --filter health=[starting, healthy, unhealthy]
can now be used.

Signed-off-by: baude <bbaude@redhat.com>