### PR TITLE
WIP - Remove 'container-' from registries.conf man links

### DIFF
--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -637,7 +637,7 @@ If you are using a useradd command within a Dockerfile with a large UID/GID, it 
 If you are using `useradd` within your build script, you should pass the `--no-log-init or -l` option to the `useradd` command.  This option tells useradd to stop creating the lastlog file.
 
 ## SEE ALSO
-podman(1), buildah(1), containers-registries.conf(5), useradd(8)
+podman(1), buildah(1), registries.conf(5), useradd(8)
 
 ## HISTORY
 May 2018, Minor revisions added by Joe Doss <joe@solidadmin.com>

--- a/docs/podman-info.1.md
+++ b/docs/podman-info.1.md
@@ -148,4 +148,4 @@ map[registries:[docker.io quay.io registry.fedoraproject.org registry.access.red
 ```
 
 ## SEE ALSO
-podman(1), containers-registries.conf(5), containers-storage.conf(5), crio(8)
+podman(1), registries.conf(5), containers-storage.conf(5), crio(8)

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -146,7 +146,7 @@ Storing signatures
 	registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-podman(1), podman-push(1), podman-login(1), containers-registries.conf(5), crio(8)
+podman(1), podman-push(1), podman-login(1), registries.conf(5), crio(8)
 
 ## HISTORY
 July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -149,7 +149,7 @@ Note: This works only with registries that implement the v2 API. If tried with a
 	registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-podman(1), containers-registries.conf(5), crio(8)
+podman(1), registries.conf(5), crio(8)
 
 ## HISTORY
 January 2018, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -233,7 +233,7 @@ Images are pulled under `XDG_DATA_HOME` when specified, otherwise in the home di
 Currently the slirp4netns package is required to be installed to create a network device, otherwise rootless containers need to run in the network namespace of the host.
 
 ## SEE ALSO
-`containers-mounts.conf(5)`, `containers-registries.conf(5)`, `containers-storage.conf(5)`, `buildah(1)`, `crio(8)`, `libpod.conf(5)`, `oci-hooks(5)`, `policy.json(5)`, `subuid(5)`, `subgid(5)`, `slirp4netns(1)`
+`containers-mounts.conf(5)`, `registries.conf(5)`, `containers-storage.conf(5)`, `buildah(1)`, `crio(8)`, `libpod.conf(5)`, `oci-hooks(5)`, `policy.json(5)`, `subuid(5)`, `subgid(5)`, `slirp4netns(1)`
 
 ## HISTORY
 Dec 2016, Originally compiled by Dan Walsh <dwalsh@redhat.com>


### PR DESCRIPTION
There's a bug and containers-registries.conf(5) is not
available atm.  Reset it to registires.conf(5) until
that is rectified.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>