### PR TITLE
docs/podman.1.md: rename "containers-registries.conf" to "registries.…

### DIFF
--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -233,7 +233,7 @@ Images are pulled under `XDG_DATA_HOME` when specified, otherwise in the home di
 Currently the slirp4netns package is required to be installed to create a network device, otherwise rootless containers need to run in the network namespace of the host.
 
 ## SEE ALSO
-`containers-mounts.conf(5)`, `containers-registries.conf(5)`, `containers-storage.conf(5)`, `buildah(1)`, `crio(8)`, `libpod.conf(5)`, `oci-hooks(5)`, `policy.json(5)`, `subuid(5)`, `subgid(5)`, `slirp4netns(1)`
+`containers-mounts.conf(5)`, `registries.conf(5)`, `containers-storage.conf(5)`, `buildah(1)`, `crio(8)`, `libpod.conf(5)`, `oci-hooks(5)`, `policy.json(5)`, `subuid(5)`, `subgid(5)`, `slirp4netns(1)`
 
 ## HISTORY
 Dec 2016, Originally compiled by Dan Walsh <dwalsh@redhat.com>


### PR DESCRIPTION
…conf"

Since the correct name for the registries man page is the shorter
"registries.conf", correct the reference in the "SEE ALSO" section.

Note that this is a temporary solution since, in order to avoid possible
future clashes with more generic man pages, all of the podman-related
man pages should ideally start with a "containers-" prefix.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>