### PR TITLE
Add three test cases for podman attach test

### DIFF
--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -4,6 +4,8 @@ package integration
 
 import (
 	"os"
+	"syscall"
+	"time"
 
 	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
@@ -72,5 +74,45 @@ var _ = Describe("Podman attach", func() {
 		results := podmanTest.Podman([]string{"attach", "test1", "test2"})
 		results.WaitWithDefaultTimeout()
 		Expect(results.ExitCode()).To(Equal(125))
+	})
+
+	It("podman attach to a running container", func() {
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "test", ALPINE, "/bin/sh", "-c", "while true; do echo test; sleep 1; done"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		results := podmanTest.Podman([]string{"attach", "test"})
+		time.Sleep(2 * time.Second)
+		results.Signal(syscall.SIGTSTP)
+		Expect(results.OutputToString()).To(ContainSubstring("test"))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+	})
+	It("podman attach to the latest container", func() {
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "test1", ALPINE, "/bin/sh", "-c", "while true; do echo test1; sleep 1; done"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"run", "-d", "--name", "test2", ALPINE, "/bin/sh", "-c", "while true; do echo test2; sleep 1; done"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		results := podmanTest.Podman([]string{"attach", "-l"})
+		time.Sleep(2 * time.Second)
+		results.Signal(syscall.SIGTSTP)
+		Expect(results.OutputToString()).To(ContainSubstring("test2"))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(2))
+	})
+
+	It("podman attach to a container with --sig-proxy set to false", func() {
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "test", ALPINE, "/bin/sh", "-c", "while true; do echo test; sleep 1; done"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		results := podmanTest.Podman([]string{"attach", "--sig-proxy=false", "test"})
+		time.Sleep(2 * time.Second)
+		results.Signal(syscall.SIGTERM)
+		results.WaitWithDefaultTimeout()
+		Expect(results.OutputToString()).To(ContainSubstring("test"))
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 	})
 })


### PR DESCRIPTION
Add following test cases for podman attach test:
1. podman attach to a running container
2. podman attach to the latest container
3. podman attach to a container with --sig-proxy set to false
