### PR TITLE
rootless: add support for kube

### DIFF
--- a/cmd/podman/generate_kube.go
+++ b/cmd/podman/generate_kube.go
@@ -5,7 +5,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
-	"github.com/containers/libpod/pkg/rootless"
 	podmanVersion "github.com/containers/libpod/version"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -53,9 +52,6 @@ func generateKubeYAMLCmd(c *cliconfig.GenerateKubeValues) error {
 		servicePorts      []v1.ServicePort
 	)
 
-	if rootless.IsRootless() {
-		return errors.Wrapf(libpod.ErrNotImplemented, "rootless users")
-	}
 	args := c.InputArgs
 	if len(args) != 1 {
 		return errors.Errorf("you must provide exactly one container|pod ID or name")

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/image"
 	ns "github.com/containers/libpod/pkg/namespaces"
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/spec"
 	"github.com/containers/storage"
 	"github.com/cri-o/ocicni/pkg/ocicni"
@@ -73,9 +72,6 @@ func playKubeYAMLCmd(c *cliconfig.KubePlayValues) error {
 	)
 
 	ctx := getContext()
-	if rootless.IsRootless() {
-		return errors.Wrapf(libpod.ErrNotImplemented, "rootless users")
-	}
 	args := c.InputArgs
 	if len(args) > 1 {
 		return errors.New("you can only play one kubernetes file at a time")

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -243,6 +243,9 @@ func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container
 		envs            map[string]string
 	)
 
+	// The default for MemorySwappiness is -1, not 0
+	containerConfig.Resources.MemorySwappiness = -1
+
 	containerConfig.Runtime = runtime
 	containerConfig.Image = containerYAML.Image
 	containerConfig.ImageID = newImage.ID()

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -48,7 +48,6 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman generate kube on container", func() {
-		SkipIfRootless()
 		session := podmanTest.RunTopContainer("top")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -62,7 +61,6 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman generate service kube on container", func() {
-		SkipIfRootless()
 		session := podmanTest.RunTopContainer("top")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -76,7 +74,6 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman generate kube on pod", func() {
-		SkipIfRootless()
 		_, rc, _ := podmanTest.CreatePod("toppod")
 		Expect(rc).To(Equal(0))
 
@@ -93,7 +90,6 @@ var _ = Describe("Podman generate kube", func() {
 	})
 
 	It("podman generate service kube on pod", func() {
-		SkipIfRootless()
 		_, rc, _ := podmanTest.CreatePod("toppod")
 		Expect(rc).To(Equal(0))
 


### PR DESCRIPTION
the only remaining issue was not correctly setting up the value for MemorySwappiness.  The issue was affecting root containers too.

Closes: https://github.com/containers/libpod/issues/2852