### PR TITLE
fix bug `system df` add a space to the output

### DIFF
--- a/cmd/podman/system_df.go
+++ b/cmd/podman/system_df.go
@@ -84,6 +84,9 @@ type volumeVerboseDiskUsage struct {
 }
 
 const systemDfDefaultFormat string = "table {{.Type}}\t{{.Total}}\t{{.Active}}\t{{.Size}}\t{{.Reclaimable}}"
+const imageVerboseFormat string = "table {{.Repository}}\t{{.Tag}}\t{{.ImageID}}\t{{.Created}}\t{{.Size}}\t{{.SharedSize}}\t{{.UniqueSize}}\t{{.Containers}}"
+const containerVerboseFormat string = "table {{.ContainerID}}\t{{.Image}}\t{{.Command}}\t{{.LocalVolumes}}\t{{.Size}}\t{{.Created}}\t{{.Status}}\t{{.Names}}"
+const volumeVerboseFormat string = "table {{.VolumeName}}\t{{.Links}}\t{{.Size}}"
 
 func init() {
 	dfSystemCommand.Command = _dfSystemCommand
@@ -472,7 +475,7 @@ func getImageVerboseDiskUsage(ctx context.Context, images []*image.Image, images
 			Repository: repo,
 			Tag:        tag,
 			ImageID:    shortID(img.ID()),
-			Created:    units.HumanDuration(time.Since((img.Created().Local()))) + " ago",
+			Created:    fmt.Sprintf("%s ago", units.HumanDuration(time.Since((img.Created().Local())))),
 			Size:       units.HumanSizeWithPrecision(float64(*size), 3),
 			SharedSize: units.HumanSizeWithPrecision(float64(*size-imgUniqueSizeMap[img.ID()]), 3),
 			UniqueSize: units.HumanSizeWithPrecision(float64(imgUniqueSizeMap[img.ID()]), 3),
@@ -501,7 +504,7 @@ func getContainerVerboseDiskUsage(containers []*libpod.Container) (containersVer
 			Command:      strings.Join(ctr.Command(), " "),
 			LocalVolumes: len(ctr.UserVolumes()),
 			Size:         units.HumanSizeWithPrecision(float64(size), 3),
-			Created:      units.HumanDuration(time.Since(ctr.CreatedTime().Local())) + "ago",
+			Created:      fmt.Sprintf("%s ago", units.HumanDuration(time.Since(ctr.CreatedTime().Local()))),
 			Status:       state.String(),
 			Names:        ctr.Name(),
 		}
@@ -547,7 +550,7 @@ func imagesVerboseOutput(ctx context.Context, metaData dfMetaData) error {
 		return errors.Wrapf(err, "error getting verbose output of images")
 	}
 	os.Stderr.WriteString("Images space usage:\n\n")
-	out := formats.StdoutTemplateArray{Output: systemDfImageVerboseDiskUsageToGeneric(imagesVerboseDiskUsage), Template: "table {{.Repository}}\t{{.Tag}}\t{{.ImageID}}\t{{.Created}}\t{{.Size}}\t{{.SharedSize}}\t{{.UniqueSize}}\t{{.Containers}}", Fields: imageVerboseHeader}
+	out := formats.StdoutTemplateArray{Output: systemDfImageVerboseDiskUsageToGeneric(imagesVerboseDiskUsage), Template: imageVerboseFormat, Fields: imageVerboseHeader}
 	formats.Writer(out).Out()
 	return nil
 }
@@ -568,7 +571,7 @@ func containersVerboseOutput(ctx context.Context, metaData dfMetaData) error {
 		return errors.Wrapf(err, "error getting verbose output of containers")
 	}
 	os.Stderr.WriteString("\nContainers space usage:\n\n")
-	out := formats.StdoutTemplateArray{Output: systemDfContainerVerboseDiskUsageToGeneric(containersVerboseDiskUsage), Template: "table {{.ContainerID}}\t{{.Image}}\t{{.Command}}\t{{.LocalVolumes}}\t{{.Size}}\t{{.Created}}\t{{.Status}}\t{{.Names}}", Fields: containerVerboseHeader}
+	out := formats.StdoutTemplateArray{Output: systemDfContainerVerboseDiskUsageToGeneric(containersVerboseDiskUsage), Template: containerVerboseFormat, Fields: containerVerboseHeader}
 	formats.Writer(out).Out()
 	return nil
 }
@@ -584,7 +587,7 @@ func volumesVerboseOutput(ctx context.Context, metaData dfMetaData) error {
 		return errors.Wrapf(err, "error getting verbose ouput of volumes")
 	}
 	os.Stderr.WriteString("\nLocal Volumes space usage:\n\n")
-	out := formats.StdoutTemplateArray{Output: systemDfVolumeVerboseDiskUsageToGeneric(volumesVerboseDiskUsage), Template: "table {{.VolumeName}}\t{{.Links}}\t{{.Size}}", Fields: volumeVerboseHeader}
+	out := formats.StdoutTemplateArray{Output: systemDfVolumeVerboseDiskUsageToGeneric(volumesVerboseDiskUsage), Template: volumeVerboseFormat, Fields: volumeVerboseHeader}
 	formats.Writer(out).Out()
 	return nil
 }

--- a/docs/podman-system-df.1.md
+++ b/docs/podman-system-df.1.md
@@ -33,12 +33,12 @@ docker.io/library/alpine   latest   5cb3aa00f899   2 weeks ago   5.79MB   0B    
 
 Containers space usage:
 
-CONTAINER ID    IMAGE   COMMAND       LOCAL VOLUMES   SIZE     CREATED            STATUS       NAMES
-073f7e62812d    5cb3    sleep 100     1               0B       About an hourago   exited       zen_joliot
-3f19f5bba242    5cb3    sleep 100     0               5.52kB   4 hoursago         exited       pedantic_archimedes
-8cd89bf645cc    5cb3    ls foodir     0               58B      2 hoursago         configured   agitated_hamilton
-a1d948a4b61d    5cb3    ls foodir     0               12B      2 hoursago         exited       laughing_wing
-eafe3e3c5bb3    5cb3    sleep 10000   0               72B      2 hoursago         running      priceless_liskov
+CONTAINER ID    IMAGE   COMMAND       LOCAL VOLUMES   SIZE     CREATED        STATUS       NAMES
+073f7e62812d    5cb3    sleep 100     1               0B       20 hours ago   exited       zen_joliot
+3f19f5bba242    5cb3    sleep 100     0               5.52kB   22 hours ago   exited       pedantic_archimedes
+8cd89bf645cc    5cb3    ls foodir     0               58B      21 hours ago   configured   agitated_hamilton
+a1d948a4b61d    5cb3    ls foodir     0               12B      21 hours ago   exited       laughing_wing
+eafe3e3c5bb3    5cb3    sleep 10000   0               72B      21 hours ago   exited       priceless_liskov
 
 Local Volumes space usage:
 


### PR DESCRIPTION
fix typo in `Containers space usage:` of `podman system df -v`, add a space for created time. Change format strings to const.
Signed-off-by: Qi Wang <qiwan@redhat.com>