### PR TITLE
fix Bug 1688041-podman image save removes existing image

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -1152,9 +1152,6 @@ func (i *Image) Save(ctx context.Context, source, format, output string, moreTag
 		}
 	}
 	if err := i.PushImageToReference(ctx, destRef, manifestType, "", "", writer, compress, SigningOptions{}, &DockerRegistryOptions{}, additionaltags); err != nil {
-		if err2 := os.Remove(output); err2 != nil {
-			logrus.Errorf("error deleting %q: %v", output, err)
-		}
 		return errors.Wrapf(err, "unable to save %q", source)
 	}
 	defer i.newImageEvent(events.Save)


### PR DESCRIPTION
fix [Bug 1688041 - podman image save removes existing image ](https://bugzilla.redhat.com/show_bug.cgi?id=1688041)
Signed-off-by: Qi Wang <qiwan@redhat.com>