### PR TITLE
Remove wait event

### DIFF
--- a/docs/podman-events.1.md
+++ b/docs/podman-events.1.md
@@ -32,7 +32,6 @@ The *container* event type will report the follow statuses:
  * sync
  * unmount
  * unpause
- * wait
 
 The *pod* event type will report the follow statuses:
  * create

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -574,7 +574,6 @@ func (c *Container) WaitWithInterval(waitTimeout time.Duration) (int32, error) {
 		return 0, err
 	}
 	exitCode := c.state.ExitCode
-	c.newContainerEvent(events.Wait)
 	return exitCode, nil
 }
 

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -104,8 +104,6 @@ const (
 	Unpause Status = "unpause"
 	// Untag ...
 	Untag Status = "untag"
-	// Wait ...
-	Wait Status = "wait"
 )
 
 // EventFilter for filtering events
@@ -261,8 +259,6 @@ func StringToStatus(name string) (Status, error) {
 		return Unpause, nil
 	case Untag.String():
 		return Untag, nil
-	case Wait.String():
-		return Wait, nil
 	}
 	return "", errors.Errorf("unknown event status %s", name)
 }


### PR DESCRIPTION
It's not necessary to log an event for a read-only operation like wait.