### PR TITLE
Update registrar unit tests to match them of cri-o

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 ZSHINSTALLDIR=${PREFIX}/share/zsh/site-functions
 
 SELINUXOPT ?= $(shell test -x /usr/sbin/selinuxenabled && selinuxenabled && echo -Z)
-PACKAGES ?= $(shell $(GO) list -tags "${BUILDTAGS}" ./... | grep -v github.com/containers/libpod/vendor | grep -v e2e | grep -v system )
 
 COMMIT_NO ?= $(shell git rev-parse HEAD 2> /dev/null || true)
 GIT_COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
@@ -172,7 +171,13 @@ testunit: libpodimage ## Run unittest on the built image
 	${CONTAINER_RUNTIME} run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e CGROUP_MANAGER=cgroupfs -e OCI_RUNTIME -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make localunit
 
 localunit: test/goecho/goecho varlink_generate
-	$(GO) test -tags "$(BUILDTAGS)" -cover $(PACKAGES)
+	ginkgo \
+		-r \
+		--skipPackage test/e2e,pkg/apparmor \
+		--cover \
+		--covermode atomic \
+		--tags "$(BUILDTAGS)" \
+		--succinct
 	$(MAKE) -C contrib/cirrus/packer test
 
 ginkgo:

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -1,0 +1,56 @@
+package framework
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+// TestFramework is used to support commonnly used test features
+type TestFramework struct {
+	setup     func(*TestFramework) error
+	teardown  func(*TestFramework) error
+	TestError error
+}
+
+// NewTestFramework creates a new test framework instance for a given `setup`
+// and `teardown` function
+func NewTestFramework(
+	setup func(*TestFramework) error,
+	teardown func(*TestFramework) error,
+) *TestFramework {
+	return &TestFramework{
+		setup,
+		teardown,
+		fmt.Errorf("error"),
+	}
+}
+
+// NilFn is a convenience function which simply does nothing
+func NilFunc(f *TestFramework) error {
+	return nil
+}
+
+// Setup is the global initialization function which runs before each test
+// suite
+func (t *TestFramework) Setup() {
+	// Global initialization for the whole framework goes in here
+
+	// Setup the actual test suite
+	gomega.Expect(t.setup(t)).To(gomega.Succeed())
+}
+
+// Teardown is the global deinitialization function which runs after each test
+// suite
+func (t *TestFramework) Teardown() {
+	// Global deinitialization for the whole framework goes in here
+
+	// Teardown the actual test suite
+	gomega.Expect(t.teardown(t)).To(gomega.Succeed())
+}
+
+// Describe is a convenience wrapper around the `ginkgo.Describe` function
+func (t *TestFramework) Describe(text string, body func()) bool {
+	return ginkgo.Describe("libpod: "+text, body)
+}


### PR DESCRIPTION
Hey, I basically copied the registrar tests from cri-o over here including their dependencies:

- Add the test framework abstraction
- Update the unit tests to run with ginkgo

As a follow-up I would remove the registrar completely from cri-o and use libpods' one.

Another general improvement could be to utilize the already vendored ginkgo sources for running the tests, like we do in cri-o:

```make
${BUILD_BIN_PATH}/ginkgo:
	$(GO) build -o ${BUILD_BIN_PATH}/ginkgo ./vendor/github.com/onsi/ginkgo/ginkgo

testunit: mockgen ${BUILD_BIN_PATH}/ginkgo
	${BUILD_BIN_PATH}/ginkgo \
		${TESTFLAGS} \
		-r \
		...
```

This would make the test results more reliable.