### PR TITLE
Rework named volumes in DB

### DIFF
--- a/docs/podman-volume-rm.1.md
+++ b/docs/podman-volume-rm.1.md
@@ -21,7 +21,8 @@ Remove all volumes.
 
 **-f**, **--force**=""
 
-Remove a volume by force, even if it is being used by a container
+Remove a volume by force.
+If it is being used by containers, the containers will be removed first.
 
 **--help**
 

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -371,7 +371,7 @@ type ContainerConfig struct {
 }
 
 // ContainerNamedVolume is a named volume that will be mounted into the
-// container.
+// container. Each named volume is a libpod Volume present in the state.
 type ContainerNamedVolume struct {
 	// Name is the name of the volume to mount in.
 	// Must resolve to a valid volume present in this Podman.
@@ -500,6 +500,22 @@ func (c *Container) ShmSize() int64 {
 // StaticDir returns the directory used to store persistent container files
 func (c *Container) StaticDir() string {
 	return c.config.StaticDir
+}
+
+// NamedVolumes returns the container's named volumes.
+// The name of each is guaranteed to point to a valid libpod Volume present in
+// the state.
+func (c *Container) NamedVolumes() []*ContainerNamedVolume {
+	volumes := []*ContainerNamedVolume{}
+	for _, vol := range c.config.NamedVolumes {
+		newVol := new(ContainerNamedVolume)
+		newVol.Name = vol.Name
+		newVol.Dest = vol.Dest
+		newVol.Options = vol.Options
+		volumes = append(volumes, newVol)
+	}
+
+	return volumes
 }
 
 // Privileged returns whether the container is privileged

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -356,9 +356,6 @@ type ContainerConfig struct {
 	// ExitCommand is the container's exit command.
 	// This Command will be executed when the container exits
 	ExitCommand []string `json:"exitCommand,omitempty"`
-	// LocalVolumes are the built-in volumes we get from the --volumes-from flag
-	// It picks up the built-in volumes of the container used by --volumes-from
-	LocalVolumes []spec.Mount
 	// IsInfra is a bool indicating whether this container is an infra container used for
 	// sharing kernel namespaces in a pod
 	IsInfra bool `json:"pause"`

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -234,6 +234,8 @@ type ContainerConfig struct {
 	// These include the SHM mount.
 	// These must be unmounted before the container's rootfs is unmounted.
 	Mounts []string `json:"mounts,omitempty"`
+	// NamedVolumes lists the named volumes to mount into the container.
+	NamedVolumes []*ContainerNamedVolume `json:"namedVolumes,omitempty"`
 
 	// Security Config
 
@@ -366,6 +368,18 @@ type ContainerConfig struct {
 
 	// HealtchCheckConfig has the health check command and related timings
 	HealthCheckConfig *manifest.Schema2HealthConfig `json:"healthcheck"`
+}
+
+// ContainerNamedVolume is a named volume that will be mounted into the
+// container.
+type ContainerNamedVolume struct {
+	// Name is the name of the volume to mount in.
+	// Must resolve to a valid volume present in this Podman.
+	Name string `json:"volumeName"`
+	// Dest is the mount's destination
+	Dest string `json:"dest"`
+	// Options are fstab style mount options
+	Options []string `json:"options,omitempty"`
 }
 
 // ContainerStatus returns a string representation for users

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1403,22 +1403,6 @@ func getExcludedCGroups() (excludes []string) {
 	return
 }
 
-// namedVolumes returns named volumes for the container
-func (c *Container) namedVolumes() ([]string, error) {
-	var volumes []string
-	for _, vol := range c.config.Spec.Mounts {
-		if strings.HasPrefix(vol.Source, c.runtime.config.VolumePath) {
-			volume := strings.TrimPrefix(vol.Source, c.runtime.config.VolumePath+"/")
-			split := strings.Split(volume, "/")
-			volume = split[0]
-			if _, err := c.runtime.state.Volume(volume); err == nil {
-				volumes = append(volumes, volume)
-			}
-		}
-	}
-	return volumes, nil
-}
-
 // this should be from chrootarchive.
 func (c *Container) copyWithTarFromImage(src, dest string) error {
 	mountpoint, err := c.mount()

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/ocicni/pkg/ocicni"
-	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
 
@@ -1105,24 +1104,6 @@ func WithUserVolumes(volumes []string) CtrCreateOption {
 		ctr.config.UserVolumes = make([]string, 0, len(volumes))
 		for _, vol := range volumes {
 			ctr.config.UserVolumes = append(ctr.config.UserVolumes, vol)
-		}
-
-		return nil
-	}
-}
-
-// WithLocalVolumes sets the built-in volumes of the container retrieved
-// from a container passed in to the --volumes-from flag.
-// This stores the built-in volume information in the Config so we can
-// add them when creating the container.
-func WithLocalVolumes(volumes []spec.Mount) CtrCreateOption {
-	return func(ctr *Container) error {
-		if ctr.valid {
-			return ErrCtrFinalized
-		}
-
-		if volumes != nil {
-			ctr.config.LocalVolumes = append(ctr.config.LocalVolumes, volumes...)
 		}
 
 		return nil

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1265,14 +1265,11 @@ func WithNamedVolumes(volumes []*ContainerNamedVolume) CtrCreateOption {
 		destinations := make(map[string]bool)
 
 		for _, vol := range volumes {
-			// First check if libpod has the volumes
-			_, err := ctr.runtime.GetVolume(vol.Name)
-			if err != nil {
-				return errors.Wrapf(err, "error retrieving volume %s to add to container", vol.Name)
-			}
+			// Don't check if they already exist.
+			// If they don't we will automatically create them.
 
 			if _, ok := destinations[vol.Dest]; ok {
-				return errors.Wrapf(err, "two volumes found with destination %s", vol.Dest)
+				return errors.Wrapf(ErrInvalidArg, "two volumes found with destination %s", vol.Dest)
 			}
 			destinations[vol.Dest] = true
 
@@ -1302,28 +1299,6 @@ func WithVolumeName(name string) VolumeCreateOption {
 		}
 		volume.config.Name = name
 
-		return nil
-	}
-}
-
-// WithVolumeUID sets the uid of the owner.
-func WithVolumeUID(uid int) VolumeCreateOption {
-	return func(volume *Volume) error {
-		if volume.valid {
-			return ErrVolumeFinalized
-		}
-		volume.config.UID = uid
-		return nil
-	}
-}
-
-// WithVolumeGID sets the gid of the owner.
-func WithVolumeGID(gid int) VolumeCreateOption {
-	return func(volume *Volume) error {
-		if volume.valid {
-			return ErrVolumeFinalized
-		}
-		volume.config.GID = gid
 		return nil
 	}
 }
@@ -1368,6 +1343,32 @@ func WithVolumeOptions(options map[string]string) VolumeCreateOption {
 		for key, value := range options {
 			volume.config.Options[key] = value
 		}
+
+		return nil
+	}
+}
+
+// WithVolumeUID sets the UID that the volume will be created as.
+func WithVolumeUID(uid int) VolumeCreateOption {
+	return func(volume *Volume) error {
+		if volume.valid {
+			return ErrVolumeFinalized
+		}
+
+		volume.config.UID = uid
+
+		return nil
+	}
+}
+
+// WithVolumeGID sets the GID that the volume will be created as.
+func WithVolumeGID(gid int) VolumeCreateOption {
+	return func(volume *Volume) error {
+		if volume.valid {
+			return ErrVolumeFinalized
+		}
+
+		volume.config.GID = gid
 
 		return nil
 	}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -173,26 +173,29 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 		ctr.config.ConmonPidFile = filepath.Join(ctr.config.StaticDir, "conmon.pid")
 	}
 
-	// Go through the volume mounts and check for named volumes
-	// If the named volme already exists continue, otherwise create
-	// the storage for the named volume.
-	for i, vol := range ctr.config.Spec.Mounts {
-		if vol.Source[0] != '/' && isNamedVolume(vol.Source) {
-			volInfo, err := r.state.Volume(vol.Source)
-			if err != nil {
-				newVol, err := r.newVolume(ctx, WithVolumeName(vol.Source), withSetCtrSpecific(), WithVolumeUID(ctr.RootUID()), WithVolumeGID(ctr.RootGID()))
-				if err != nil {
-					return nil, errors.Wrapf(err, "error creating named volume %q", vol.Source)
-				}
-				ctr.config.Spec.Mounts[i].Source = newVol.MountPoint()
-				if err := ctr.copyWithTarFromImage(ctr.config.Spec.Mounts[i].Destination, ctr.config.Spec.Mounts[i].Source); err != nil && !os.IsNotExist(err) {
-					return nil, errors.Wrapf(err, "failed to copy content into new volume mount %q", vol.Source)
-				}
-				continue
-			}
-			ctr.config.Spec.Mounts[i].Source = volInfo.MountPoint()
-		}
-	}
+	// // Go through the volume mounts and check for named volumes
+	// // If the named volme already exists continue, otherwise create
+	// // the storage for the named volume.
+	// for i, vol := range ctr.config.Spec.Mounts {
+	// 	if vol.Source[0] != '/' && isNamedVolume(vol.Source) {
+	// 		volInfo, err := r.state.Volume(vol.Source)
+	// 		if err != nil {
+	// 			newVol, err := r.newVolume(ctx, WithVolumeName(vol.Source), withSetCtrSpecific())
+	// 			if err != nil {
+	// 				return nil, errors.Wrapf(err, "error creating named volume %q", vol.Source)
+	// 			}
+	// 			ctr.config.Spec.Mounts[i].Source = newVol.MountPoint()
+				// if err := os.Chown(ctr.config.Spec.Mounts[i].Source, ctr.RootUID(), ctr.RootGID()); err != nil {
+				// 	return nil, errors.Wrapf(err, "cannot chown %q to %d:%d", ctr.config.Spec.Mounts[i].Source, ctr.RootUID(), ctr.RootGID())
+				// }
+	// 			if err := ctr.copyWithTarFromImage(ctr.config.Spec.Mounts[i].Destination, ctr.config.Spec.Mounts[i].Source); err != nil && !os.IsNotExist(err) {
+	// 				return nil, errors.Wrapf(err, "Failed to copy content into new volume mount %q", vol.Source)
+	// 			}
+	// 			continue
+	// 		}
+	// 		ctr.config.Spec.Mounts[i].Source = volInfo.MountPoint()
+	// 	}
+	// }
 
 	if ctr.config.LogPath == "" {
 		ctr.config.LogPath = filepath.Join(ctr.config.StaticDir, "ctr.log")
@@ -344,13 +347,6 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 		return errors.Wrapf(ErrCtrExists, "container %s has dependent containers which must be removed before it: %s", c.ID(), depsStr)
 	}
 
-	var volumes []string
-	if removeVolume {
-		volumes, err = c.namedVolumes()
-		if err != nil {
-			logrus.Errorf("unable to retrieve builtin volumes for container %v: %v", c.ID(), err)
-		}
-	}
 	var cleanupErr error
 	// Remove the container from the state
 	if c.config.Pod != "" {
@@ -415,8 +411,12 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 		}
 	}
 
-	for _, v := range volumes {
-		if volume, err := runtime.state.Volume(v); err == nil {
+	if !removeVolume {
+		return cleanupErr
+	}
+
+	for _, v := range c.config.NamedVolumes {
+		if volume, err := runtime.state.Volume(v.Name); err == nil {
 			if !volume.IsCtrSpecific() {
 				continue
 			}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -182,6 +182,8 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 			return nil, errors.Wrapf(err, "error retrieving named volume %s for new container", vol.Name)
 		}
 
+		logrus.Debugf("Creating new volume %s for container", vol.Name)
+
 		// The volume does not exist, so we need to create it.
 		newVol, err := r.newVolume(ctx, WithVolumeName(vol.Name), withSetCtrSpecific(),
 			WithVolumeUID(ctr.RootUID()), WithVolumeGID(ctr.RootGID()))

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -545,14 +545,6 @@ func (r *Runtime) GetLatestContainer() (*Container, error) {
 	return ctrs[lastCreatedIndex], nil
 }
 
-// Check if volName is a named volume and not one of the default mounts we add to containers
-func isNamedVolume(volName string) bool {
-	if volName != "proc" && volName != "tmpfs" && volName != "devpts" && volName != "shm" && volName != "mqueue" && volName != "sysfs" && volName != "cgroup" {
-		return true
-	}
-	return false
-}
-
 // Export is the libpod portion of exporting a container to a tar file
 func (r *Runtime) Export(name string, path string) error {
 	ctr, err := r.LookupContainer(name)

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -116,7 +116,7 @@ func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool) error
 			// containers?
 			// I'm inclined to say no, in case someone accidentally
 			// wipes a container they're using...
-			if err := r.removeContainer(ctx, ctr, false, true); err != nil {
+			if err := r.removeContainer(ctx, ctr, false, false); err != nil {
 				return errors.Wrapf(err, "error removing container %s that depends on volume %s", ctr.ID(), v.Name())
 			}
 		}

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -98,14 +98,12 @@ func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool) error
 		if !force {
 			return errors.Wrapf(ErrVolumeBeingUsed, "volume %s is being used by the following container(s): %s", v.Name(), depsStr)
 		}
-		// If using force, log the warning that the volume is being used by at least one container
-		logrus.Warnf("volume %s is being used by the following container(s): %s", v.Name(), depsStr)
-		// Remove the container dependencies so we can go ahead and delete the volume
-		for _, dep := range deps {
-			if err := r.state.RemoveVolCtrDep(v, dep); err != nil {
-				return errors.Wrapf(err, "unable to remove container dependency %q from volume %q while trying to delete volume by force", dep, v.Name())
-			}
-		}
+
+		// TODO: force-removing a volume makes *no sense*
+		// I do not believe we should be allowing this at all.
+		// For now, return angry errors.
+		// TODO: need to do something more sane in this case
+		return errors.Wrapf(ErrVolumeBeingUsed, "TODO: FIXME - still refusing to remove because force-removing an in-use volume is not good.")
 	}
 
 	// Set volume as invalid so it can no longer be used

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -192,10 +192,6 @@ type State interface {
 	// AddVolume adds the specified volume to state. The volume's name
 	// must be unique within the list of existing volumes
 	AddVolume(volume *Volume) error
-	// RemoveVolCtrDep updates the list of container dependencies that the
-	// volume has. It either deletes the dependent container ID from
-	// the sub-bucket
-	RemoveVolCtrDep(volume *Volume, ctrID string) error
 	// RemoveVolume removes the specified volume.
 	// Only volumes that have no container dependencies can be removed
 	RemoveVolume(volume *Volume) error

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -130,11 +130,12 @@ type CreateConfig struct {
 	Mounts             []spec.Mount          //mounts
 	Volumes            []string              //volume
 	VolumesFrom        []string
-	WorkDir            string   //workdir
-	LabelOpts          []string //SecurityOpts
-	NoNewPrivs         bool     //SecurityOpts
-	ApparmorProfile    string   //SecurityOpts
-	SeccompProfilePath string   //SecurityOpts
+	NamedVolumes       []*libpod.ContainerNamedVolume // Filled in by CreateConfigToOCISpec
+	WorkDir            string                         //workdir
+	LabelOpts          []string                       //SecurityOpts
+	NoNewPrivs         bool                           //SecurityOpts
+	ApparmorProfile    string                         //SecurityOpts
+	SeccompProfilePath string                         //SecurityOpts
 	SecurityOpts       []string
 	Rootfs             string
 	LocalVolumes       []spec.Mount //Keeps track of the built-in volumes of container used in the --volumes-from flag
@@ -217,7 +218,7 @@ func (c *CreateConfig) initFSMounts() []spec.Mount {
 	return mounts
 }
 
-//GetVolumeMounts takes user provided input for bind mounts and creates Mount structs
+// GetVolumeMounts takes user provided input for bind mounts and creates Mount structs
 func (c *CreateConfig) GetVolumeMounts(specMounts []spec.Mount) ([]spec.Mount, error) {
 	m := c.LocalVolumes
 	for _, i := range c.Volumes {
@@ -421,6 +422,10 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime, pod *l
 		}
 
 		options = append(options, libpod.WithUserVolumes(volumes))
+	}
+
+	if len(c.NamedVolumes) != 0 {
+		options = append(options, libpod.WithNamedVolumes(c.NamedVolumes))
 	}
 
 	if len(c.LocalVolumes) != 0 {

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -20,7 +20,6 @@ import (
 )
 
 const cpuPeriod = 100000
-const bindMount = "bind"
 
 func supercedeUserMounts(mounts []spec.Mount, configMount []spec.Mount) []spec.Mount {
 	if len(mounts) > 0 {
@@ -56,7 +55,7 @@ func splitNamedVolumes(mounts []spec.Mount) ([]spec.Mount, []*libpod.ContainerNa
 	namedVolumes := make([]*libpod.ContainerNamedVolume, 0)
 	for _, mount := range mounts {
 		// If it's not a named volume, append unconditionally
-		if mount.Type != bindMount {
+		if mount.Type != TypeBind {
 			newMounts = append(newMounts, mount)
 			continue
 		}
@@ -128,7 +127,7 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 		}
 		sysMnt := spec.Mount{
 			Destination: "/sys",
-			Type:        bindMount,
+			Type:        TypeBind,
 			Source:      "/sys",
 			Options:     []string{"rprivate", "nosuid", "noexec", "nodev", r, "rbind"},
 		}
@@ -155,7 +154,7 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 		g.RemoveMount("/dev/mqueue")
 		devMqueue := spec.Mount{
 			Destination: "/dev/mqueue",
-			Type:        bindMount,
+			Type:        TypeBind,
 			Source:      "/dev/mqueue",
 			Options:     []string{"bind", "nosuid", "noexec", "nodev"},
 		}
@@ -165,7 +164,7 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 		g.RemoveMount("/proc")
 		procMount := spec.Mount{
 			Destination: "/proc",
-			Type:        bindMount,
+			Type:        TypeBind,
 			Source:      "/proc",
 			Options:     []string{"rbind", "nosuid", "noexec", "nodev"},
 		}

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Podman commit", func() {
 		inspect.WaitWithDefaultTimeout()
 		Expect(inspect.ExitCode()).To(Equal(0))
 		image := inspect.InspectImageJSON()
-		_, ok := image[0].Config.Volumes["/tmp"]
+		_, ok := image[0].Config.Volumes["/foo"]
 		Expect(ok).To(BeTrue())
 
 		r := podmanTest.Podman([]string{"run", "newimage"})

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -611,7 +611,6 @@ USER mail`
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring("data"))
-
 	})
 
 	It("podman run --volumes flag with multiple volumes", func() {

--- a/test/e2e/volume_rm_test.go
+++ b/test/e2e/volume_rm_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Podman volume rm", func() {
 
 	})
 
-	It("podman rm volume", func() {
+	It("podman volume rm", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -47,7 +47,7 @@ var _ = Describe("Podman volume rm", func() {
 		Expect(len(session.OutputToStringArray())).To(Equal(0))
 	})
 
-	It("podman rm with --force flag", func() {
+	It("podman volume rm with --force flag", func() {
 		SkipIfRemote()
 		session := podmanTest.Podman([]string{"create", "-v", "myvol:/myvol", ALPINE, "ls"})
 		cid := session.OutputToString()


### PR DESCRIPTION
I haven't done more than compile test this, but the code's finally done, so I figured I'd put it up for review.

This swaps the backend for named volumes, making them explicit in the database rather than intermixed with other container volumes. This has numerous advantages, especially with volumes that require mounts - we can ensure they're mounted when we start the container easily.

The biggest issue with this is the changes to the way the database tracks dependency containers for a volume. I've written things such that we don't need any changes to existing containers in the database - things should continue working as before on an upgrade. We won't know to remove container dependencies from the volume as it is removed, but the DB has been changed to gracefully handle this. The issue will come if you downgrade to an earlier Podman after using this patch - you may end up with volumes that can never be removed without upgrading back to a version with this patch. I don't have a good way around that.