### PR TITLE
Alter container/pod/volume name regexp to match Docker

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	nameRegex = regexp.MustCompile("[a-zA-Z0-9_-]+")
+	nameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 )
 
 // Runtime Creation Options


### PR DESCRIPTION
Docker's upstream name validation regex has two major differences from ours that we pick up in this PR.

The first requires that the first character of a name is a letter or number, not a special character.

The second allows periods in names.