### PR TITLE
add image rmi event

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -361,6 +361,7 @@ func (i *Image) Remove(force bool) error {
 	if _, err := i.imageruntime.store.DeleteImage(i.ID(), true); err != nil {
 		return err
 	}
+	i.newImageEvent(events.Remove)
 	for parent != nil {
 		nextParent, err := parent.GetParent()
 		if err != nil {
@@ -383,7 +384,6 @@ func (i *Image) Remove(force bool) error {
 		}
 		parent = nextParent
 	}
-	defer i.newImageEvent(events.Remove)
 	return nil
 }
 


### PR DESCRIPTION
when deleting a commited image, the path for deletion has an early exit
and the image remove event was not being triggered.

Signed-off-by: baude <bbaude@redhat.com>