### PR TITLE
Ensure that we make a netns for CNI non-default nets

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -930,7 +930,7 @@ func WithNetNS(portMappings []ocicni.PortMapping, postConfigureNetNS bool, netmo
 
 		ctr.config.PostConfigureNetNS = postConfigureNetNS
 		ctr.config.NetMode = namespaces.NetworkMode(netmode)
-		ctr.config.CreateNetNS = !ctr.config.NetMode.IsUserDefined()
+		ctr.config.CreateNetNS = true
 		ctr.config.PortMappings = portMappings
 		ctr.config.Networks = networks
 

--- a/pkg/namespaces/namespaces.go
+++ b/pkg/namespaces/namespaces.go
@@ -228,12 +228,12 @@ func (n NetworkMode) IsSlirp4netns() bool {
 	return n == "slirp4netns"
 }
 
-// IsNS() indicates a network namespace passed in by path (ns:<path>)
+// IsNS indicates a network namespace passed in by path (ns:<path>)
 func (n NetworkMode) IsNS() bool {
 	return strings.HasPrefix(string(n), "ns:")
 }
 
-// NS() gets the path associated with a ns:<path> network ns
+// NS gets the path associated with a ns:<path> network ns
 func (n NetworkMode) NS() string {
 	parts := strings.SplitN(string(n), ":", 2)
 	if len(parts) > 1 {
@@ -242,7 +242,7 @@ func (n NetworkMode) NS() string {
 	return ""
 }
 
-// IsPod() returns whether the network refers to pod networking
+// IsPod returns whether the network refers to pod networking
 func (n NetworkMode) IsPod() bool {
 	return n == "pod"
 }

--- a/pkg/namespaces/namespaces.go
+++ b/pkg/namespaces/namespaces.go
@@ -228,7 +228,26 @@ func (n NetworkMode) IsSlirp4netns() bool {
 	return n == "slirp4netns"
 }
 
+// IsNS() indicates a network namespace passed in by path (ns:<path>)
+func (n NetworkMode) IsNS() bool {
+	return strings.HasPrefix(string(n), "ns:")
+}
+
+// NS() gets the path associated with a ns:<path> network ns
+func (n NetworkMode) NS() string {
+	parts := strings.SplitN(string(n), ":", 2)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
+}
+
+// IsPod() returns whether the network refers to pod networking
+func (n NetworkMode) IsPod() bool {
+	return n == "pod"
+}
+
 // IsUserDefined indicates user-created network
 func (n NetworkMode) IsUserDefined() bool {
-	return !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer() && !n.IsSlirp4netns()
+	return !n.IsDefault() && !n.IsBridge() && !n.IsHost() && !n.IsNone() && !n.IsContainer() && !n.IsSlirp4netns() && !n.IsNS()
 }

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -451,16 +451,15 @@ func (c *CreateConfig) GetContainerCreateOptions(runtime *libpod.Runtime, pod *l
 		}
 	}
 
-	if IsNS(string(c.NetMode)) {
-		split := strings.SplitN(string(c.NetMode), ":", 2)
-		if len(split[0]) != 2 {
-			return nil, errors.Errorf("invalid user defined network namespace %q", c.NetMode.UserDefined())
+	if c.NetMode.IsNS() {
+		ns := c.NetMode.NS()
+		if ns == "" {
+			return nil, errors.Errorf("invalid empty user-defined network namespace")
 		}
-		_, err := os.Stat(split[1])
+		_, err := os.Stat(ns)
 		if err != nil {
 			return nil, err
 		}
-		options = append(options, libpod.WithNetNS(portBindings, false, string(c.NetMode), networks))
 	} else if c.NetMode.IsContainer() {
 		connectedCtr, err := c.Runtime.LookupContainer(c.NetMode.Container())
 		if err != nil {


### PR DESCRIPTION
We accidentally patched this out trying to enable ns:/path/to/ns, I think.

This should restore the ability to configure nondefault CNI networks with Podman, by ensuring that they request creation of a network namespace.

Completely remove the WithNetNS() call when we do use an explicit namespace from a path. We use that call to indicate that a netns is going to be created - there should not be any question about whether it actually does.

Fixes #2795