### PR TITLE
fix bug remote-podman images --digests

### DIFF
--- a/API.md
+++ b/API.md
@@ -1472,6 +1472,8 @@ gid_map [IDMap](#IDMap)
 
 id [string](https://godoc.org/builtin#string)
 
+digest [string](https://godoc.org/builtin#string)
+
 parentId [string](https://godoc.org/builtin#string)
 
 repoTags [[]string](#[]string)

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -59,6 +59,7 @@ type VolumeRemoveOpts (
 
 type Image (
   id: string,
+  digest:   string,
   parentId: string,
   repoTags: []string,
   repoDigests: []string,

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -137,6 +137,7 @@ func imageInListToContainerImage(i iopodman.Image, name string, runtime *LocalRu
 	ri := remoteImage{
 		InputName:   name,
 		ID:          i.Id,
+		Digest:      digest.Digest(i.Digest),
 		Labels:      i.Labels,
 		RepoTags:    i.RepoTags,
 		RepoDigests: i.RepoTags,

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -54,6 +54,7 @@ func (i *LibpodAPI) ListImages(call iopodman.VarlinkCall) error {
 
 		i := iopodman.Image{
 			Id:          image.ID(),
+			Digest:      string(image.Digest()),
 			ParentId:    image.Parent,
 			RepoTags:    image.Names(),
 			RepoDigests: repoDigests,


### PR DESCRIPTION
close #2756 
Show image digests when using --digests in podman-remote.
```
$ PODMAN_VARLINK_ADDRESS="tcp:127.0.0.1:1234" sudo bin/podman-remote images --digests
REPOSITORY                  TAG      DIGEST                                                                    IMAGE ID       CREATED       SIZE
docker.io/library/alpine    latest   sha256:d05ecd4520cab5d9e5d877595fb0532aadcd6c90f4bbc837bc11679f704c4c82   5cb3aa00f899   2 weeks ago   5.79 MB
docker.io/library/busybox   latest   sha256:4415a904b1aca178c2450fd54928ab362825e863c0ad5452fd020e92f7a6a47e   d8233ab899d4   5 weeks ago   1.42 MB
```

Signed-off-by: Qi Wang <qiwan@redhat.com>