### PR TITLE
BATS: new tests, and improvements to existing ones

### DIFF
--- a/test/system/000-TEMPLATE
+++ b/test/system/000-TEMPLATE
@@ -52,7 +52,7 @@ function teardown() {
 @test "podman FOO - description of test" {
     # FIXME: please try to remove this line; that is, try to write tests
     # that will pass as both root and rootless.
-    skip_if_rootless
+    skip_if_rootless "Short explanation of why this doesn't work rootless"
 
     # FIXME: template for run commands. Always use 'run_podman'!
     # FIXME: The '?' means 'ignore exit status'; use a number if you

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -18,7 +18,34 @@ load helpers
     is "$output" "$rand_string" "output from podman-start on created ctr"
     is "$output" "$rand_string" "logs of started container"
 
+    run_podman logs $cid
+    is "$output" "$rand_string" "output from podman-logs after container is run"
+
     run_podman rm $cid
+}
+
+@test "podman logs - multi" {
+    # Simple helper to make the container starts, below, easier to read
+    local -a cid
+    doit() {
+        run_podman run --rm -d --name "$1" $IMAGE sh -c "$2";
+        cid+=($(echo "${output:0:12}"))
+    }
+
+    # Not really a guarantee that we'll get a-b-c-d in order, but it's
+    # the best we can do. The trailing 'sleep' in each container
+    # minimizes the chance of a race condition in which the container
+    # is removed before 'podman logs' has a chance to wake up and read
+    # the final output.
+    doit c1         "echo a;sleep 10;echo d;sleep 3"
+    doit c2 "sleep 1;echo b;sleep  2;echo c;sleep 3"
+
+    run_podman logs -f c1 c2
+    is "$output" \
+       "${cid[0]} a
+${cid[1]} b
+${cid[1]} c
+${cid[0]} d"   "Sequential output from logs"
 }
 
 # vim: filetype=sh

--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -5,7 +5,7 @@ load helpers
 
 @test "podman mount - basic test" {
     # Only works with root (FIXME: does it work with rootless + vfs?)
-    skip_if_rootless
+    skip_if_rootless "mount does not work rootless"
 
     f_path=/tmp/tmpfile_$(random_string 8)
     f_content=$(random_string 30)

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# Tests for podman exec
+#
+
+load helpers
+
+@test "podman exec - basic test" {
+    rand_filename=$(random_string 20)
+    rand_content=$(random_string 50)
+
+    # Start a container. Write random content to random file, then stay
+    # alive as long as file exists. (This test will remove that file soon.)
+    run_podman run -d $IMAGE sh -c \
+               "echo $rand_content >/$rand_filename;echo READY;while [ -f /$rand_filename ]; do sleep 1; done"
+    cid="$output"
+    wait_for_ready $cid
+
+    run_podman exec $cid sh -c "cat /$rand_filename"
+    is "$output" "$rand_content" "Can exec and see file in running container"
+
+    run_podman exec $cid rm -f /$rand_filename
+
+    run_podman wait $cid
+    is "$output" "0"   "output from podman wait (container exit code)"
+
+    run_podman rm $cid
+}
+
+# vim: filetype=sh

--- a/test/system/120-load.bats
+++ b/test/system/120-load.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# tests for podman load
+#
+
+load helpers
+
+# Custom helpers for this test only. These just save us having to duplicate
+# the same thing four times (two tests, each with -i and stdin).
+#
+# initialize, read image ID and name
+get_iid_and_name() {
+    run_podman images --format '{{.ID}} {{.Repository}}:{{.Tag}}'
+    read iid img_name < <(echo "$output")
+
+    archive=$PODMAN_TMPDIR/myimage-$(random_string 8).tar
+}
+
+# Simple verification of image ID and name
+verify_iid_and_name() {
+    run_podman images --format '{{.ID}} {{.Repository}}:{{.Tag}}'
+    read new_iid new_img_name < <(echo "$output")
+
+    # Verify
+    is "$new_iid"      "$iid" "Image ID of loaded image == original"
+    is "$new_img_name" "$1"   "Name & tag of restored image"
+}
+
+
+@test "podman load - by image ID" {
+    # FIXME: how to build a simple archive instead?
+    get_iid_and_name
+
+    # Save image by ID, and remove it.
+    run_podman save $iid -o $archive
+    run_podman rmi $iid
+
+    # Load using -i; IID should be preserved, but name is not.
+    run_podman load -i $archive
+    verify_iid_and_name "<none>:<none>"
+
+    # Same as above, using stdin
+    run_podman rmi $iid
+    run_podman load < $archive
+    verify_iid_and_name "<none>:<none>"
+
+    # Cleanup: since load-by-iid doesn't preserve name, re-tag it;
+    # otherwise our global teardown will rmi and re-pull our standard image.
+    run_podman tag $iid $img_name
+}
+
+@test "podman load - by image name" {
+    get_iid_and_name
+    run_podman save $img_name -o $archive
+    run_podman rmi $iid
+
+    # Load using -i; this time the image should be tagged.
+    run_podman load -i $archive
+    verify_iid_and_name $img_name
+
+    # Same as above, using stdin
+    run_podman rmi $iid
+    run_podman load < $archive
+    verify_iid_and_name $img_name
+}
+
+@test "podman load - NAME and NAME:TAG arguments work (requires: #2674)" {
+    get_iid_and_name
+    run_podman save $iid -o $archive
+    run_podman rmi $iid
+
+    # Load with just a name (note: names must be lower-case)
+    random_name=$(random_string 20 | tr A-Z a-z)
+    run_podman load -i $archive $random_name
+    verify_iid_and_name "localhost/$random_name:latest"
+
+    # Load with NAME:TAG arg
+    run_podman rmi $iid
+    random_tag=$(random_string 10 | tr A-Z a-z)
+    run_podman load -i $archive $random_name:$random_tag
+    verify_iid_and_name "localhost/$random_name:$random_tag"
+
+    # Cleanup: restore desired image name
+    run_podman tag $iid $img_name
+    run_podman rmi "$random_name:$random_tag"
+}
+
+
+@test "podman load - will not read from tty" {
+    run_podman 125 load
+    is "$output" \
+       "Error: cannot read from terminal. Use command-line redirection" \
+       "Diagnostic from 'podman load' without redirection or -i"
+}
+
+# vim: filetype=sh

--- a/test/system/300-cli-parsing.bats
+++ b/test/system/300-cli-parsing.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# Various command-line parsing regression tests that don't fit in elsewhere
+#
+
+load helpers
+
+@test "podman cli parsing - quoted args - #2574" {
+    # 1.1.2 fails with:
+    #   Error: invalid argument "true=\"false\"" for "-l, --label" \
+    #      flag: parse error on line 1, column 5: bare " in non-quoted-field
+    run_podman run --rm --label 'true="false"' $IMAGE true
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
New:
 - podman exec
 - podman load (requires #2674)
 - CLI parsing (regression test for #2574)

Improved:
 - help: test "podman NoSuchCommand", and subcommands
 - help: test "podman cmd" without required args
 - pod: start with --infra=false; this allows running rootless
 - log: also run 'logs' after container is run
 - log: test -f with two containers

Also, use helpful descriptions for skip_if_rootless

Tested on f29, root and rootless. As soon as podman-remote
supports rm, I'll start testing that too.

Signed-off-by: Ed Santiago <santiago@redhat.com>