### PR TITLE
Export ConmonPidFile in 'podman inspect' for containers

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -93,6 +93,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *inspect.Data)
 		HostsPath:       hostsPath,
 		StaticDir:       config.StaticDir,
 		LogPath:         config.LogPath,
+		ConmonPidFile:   config.ConmonPidFile,
 		Name:            config.Name,
 		Driver:          driverData.Name,
 		MountLabel:      config.MountLabel,

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -158,6 +158,7 @@ type ContainerInspectData struct {
 	HostsPath       string                 `json:"HostsPath"`
 	StaticDir       string                 `json:"StaticDir"`
 	LogPath         string                 `json:"LogPath"`
+	ConmonPidFile   string                 `json:"ConmonPidFile"`
 	Name            string                 `json:"Name"`
 	RestartCount    int32                  `json:"RestartCount"` //TODO
 	Driver          string                 `json:"Driver"`

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -66,6 +66,16 @@ var _ = Describe("Podman inspect", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
+	It("podman inspect container with GO format for ConmonPidFile", func() {
+		SkipIfRemote()
+		session, ec, _ := podmanTest.RunLsContainer("test1")
+		Expect(ec).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"inspect", "--format", "{{.ConmonPidFile}}", "test1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman inspect container with size", func() {
 		SkipIfRemote()
 		_, ec, _ := podmanTest.RunLsContainer("")


### PR DESCRIPTION
This can help scripts provide a more meaningful message when coming
across issues [1] which require the container to be re-created.

[1] eg., https://github.com/containers/libpod/issues/2673

Signed-off-by: Debarshi Ray <rishi@fedoraproject.org>