### PR TITLE
Don't skip rootless storage setup for ps if --size set

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -79,7 +79,6 @@ var cmdsNotRequiringRootless = map[*cobra.Command]bool{
 	_podStopCommand:    true,
 	_podTopCommand:     true,
 	_restartCommand:    true,
-	&_psCommand:        true,
 	_rmCommand:         true,
 	_runCommand:        true,
 	_unpauseCommand:    true,

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -202,7 +202,7 @@ func init() {
 }
 
 func psCmd(c *cliconfig.PsValues) error {
-	if os.Geteuid() != 0 {
+	if os.Geteuid() != 0 && !c.Size {
 		rootless.SetSkipStorageSetup(true)
 	}
 	if c.Bool("trace") {


### PR DESCRIPTION
We need the store to look up sizes for containers.

Fixes #2824
