### PR TITLE
doc: add note that pod publish ports are static once defined

### DIFF
--- a/docs/podman-pod-create.1.md
+++ b/docs/podman-pod-create.1.md
@@ -60,6 +60,8 @@ Both hostPort and containerPort can be specified as a range of ports.
 When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range.
 Use `podman port` to see the actual mapping: `podman port CONTAINER $CONTAINERPORT`
 
+NOTE: This cannot be modified once the pod is created.
+
 **--share**=""
 
 A comma deliminated list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared. The namespaces to choose from are ipc, net, pid, user, uts.


### PR DESCRIPTION
Added note to manpage I mentioned in the other PR.

Since publish ports are static to a pod, it should be hinted at in the manpage.