### PR TITLE
docs/podman-rm.1.md: delete "Not yet implemented" msg for volume removal

### DIFF
--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -32,7 +32,7 @@ The latest option is not supported on the remote client.
 
 **--volumes, -v**
 
-Remove the volumes associated with the container. (Not yet implemented)
+Remove the volumes associated with the container.
 
 ## EXAMPLE
 Remove a container by its name *mywebserver*


### PR DESCRIPTION
Since this feature appears to be implemented, remove the qualifier.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>