### PR TITLE
Need to pass the true paramater with --syslog in cobra

### DIFF
--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -363,7 +363,7 @@ func (c *CreateConfig) createExitCommand() []string {
 		command = append(command, []string{"--storage-driver", config.StorageConfig.GraphDriverName}...)
 	}
 	if c.Syslog {
-		command = append(command, "--syslog")
+		command = append(command, "--syslog", "true")
 	}
 	command = append(command, []string{"container", "cleanup"}...)
 


### PR DESCRIPTION
Currently cobra can not handle a boolean option without a vailue.

This change fixes an issue if you want syslog information to show up
based on the cleanup call.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>