### PR TITLE
Enabling checkpoint/restore testing on Fedora >= 29 again

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -55,6 +55,8 @@ then
             CON_SEL="https://kojipkgs.fedoraproject.org/packages/container-selinux/2.100/1.git3b78187.fc29/noarch/container-selinux-2.100-1.git3b78187.fc29.noarch.rpm"
             echo ">>>>> OVERRIDING container-selinux WITH $CON_SEL <<<<<"
             dnf -y install $CON_SEL
+            echo ">>>>> OVERRIDING criu and selinux-policy with latest package <<<<<"
+            dnf -y upgrade criu selinux-policy
             ;&  # Continue to the next item
         fedora-28)
             echo ">>>>> OVERRIDING source-built runc with latest package <<<<<"

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Podman checkpoint", func() {
 	)
 
 	BeforeEach(func() {
+		SkipIfRootless()
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)
@@ -41,11 +42,12 @@ var _ = Describe("Podman checkpoint", func() {
 		if !criu.CheckForCriu() {
 			Skip("CRIU is missing or too old.")
 		}
-		// TODO: Remove the skip when the current CRIU SELinux problem is solved.
-		// See: https://github.com/containers/libpod/issues/2334
+		// Only Fedora 29 and newer has a new enough selinux-policy and
+		// container-selinux package to support CRIU in correctly
+		// restoring threaded processes
 		hostInfo := podmanTest.Host
-		if hostInfo.Distribution == "fedora" {
-			Skip("Checkpointing containers on Fedora currently broken.")
+		if hostInfo.Distribution == "fedora" && hostInfo.Version < "29" {
+			Skip("Checkpoint/Restore with SELinux only works on Fedora >= 29")
 		}
 
 	})


### PR DESCRIPTION
Trying to enable checkpoint/restore and container migration in https://github.com/containers/libpod/pull/2272 fails with different (sometimes checkpoint/restore unrelated) errors. To make sure that this is not some side-effect of my code changes, I am using this PR to understand if and how my changes break the CI results.