### PR TITLE
docs/podman-pod-create.1.md: add example with port mapping

### DIFF
--- a/docs/podman-pod-create.1.md
+++ b/docs/podman-pod-create.1.md
@@ -81,6 +81,8 @@ $ podman pod create --name test
 $ podman pod create --infra=false
 
 $ podman pod create --infra-command /top
+
+$ podman pod create --publish 8443:443
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
Given that you can't change ports in a pod after creation[1], I thought it might be nice to include an example of how to set up the port mapping in the manpage.

Should the manpage mention you can't change ports after creation?


[1] https://developers.redhat.com/blog/2019/01/15/podman-managing-containers-pods/
"Most of the attributes that make up the Pod are actually assigned to the “infra” container.  Port bindings, cgroup-parent values, and kernel namespaces are all assigned to the “infra” container. This is critical to understand, because once the pod is created these attributes are assigned to the “infra” container and cannot be changed. For example, if you create a pod and then later decide you want to add a container that binds new ports, Podman will not be able to do this.  You would need to recreate the pod with the additional port bindings before adding the new container."