### PR TITLE
Add --dns=none

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -389,6 +389,10 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"Connect a container to a network",
 	)
 	createFlags.Bool(
+		"no-hosts", false,
+		"Do not create /etc/hosts within the container, instead use the version from the image",
+	)
+	createFlags.Bool(
 		"oom-kill-disable", false,
 		"Disable OOM Killer",
 	)

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -357,10 +357,8 @@ func ParseCreateOpts(ctx context.Context, c *cliconfig.PodmanCommand, runtime *l
 		return nil, errors.Errorf("--cpu-quota and --cpus cannot be set together")
 	}
 
-	if c.Flag("no-hosts").Changed && c.Flag("add-host").Changed {
-		if c.Bool("no-hosts") {
-			return nil, errors.Errorf("--no-hosts and --add-host cannot be set together")
-		}
+	if c.Bool("no-hosts") && c.Flag("add-host").Changed {
+		return nil, errors.Errorf("--no-hosts and --add-host cannot be set together")
 	}
 
 	// EXPOSED PORTS

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -357,6 +357,12 @@ func ParseCreateOpts(ctx context.Context, c *cliconfig.PodmanCommand, runtime *l
 		return nil, errors.Errorf("--cpu-quota and --cpus cannot be set together")
 	}
 
+	if c.Flag("no-hosts").Changed && c.Flag("add-host").Changed {
+		if c.Bool("no-hosts") {
+			return nil, errors.Errorf("--no-hosts and --add-host cannot be set together")
+		}
+	}
+
 	// EXPOSED PORTS
 	var portBindings map[nat.Port][]nat.PortBinding
 	if data != nil {
@@ -646,6 +652,7 @@ func ParseCreateOpts(ctx context.Context, c *cliconfig.PodmanCommand, runtime *l
 		GroupAdd:    c.StringSlice("group-add"),
 		Hostname:    c.String("hostname"),
 		HostAdd:     c.StringSlice("add-host"),
+		NoHosts:     c.Bool("no-hosts"),
 		IDMappings:  idmappings,
 		Image:       imageName,
 		ImageID:     imageID,

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1727,6 +1727,7 @@ _podman_container_run() {
 		--memory-reservation
 		--name
 		--network
+		--no-hosts
 		--oom-score-adj
 		--pid
 		--pids-limit

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -204,6 +204,9 @@ configuration passed to the container. Typically this is necessary when the
 host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this
 is the case the **--dns** flags is necessary for every run.
 
+The special sigil **none** can be specified to disable creation of **/etc/resolv.conf** in the container by Podman.
+The **/etc/resolv.conf** file in the image will be used without changes.
+
 **--dns-option**=[]
 
 Set custom DNS options
@@ -456,6 +459,13 @@ Set the Network mode for the container
 **--network-alias**=[]
 
 Not implemented
+
+**--no-hosts**=*true*|*false*
+
+Do not create /etc/hosts for the container.
+By default, Podman will manage /etc/hosts, adding the container's own IP address and any hosts from **--add-host**.
+**--no-hosts** disables this, and the image's **/etc/host** will be preserved unmodified.
+This conflicts with **--add-host**.
 
 **--oom-kill-disable**=*true*|*false*
 

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -204,7 +204,7 @@ configuration passed to the container. Typically this is necessary when the
 host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this
 is the case the **--dns** flags is necessary for every run.
 
-The special sigil **none** can be specified to disable creation of **/etc/resolv.conf** in the container by Podman.
+The special value **none** can be specified to disable creation of **/etc/resolv.conf** in the container by Podman.
 The **/etc/resolv.conf** file in the image will be used without changes.
 
 **--dns-option**=[]
@@ -465,7 +465,7 @@ Not implemented
 Do not create /etc/hosts for the container.
 By default, Podman will manage /etc/hosts, adding the container's own IP address and any hosts from **--add-host**.
 **--no-hosts** disables this, and the image's **/etc/host** will be preserved unmodified.
-This conflicts with **--add-host**.
+This option conflicts with **--add-host**.
 
 **--oom-kill-disable**=*true*|*false*
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -210,7 +210,7 @@ configuration passed to the container. Typically this is necessary when the
 host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this
 is the case the **--dns** flags is necessary for every run.
 
-The special sigil **none** can be specified to disable creation of **/etc/resolv.conf** in the container by Podman.
+The special value **none** can be specified to disable creation of **/etc/resolv.conf** in the container by Podman.
 The **/etc/resolv.conf** file in the image will be used without changes.
 
 **--dns-option**=[]
@@ -449,7 +449,7 @@ Not implemented
 Do not create /etc/hosts for the container.
 By default, Podman will manage /etc/hosts, adding the container's own IP address and any hosts from **--add-host**.
 **--no-hosts** disables this, and the image's **/etc/host** will be preserved unmodified.
-This conflicts with **--add-host**.
+This option conflicts with **--add-host**.
 
 **--oom-kill-disable**=*true*|*false*
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -210,6 +210,9 @@ configuration passed to the container. Typically this is necessary when the
 host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this
 is the case the **--dns** flags is necessary for every run.
 
+The special sigil **none** can be specified to disable creation of **/etc/resolv.conf** in the container by Podman.
+The **/etc/resolv.conf** file in the image will be used without changes.
+
 **--dns-option**=[]
 
 Set custom DNS options
@@ -440,6 +443,13 @@ Set the Network mode for the container:
 **--network-alias**=[]
 
 Not implemented
+
+**--no-hosts**=*true*|*false*
+
+Do not create /etc/hosts for the container.
+By default, Podman will manage /etc/hosts, adding the container's own IP address and any hosts from **--add-host**.
+**--no-hosts** disables this, and the image's **/etc/host** will be preserved unmodified.
+This conflicts with **--add-host**.
 
 **--oom-kill-disable**=*true*|*false*
 

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -293,10 +293,10 @@ type ContainerConfig struct {
 	// namespace
 	// These are not used unless CreateNetNS is true
 	PortMappings []ocicni.PortMapping `json:"portMappings,omitempty"`
-	// NoCreateResolvConf indicates that resolv.conf should not be
+	// UseImageResolvConf indicates that resolv.conf should not be
 	// bind-mounted inside the container.
 	// Conflicts with DNSServer, DNSSearch, DNSOption.
-	NoCreateResolvConf bool
+	UseImageResolvConf bool
 	// DNS servers to use in container resolv.conf
 	// Will override servers in host resolv if set
 	DNSServer []net.IP `json:"dnsServer,omitempty"`
@@ -306,10 +306,10 @@ type ContainerConfig struct {
 	// DNS options to be set in container resolv.conf
 	// With override options in host resolv if set
 	DNSOption []string `json:"dnsOption,omitempty"`
-	// NoCreateHosts indicates that /etc/hosts should not be
+	// UseImageHosts indicates that /etc/hosts should not be
 	// bind-mounted inside the container.
 	// Conflicts with HostAdd.
-	NoCreateHosts bool
+	UseImageHosts bool
 	// Hosts to add in container
 	// Will be appended to host's host file
 	HostAdd []string `json:"hostsAdd,omitempty"`

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -293,6 +293,10 @@ type ContainerConfig struct {
 	// namespace
 	// These are not used unless CreateNetNS is true
 	PortMappings []ocicni.PortMapping `json:"portMappings,omitempty"`
+	// NoCreateResolvConf indicates that resolv.conf should not be
+	// bind-mounted inside the container.
+	// Conflicts with DNSServer, DNSSearch, DNSOption.
+	NoCreateResolvConf bool
 	// DNS servers to use in container resolv.conf
 	// Will override servers in host resolv if set
 	DNSServer []net.IP `json:"dnsServer,omitempty"`
@@ -302,6 +306,10 @@ type ContainerConfig struct {
 	// DNS options to be set in container resolv.conf
 	// With override options in host resolv if set
 	DNSOption []string `json:"dnsOption,omitempty"`
+	// NoCreateHosts indicates that /etc/hosts should not be
+	// bind-mounted inside the container.
+	// Conflicts with HostAdd.
+	NoCreateHosts bool
 	// Hosts to add in container
 	// Will be appended to host's host file
 	HostAdd []string `json:"hostsAdd,omitempty"`

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -703,7 +703,7 @@ func (c *Container) makeBindMounts() error {
 			}
 		}
 
-		if c.config.NetNsCtr != "" && (!c.config.NoCreateHosts || !c.config.NoCreateResolvConf) {
+		if c.config.NetNsCtr != "" && (!c.config.UseImageResolvConf || !c.config.UseImageHosts) {
 			// We share a net namespace.
 			// We want /etc/resolv.conf and /etc/hosts from the
 			// other container. Unless we're not creating both of
@@ -719,7 +719,7 @@ func (c *Container) makeBindMounts() error {
 				return errors.Wrapf(err, "error fetching bind mounts from dependency %s of container %s", depCtr.ID(), c.ID())
 			}
 
-			if !c.config.NoCreateResolvConf {
+			if !c.config.UseImageResolvConf {
 				// The other container may not have a resolv.conf or /etc/hosts
 				// If it doesn't, don't copy them
 				resolvPath, exists := bindMounts["/etc/resolv.conf"]
@@ -728,7 +728,7 @@ func (c *Container) makeBindMounts() error {
 				}
 			}
 
-			if !c.config.NoCreateHosts {
+			if !c.config.UseImageHosts {
 				// check if dependency container has an /etc/hosts file
 				hostsPath, exists := bindMounts["/etc/hosts"]
 				if !exists {
@@ -751,7 +751,7 @@ func (c *Container) makeBindMounts() error {
 				c.state.BindMounts["/etc/hosts"] = hostsPath
 			}
 		} else {
-			if !c.config.NoCreateResolvConf {
+			if !c.config.UseImageResolvConf {
 				newResolv, err := c.generateResolvConf()
 				if err != nil {
 					return errors.Wrapf(err, "error creating resolv.conf for container %s", c.ID())
@@ -759,7 +759,7 @@ func (c *Container) makeBindMounts() error {
 				c.state.BindMounts["/etc/resolv.conf"] = newResolv
 			}
 
-			if !c.config.NoCreateHosts {
+			if !c.config.UseImageHosts {
 				newHosts, err := c.generateHosts("/etc/hosts")
 				if err != nil {
 					return errors.Wrapf(err, "error creating hosts file for container %s", c.ID())

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -997,7 +997,7 @@ func WithDNSSearch(searchDomains []string) CtrCreateOption {
 		if ctr.valid {
 			return ErrCtrFinalized
 		}
-		if ctr.config.NoCreateResolvConf {
+		if ctr.config.UseImageResolvConf {
 			return errors.Wrapf(ErrInvalidArg, "cannot add DNS search domains if container will not create /etc/resolv.conf")
 		}
 		ctr.config.DNSSearch = searchDomains
@@ -1011,7 +1011,7 @@ func WithDNS(dnsServers []string) CtrCreateOption {
 		if ctr.valid {
 			return ErrCtrFinalized
 		}
-		if ctr.config.NoCreateResolvConf {
+		if ctr.config.UseImageResolvConf {
 			return errors.Wrapf(ErrInvalidArg, "cannot add DNS servers if container will not create /etc/resolv.conf")
 		}
 		var dns []net.IP
@@ -1033,7 +1033,7 @@ func WithDNSOption(dnsOptions []string) CtrCreateOption {
 		if ctr.valid {
 			return ErrCtrFinalized
 		}
-		if ctr.config.NoCreateResolvConf {
+		if ctr.config.UseImageResolvConf {
 			return errors.Wrapf(ErrInvalidArg, "cannot add DNS options if container will not create /etc/resolv.conf")
 		}
 		ctr.config.DNSOption = dnsOptions
@@ -1048,7 +1048,7 @@ func WithHosts(hosts []string) CtrCreateOption {
 			return ErrCtrFinalized
 		}
 
-		if ctr.config.NoCreateHosts {
+		if ctr.config.UseImageHosts {
 			return errors.Wrapf(ErrInvalidArg, "cannot add hosts if container will not create /etc/hosts")
 		}
 
@@ -1198,9 +1198,9 @@ func WithCtrNamespace(ns string) CtrCreateOption {
 	}
 }
 
-// WithNoCreateResolvConf tells the container not to bind-mount resolv.conf in.
+// WithUseImageResolvConf tells the container not to bind-mount resolv.conf in.
 // This conflicts with other DNS-related options.
-func WithNoCreateResolvConf() CtrCreateOption {
+func WithUseImageResolvConf() CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
 			return ErrCtrFinalized
@@ -1212,15 +1212,15 @@ func WithNoCreateResolvConf() CtrCreateOption {
 			return errors.Wrapf(ErrInvalidArg, "not creating resolv.conf conflicts with DNS options")
 		}
 
-		ctr.config.NoCreateResolvConf = true
+		ctr.config.UseImageResolvConf = true
 
 		return nil
 	}
 }
 
-// WithNoCreateHosts tells the container not to bind-mount /etc/hosts in.
+// WithUseImageHosts tells the container not to bind-mount /etc/hosts in.
 // This conflicts with WithHosts().
-func WithNoCreateHosts() CtrCreateOption {
+func WithUseImageHosts() CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
 			return ErrCtrFinalized
@@ -1230,7 +1230,7 @@ func WithNoCreateHosts() CtrCreateOption {
 			return errors.Wrapf(ErrInvalidArg, "not creating /etc/hosts conflicts with adding to the hosts file")
 		}
 
-		ctr.config.NoCreateHosts = true
+		ctr.config.UseImageHosts = true
 
 		return nil
 	}

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -505,7 +505,11 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime, pod *l
 		options = append(options, libpod.WithDNSSearch(c.DNSSearch))
 	}
 	if len(c.DNSServers) > 0 {
-		options = append(options, libpod.WithDNS(c.DNSServers))
+		if len(c.DNSServers) == 1 && c.DNSServers[0] == "none" {
+			options = append(options, libpod.WithNoCreateResolvConf())
+		} else {
+			options = append(options, libpod.WithDNS(c.DNSServers))
+		}
 	}
 	if len(c.DNSOpt) > 0 {
 		options = append(options, libpod.WithDNSOption(c.DNSOpt))

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -88,6 +88,7 @@ type CreateConfig struct {
 	ExposedPorts       map[nat.Port]struct{}
 	GroupAdd           []string // group-add
 	HealthCheck        *manifest.Schema2HealthConfig
+	NoHosts            bool
 	HostAdd            []string //add-host
 	Hostname           string   //hostname
 	Image              string
@@ -514,7 +515,10 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime, pod *l
 	if len(c.DNSOpt) > 0 {
 		options = append(options, libpod.WithDNSOption(c.DNSOpt))
 	}
-	if len(c.HostAdd) > 0 {
+	if c.NoHosts {
+		options = append(options, libpod.WithNoCreateHosts())
+	}
+	if len(c.HostAdd) > 0 && !c.NoHosts {
 		options = append(options, libpod.WithHosts(c.HostAdd))
 	}
 	logPath := getLoggingPath(c.LogDriverOpt)

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -506,8 +506,8 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime, pod *l
 		options = append(options, libpod.WithDNSSearch(c.DNSSearch))
 	}
 	if len(c.DNSServers) > 0 {
-		if len(c.DNSServers) == 1 && c.DNSServers[0] == "none" {
-			options = append(options, libpod.WithNoCreateResolvConf())
+		if len(c.DNSServers) == 1 && strings.ToLower(c.DNSServers[0]) == "none" {
+			options = append(options, libpod.WithUseImageResolvConf())
 		} else {
 			options = append(options, libpod.WithDNS(c.DNSServers))
 		}
@@ -516,7 +516,7 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime, pod *l
 		options = append(options, libpod.WithDNSOption(c.DNSOpt))
 	}
 	if c.NoHosts {
-		options = append(options, libpod.WithNoCreateHosts())
+		options = append(options, libpod.WithUseImageHosts())
 	}
 	if len(c.HostAdd) > 0 && !c.NoHosts {
 		options = append(options, libpod.WithHosts(c.HostAdd))

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -749,13 +749,19 @@ USER mail`
 
 	It("podman run with bad healthcheck timeout", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--healthcheck-cmd", "foo", "--healthcheck-timeout", "0s", ALPINE, "top"})
-		session.Wait()
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).ToNot(Equal(0))
 	})
 
 	It("podman run with bad healthcheck start-period", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--healthcheck-cmd", "foo", "--healthcheck-start-period", "-1s", ALPINE, "top"})
-		session.Wait()
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).ToNot(Equal(0))
+	})
+
+	It("podman run with --add-host and --no-hosts fails", func() {
+		session := podmanTest.Podman([]string{"run", "-dt", "--add-host", "test1:127.0.0.1", "--no-hosts", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).ToNot(Equal(0))
 	})
 })


### PR DESCRIPTION
Fix for #2744 

This adds support for --dns=none, which specifies that we should not bind-mount in `/etc/resolv.conf`.

Still to be added: similar flag for disabling addition of `/etc/hosts` (can't reuse the existing flag). Also needs tests.