### PR TITLE
Improve podman pod rm -a test

### DIFF
--- a/test/e2e/pod_rm_test.go
+++ b/test/e2e/pod_rm_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/containers/libpod/test/utils"
@@ -95,28 +96,41 @@ var _ = Describe("Podman pod rm", func() {
 	})
 
 	It("podman pod rm -a doesn't remove a running container", func() {
+		fmt.Printf("To start, there are %d pods\n", podmanTest.NumberOfPods())
 		_, ec, podid1 := podmanTest.CreatePod("")
 		Expect(ec).To(Equal(0))
 
 		_, ec, _ = podmanTest.CreatePod("")
 		Expect(ec).To(Equal(0))
+		fmt.Printf("Started %d pods\n", podmanTest.NumberOfPods())
 
 		session := podmanTest.RunTopContainerInPod("", podid1)
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		podmanTest.WaitForContainer()
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
+		fmt.Printf("Started container running in one pod")
 
+		num_pods := podmanTest.NumberOfPods()
+		Expect(num_pods).To(Equal(2))
+		ps := podmanTest.Podman([]string{"pod", "ps"})
+		ps.WaitWithDefaultTimeout()
+		fmt.Printf("Current %d pod(s):\n%s\n", num_pods, ps.OutputToString())
+
+		fmt.Printf("Removing all empty pods\n")
 		result := podmanTest.Podman([]string{"pod", "rm", "-a"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Not(Equal(0)))
+		foundExpectedError, _ := result.ErrorGrepString("contains containers and cannot be removed")
+		Expect(foundExpectedError).To(Equal(true))
 
-		result = podmanTest.Podman([]string{"ps", "-q"})
-		result.WaitWithDefaultTimeout()
-		Expect(len(result.OutputToStringArray())).To(Equal(1))
-
-		// one pod should have been deleted
-		result = podmanTest.Podman([]string{"pod", "ps", "-q"})
-		result.WaitWithDefaultTimeout()
-		Expect(len(result.OutputToStringArray())).To(Equal(1))
+		num_pods = podmanTest.NumberOfPods()
+		ps = podmanTest.Podman([]string{"pod", "ps"})
+		ps.WaitWithDefaultTimeout()
+		fmt.Printf("Final %d pod(s):\n%s\n", num_pods, ps.OutputToString())
+		Expect(num_pods).To(Equal(1))
+		// Confirm top container still running inside remaining pod
+		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 	})
 
 	It("podman pod rm -fa removes everything", func() {


### PR DESCRIPTION
When running as a user, the order of removal is database ID dependent.
This results in this test randomly failing.  This condition was
very difficult to debug and the test was missing two critical checks.
One to confirm an expected error message was produced, and another
to verify the expected running container, remains running.

Fix the container and missing error-message checks, and vastly improve
the debug-ability of this test.  Fixing the random-failures requires
intensive fixes in other areas, so that task will be left up to future
work.

Signed-off-by: Chris Evich <cevich@redhat.com>