### PR TITLE
rootless: single user namespace

### DIFF
--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -58,9 +58,6 @@ func cpCmd(c *cliconfig.CpValues) error {
 	if len(args) != 2 {
 		return errors.Errorf("you must provide a source path and a destination path")
 	}
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
-	}
 
 	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
 	if err != nil {

--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/containers/buildah/pkg/chrootuser"
@@ -12,7 +10,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/chrootarchive"
@@ -85,34 +82,6 @@ func copyBetweenHostAndContainer(runtime *libpod.Runtime, src string, dest strin
 	isFromHostToCtr := (ctr == nil)
 	if isFromHostToCtr {
 		ctr = destCtr
-	}
-
-	if os.Geteuid() != 0 {
-		s, err := ctr.State()
-		if err != nil {
-			return err
-		}
-		var became bool
-		var ret int
-		if s == libpod.ContainerStateRunning || s == libpod.ContainerStatePaused {
-			data, err := ioutil.ReadFile(ctr.Config().ConmonPidFile)
-			if err != nil {
-				return errors.Wrapf(err, "cannot read conmon PID file %q", ctr.Config().ConmonPidFile)
-			}
-			conmonPid, err := strconv.Atoi(string(data))
-			if err != nil {
-				return errors.Wrapf(err, "cannot parse PID %q", data)
-			}
-			became, ret, err = rootless.JoinDirectUserAndMountNS(uint(conmonPid))
-		} else {
-			became, ret, err = rootless.BecomeRootInUserNS()
-		}
-		if err != nil {
-			return err
-		}
-		if became {
-			os.Exit(ret)
-		}
 	}
 
 	mountPoint, err := ctr.Mount()

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/cmd/podman/shared"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -52,10 +50,6 @@ func createCmd(c *cliconfig.CreateValues) error {
 
 	if err := createInit(&c.PodmanCommand); err != nil {
 		return err
-	}
-
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
 	}
 
 	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/cmd/podman/shared/parse"
 	"github.com/containers/libpod/libpod"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -104,32 +103,6 @@ func execCmd(c *cliconfig.ExecValues) error {
 			}
 		}
 
-	}
-
-	if os.Geteuid() != 0 {
-		var became bool
-		var ret int
-
-		data, err := ioutil.ReadFile(ctr.Config().ConmonPidFile)
-		if err == nil {
-			conmonPid, err := strconv.Atoi(string(data))
-			if err != nil {
-				return errors.Wrapf(err, "cannot parse PID %q", data)
-			}
-			became, ret, err = rootless.JoinDirectUserAndMountNS(uint(conmonPid))
-		} else {
-			pid, err := ctr.PID()
-			if err != nil {
-				return err
-			}
-			became, ret, err = rootless.JoinNS(uint(pid), c.PreserveFDs)
-		}
-		if err != nil {
-			return err
-		}
-		if became {
-			os.Exit(ret)
-		}
 	}
 
 	// ENVIRONMENT VARIABLES

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -67,7 +67,6 @@ func execCmd(c *cliconfig.ExecValues) error {
 	if c.Latest {
 		argStart = 0
 	}
-	rootless.SetSkipStorageSetup(true)
 	cmd := args[argStart:]
 	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
 	if err != nil {

--- a/cmd/podman/export.go
+++ b/cmd/podman/export.go
@@ -6,7 +6,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/shared/parse"
 	"github.com/containers/libpod/pkg/adapter"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -41,10 +40,6 @@ func init() {
 
 // exportCmd saves a container to a tarball on disk
 func exportCmd(c *cliconfig.ExportValues) error {
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
-	}
-
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/kill.go
+++ b/cmd/podman/kill.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/containers/libpod/pkg/adapter"
-	"github.com/opentracing/opentracing-go"
-
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/libpod/pkg/adapter"
 	"github.com/docker/docker/pkg/signal"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -63,7 +61,6 @@ func killCmd(c *cliconfig.KillValues) error {
 		return err
 	}
 
-	rootless.SetSkipStorageSetup(true)
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -60,10 +60,6 @@ type jsonMountPoint struct {
 }
 
 func mountCmd(c *cliconfig.MountValues) error {
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
-	}
-
 	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/pod.go
+++ b/cmd/podman/pod.go
@@ -1,12 +1,7 @@
 package main
 
 import (
-	"os"
-
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/pkg/adapter"
-	"github.com/containers/libpod/pkg/rootless"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -37,48 +32,6 @@ var podSubCommands = []*cobra.Command{
 	_podStopCommand,
 	_podTopCommand,
 	_podUnpauseCommand,
-}
-
-func joinPodNS(runtime *adapter.LocalRuntime, all, latest bool, inputArgs []string) ([]string, bool, bool, error) {
-	if rootless.IsRootless() {
-		if os.Geteuid() == 0 {
-			return []string{rootless.Argument()}, false, false, nil
-		} else {
-			var err error
-			var pods []*adapter.Pod
-			if all {
-				pods, err = runtime.GetAllPods()
-				if err != nil {
-					return nil, false, false, errors.Wrapf(err, "unable to get pods")
-				}
-			} else if latest {
-				pod, err := runtime.GetLatestPod()
-				if err != nil {
-					return nil, false, false, errors.Wrapf(err, "unable to get latest pod")
-				}
-				pods = append(pods, pod)
-			} else {
-				for _, i := range inputArgs {
-					pod, err := runtime.LookupPod(i)
-					if err != nil {
-						return nil, false, false, errors.Wrapf(err, "unable to lookup pod %s", i)
-					}
-					pods = append(pods, pod)
-				}
-			}
-			for _, p := range pods {
-				_, ret, err := runtime.JoinOrCreateRootlessPod(p)
-				if err != nil {
-					return nil, false, false, err
-				}
-				if ret != 0 {
-					os.Exit(ret)
-				}
-			}
-			os.Exit(0)
-		}
-	}
-	return inputArgs, all, latest, nil
 }
 
 func init() {

--- a/cmd/podman/pod_kill.go
+++ b/cmd/podman/pod_kill.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -49,7 +48,6 @@ func init() {
 
 // podKillCmd kills one or more pods with a signal
 func podKillCmd(c *cliconfig.PodKillValues) error {
-	rootless.SetSkipStorageSetup(true)
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/pod_restart.go
+++ b/cmd/podman/pod_restart.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -52,15 +51,6 @@ func podRestartCmd(c *cliconfig.PodRestartValues) error {
 		return errors.Wrapf(err, "could not get runtime")
 	}
 	defer runtime.Shutdown(false)
-
-	if rootless.IsRootless() {
-		var err error
-
-		c.InputArgs, c.All, c.Latest, err = joinPodNS(runtime, c.All, c.Latest, c.InputArgs)
-		if err != nil {
-			return err
-		}
-	}
 
 	restartIDs, conErrors, restartErrors := runtime.RestartPods(getContext(), c)
 

--- a/cmd/podman/pod_restart.go
+++ b/cmd/podman/pod_restart.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
@@ -48,9 +47,6 @@ func init() {
 
 func podRestartCmd(c *cliconfig.PodRestartValues) error {
 	var lastError error
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
-	}
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/pod_rm.go
+++ b/cmd/podman/pod_rm.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
@@ -48,9 +47,6 @@ func init() {
 
 // podRmCmd deletes pods
 func podRmCmd(c *cliconfig.PodRmValues) error {
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
-	}
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/pod_rm.go
+++ b/cmd/podman/pod_rm.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -52,14 +51,6 @@ func podRmCmd(c *cliconfig.PodRmValues) error {
 		return errors.Wrapf(err, "could not get runtime")
 	}
 	defer runtime.Shutdown(false)
-
-	if rootless.IsRootless() {
-		var err error
-		c.InputArgs, c.All, c.Latest, err = joinPodNS(runtime, c.All, c.Latest, c.InputArgs)
-		if err != nil {
-			return err
-		}
-	}
 
 	podRmIds, podRmErrors := runtime.RemovePods(getContext(), c)
 	for _, p := range podRmIds {

--- a/cmd/podman/pod_stop.go
+++ b/cmd/podman/pod_stop.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
@@ -48,10 +47,6 @@ func init() {
 }
 
 func podStopCmd(c *cliconfig.PodStopValues) error {
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
-	}
-
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/pod_stop.go
+++ b/cmd/podman/pod_stop.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -52,14 +51,6 @@ func podStopCmd(c *cliconfig.PodStopValues) error {
 		return errors.Wrapf(err, "could not get runtime")
 	}
 	defer runtime.Shutdown(false)
-
-	if rootless.IsRootless() {
-		var err error
-		c.InputArgs, c.All, c.Latest, err = joinPodNS(runtime, c.All, c.Latest, c.InputArgs)
-		if err != nil {
-			return err
-		}
-	}
 
 	podStopIds, podStopErrors := runtime.StopPods(getContext(), c)
 	for _, p := range podStopIds {

--- a/cmd/podman/pod_top.go
+++ b/cmd/podman/pod_top.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -53,10 +52,6 @@ func podTopCmd(c *cliconfig.PodTopValues) error {
 		descriptors []string
 	)
 	args := c.InputArgs
-
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
-	}
 
 	if c.ListDescriptors {
 		descriptors, err := libpod.GetContainerPidInformationDescriptors()

--- a/cmd/podman/pod_top.go
+++ b/cmd/podman/pod_top.go
@@ -78,26 +78,6 @@ func podTopCmd(c *cliconfig.PodTopValues) error {
 		descriptors = args[1:]
 	}
 
-	if os.Geteuid() != 0 {
-		var pod *adapter.Pod
-		var err error
-		if c.Latest {
-			pod, err = runtime.GetLatestPod()
-		} else {
-			pod, err = runtime.LookupPod(c.InputArgs[0])
-		}
-		if err != nil {
-			return errors.Wrapf(err, "unable to lookup requested container")
-		}
-		became, ret, err := runtime.JoinOrCreateRootlessPod(pod)
-		if err != nil {
-			return err
-		}
-		if became {
-			os.Exit(ret)
-		}
-	}
-
 	w := tabwriter.NewWriter(os.Stdout, 5, 1, 3, ' ', 0)
 	psOutput, err := runtime.PodTop(c, descriptors)
 	if err != nil {

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/libpod"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/docker/go-units"
@@ -202,9 +201,6 @@ func init() {
 }
 
 func psCmd(c *cliconfig.PsValues) error {
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
-	}
 	if c.Bool("trace") {
 		span, _ := opentracing.StartSpanFromContext(Ctx, "psCmd")
 		defer span.Finish()

--- a/cmd/podman/restart.go
+++ b/cmd/podman/restart.go
@@ -57,9 +57,6 @@ func restartCmd(c *cliconfig.RestartValues) error {
 		restartContainers []*libpod.Container
 	)
 
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
-	}
 	if rootless.IsRootless() {
 		// If we are in the re-execed rootless environment,
 		// override the arg to deal only with one container.

--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -82,9 +82,6 @@ func rmCmd(c *cliconfig.RmValues) error {
 	var (
 		deleteFuncs []shared.ParallelWorkerInput
 	)
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
-	}
 
 	ctx := getContext()
 	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/libpod"
-	"github.com/containers/libpod/pkg/rootless"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -56,9 +55,6 @@ func runCmd(c *cliconfig.RunValues) error {
 
 	if err := createInit(&c.PodmanCommand); err != nil {
 		return err
-	}
-	if os.Geteuid() != 0 {
-		rootless.SetSkipStorageSetup(true)
 	}
 
 	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -75,7 +75,8 @@ func CreateContainer(ctx context.Context, c *cliconfig.PodmanCommand, runtime *l
 	imageName := ""
 	var data *inspect.ImageData = nil
 
-	if rootfs == "" && !rootless.SkipStorageSetup() {
+	// Set the storage if we are running as euid == 0 and there is no rootfs specified
+	if rootfs == "" && os.Geteuid() == 0 {
 		var writer io.Writer
 		if !c.Bool("quiet") {
 			writer = os.Stderr

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -759,71 +758,6 @@ type namespace interface {
 	Container() string
 }
 
-func joinOrCreateRootlessUserNamespace(createConfig *cc.CreateConfig, runtime *libpod.Runtime) (bool, int, error) {
-	if os.Geteuid() == 0 {
-		return false, 0, nil
-	}
-
-	if createConfig.Pod != "" {
-		pod, err := runtime.LookupPod(createConfig.Pod)
-		if err != nil {
-			return false, -1, err
-		}
-		inspect, err := pod.Inspect()
-		for _, ctr := range inspect.Containers {
-			prevCtr, err := runtime.LookupContainer(ctr.ID)
-			if err != nil {
-				return false, -1, err
-			}
-			s, err := prevCtr.State()
-			if err != nil {
-				return false, -1, err
-			}
-			if s != libpod.ContainerStateRunning && s != libpod.ContainerStatePaused {
-				continue
-			}
-			data, err := ioutil.ReadFile(prevCtr.Config().ConmonPidFile)
-			if err != nil {
-				return false, -1, errors.Wrapf(err, "cannot read conmon PID file %q", prevCtr.Config().ConmonPidFile)
-			}
-			conmonPid, err := strconv.Atoi(string(data))
-			if err != nil {
-				return false, -1, errors.Wrapf(err, "cannot parse PID %q", data)
-			}
-			return rootless.JoinDirectUserAndMountNS(uint(conmonPid))
-		}
-	}
-
-	namespacesStr := []string{string(createConfig.IpcMode), string(createConfig.NetMode), string(createConfig.UsernsMode), string(createConfig.PidMode), string(createConfig.UtsMode)}
-	for _, i := range namespacesStr {
-		if cc.IsNS(i) {
-			return rootless.JoinNSPath(cc.NS(i))
-		}
-	}
-
-	namespaces := []namespace{createConfig.IpcMode, createConfig.NetMode, createConfig.UsernsMode, createConfig.PidMode, createConfig.UtsMode}
-	for _, i := range namespaces {
-		if i.IsContainer() {
-			ctr, err := runtime.LookupContainer(i.Container())
-			if err != nil {
-				return false, -1, err
-			}
-			pid, err := ctr.PID()
-			if err != nil {
-				return false, -1, err
-			}
-			if pid == 0 {
-				if createConfig.Pod != "" {
-					continue
-				}
-				return false, -1, errors.Errorf("dependency container %s is not running", ctr.ID())
-			}
-			return rootless.JoinNS(uint(pid), 0)
-		}
-	}
-	return rootless.BecomeRootInUserNS()
-}
-
 func CreateContainerFromCreateConfig(r *libpod.Runtime, createConfig *cc.CreateConfig, ctx context.Context, pod *libpod.Pod) (*libpod.Container, error) {
 	runtimeSpec, err := cc.CreateConfigToOCISpec(createConfig)
 	if err != nil {
@@ -833,13 +767,6 @@ func CreateContainerFromCreateConfig(r *libpod.Runtime, createConfig *cc.CreateC
 	options, err := createConfig.GetContainerCreateOptions(r, pod)
 	if err != nil {
 		return nil, err
-	}
-	became, ret, err := joinOrCreateRootlessUserNamespace(createConfig, r)
-	if err != nil {
-		return nil, err
-	}
-	if became {
-		os.Exit(ret)
 	}
 
 	ctr, err := r.NewContainer(ctx, runtimeSpec, options...)

--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -7,7 +7,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/adapter"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -59,7 +58,6 @@ func stopCmd(c *cliconfig.StopValues) error {
 		defer span.Finish()
 	}
 
-	rootless.SetSkipStorageSetup(true)
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/top.go
+++ b/cmd/podman/top.go
@@ -77,7 +77,6 @@ func topCmd(c *cliconfig.TopValues) error {
 		return errors.Errorf("you must provide the name or id of a running container")
 	}
 
-	rootless.SetSkipStorageSetup(true)
 	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")

--- a/cmd/podman/top.go
+++ b/cmd/podman/top.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -102,18 +101,6 @@ func topCmd(c *cliconfig.TopValues) error {
 	}
 	if conStat != libpod.ContainerStateRunning {
 		return errors.Errorf("top can only be used on running containers")
-	}
-
-	pid, err := container.PID()
-	if err != nil {
-		return err
-	}
-	became, ret, err := rootless.JoinNS(uint(pid), 0)
-	if err != nil {
-		return err
-	}
-	if became {
-		os.Exit(ret)
 	}
 	psOutput, err := container.GetContainerPidInformation(descriptors)
 	if err != nil {

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -742,7 +742,7 @@ func makeRuntime(runtime *Runtime) (err error) {
 
 	// Set up containers/storage
 	var store storage.Store
-	if rootless.SkipStorageSetup() {
+	if os.Geteuid() != 0 {
 		logrus.Debug("Not configuring container store")
 	} else {
 		store, err = storage.GetStore(runtime.config.StorageConfig)

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -2,11 +2,9 @@ package libpod
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -563,37 +561,6 @@ func (r *Runtime) Export(name string, path string) error {
 	ctr, err := r.LookupContainer(name)
 	if err != nil {
 		return err
-	}
-	if os.Geteuid() != 0 {
-		state, err := ctr.State()
-		if err != nil {
-			return errors.Wrapf(err, "cannot read container state %q", ctr.ID())
-		}
-		if state == ContainerStateRunning || state == ContainerStatePaused {
-			data, err := ioutil.ReadFile(ctr.Config().ConmonPidFile)
-			if err != nil {
-				return errors.Wrapf(err, "cannot read conmon PID file %q", ctr.Config().ConmonPidFile)
-			}
-			conmonPid, err := strconv.Atoi(string(data))
-			if err != nil {
-				return errors.Wrapf(err, "cannot parse PID %q", data)
-			}
-			became, ret, err := rootless.JoinDirectUserAndMountNS(uint(conmonPid))
-			if err != nil {
-				return err
-			}
-			if became {
-				os.Exit(ret)
-			}
-		} else {
-			became, ret, err := rootless.BecomeRootInUserNS()
-			if err != nil {
-				return err
-			}
-			if became {
-				os.Exit(ret)
-			}
-		}
 	}
 	return ctr.Export(path)
 

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strconv"
 	"text/template"
 
 	"github.com/containers/buildah"
@@ -123,38 +122,6 @@ func (r *LocalRuntime) Export(name string, path string) error {
 	if err != nil {
 		return errors.Wrapf(err, "error looking up container %q", name)
 	}
-	if os.Geteuid() != 0 {
-		state, err := ctr.State()
-		if err != nil {
-			return errors.Wrapf(err, "cannot read container state %q", ctr.ID())
-		}
-		if state == libpod.ContainerStateRunning || state == libpod.ContainerStatePaused {
-			data, err := ioutil.ReadFile(ctr.Config().ConmonPidFile)
-			if err != nil {
-				return errors.Wrapf(err, "cannot read conmon PID file %q", ctr.Config().ConmonPidFile)
-			}
-			conmonPid, err := strconv.Atoi(string(data))
-			if err != nil {
-				return errors.Wrapf(err, "cannot parse PID %q", data)
-			}
-			became, ret, err := rootless.JoinDirectUserAndMountNS(uint(conmonPid))
-			if err != nil {
-				return err
-			}
-			if became {
-				os.Exit(ret)
-			}
-		} else {
-			became, ret, err := rootless.BecomeRootInUserNS()
-			if err != nil {
-				return err
-			}
-			if became {
-				os.Exit(ret)
-			}
-		}
-	}
-
 	return ctr.Export(path)
 }
 
@@ -340,46 +307,6 @@ func IsImageNotFound(err error) bool {
 // HealthCheck is a wrapper to same named function in libpod
 func (r *LocalRuntime) HealthCheck(c *cliconfig.HealthCheckValues) (libpod.HealthCheckStatus, error) {
 	return r.Runtime.HealthCheck(c.InputArgs[0])
-}
-
-// JoinOrCreateRootlessPod joins the specified pod if it is running or it creates a new user namespace
-// if the pod is stopped
-func (r *LocalRuntime) JoinOrCreateRootlessPod(pod *Pod) (bool, int, error) {
-	if os.Geteuid() == 0 {
-		return false, 0, nil
-	}
-	opts := rootless.Opts{
-		Argument: pod.ID(),
-	}
-
-	inspect, err := pod.Inspect()
-	if err != nil {
-		return false, 0, err
-	}
-	for _, ctr := range inspect.Containers {
-		prevCtr, err := r.LookupContainer(ctr.ID)
-		if err != nil {
-			return false, -1, err
-		}
-		s, err := prevCtr.State()
-		if err != nil {
-			return false, -1, err
-		}
-		if s != libpod.ContainerStateRunning && s != libpod.ContainerStatePaused {
-			continue
-		}
-		data, err := ioutil.ReadFile(prevCtr.Config().ConmonPidFile)
-		if err != nil {
-			return false, -1, errors.Wrapf(err, "cannot read conmon PID file %q", prevCtr.Config().ConmonPidFile)
-		}
-		conmonPid, err := strconv.Atoi(string(data))
-		if err != nil {
-			return false, -1, errors.Wrapf(err, "cannot parse PID %q", data)
-		}
-		return rootless.JoinDirectUserAndMountNSWithOpts(uint(conmonPid), &opts)
-	}
-
-	return rootless.BecomeRootInUserNSWithOpts(&opts)
 }
 
 // Events is a wrapper to libpod to obtain libpod/podman events

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -755,13 +755,6 @@ func (r *LocalRuntime) HealthCheck(c *cliconfig.HealthCheckValues) (libpod.Healt
 	return -1, libpod.ErrNotImplemented
 }
 
-// JoinOrCreateRootlessPod joins the specified pod if it is running or it creates a new user namespace
-// if the pod is stopped
-func (r *LocalRuntime) JoinOrCreateRootlessPod(pod *Pod) (bool, int, error) {
-	// Nothing to do in the remote case
-	return true, 0, nil
-}
-
 // Events monitors libpod/podman events over a varlink connection
 func (r *LocalRuntime) Events(c *cliconfig.EventValues) error {
 	var more uint64

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -1,9 +1,0 @@
-package rootless
-
-// Opts allows to customize how re-execing to a rootless process is done
-type Opts struct {
-	// Argument overrides the arguments on the command line
-	// for the re-execed process.  The process in the namespace
-	// must use rootless.Argument() to read its value.
-	Argument string
-}

--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -13,9 +13,35 @@
 #include <sys/wait.h>
 #include <string.h>
 #include <stdbool.h>
+#include <sys/types.h>
+#include <sys/prctl.h>
+#include <dirent.h>
 
 static const char *_max_user_namespaces = "/proc/sys/user/max_user_namespaces";
 static const char *_unprivileged_user_namespaces = "/proc/sys/kernel/unprivileged_userns_clone";
+
+static int n_files;
+
+static void __attribute__((constructor)) init()
+{
+  DIR *d;
+
+  /* Store how many FDs were open before the Go runtime kicked in.  */
+  d = opendir ("/proc/self/fd");
+  if (d)
+    {
+      struct dirent *ent;
+
+      for (ent = readdir (d); ent; ent = readdir (d))
+        {
+          int fd = atoi (ent->d_name);
+          if (fd > n_files && fd != dirfd (d))
+            n_files = fd;
+        }
+      closedir (d);
+    }
+}
+
 
 static int
 syscall_setresuid (uid_t ruid, uid_t euid, uid_t suid)
@@ -133,11 +159,24 @@ reexec_userns_join (int userns, int mountns)
   pid = fork ();
   if (pid < 0)
     fprintf (stderr, "cannot fork: %s\n", strerror (errno));
+
   if (pid)
-    return pid;
+    {
+      /* We passed down these fds, close them.  */
+      int f;
+      for (f = 3; f < n_files; f++)
+        close (f);
+      return pid;
+    }
 
   setenv ("_CONTAINERS_USERNS_CONFIGURED", "init", 1);
   setenv ("_CONTAINERS_ROOTLESS_UID", uid, 1);
+
+  if (prctl (PR_SET_PDEATHSIG, SIGTERM, 0, 0, 0) < 0)
+    {
+      fprintf (stderr, "cannot prctl(PR_SET_PDEATHSIG): %s\n", strerror (errno));
+      _exit (EXIT_FAILURE);
+    }
 
   if (setns (userns, 0) < 0)
     {

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -46,20 +46,6 @@ func IsRootless() bool {
 	return isRootless
 }
 
-var (
-	skipStorageSetup = false
-)
-
-// SetSkipStorageSetup tells the runtime to not setup containers/storage
-func SetSkipStorageSetup(v bool) {
-	skipStorageSetup = v
-}
-
-// SkipStorageSetup tells if we should skip the containers/storage setup
-func SkipStorageSetup() bool {
-	return skipStorageSetup
-}
-
 // Argument returns the argument that was set for the rootless session.
 func Argument() string {
 	return os.Getenv("_CONTAINERS_ROOTLESS_ARG")

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -30,15 +30,6 @@ func GetRootlessUID() int {
 	return -1
 }
 
-// SetSkipStorageSetup tells the runtime to not setup containers/storage
-func SetSkipStorageSetup(bool) {
-}
-
-// SkipStorageSetup tells if we should skip the containers/storage setup
-func SkipStorageSetup() bool {
-	return false
-}
-
 // JoinNS re-exec podman in a new userNS and join the user namespace of the specified
 // PID.
 func JoinNS(pid uint, preserveFDs int) (bool, int, error) {

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -19,45 +19,15 @@ func BecomeRootInUserNS() (bool, int, error) {
 	return false, -1, errors.New("this function is not supported on this os")
 }
 
-// BecomeRootInUserNS is a stub function that always returns false and an
-// error on unsupported OS's
-func BecomeRootInUserNSWithOpts(opts *Opts) (bool, int, error) {
-	return false, -1, errors.New("this function is not supported on this os")
-}
-
 // GetRootlessUID returns the UID of the user in the parent userNS
 func GetRootlessUID() int {
 	return -1
 }
 
-// JoinNS re-exec podman in a new userNS and join the user namespace of the specified
-// PID.
-func JoinNS(pid uint, preserveFDs int) (bool, int, error) {
-	return false, -1, errors.New("this function is not supported on this os")
-}
-
-// JoinNSPath re-exec podman in a new userNS and join the owner user namespace of the
-// specified path.
-func JoinNSPath(path string) (bool, int, error) {
-	return false, -1, errors.New("this function is not supported on this os")
-}
-
-// JoinDirectUserAndMountNSWithOpts re-exec podman in a new userNS and join the user and
-// mount namespace of the specified PID without looking up its parent.  Useful to join
-// directly the conmon process.
-func JoinDirectUserAndMountNSWithOpts(pid uint, opts *Opts) (bool, int, error) {
-	return false, -1, errors.New("this function is not supported on this os")
-}
-
-// JoinDirectUserAndMountNS re-exec podman in a new userNS and join the user and mount
+// JoinUserAndMountNS re-exec podman in a new userNS and join the user and mount
 // namespace of the specified PID without looking up its parent.  Useful to join directly
-// the conmon process.  It is a convenience function for JoinDirectUserAndMountNSWithOpts
+// the conmon process.  It is a convenience function for JoinUserAndMountNSWithOpts
 // with a default configuration.
-func JoinDirectUserAndMountNS(pid uint) (bool, int, error) {
+func JoinUserAndMountNS(pid uint) (bool, int, error) {
 	return false, -1, errors.New("this function is not supported on this os")
-}
-
-// Argument returns the argument that was set for the rootless session.
-func Argument() string {
-	return ""
 }

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/image/manifest"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/namespaces"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/cri-o/ocicni/pkg/ocicni"
@@ -271,7 +270,7 @@ func (c *CreateConfig) GetVolumeMounts(specMounts []spec.Mount) ([]spec.Mount, e
 func (c *CreateConfig) GetVolumesFrom() error {
 	var options string
 
-	if rootless.SkipStorageSetup() {
+	if os.Geteuid() != 0 {
 		return nil
 	}
 


### PR DESCRIPTION
simplify the rootless implementation to use a single user namespace for all the running containers.
    
This makes the rootless implementation behave more like root Podman, where each container is created in the host environment.
    
There are multiple advantages to it:

- much simpler implementation as there is only one namespace to join.
- we can join namespaces owned by different containers.
- commands like ps won't be limited to what container they can access as previously we either had access to the storage from a new namespace or access to /proc when running from the host.
- rootless varlink works.
- there are only two ways to enter in a namespace, either by creating a new one if no containers are running or joining the existing one from any container.


Containers created by older Podman versions must be restarted.  Should we set the rpm update to need a reboot?
