### PR TITLE
Cirrus: Various fixes for rootless testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,8 +70,6 @@ env:
     #### Default to NOT running in rootless-testing mode
     ####
     ROOTLESS_USER: ""
-    ROOTLESS_UID: ""
-    ROOTLESS_GID: ""
 
     ####
     #### Credentials and other secret-sauces, decrypted at runtime when authorized.
@@ -101,7 +99,7 @@ env:
         CIRRUS_TASK_ID CIRRUS_REPO_NAME CIRRUS_REPO_OWNER CIRRUS_REPO_FULL_NAME
         CIRRUS_REPO_CLONE_URL CIRRUS_SHELL CIRRUS_USER_COLLABORATOR CIRRUS_USER_PERMISSION
         CIRRUS_WORKING_DIR CIRRUS_HTTP_CACHE_HOST PACKER_BUILDS BUILT_IMAGE_SUFFIX
-        XDG_DATA_DIRS XDG_RUNTIME_DIR XDG_SESSION_ID ROOTLESS_USER ROOTLESS_UID ROOTLESS_GID
+        XDG_DATA_DIRS XDG_RUNTIME_DIR XDG_SESSION_ID ROOTLESS_USER
 
 
 # Every *_task runs in parallel in separate VMsd. The name prefix only for reference
@@ -252,8 +250,6 @@ rootless_testing_task:
 
     env:
         ROOTLESS_USER: "olympiclongjumpingwithjesus"
-        ROOTLESS_UID: 123456
-        ROOTLESS_GID: 123456
 
     timeout_in: 120m
 

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -44,8 +44,6 @@ then
         "export OS_RELEASE_VER=\"$(os_release_ver)\"" \
         "export OS_REL_VER=\"$(os_release_id)-$(os_release_ver)\"" \
         "export ROOTLESS_USER=$ROOTLESS_USER" \
-        "export ROOTLESS_UID=$ROOTLESS_UID" \
-        "export ROOTLESS_GID=$ROOTLESS_GID" \
         "export BUILT_IMAGE_SUFFIX=\"-$CIRRUS_REPO_NAME-${CIRRUS_CHANGE_IN_REPO:0:8}\"" \
         "export GOPATH=\"/var/tmp/go\"" \
         'export PATH="$HOME/bin:$GOPATH/bin:/usr/local/bin:$PATH"' \
@@ -74,6 +72,7 @@ then
     esac
 
     cd "${GOSRC}/"
+    # Reload to incorporate any changes from above
     source "$SCRIPT_BASE/lib.sh"
 
     if run_rootless
@@ -83,12 +82,6 @@ then
         go get github.com/onsi/ginkgo/ginkgo
         go get github.com/onsi/gomega/...
         dnf -y update runc
-    else
-        # Includes some $HOME relative details
-        go env | while read envline
-        do
-            X=$(echo "export $envline" | tee -a "$HOME/$ENVLIB") && eval "$X" && echo "$X"
-        done
     fi
 fi
 

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -19,6 +19,7 @@ PROJECT="libpod-218412"
 GOSRC="/var/tmp/go/src/github.com/containers/libpod"
 GCLOUD_IMAGE=${GCLOUD_IMAGE:-quay.io/cevich/gcloud_centos:latest}
 GCLOUD_SUDO=${GCLOUD_SUDO-sudo}
+ROOTLESS_USER="madcowdog"
 
 # Shared tmp directory between container and us
 TMPDIR=$(mktemp -d --tmpdir $(basename $0)_tmpdir_XXXXXX)
@@ -69,7 +70,9 @@ image_hints() {
 
 show_usage() {
     echo -e "\n${RED}ERROR: $1${NOR}"
-    echo -e "${YEL}Usage: $(basename $0) [-s | -p] <image_name>${NOR}\n"
+    echo -e "${YEL}Usage: $(basename $0) [-s | -p | -r] <image_name>${NOR}"
+    echo "Use -s / -p to select source or package based dependencies"
+    echo -e "Use -r to setup and run tests as a regular user.\n"
     if [[ -r ".cirrus.yml" ]]
     then
         echo -e "${YEL}Some possible image_name values (from .cirrus.yml):${NOR}"
@@ -106,7 +109,7 @@ parse_args(){
         IMAGE_NAME="$2"
     elif [[ "$1" == "-r" ]]
     then
-        DEPS="ROOTLESS_USER=madcowdog ROOTLESS_UID=3210 ROOTLESS_GID=3210"
+        DEPS="ROOTLESS_USER=$ROOTLESS_USER"
         IMAGE_NAME="$2"
     else  # no -s or -p
         DEPS="$(get_env_vars)"
@@ -213,4 +216,8 @@ echo -e "\n${YEL}Executing environment setup${NOR}"
 showrun $SSH_CMD --command "$SETUP_CMD"
 
 echo -e "\n${YEL}Connecting to $VMNAME ${RED}(option to delete VM upon logout).${NOR}\n"
+if [[ "$1" == "-r" ]]
+then
+    SSH_CMD="$PGCLOUD compute ssh $ROOTLESS_USER@$VMNAME"
+fi
 showrun $SSH_CMD -- -t "cd $GOSRC && exec env $DEPS bash -il"


### PR DESCRIPTION
* Randomize the user's UID and GID
* Simplify `setup_environment.sh`
* Support new "-r" option for `hack/get_ci_vm.sh` setting up rootless
* Connect as $ROOTLESS_USER when using "-r" with `hack/get_ci_vm.sh`

Signed-off-by: Chris Evich <cevich@redhat.com>