### PR TITLE
userns: do not use an intermediate mount namespace

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -146,18 +146,12 @@ type ContainerState struct {
 	ConfigPath string `json:"configPath,omitempty"`
 	// RunDir is a per-boot directory for container content
 	RunDir string `json:"runDir,omitempty"`
-	// DestinationRunDir is where the files in RunDir will be accessible for the container.
-	// It is different than RunDir when using userNS
-	DestinationRunDir string `json:"destinationRunDir,omitempty"`
 	// Mounted indicates whether the container's storage has been mounted
 	// for use
 	Mounted bool `json:"mounted,omitempty"`
 	// Mountpoint contains the path to the container's mounted storage as given
-	// by containers/storage.  It can be different than RealMountpoint when
-	// usernamespaces are used
+	// by containers/storage.
 	Mountpoint string `json:"mountPoint,omitempty"`
-	// RealMountpoint contains the path to the container's mounted storage
-	RealMountpoint string `json:"realMountPoint,omitempty"`
 	// StartedTime is the time the container was started
 	StartedTime time.Time `json:"startedTime,omitempty"`
 	// FinishedTime is the time the container finished executing
@@ -185,10 +179,6 @@ type ContainerState struct {
 	// This maps the path the file will be mounted to in the container to
 	// the path of the file on disk outside the container
 	BindMounts map[string]string `json:"bindMounts,omitempty"`
-
-	// UserNSRoot is the directory used as root for the container when using
-	// user namespaces.
-	UserNSRoot string `json:"userNSRoot,omitempty"`
 
 	// ExtensionStageHooks holds hooks which will be executed by libpod
 	// and not delegated to the OCI runtime.

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1274,6 +1274,28 @@ func WithVolumeName(name string) VolumeCreateOption {
 	}
 }
 
+// WithVolumeUID sets the uid of the owner.
+func WithVolumeUID(uid int) VolumeCreateOption {
+	return func(volume *Volume) error {
+		if volume.valid {
+			return ErrVolumeFinalized
+		}
+		volume.config.UID = uid
+		return nil
+	}
+}
+
+// WithVolumeGID sets the gid of the owner.
+func WithVolumeGID(gid int) VolumeCreateOption {
+	return func(volume *Volume) error {
+		if volume.valid {
+			return ErrVolumeFinalized
+		}
+		volume.config.GID = gid
+		return nil
+	}
+}
+
 // WithVolumeLabels sets the labels of the volume.
 func WithVolumeLabels(labels map[string]string) VolumeCreateOption {
 	return func(volume *Volume) error {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -201,11 +201,7 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 	}
 
 	if !MountExists(ctr.config.Spec.Mounts, "/dev/shm") && ctr.config.ShmDir == "" {
-		if ctr.state.UserNSRoot == "" {
-			ctr.config.ShmDir = filepath.Join(ctr.bundlePath(), "shm")
-		} else {
-			ctr.config.ShmDir = filepath.Join(ctr.state.UserNSRoot, "shm")
-		}
+		ctr.config.ShmDir = filepath.Join(ctr.bundlePath(), "shm")
 		if err := os.MkdirAll(ctr.config.ShmDir, 0700); err != nil {
 			if !os.IsExist(err) {
 				return nil, errors.Wrapf(err, "unable to create shm %q dir", ctr.config.ShmDir)

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -182,14 +182,11 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 		if vol.Source[0] != '/' && isNamedVolume(vol.Source) {
 			volInfo, err := r.state.Volume(vol.Source)
 			if err != nil {
-				newVol, err := r.newVolume(ctx, WithVolumeName(vol.Source), withSetCtrSpecific())
+				newVol, err := r.newVolume(ctx, WithVolumeName(vol.Source), withSetCtrSpecific(), WithVolumeUID(ctr.RootUID()), WithVolumeGID(ctr.RootGID()))
 				if err != nil {
 					return nil, errors.Wrapf(err, "error creating named volume %q", vol.Source)
 				}
 				ctr.config.Spec.Mounts[i].Source = newVol.MountPoint()
-				if err := os.Chown(ctr.config.Spec.Mounts[i].Source, ctr.RootUID(), ctr.RootGID()); err != nil {
-					return nil, errors.Wrapf(err, "cannot chown %q to %d:%d", ctr.config.Spec.Mounts[i].Source, ctr.RootUID(), ctr.RootGID())
-				}
 				if err := ctr.copyWithTarFromImage(ctr.config.Spec.Mounts[i].Destination, ctr.config.Spec.Mounts[i].Source); err != nil && !os.IsNotExist(err) {
 					return nil, errors.Wrapf(err, "failed to copy content into new volume mount %q", vol.Source)
 				}

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -21,6 +21,8 @@ type VolumeConfig struct {
 	Options       map[string]string `json:"options"`
 	Scope         string            `json:"scope"`
 	IsCtrSpecific bool              `json:"ctrSpecific"`
+	UID           int               `json:"uid"`
+	GID           int               `json:"gid"`
 }
 
 // Name retrieves the volume's name

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# Tests #2730 - regular users are not able to read/write container storage
+#
+
+load helpers
+
+@test "podman container storage is not accessible by unprivileged users" {
+    skip_if_rootless "test meaningless without suid"
+
+    run_podman run --name c_uidmap   --uidmap 0:10000:10000 $IMAGE true
+    run_podman run --name c_uidmap_v --uidmap 0:10000:10000 -v foo:/foo $IMAGE true
+
+    run_podman run --name c_mount $IMAGE \
+               sh -c "echo hi > /myfile;mkdir -p /mydir/mysubdir; chmod 777 /myfile /mydir /mydir/mysubdir"
+
+    run_podman mount c_mount
+    mount_path=$output
+
+    # Do all the work from within a test script. Since we'll be invoking it
+    # as a user, the parent directory must be world-readable.
+    test_script=$PODMAN_TMPDIR/fail-if-writable
+    cat >$test_script <<"EOF"
+#!/bin/sh
+
+path="$1"
+
+die() {
+    echo "#/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"  >&2
+    echo "#| FAIL: $*"                                           >&2
+    echo "#\\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" >&2
+
+    exit 1
+}
+
+parent=$(dirname "$path")
+if chmod +w $parent; then
+    die "Able to chmod $parent"
+fi
+if chmod +w "$path"; then
+    die "Able to chmod $path"
+fi
+
+if [ -d "$path" ]; then
+    if ls "$path" >/dev/null; then
+        die "Able to run 'ls $path' without error"
+    fi
+    if echo hi >"$path"/test; then
+        die "Able to write to file under $path"
+    fi
+else
+    # Plain file
+    if cat "$path" >/dev/null; then
+        die "Able to read $path"
+    fi
+    if echo hi >"$path"; then
+        die "Able to write to $path"
+    fi
+fi
+
+exit 0
+EOF
+    chmod 755 $PODMAN_TMPDIR $test_script
+
+    # get podman image and container storage directories
+    run_podman info --format '{{.store.GraphRoot}}'
+    GRAPH_ROOT="$output"
+    run_podman info --format '{{.store.RunRoot}}'
+    RUN_ROOT="$output"
+
+    # The main test: find all world-writable files or directories underneath
+    # container storage, run the test script as a nonroot user, and try to
+    # access each path.
+    find $GRAPH_ROOT $RUN_ROOT \! -type l -perm -o+w -print | while read i; do
+        dprint " o+w: $i"
+
+        # use chroot because su fails if uid/gid don't exist or have no shell
+        # For development: test all this by removing the "--userspec x:x"
+        chroot --userspec 1000:1000 / $test_script "$i"
+    done
+
+    # Done. Clean up.
+    rm -f $test_script
+
+    run_podman umount c_mount
+    run_podman rm c_mount
+
+    run_podman rm c_uidmap c_uidmap_v
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
We have an issue in the current implementation where the cleanup
process is not able to umount the storage as it is running in a
separate namespace.

Simplify the implementation for user namespaces by not using an
intermediate mount namespace.  For doing it, we need to relax the
permissions on the parent directories and allow browsing
them. Containers that are running without a user namespace, will still
maintain mode 0700 on their directory.

Alternative for: https://github.com/containers/libpod/pull/2728

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>