### PR TITLE
--size does not work with rootless at present

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -209,6 +209,10 @@ func psCmd(c *cliconfig.PsValues) error {
 		span, _ := opentracing.StartSpanFromContext(Ctx, "psCmd")
 		defer span.Finish()
 	}
+	// TODO disable when single rootless userns merges
+	if c.Bool("size") && os.Geteuid() != 0 {
+		return errors.New("the --size option is not presently supported without root")
+	}
 
 	var watch bool
 


### PR DESCRIPTION
We'd need to join multiple container's user namespaces, which is not possible for now. The rootless single userns patches under development by Giuseppe will fix this, but won't land in 1.2.x.

For now, disable --size as rootless.