### PR TITLE
podman: do not split --env on comma

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -264,7 +264,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"entrypoint", "",
 		"Overwrite the default ENTRYPOINT of the image",
 	)
-	createFlags.StringSliceP(
+	createFlags.StringArrayP(
 		"env", "e", []string{},
 		"Set environment variables in container",
 	)

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -41,7 +41,7 @@ func init() {
 	execCommand.SetUsageTemplate(UsageTemplate())
 	flags := execCommand.Flags()
 	flags.SetInterspersed(false)
-	flags.StringSliceVarP(&execCommand.Env, "env", "e", []string{}, "Set environment variables")
+	flags.StringArrayVarP(&execCommand.Env, "env", "e", []string{}, "Set environment variables")
 	flags.BoolVarP(&execCommand.Interfactive, "interactive", "i", false, "Not supported.  All exec commands are interactive by default")
 	flags.BoolVarP(&execCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&execCommand.Privileged, "privileged", false, "Give the process extended Linux capabilities inside the container.  The default is false")

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -499,7 +499,7 @@ func ParseCreateOpts(ctx context.Context, c *cliconfig.PodmanCommand, runtime *l
 			}
 		}
 	}
-	if err := parse.ReadKVStrings(env, c.StringSlice("env-file"), c.StringSlice("env")); err != nil {
+	if err := parse.ReadKVStrings(env, c.StringSlice("env-file"), c.StringArray("env")); err != nil {
 		return nil, errors.Wrapf(err, "unable to process environment variables")
 	}
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -152,10 +152,10 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run environment test", func() {
-		session := podmanTest.Podman([]string{"run", "--rm", "--env", "FOO=BAR", ALPINE, "printenv", "FOO"})
+		session := podmanTest.Podman([]string{"run", "--rm", "--env", "FOO=BAR,BAZ", ALPINE, "printenv", "FOO"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		match, _ := session.GrepString("BAR")
+		match, _ := session.GrepString("BAR,BAZ")
 		Expect(match).Should(BeTrue())
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--env", "PATH=/bin", ALPINE, "printenv", "PATH"})


### PR DESCRIPTION
if --env "a=b,c" is used, do not split into a=b and c=.

Closes: https://github.com/containers/libpod/issues/2712

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>