### PR TITLE
docs/podman*.md: fix numerous option typos and spacing errors

### DIFF
--- a/docs/podman-container-checkpoint.1.md
+++ b/docs/podman-container-checkpoint.1.md
@@ -10,7 +10,7 @@ podman\-container\-checkpoint - Checkpoints one or more running containers
 Checkpoints all the processes in one or more containers. You may use container IDs or names as input.
 
 ## OPTIONS
-**-k**, **--keep**
+**--keep**, **-k**
 
 Keep all temporary log and statistics files created by CRIU during checkpointing. These files
 are not deleted if checkpointing fails for further debugging. If checkpointing succeeds these

--- a/docs/podman-container-restore.1.md
+++ b/docs/podman-container-restore.1.md
@@ -10,7 +10,7 @@ podman\-container\-restore - Restores one or more running containers
 Restores a container from a checkpoint. You may use container IDs or names as input.
 
 ## OPTIONS
-**-k**, **--keep**
+**--keep**, **-k**
 
 Keep all temporary log and statistics files created by CRIU during
 checkpointing as well as restoring. These files are not deleted if restoring

--- a/docs/podman-container-runlabel.1.md
+++ b/docs/podman-container-runlabel.1.md
@@ -76,11 +76,12 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
-**-h** **--help**
+**--help** **-h**
 Print usage statement
 
-**-n** **--name**=""
- Use this name for creating content for the container. NAME will default to the IMAGENAME if it is not specified.
+**--name** **-n**=""
+
+Use this name for creating content for the container. NAME will default to the IMAGENAME if it is not specified.
 
 **--quiet, -q**
 

--- a/docs/podman-generate-kube.1.md
+++ b/docs/podman-generate-kube.1.md
@@ -5,7 +5,7 @@
 podman-generate-kube - Generate Kubernetes YAML
 
 # SYNOPSIS
-**podman generate kube** [*-s*][*--service*] *container* | *pod*
+**podman generate kube** [*-s*|*--service*] *container* | *pod*
 
 # DESCRIPTION
 **podman generate kube** will generate Kubernetes Pod YAML (v1 specification) from a podman container or pod. Whether
@@ -20,7 +20,8 @@ Note that the generated Kubernetes YAML file can be used to re-run the deploymen
 
 # OPTIONS:
 
-**s** **--service**
+**--service** **-s**
+
 Generate a Kubernetes service object in addition to the Pods.
 
 ## Examples ##

--- a/docs/podman-pod-kill.1.md
+++ b/docs/podman-pod-kill.1.md
@@ -21,7 +21,7 @@ to run pods such as CRI-O, the last started pod could be from either of those me
 
 The latest option is not supported on the remote client.
 
-**--signal, s**
+**--signal, -s**
 
 Signal to send to the containers in the pod. For more information on Linux signals, refer to *man signal(7)*.
 

--- a/docs/podman-pod-pause.1.md
+++ b/docs/podman-pod-pause.1.md
@@ -11,7 +11,7 @@ Pauses all the running processes in the containers of one or more pods.  You may
 
 ## OPTIONS
 
-**--all, a**
+**--all, -a**
 
 Pause all pods.
 

--- a/docs/podman-pod-rm.1.md
+++ b/docs/podman-pod-rm.1.md
@@ -11,7 +11,7 @@ podman\-pod\-rm - Remove one or more pods
 
 ## OPTIONS
 
-**--all, a**
+**--all, -a**
 
 Remove all pods.  Can be used in conjunction with \-f as well.
 
@@ -21,7 +21,7 @@ Instead of providing the pod name or ID, remove the last created pod.
 
 The latest option is not supported on the remote client.
 
-**--force, f**
+**--force, -f**
 
 Stop running containers and delete all stopped containers before removal of pod.
 

--- a/docs/podman-pod-stop.1.md
+++ b/docs/podman-pod-stop.1.md
@@ -21,7 +21,7 @@ Instead of providing the pod name or ID, stop the last created pod.
 
 The latest option is not supported on the remote client.
 
-**--timeout, --time, t**
+**--timeout, --time, -t**
 
 Timeout to wait before forcibly stopping the containers in the pod.
 

--- a/docs/podman-pod-unpause.1.md
+++ b/docs/podman-pod-unpause.1.md
@@ -11,7 +11,7 @@ Unpauses all the paused processes in the containers of one or more pods.  You ma
 
 ## OPTIONS
 
-**--all, a**
+**--all, -a**
 
 Unpause all pods.
 

--- a/docs/podman-port.1.md
+++ b/docs/podman-port.1.md
@@ -11,7 +11,7 @@ List port mappings for the *container* or lookup the public-facing port that is 
 
 ## OPTIONS
 
-**--all, a**
+**--all, -a**
 
 List all known port mappings for running containers.  When using this option, you cannot pass any container names
 or private ports/protocols as filters.

--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -13,11 +13,11 @@ podman\-container\-rm (podman\-rm) - Remove one or more containers
 
 ## OPTIONS
 
-**--all, a**
+**--all, -a**
 
 Remove all containers.  Can be used in conjunction with -f as well.
 
-**--force, f**
+**--force, -f**
 
 Force the removal of running and paused containers.  Forcing a containers removal also
 removes containers from container storage even if the container is not known to podman.

--- a/docs/podman-volume-inspect.1.md
+++ b/docs/podman-volume-inspect.1.md
@@ -15,7 +15,7 @@ existing volumes, use the **--all** flag.
 
 ## OPTIONS
 
-**-a**, **--all**=""
+**-a**, **--all**
 
 Inspect all volumes.
 

--- a/docs/podman-wait.1.md
+++ b/docs/podman-wait.1.md
@@ -17,7 +17,7 @@ After the container stops, the container's return code is printed.
 
   Print usage statement
 
-**--interval, i**"
+**--interval, -i**"
   Microseconds to wait before polling for completion
 
 **--latest, -l**


### PR DESCRIPTION
Cursory examination of man pages shows a number of typos:

  - missing hyphens
  - missing blank line
  - longer option should precede shorter option

This is not an extensive fix, there's still a lot that could
be cleaned up.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>