### PR TITLE
Add locking to ensure events file is concurrency-safe

### DIFF
--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/containers/storage"
 	"github.com/pkg/errors"
 )
 
@@ -122,6 +123,13 @@ func NewEvent(status Status) Event {
 
 // Write will record the event to the given path
 func (e *Event) Write(path string) error {
+	// We need to lock events file
+	lock, err := storage.GetLockfile(path + ".lock")
+	if err != nil {
+		return err
+	}
+	lock.Lock()
+	defer lock.Unlock()
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0700)
 	if err != nil {
 		return err


### PR DESCRIPTION
Quick and dirty locking for the events file to make sure that we don't end up with concurrent writes.

In my unscientific testing, costs us about 10ms on a full `podman run -t -i --rm fedora ls /` on my system (which ends up being 7 events total - create, init, attach, start, died, wait, removed).

Looked into adding an SHM lock, but storing it was an issue - we'd need DB changes to squirrel the lock number away somewhere.