### PR TITLE
Update Dockerfile to use golang:1.12 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM golang:1.11
-
-RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list
+FROM golang:1.12
 
 RUN apt-get update && apt-get install -y \
     apparmor \
@@ -23,6 +21,8 @@ RUN apt-get update && apt-get install -y \
     libostree-dev \
     libprotobuf-dev \
     libprotobuf-c0-dev \
+    libseccomp2 \
+    libseccomp-dev \
     libtool \
     libudev-dev \
     protobuf-c-compiler \
@@ -40,17 +40,6 @@ RUN apt-get update && apt-get install -y \
     xz-utils \
     --no-install-recommends \
     && apt-get clean
-
-ENV LIBSECCOMP_COMMIT release-2.3
-RUN set -x \
-       && git clone https://github.com/seccomp/libseccomp "$GOPATH/src/github.com/seccomp/libseccomp" \
-       && cd "$GOPATH/src/github.com/seccomp/libseccomp" \
-       && git fetch origin --tags \
-       && git checkout -q "$LIBSECCOMP_COMMIT" \
-       && ./autogen.sh \
-       && ./configure --prefix=/usr \
-       && make all \
-       && make install
 
 # Install runc
 ENV RUNC_COMMIT 96ec2177ae841256168fcf76954f7177af9446eb


### PR DESCRIPTION
Hey, I simply updated the image and switched to the official seccomp packages, which should now be fulfilling since the golang images are based on stretch.