### PR TITLE
Add restart policy for containers

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -444,7 +444,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.String(
 		"restart", "",
-		"Restart is not supported.  Please use a systemd unit file for restart",
+		"Restart policy to apply when a container exits",
 	)
 	createFlags.Bool(
 		"rm", false,

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -279,9 +279,6 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		blkioWeight                                              uint16
 		namespaces                                               map[string]string
 	)
-	if c.IsSet("restart") {
-		return nil, errors.Errorf("--restart option is not supported.\nUse systemd unit files for restarting containers")
-	}
 
 	idmappings, err := util.ParseIDMapping(c.StringSlice("uidmap"), c.StringSlice("gidmap"), c.String("subuidname"), c.String("subgidname"))
 	if err != nil {
@@ -676,21 +673,22 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 			PidsLimit:         c.Int64("pids-limit"),
 			Ulimit:            c.StringSlice("ulimit"),
 		},
-		Rm:          c.Bool("rm"),
-		StopSignal:  stopSignal,
-		StopTimeout: c.Uint("stop-timeout"),
-		Sysctl:      sysctl,
-		Systemd:     systemd,
-		Tmpfs:       c.StringSlice("tmpfs"),
-		Tty:         tty,
-		User:        user,
-		UsernsMode:  usernsMode,
-		MountsFlag:  c.StringArray("mount"),
-		Volumes:     c.StringArray("volume"),
-		WorkDir:     workDir,
-		Rootfs:      rootfs,
-		VolumesFrom: c.StringSlice("volumes-from"),
-		Syslog:      c.Bool("syslog"),
+		RestartPolicy: c.String("restart"),
+		Rm:            c.Bool("rm"),
+		StopSignal:    stopSignal,
+		StopTimeout:   c.Uint("stop-timeout"),
+		Sysctl:        sysctl,
+		Systemd:       systemd,
+		Tmpfs:         c.StringSlice("tmpfs"),
+		Tty:           tty,
+		User:          user,
+		UsernsMode:    usernsMode,
+		MountsFlag:    c.StringArray("mount"),
+		Volumes:       c.StringArray("volume"),
+		WorkDir:       workDir,
+		Rootfs:        rootfs,
+		VolumesFrom:   c.StringSlice("volumes-from"),
+		Syslog:        c.Bool("syslog"),
 	}
 
 	if config.Privileged {

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -42,7 +42,7 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		defer span.Finish()
 	}
 	if c.Bool("rm") && c.String("restart") != "" && c.String("restart") != "no" {
-		return nil, nil, errors.Errorf("the --rm flag conflicts with --restart")
+		return nil, nil, errors.Errorf("the --rm option conflicts with --restart")
 	}
 
 	rtc, err := runtime.GetConfig()

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -41,6 +41,9 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		span, _ := opentracing.StartSpanFromContext(ctx, "createContainer")
 		defer span.Finish()
 	}
+	if c.Bool("rm") && c.String("restart") != "" && c.String("restart") != "no" {
+		return nil, nil, errors.Errorf("the --rm flag conflicts with --restart")
+	}
 
 	rtc, err := runtime.GetConfig()
 	if err != nil {

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -567,11 +567,17 @@ If container is running in --read-only mode, then mount a read-write tmpfs on /r
 
 **--restart=""**
 
-Not implemented.
+Restart policy to follow when containers exit.
+Restart policy will not take effect if a container is stopped via the `podman kill` or `podman stop` commands.
+Valid values are:
 
-Restart should be handled via a systemd unit files. Please add your podman
-commands to a unit file and allow systemd or your init system to handle the
-restarting of the container processes.  See example below.
+- `no`                       : Do not restart containers on exit
+- `on-failure[:max_retries]` : Restart containers when they exit with a non-0 exit code, retrying indefinitely or until the optional max_retries count is hit
+- `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
+
+Please note that restart will not restart containers after a system reboot.
+If you require this functionality, please add your Podman commands to a systemd unit file, or create an init script for your init system of choice.
+There is an example of restarting a container with systemd below.
 
 **--rm**=*true*|*false*
 

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -576,7 +576,7 @@ Valid values are:
 - `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
 
 Please note that restart will not restart containers after a system reboot.
-This this functionality is required in your environment, you can invoke Podman from a systemd unit file, or create an init script for whichever init system is in use.
+If this functionality is required in your environment, you can invoke Podman from a systemd unit file, or create an init script for whichever init system is in use.
 To generate systemd unit files, please see *podman generate systemd*
 
 **--rm**=*true*|*false*

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -576,8 +576,8 @@ Valid values are:
 - `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
 
 Please note that restart will not restart containers after a system reboot.
-If you require this functionality, please add your Podman commands to a systemd unit file, or create an init script for your init system of choice.
-There is an example of restarting a container with systemd below.
+This this functionality is required in your environment, you can invoke Podman from a systemd unit file, or create an init script for whichever init system is in use.
+To generate systemd unit files, please see *podman generate systemd*
 
 **--rm**=*true*|*false*
 
@@ -863,21 +863,6 @@ the uids and gids from the host.
 
 ```
 $ podman create --uidmap 0:30000:7000 --gidmap 0:30000:7000 fedora echo hello
-```
-
-### Running a podman container to restart inside of a systemd unit file
-
-
-```
-[Unit]
-Description=My App
-[Service]
-Restart=always
-ExecStart=/usr/bin/podman start -a my_app
-ExecStop=/usr/bin/podman stop -t 10 my_app
-KillMode=process
-[Install]
-WantedBy=multi-user.target
 ```
 
 ### Rootless Containers

--- a/docs/podman-events.1.md
+++ b/docs/podman-events.1.md
@@ -28,6 +28,7 @@ The *container* event type will report the follow statuses:
  * pause
  * prune
  * remove
+ * restart
  * restore
  * start
  * stop

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -598,8 +598,8 @@ Valid values are:
 - `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
 
 Please note that restart will not restart containers after a system reboot.
-If you require this functionality, please add your Podman commands to a systemd unit file, or create an init script for your init system of choice.
-To manage container restart via systemd, see *podman generate systemd*.
+This this functionality is required in your environment, you can invoke Podman from a systemd unit file, or create an init script for whichever init system is in use.
+To generate systemd unit files, please see *podman generate systemd*
 
 **--rm**=*true*|*false*
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -598,7 +598,7 @@ Valid values are:
 - `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
 
 Please note that restart will not restart containers after a system reboot.
-This this functionality is required in your environment, you can invoke Podman from a systemd unit file, or create an init script for whichever init system is in use.
+If this functionality is required in your environment, you can invoke Podman from a systemd unit file, or create an init script for whichever init system is in use.
 To generate systemd unit files, please see *podman generate systemd*
 
 **--rm**=*true*|*false*

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -589,11 +589,17 @@ If container is running in --read-only mode, then mount a read-write tmpfs on /r
 
 **--restart=""**
 
-Not implemented.
+Restart policy to follow when containers exit.
+Restart policy will not take effect if a container is stopped via the `podman kill` or `podman stop` commands.
+Valid values are:
 
-Restart should be handled via a systemd unit files. Please add your podman
-commands to a unit file and allow systemd or your init system to handle the
-restarting of the container processes. See *podman generate systemd*.
+- `no`                       : Do not restart containers on exit
+- `on-failure[:max_retries]` : Restart containers when they exit with a non-0 exit code, retrying indefinitely or until the optional max_retries count is hit
+- `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
+
+Please note that restart will not restart containers after a system reboot.
+If you require this functionality, please add your Podman commands to a systemd unit file, or create an init script for your init system of choice.
+To manage container restart via systemd, see *podman generate systemd*.
 
 **--rm**=*true*|*false*
 

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -185,6 +185,10 @@ type ContainerState struct {
 	// RestartPolicyMatch indicates whether the conditions for restart
 	// policy have been met.
 	RestartPolicyMatch bool `json:"restartPolicyMatch,omitempty"`
+	// RestartCount is how many times the container was restarted by its
+	// restart policy. This is NOT incremented by normal container restarts
+	// (only by restart policy).
+	RestartCount uint `json:"restartCount,omitempty"`
 
 	// ExtensionStageHooks holds hooks which will be executed by libpod
 	// and not delegated to the OCI runtime.

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -181,7 +181,10 @@ type ContainerState struct {
 	BindMounts map[string]string `json:"bindMounts,omitempty"`
 	// StoppedByUser indicates whether the container was stopped by an
 	// explicit call to the Stop() API.
-	StoppedByUser bool
+	StoppedByUser bool `json:"stoppedByUser,omitempty"`
+	// RestartPolicyMatch indicates whether the conditions for restart
+	// policy have been met.
+	RestartPolicyMatch bool `json:"restartPolicyMatch,omitempty"`
 
 	// ExtensionStageHooks holds hooks which will be executed by libpod
 	// and not delegated to the OCI runtime.
@@ -349,6 +352,17 @@ type ContainerConfig struct {
 	LogPath string `json:"logPath"`
 	// File containing the conmon PID
 	ConmonPidFile string `json:"conmonPidFile,omitempty"`
+	// RestartPolicy indicates what action the container will take upon
+	// exiting naturally.
+	// Allowed options are "no" (take no action), "on-failure" (restart on
+	// non-zero exit code, up an a maximum of RestartRetries times),
+	// and "always" (always restart the container on any exit code).
+	// The empty string is treated as the default ("no")
+	RestartPolicy string `json:"restart_policy,omitempty"`
+	// RestartRetries indicates the number of attempts that will be made to
+	// restart the container. Used only if RestartPolicy is set to
+	// "on-failure".
+	RestartRetries uint `json:"restart_retries,omitempty"`
 	// TODO log options for log drivers
 
 	PostConfigureNetNS bool `json:"postConfigureNetNS"`
@@ -730,6 +744,17 @@ func (c *Container) CgroupParent() string {
 // in the runtime
 func (c *Container) LogPath() string {
 	return c.config.LogPath
+}
+
+// RestartPolicy returns the container's restart policy.
+func (c *Container) RestartPolicy() string {
+	return c.config.RestartPolicy
+}
+
+// RestartRetries returns the number of retries that will be attempted when
+// using the "on-failure" restart policy
+func (c *Container) RestartRetries() uint {
+	return c.config.RestartRetries
 }
 
 // RuntimeName returns the name of the runtime

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -102,6 +102,20 @@ func (ns LinuxNS) String() string {
 	}
 }
 
+// Valid restart policy types.
+const (
+	// RestartPolicyNone indicates that no restart policy has been requested
+	// by a container.
+	RestartPolicyNone = ""
+	// RestartPolicyNo is identical in function to RestartPolicyNone.
+	RestartPolicyNo = "no"
+	// RestartPolicyAlways unconditionally restarts the container.
+	RestartPolicyAlways = "always"
+	// RestartPolicyOnFailure restarts the container on non-0 exit code,
+	// with an optional maximum number of retries.
+	RestartPolicyOnFailure = "on-failure"
+)
+
 // Container is a single OCI container.
 // All operations on a Container that access state must begin with a call to
 // syncContainer().

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -605,13 +605,13 @@ func (c *Container) Cleanup(ctx context.Context) error {
 	// restart the container.
 	// However, perform a full validation of restart policy first.
 	if c.state.RestartPolicyMatch {
-		if c.config.RestartPolicy == "on-failure" && c.state.ExitCode != 0 {
+		if c.config.RestartPolicy == RestartPolicyOnFailure && c.state.ExitCode != 0 {
 			logrus.Debugf("Container %s restart policy trigger: on retry %d (of %d)",
 				c.ID(), c.state.RestartCount, c.config.RestartRetries)
 		}
-		if (c.config.RestartPolicy == "on-failure" && c.state.ExitCode != 0 &&
+		if (c.config.RestartPolicy == RestartPolicyOnFailure && c.state.ExitCode != 0 &&
 			(c.config.RestartRetries > 0 && c.state.RestartCount < c.config.RestartRetries)) ||
-			c.config.RestartPolicy == "always" {
+			c.config.RestartPolicy == RestartPolicyAlways {
 			// The container stopped. We need to restart it.
 			return c.handleRestartPolicy(ctx)
 		}

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -199,8 +199,15 @@ func (c *Container) Kill(signal uint) error {
 	if c.state.State != ContainerStateRunning {
 		return errors.Wrapf(ErrCtrStateInvalid, "can only kill running containers")
 	}
+
 	defer c.newContainerEvent(events.Kill)
-	return c.runtime.ociRuntime.killContainer(c, signal)
+	if err := c.runtime.ociRuntime.killContainer(c, signal); err != nil {
+		return err
+	}
+
+	c.state.StoppedByUser = true
+
+	return c.save()
 }
 
 // Exec starts a new process inside the container

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -95,6 +95,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *inspect.Data)
 		LogPath:         config.LogPath,
 		ConmonPidFile:   config.ConmonPidFile,
 		Name:            config.Name,
+		RestartCount:    int32(runtimeInfo.RestartCount),
 		Driver:          driverData.Name,
 		MountLabel:      config.MountLabel,
 		ProcessLabel:    config.ProcessLabel,

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -275,7 +275,7 @@ func (c *Container) syncContainer() error {
 		// Only save back to DB if state changed
 		if c.state.State != oldState {
 			// Check for a restart policy match
-			if c.config.RestartPolicy != "" && c.config.RestartPolicy != "no" &&
+			if c.config.RestartPolicy != RestartPolicyNone && c.config.RestartPolicy != RestartPolicyNo &&
 				(oldState == ContainerStateRunning || oldState == ContainerStatePaused) &&
 				(c.state.State == ContainerStateStopped || c.state.State == ContainerStateExited) &&
 				!c.state.StoppedByUser {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -235,7 +235,7 @@ func (c *Container) handleRestartPolicy(ctx context.Context) (restarted bool, er
 				logrus.Debugf("Container %s restart policy trigger: on retry %d (of %d)",
 					c.ID(), c.state.RestartCount, c.config.RestartRetries)
 			} else {
-				logrus.Debugf("Container %s restart policy trigger: retries exhausted")
+				logrus.Debugf("Container %s restart policy trigger: retries exhausted", c.ID())
 				return false, nil
 			}
 		}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -221,6 +221,14 @@ func (c *Container) handleRestartPolicy(ctx context.Context) (err error) {
 		return err
 	}
 
+	// Is the container running again?
+	// If so, we don't have to do anything
+	if c.state.State == ContainerStateRunning || c.state.State == ContainerStatePaused {
+		return nil
+	} else if c.state.State == ContainerStateUnknown {
+		return errors.Wrapf(ErrInternal, "invalid container state encountered in restart attempt!")
+	}
+
 	// Increment restart count
 	c.state.RestartCount = c.state.RestartCount + 1
 	logrus.Debugf("Container %s now on retry %d", c.ID(), c.state.RestartCount)

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -229,6 +229,8 @@ func (c *Container) handleRestartPolicy(ctx context.Context) (err error) {
 		return errors.Wrapf(ErrInternal, "invalid container state encountered in restart attempt!")
 	}
 
+	c.newContainerEvent(events.Restart)
+
 	// Increment restart count
 	c.state.RestartCount = c.state.RestartCount + 1
 	logrus.Debugf("Container %s now on retry %d", c.ID(), c.state.RestartCount)
@@ -1059,6 +1061,8 @@ func (c *Container) restartWithTimeout(ctx context.Context, timeout uint) (err e
 	if c.state.State == ContainerStateUnknown || c.state.State == ContainerStatePaused {
 		return errors.Wrapf(ErrCtrStateInvalid, "unable to restart a container in a paused or unknown state")
 	}
+
+	c.newContainerEvent(events.Restart)
 
 	if c.state.State == ContainerStateRunning {
 		if err := c.stop(timeout); err != nil {

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -134,6 +134,8 @@ const (
 	// Renumber indicates that lock numbers were reallocated at user
 	// request.
 	Renumber Status = "renumber"
+	// Restart indicates the target was restarted via an API call.
+	Restart Status = "restart"
 	// Restore ...
 	Restore Status = "restore"
 	// Save ...

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -144,6 +144,8 @@ func StringToStatus(name string) (Status, error) {
 		return Remove, nil
 	case Renumber.String():
 		return Renumber, nil
+	case Restart.String():
+		return Restart, nil
 	case Restore.String():
 		return Restore, nil
 	case Save.String():

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1239,6 +1239,41 @@ func WithUseImageHosts() CtrCreateOption {
 	}
 }
 
+// WithRestartPolicy sets the container's restart policy. Valid values are
+// "no", "on-failure", and "always". The empty string is allowed, and will be
+// equivalent to "no".
+func WithRestartPolicy(policy string) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return ErrCtrFinalized
+		}
+
+		switch policy {
+		case "", "no", "on-failure", "always":
+			ctr.config.RestartPolicy = policy
+		default:
+			return errors.Wrapf(ErrInvalidArg, "%q is not a valid restart policy", policy)
+		}
+
+		return nil
+	}
+}
+
+// WithRestartRetries sets the number of retries to use when restarting a
+// container with the "on-failure" restart policy.
+// 0 is an allowed value, and indicates infinite retries.
+func WithRestartRetries(tries uint) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return ErrCtrFinalized
+		}
+
+		ctr.config.RestartRetries = tries
+
+		return nil
+	}
+}
+
 // withIsInfra sets the container to be an infra container. This means the container will be sometimes hidden
 // and expected to be the first container in the pod.
 func withIsInfra() CtrCreateOption {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1249,7 +1249,7 @@ func WithRestartPolicy(policy string) CtrCreateOption {
 		}
 
 		switch policy {
-		case "", "no", "on-failure", "always":
+		case RestartPolicyNone, RestartPolicyNo, RestartPolicyOnFailure, RestartPolicyAlways:
 			ctr.config.RestartPolicy = policy
 		default:
 			return errors.Wrapf(ErrInvalidArg, "%q is not a valid restart policy", policy)

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -364,6 +364,13 @@ func (p *Pod) Kill(signal uint) (map[string]error, error) {
 		}
 
 		logrus.Debugf("Killed container %s with signal %d", ctr.ID(), signal)
+
+		ctr.state.StoppedByUser = true
+		if err := ctr.save(); err != nil {
+			ctrErrors[ctr.ID()] = err
+		}
+
+		ctr.lock.Unlock()
 	}
 
 	if len(ctrErrors) > 0 {

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -161,7 +161,7 @@ type ContainerInspectData struct {
 	LogPath         string                 `json:"LogPath"`
 	ConmonPidFile   string                 `json:"ConmonPidFile"`
 	Name            string                 `json:"Name"`
-	RestartCount    int32                  `json:"RestartCount"` //TODO
+	RestartCount    int32                  `json:"RestartCount"`
 	Driver          string                 `json:"Driver"`
 	MountLabel      string                 `json:"MountLabel"`
 	ProcessLabel    string                 `json:"ProcessLabel"`

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -376,8 +376,7 @@ func (c *CreateConfig) getContainerCreateOptions(runtime *libpod.Runtime, pod *l
 			}
 			options = append(options, libpod.WithRestartRetries(uint(numTries)))
 		}
-
-		options = append(options, libpod.WithRestartPolicy(c.RestartPolicy))
+		options = append(options, libpod.WithRestartPolicy(split[0]))
 	}
 
 	// Always use a cleanup process to clean up Podman after termination

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -108,6 +108,7 @@ type CreateConfig struct {
 	ReadOnlyRootfs     bool     //read-only
 	ReadOnlyTmpfs      bool     //read-only-tmpfs
 	Resources          CreateResourceConfig
+	RestartPolicy      string
 	Rm                 bool              //rm
 	StopSignal         syscall.Signal    // stop-signal
 	StopTimeout        uint              // stop-timeout
@@ -357,6 +358,26 @@ func (c *CreateConfig) getContainerCreateOptions(runtime *libpod.Runtime, pod *l
 
 	if c.CgroupParent != "" {
 		options = append(options, libpod.WithCgroupParent(c.CgroupParent))
+	}
+
+	if c.RestartPolicy != "" {
+		if c.RestartPolicy == "unless-stopped" {
+			return nil, errors.Wrapf(libpod.ErrInvalidArg, "the unless-stopped restart policy is not supported")
+		}
+
+		split := strings.Split(c.RestartPolicy, ":")
+		if len(split) > 1 {
+			numTries, err := strconv.Atoi(split[1])
+			if err != nil {
+				return nil, errors.Wrapf(err, "%s is not a valid number of retries for restart policy", split[1])
+			}
+			if numTries < 0 {
+				return nil, errors.Wrapf(libpod.ErrInvalidArg, "restart policy requires a positive number of retries")
+			}
+			options = append(options, libpod.WithRestartRetries(uint(numTries)))
+		}
+
+		options = append(options, libpod.WithRestartPolicy(c.RestartPolicy))
 	}
 
 	// Always use a cleanup process to clean up Podman after termination

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -725,15 +725,19 @@ USER mail`
 	It("podman run with restart-policy always restarts containers", func() {
 		podmanTest.RestoreArtifact(fedoraMinimal)
 
-		aliveFile := filepath.Join(podmanTest.RunRoot, "running")
+		testDir := filepath.Join(podmanTest.RunRoot, "restart-test")
+		err := os.Mkdir(testDir, 0755)
+		Expect(err).To(BeNil())
+
+		aliveFile := filepath.Join(testDir, "running")
 		file, err := os.Create(aliveFile)
 		Expect(err).To(BeNil())
 		file.Close()
 
-		session := podmanTest.Podman([]string{"run", "-dt", "--restart", "always", "-v", fmt.Sprintf("%s:/tmp/runroot", podmanTest.RunRoot), fedoraMinimal, "bash", "-c", "date +%N > /tmp/runroot/ran && while test -r /tmp/runroot/running; do sleep 0.1s; done"})
+		session := podmanTest.Podman([]string{"run", "-dt", "--restart", "always", "-v", fmt.Sprintf("%s:/tmp/runroot:Z", testDir), fedoraMinimal, "bash", "-c", "date +%N > /tmp/runroot/ran && while test -r /tmp/runroot/running; do sleep 0.1s; done"})
 
 		found := false
-		testFile := filepath.Join(podmanTest.RunRoot, "ran")
+		testFile := filepath.Join(testDir, "ran")
 		for i := 0; i < 10; i++ {
 			time.Sleep(1 * time.Second)
 			if _, err := os.Stat(testFile); err == nil {

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/containers/libpod/test/utils"
 	"github.com/mrunalp/fileutils"
@@ -719,5 +720,45 @@ USER mail`
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(1))
 		os.Unsetenv("http_proxy")
+	})
+
+	It("podman run with restart-policy always restarts containers", func() {
+		podmanTest.RestoreArtifact(fedoraMinimal)
+
+		aliveFile := filepath.Join(podmanTest.RunRoot, "running")
+		file, err := os.Create(aliveFile)
+		Expect(err).To(BeNil())
+		file.Close()
+
+		session := podmanTest.Podman([]string{"run", "-dt", "--restart", "always", "-v", fmt.Sprintf("%s:/tmp/runroot", podmanTest.RunRoot), fedoraMinimal, "bash", "-c", "date +%N > /tmp/runroot/ran && while test -r /tmp/runroot/running; do sleep 0.1s; done"})
+
+		found := false
+		testFile := filepath.Join(podmanTest.RunRoot, "ran")
+		for i := 0; i < 10; i++ {
+			time.Sleep(1 * time.Second)
+			if _, err := os.Stat(testFile); err == nil {
+				found = true
+				err = os.Remove(testFile)
+				Expect(err).To(BeNil())
+				break
+			}
+		}
+		Expect(found).To(BeTrue())
+
+		err = os.Remove(aliveFile)
+		Expect(err).To(BeNil())
+
+		session.WaitWithDefaultTimeout()
+
+		// 10 seconds to restart the container
+		found = false
+		for i := 0; i < 10; i++ {
+			time.Sleep(1 * time.Second)
+			if _, err := os.Stat(testFile); err == nil {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue())
 	})
 })


### PR DESCRIPTION
Cooked this up after lunch. Implements most of Docker's `--restart` flag. We can't implement `unless-stopped` (we don't have a daemon and as such never experience a daemon restart), and I haven't coded up restart counts yet (another half hour or so of work), but `always` and `on-error` with infinite restarts work as advertised.

Needs tests, bash completions, and for me to stop being lazy and code up restart count.