### PR TITLE
userns: mount the volumes from the intermediate namespace

### DIFF
--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -200,35 +200,6 @@ func getPodsFromContext(c *cliconfig.PodmanCommand, r *libpod.Runtime) ([]*libpo
 	return pods, lastError
 }
 
-func getVolumesFromContext(c *cliconfig.PodmanCommand, r *libpod.Runtime) ([]*libpod.Volume, error) {
-	args := c.InputArgs
-	var (
-		vols      []*libpod.Volume
-		lastError error
-		err       error
-	)
-
-	if c.Bool("all") {
-		vols, err = r.Volumes()
-		if err != nil {
-			return nil, errors.Wrapf(err, "unable to get all volumes")
-		}
-	}
-
-	for _, i := range args {
-		vol, err := r.GetVolume(i)
-		if err != nil {
-			if lastError != nil {
-				logrus.Errorf("%q", lastError)
-			}
-			lastError = errors.Wrapf(err, "unable to find volume %s", i)
-			continue
-		}
-		vols = append(vols, vol)
-	}
-	return vols, lastError
-}
-
 //printParallelOutput takes the map of parallel worker results and outputs them
 // to stdout
 func printParallelOutput(m map[string]error, errCount int) error {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -186,8 +186,11 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 					return nil, errors.Wrapf(err, "error creating named volume %q", vol.Source)
 				}
 				ctr.config.Spec.Mounts[i].Source = newVol.MountPoint()
+				if err := os.Chown(ctr.config.Spec.Mounts[i].Source, ctr.RootUID(), ctr.RootGID()); err != nil {
+					return nil, errors.Wrapf(err, "cannot chown %q to %d:%d", ctr.config.Spec.Mounts[i].Source, ctr.RootUID(), ctr.RootGID())
+				}
 				if err := ctr.copyWithTarFromImage(ctr.config.Spec.Mounts[i].Destination, ctr.config.Spec.Mounts[i].Source); err != nil && !os.IsNotExist(err) {
-					return nil, errors.Wrapf(err, "Failed to copy content into new volume mount %q", vol.Source)
+					return nil, errors.Wrapf(err, "failed to copy content into new volume mount %q", vol.Source)
 				}
 				continue
 			}

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -69,6 +69,21 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("podman uidmapping and gidmapping with a volume", func() {
+		if os.Getenv("SKIP_USERNS") != "" {
+			Skip("Skip userns tests.")
+		}
+		if _, err := os.Stat("/proc/self/uid_map"); err != nil {
+			Skip("User namespaces not supported.")
+		}
+
+		session := podmanTest.Podman([]string{"run", "--uidmap=0:1:70000", "--gidmap=0:20000:70000", "-v", "my-foo-volume:/foo:Z", "busybox", "echo", "hello"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		ok, _ := session.GrepString("hello")
+		Expect(ok).To(BeTrue())
+	})
+
 	It("podman uidmapping and gidmapping --net=host", func() {
 		if os.Getenv("SKIP_USERNS") != "" {
 			Skip("Skip userns tests.")


### PR DESCRIPTION
when `--uidmap` is used, the user won't be able to access `/var/lib/containers/storage/volumes`.  Use the intermediate mount namespace, that is accessible to root in the container, for mounting the volumes inside the container.

Closes: https://github.com/containers/libpod/issues/2713
