### PR TITLE
Remove two bits of dead code

### DIFF
--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -118,16 +118,3 @@ func searchToGeneric(params []image.SearchResult) (genericParams []interface{}) 
 	}
 	return genericParams
 }
-
-func genSearchOutputMap() map[string]string {
-	io := image.SearchResult{}
-	v := reflect.Indirect(reflect.ValueOf(io))
-	values := make(map[string]string)
-
-	for i := 0; i < v.NumField(); i++ {
-		key := v.Type().Field(i).Name
-		value := key
-		values[key] = strings.ToUpper(splitCamelCase(value))
-	}
-	return values
-}

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -726,11 +726,6 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 	return config, nil
 }
 
-type namespace interface {
-	IsContainer() bool
-	Container() string
-}
-
 func CreateContainerFromCreateConfig(r *libpod.Runtime, createConfig *cc.CreateConfig, ctx context.Context, pod *libpod.Pod) (*libpod.Container, error) {
 	runtimeSpec, err := cc.CreateConfigToOCISpec(createConfig)
 	if err != nil {


### PR DESCRIPTION
These two deadcode findings popped in during the switch from gometalinter -> golangci-lint.  I have no idea if that's a proper lint fix or not.  

Signed-off-by: Chris Evich <cevich@redhat.com>