### PR TITLE
podman umount: error out if called with no args

### DIFF
--- a/cmd/podman/generate_kube.go
+++ b/cmd/podman/generate_kube.go
@@ -57,8 +57,8 @@ func generateKubeYAMLCmd(c *cliconfig.GenerateKubeValues) error {
 		return errors.Wrapf(libpod.ErrNotImplemented, "rootless users")
 	}
 	args := c.InputArgs
-	if len(args) > 1 || (len(args) < 1 && !c.Bool("latest")) {
-		return errors.Errorf("you must provide one container|pod ID or name or --latest")
+	if len(args) != 1 {
+		return errors.Errorf("you must provide exactly one container|pod ID or name")
 	}
 
 	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)

--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -25,7 +25,7 @@ var (
 `
 
 	_mountCommand = &cobra.Command{
-		Use:   "mount [flags] CONTAINER",
+		Use:   "mount [flags] [CONTAINER]",
 		Short: "Mount a working container's root filesystem",
 		Long:  mountDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/pod_stats.go
+++ b/cmd/podman/pod_stats.go
@@ -25,7 +25,7 @@ var (
 	podStatsDescription = `For each specified pod this command will display percentage of CPU, memory, network I/O, block I/O and PIDs for containers in one the pods.`
 
 	_podStatsCommand = &cobra.Command{
-		Use:   "stats [flags] POD [POD...]",
+		Use:   "stats [flags] [POD...]",
 		Short: "Display a live stream of resource usage statistics for the containers in one or more pods",
 		Long:  podStatsDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/umount.go
+++ b/cmd/podman/umount.go
@@ -31,7 +31,7 @@ var (
 			return umountCmd(&umountCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, true)
+			return checkAllAndLatest(cmd, args, false)
 		},
 		Example: `podman umount ctrID
   podman umount ctrID1 ctrID2 ctrID3


### PR DESCRIPTION
Inspired by #2684, I wrote a CI test to look for other such
instances in which a command is invoked without a required
argument. 'podman umount' seems to be the only one.

Signed-off-by: Ed Santiago <santiago@redhat.com>