### PR TITLE
rootless: change env prefix

### DIFF
--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -325,8 +325,8 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 	cmd.Env = append(r.conmonEnv, fmt.Sprintf("_OCI_SYNCPIPE=%d", 3))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("_OCI_STARTPIPE=%d", 4))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", runtimeDir))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("_LIBPOD_USERNS_CONFIGURED=%s", os.Getenv("_LIBPOD_USERNS_CONFIGURED")))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("_LIBPOD_ROOTLESS_UID=%s", os.Getenv("_LIBPOD_ROOTLESS_UID")))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("_CONTAINERS_USERNS_CONFIGURED=%s", os.Getenv("_CONTAINERS_USERNS_CONFIGURED")))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("_CONTAINERS_ROOTLESS_UID=%s", os.Getenv("_CONTAINERS_ROOTLESS_UID")))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", os.Getenv("HOME")))
 
 	if r.reservePorts && !ctr.config.NetMode.IsSlirp4netns() {

--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -136,8 +136,8 @@ reexec_userns_join (int userns, int mountns)
   if (pid)
     return pid;
 
-  setenv ("_LIBPOD_USERNS_CONFIGURED", "init", 1);
-  setenv ("_LIBPOD_ROOTLESS_UID", uid, 1);
+  setenv ("_CONTAINERS_USERNS_CONFIGURED", "init", 1);
+  setenv ("_CONTAINERS_ROOTLESS_UID", uid, 1);
 
   if (setns (userns, 0) < 0)
     {
@@ -265,8 +265,8 @@ reexec_in_user_namespace (int ready)
     setenv("LISTEN_PID", s, true);
   }
 
-  setenv ("_LIBPOD_USERNS_CONFIGURED", "init", 1);
-  setenv ("_LIBPOD_ROOTLESS_UID", uid, 1);
+  setenv ("_CONTAINERS_USERNS_CONFIGURED", "init", 1);
+  setenv ("_CONTAINERS_ROOTLESS_UID", uid, 1);
 
   do
     ret = read (ready, &b, 1) < 0;

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -29,7 +29,7 @@ extern int reexec_userns_join(int userns, int mountns);
 import "C"
 
 func runInUser() error {
-	os.Setenv("_LIBPOD_USERNS_CONFIGURED", "done")
+	os.Setenv("_CONTAINERS_USERNS_CONFIGURED", "done")
 	return nil
 }
 
@@ -41,7 +41,7 @@ var (
 // IsRootless tells us if we are running in rootless mode
 func IsRootless() bool {
 	isRootlessOnce.Do(func() {
-		isRootless = os.Geteuid() != 0 || os.Getenv("_LIBPOD_USERNS_CONFIGURED") != ""
+		isRootless = os.Geteuid() != 0 || os.Getenv("_CONTAINERS_USERNS_CONFIGURED") != ""
 	})
 	return isRootless
 }
@@ -62,12 +62,12 @@ func SkipStorageSetup() bool {
 
 // Argument returns the argument that was set for the rootless session.
 func Argument() string {
-	return os.Getenv("_LIBPOD_ROOTLESS_ARG")
+	return os.Getenv("_CONTAINERS_ROOTLESS_ARG")
 }
 
 // GetRootlessUID returns the UID of the user in the parent userNS
 func GetRootlessUID() int {
-	uidEnv := os.Getenv("_LIBPOD_ROOTLESS_UID")
+	uidEnv := os.Getenv("_CONTAINERS_ROOTLESS_UID")
 	if uidEnv != "" {
 		u, _ := strconv.Atoi(uidEnv)
 		return u
@@ -107,7 +107,7 @@ func tryMappingTool(tool string, pid int, hostID int, mappings []idtools.IDMap) 
 // JoinNS re-exec podman in a new userNS and join the user namespace of the specified
 // PID.
 func JoinNS(pid uint, preserveFDs int) (bool, int, error) {
-	if os.Geteuid() == 0 || os.Getenv("_LIBPOD_USERNS_CONFIGURED") != "" {
+	if os.Geteuid() == 0 || os.Getenv("_CONTAINERS_USERNS_CONFIGURED") != "" {
 		return false, -1, nil
 	}
 
@@ -149,7 +149,7 @@ func JoinDirectUserAndMountNS(pid uint) (bool, int, error) {
 // mount namespace of the specified PID without looking up its parent.  Useful to join
 // directly the conmon process.
 func JoinDirectUserAndMountNSWithOpts(pid uint, opts *Opts) (bool, int, error) {
-	if os.Geteuid() == 0 || os.Getenv("_LIBPOD_USERNS_CONFIGURED") != "" {
+	if os.Geteuid() == 0 || os.Getenv("_CONTAINERS_USERNS_CONFIGURED") != "" {
 		return false, -1, nil
 	}
 
@@ -166,7 +166,7 @@ func JoinDirectUserAndMountNSWithOpts(pid uint, opts *Opts) (bool, int, error) {
 	defer userNS.Close()
 
 	if opts != nil && opts.Argument != "" {
-		if err := os.Setenv("_LIBPOD_ROOTLESS_ARG", opts.Argument); err != nil {
+		if err := os.Setenv("_CONTAINERS_ROOTLESS_ARG", opts.Argument); err != nil {
 			return false, -1, err
 		}
 	}
@@ -187,7 +187,7 @@ func JoinDirectUserAndMountNSWithOpts(pid uint, opts *Opts) (bool, int, error) {
 // JoinNSPath re-exec podman in a new userNS and join the owner user namespace of the
 // specified path.
 func JoinNSPath(path string) (bool, int, error) {
-	if os.Geteuid() == 0 || os.Getenv("_LIBPOD_USERNS_CONFIGURED") != "" {
+	if os.Geteuid() == 0 || os.Getenv("_CONTAINERS_USERNS_CONFIGURED") != "" {
 		return false, -1, nil
 	}
 
@@ -223,8 +223,8 @@ func BecomeRootInUserNS() (bool, int, error) {
 // If podman was re-executed the caller needs to propagate the error code returned by the child
 // process.
 func BecomeRootInUserNSWithOpts(opts *Opts) (bool, int, error) {
-	if os.Geteuid() == 0 || os.Getenv("_LIBPOD_USERNS_CONFIGURED") != "" {
-		if os.Getenv("_LIBPOD_USERNS_CONFIGURED") == "init" {
+	if os.Geteuid() == 0 || os.Getenv("_CONTAINERS_USERNS_CONFIGURED") != "" {
+		if os.Getenv("_CONTAINERS_USERNS_CONFIGURED") == "init" {
 			return false, 0, runInUser()
 		}
 		return false, 0, nil
@@ -242,7 +242,7 @@ func BecomeRootInUserNSWithOpts(opts *Opts) (bool, int, error) {
 	defer w.Write([]byte("0"))
 
 	if opts != nil && opts.Argument != "" {
-		if err := os.Setenv("_LIBPOD_ROOTLESS_ARG", opts.Argument); err != nil {
+		if err := os.Setenv("_CONTAINERS_ROOTLESS_ARG", opts.Argument); err != nil {
 			return false, -1, err
 		}
 	}


### PR DESCRIPTION
from _LIBPOD to _CONTAINERS.  The same change was done in buildah
unshare.

This is necessary for podman to detect we are running in a rootless
environment and work properly from a "buildah unshare" session.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>