### PR TITLE
Fix Dockerfile dependencies for packer tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN apt-get update && apt-get install -y \
     socat \
     lsof \
     xz-utils \
+    unzip \
+    python3-yaml \
     --no-install-recommends \
     && apt-get clean
 


### PR DESCRIPTION
This commit adds unzip and python3-yaml to the Dockerfile, which are
needed to run the tests in `contrib/cirrus/packer` within the libpod
container image.

Running `make testunit` should now be fixed together with the PRs
#2838 and #2839.