### PR TITLE
support for macvlan & ipvlan added.

### DIFF
--- a/pkg/namespaces/namespaces.go
+++ b/pkg/namespaces/namespaces.go
@@ -228,7 +228,17 @@ func (n NetworkMode) IsSlirp4netns() bool {
 	return n == "slirp4netns"
 }
 
+// IsIPVLan indicates whether container uses the ipvlan network stack
+func (n NetworkMode) IsIPVLan() bool {
+	return n == "ipvlan"
+}
+
+//IsMacVLan indicates whether container uses the macvlan network stack
+func (n NetworkMode) IsMacVLan() bool {
+	return n == "macvlan"
+}
+
 // IsUserDefined indicates user-created network
 func (n NetworkMode) IsUserDefined() bool {
-	return !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer() && !n.IsSlirp4netns()
+	return !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer() && !n.IsSlirp4netns() && !n.IsIPVLan() && !n.IsMacVLan()
 }

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -542,6 +542,12 @@ func addNetNS(config *CreateConfig, g *generate.Generator) error {
 	} else if netMode.IsSlirp4netns() {
 		logrus.Debug("Using slirp4netns netmode")
 		return nil
+	} else if netMode.IsIPVLan() {
+		logrus.Debug("Using ipvlan netmode")
+		return nil
+	} else if netMode.IsMacVLan() {
+		logrus.Debug("Using macvlan netmode")
+		return nil
 	} else if netMode.IsUserDefined() {
 		logrus.Debug("Using user defined netmode")
 		return nil


### PR DESCRIPTION
CNI plugins for macvlan and ipvlan will be invoked
instead treating them as user defined network

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>