### PR TITLE
fix bug podman cp directory

### DIFF
--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -112,4 +112,37 @@ var _ = Describe("Podman cp", func() {
 		}
 		Expect(string(output)).To(Equal("copy from host to container directory"))
 	})
+
+	It("podman cp dir to dir", func() {
+		path, err := os.Getwd()
+		if err != nil {
+			os.Exit(1)
+		}
+		testDirPath := filepath.Join(path, "TestDir")
+		err = os.Mkdir(testDirPath, 0777)
+		if err != nil {
+			os.Exit(1)
+		}
+
+		session := podmanTest.Podman([]string{"create", ALPINE, "ls", "/foodir"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		name := session.OutputToString()
+
+		session = podmanTest.Podman([]string{"cp", testDirPath, name + ":/foodir"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"start", "-a", name})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"cp", testDirPath, name + ":/foodir"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"start", "-a", name})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("TestDir"))
+	})
 })


### PR DESCRIPTION
close #2836 
`podman cp` used to copy the contents under the source directory to the destination. But according to the specification in podman-cp.md. it should copy the whole directory to the destination if the destination directory already exists.
- src dir ends with /., copy the contents to dest dir
- src dir does not end with /.
    - dest dir `/home` does not exist, copy the contents
    - dest dir `/home` exists, copy the directory

```
$ sudo podman cp /home/qiwan/Documents/empty 7c47:/home
$ sudo podman exec -it 7c47 ls /home
$

$ sudo podman cp /home/qiwan/Documents/empty 7c47:/home
$ sudo podman exec -it 7c47 ls /home
empty

```

Signed-off-by: Qi Wang <qiwan@redhat.com>