### PR TITLE
Increase resources for build_each_commit task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -179,9 +179,9 @@ build_each_commit_task:
     gce_instance:
         image_project: "libpod-218412"
         zone: "us-central1-a"  # Required by Cirrus for the time being
-        cpu: 2
-        memory: "4Gb"
-        disk: 40
+        cpu: 8
+        memory: "8Gb"
+        disk: 200
         image_name: "${FEDORA_CACHE_IMAGE_NAME}"
 
     timeout_in: 30m


### PR DESCRIPTION
The build_each_commit task builds each commit in a pull request
to verify that we have a (at least minimally) functional Podman
at every point, to aid in bisecting.

This task is, right now, extremely slow, taking around 1m40s to
build each commit - which quickly grows unreasonable as PRs grow
to 10+ commits.

Upping resources available to the task should decrease time spent
in CI and reduce the risk of hitting timeouts.

Signed-off-by: Matthew Heon <matthew.heon@pm.me>