### PR TITLE
Add the ability to attach remotely to a container

### DIFF
--- a/API.md
+++ b/API.md
@@ -3,6 +3,10 @@ Podman Service Interface and API description.  The master version of this docume
 in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in the upstream libpod repository.
 ## Index
 
+[func Attach(name: string) ](#Attach)
+
+[func AttachControl(name: string) ](#AttachControl)
+
 [func BuildImage(build: BuildInfo) MoreResponse](#BuildImage)
 
 [func BuildImageHierarchyMap(name: string) string](#BuildImageHierarchyMap)
@@ -135,6 +139,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func SendFile(type: string, length: int) string](#SendFile)
 
+[func Spec(name: string) string](#Spec)
+
 [func StartContainer(name: string) string](#StartContainer)
 
 [func StartPod(name: string) string](#StartPod)
@@ -252,6 +258,16 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 [error WantsMoreRequired](#WantsMoreRequired)
 
 ## Methods
+### <a name="Attach"></a>func Attach
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method Attach(name: [string](https://godoc.org/builtin#string)) </div>
+
+### <a name="AttachControl"></a>func AttachControl
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method AttachControl(name: [string](https://godoc.org/builtin#string)) </div>
+
 ### <a name="BuildImage"></a>func BuildImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -945,6 +961,11 @@ search results per registry.
 
 method SendFile(type: [string](https://godoc.org/builtin#string), length: [int](https://godoc.org/builtin#int)) [string](https://godoc.org/builtin#string)</div>
 Sendfile allows a remote client to send a file to the host
+### <a name="Spec"></a>func Spec
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method Spec(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+Spec returns the oci spec for a container.  This call is for development of Podman only and generally should not be used.
 ### <a name="StartContainer"></a>func StartContainer
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 

--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -11,7 +11,6 @@ const remoteclient = false
 // Commands that the local client implements
 func getMainCommands() []*cobra.Command {
 	rootCommands := []*cobra.Command{
-		_attachCommand,
 		_commitCommand,
 		_execCommand,
 		_generateCommand,
@@ -47,7 +46,6 @@ func getImageSubCommands() []*cobra.Command {
 func getContainerSubCommands() []*cobra.Command {
 
 	return []*cobra.Command{
-		_attachCommand,
 		_checkpointCommand,
 		_cleanupCommand,
 		_commitCommand,

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -50,6 +50,7 @@ var (
 
 	// Commands that are universally implemented.
 	containerCommands = []*cobra.Command{
+		_attachCommand,
 		_containerExistsCommand,
 		_contInspectSubCommand,
 		_diffCommand,

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -38,6 +38,7 @@ var (
 // Commands that the remote and local client have
 // implemented.
 var mainCommands = []*cobra.Command{
+	_attachCommand,
 	_buildCommand,
 	_diffCommand,
 	_createCommand,

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -658,8 +658,9 @@ method PauseContainer(name: string) -> (container: string)
 # See also [PauseContainer](#PauseContainer).
 method UnpauseContainer(name: string) -> (container: string)
 
-# This method has not be implemented yet.
-# method AttachToContainer() -> (notimplemented: NotImplemented)
+method Attach(name: string) -> ()
+
+method AttachControl(name: string) -> ()
 
 # GetAttachSockets takes the name or ID of an existing container.  It returns file paths for two sockets needed
 # to properly communicate with a container.  The first is the actual I/O socket that the container uses.  The
@@ -1153,6 +1154,9 @@ method PodStateData(name: string) -> (config: string)
 
 # This call is for the development of Podman only and should not be used.
 method CreateFromCC(in: []string) -> (id: string)
+
+# Spec returns the oci spec for a container.  This call is for development of Podman only and generally should not be used.
+method Spec(name: string) -> (config: string)
 
 # Sendfile allows a remote client to send a file to the host
 method SendFile(type: string, length: int) -> (file_handle: string)

--- a/pkg/varlinkapi/attach.go
+++ b/pkg/varlinkapi/attach.go
@@ -1,0 +1,75 @@
+// +build varlink
+
+package varlinkapi
+
+import (
+	"io"
+
+	"github.com/containers/libpod/cmd/podman/varlink"
+	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/pkg/varlinkapi/virtwriter"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// Close is method to close the writer
+
+// Attach ...
+func (i *LibpodAPI) Attach(call iopodman.VarlinkCall, name string) error {
+	var finalErr error
+	resize := make(chan remotecommand.TerminalSize)
+	errChan := make(chan error)
+
+	if !call.WantsUpgrade() {
+		return call.ReplyErrorOccurred("client must use upgraded connection to attach")
+	}
+	ctr, err := i.Runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+
+	// These are the varlink sockets
+	reader := call.Call.Reader
+	writer := call.Call.Writer
+
+	// This pipe is used to pass stdin from the client to the input stream
+	// once the msg has been "decoded"
+	pr, pw := io.Pipe()
+
+	stdoutWriter := virtwriter.NewVirtWriteCloser(writer, virtwriter.ToStdout)
+	// TODO if runc ever starts passing stderr, we can too
+	//stderrWriter := NewVirtWriteCloser(writer, ToStderr)
+
+	streams := libpod.AttachStreams{
+		OutputStream: stdoutWriter,
+		InputStream:  pr,
+		// Runc eats the error stream
+		ErrorStream:  stdoutWriter,
+		AttachInput:  true,
+		AttachOutput: true,
+		// Runc eats the error stream
+		AttachError: true,
+	}
+
+	go func() {
+		if err := virtwriter.Reader(reader, nil, nil, pw, resize); err != nil {
+			errChan <- err
+		}
+	}()
+
+	go func() {
+		// TODO allow for customizable detach keys
+		if err := ctr.Attach(&streams, "", resize); err != nil {
+			errChan <- err
+		}
+	}()
+
+	select {
+	// Blocking on an error
+	case finalErr = <-errChan:
+		// Need to close up shop
+		_ = finalErr
+	}
+	quitWriter := virtwriter.NewVirtWriteCloser(writer, virtwriter.Quit)
+	_, err = quitWriter.Write([]byte("HANG-UP"))
+	return call.Writer.Flush()
+}

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -634,6 +634,22 @@ func (i *LibpodAPI) GetContainerStatsWithHistory(call iopodman.VarlinkCall, prev
 	return call.ReplyGetContainerStatsWithHistory(cStats)
 }
 
+// Spec ...
+func (i *LibpodAPI) Spec(call iopodman.VarlinkCall, name string) error {
+	ctr, err := i.Runtime.LookupContainer(name)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+
+	spec := ctr.Spec()
+	b, err := json.Marshal(spec)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+
+	return call.ReplySpec(string(b))
+}
+
 // GetContainersLogs is the varlink endpoint to obtain one or more container logs
 func (i *LibpodAPI) GetContainersLogs(call iopodman.VarlinkCall, names []string, follow, latest bool, since string, tail int64, timestamps bool) error {
 	var wg sync.WaitGroup

--- a/pkg/varlinkapi/virtwriter/virtwriter.go
+++ b/pkg/varlinkapi/virtwriter/virtwriter.go
@@ -1,0 +1,155 @@
+package virtwriter
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// SocketDest is the "key" to where IO should go on the varlink
+// multiplexed socket
+type SocketDest int
+
+const (
+	// ToStdout indicates traffic should go stdout
+	ToStdout SocketDest = iota
+	// ToStdin indicates traffic came from stdin
+	ToStdin SocketDest = iota
+	// ToStderr indicates traffuc should go to stderr
+	ToStderr SocketDest = iota
+	// TerminalResize indicates a terminal resize event has occurred
+	// and data should be passed to resizer
+	TerminalResize SocketDest = iota
+	// Quit and detach
+	Quit SocketDest = iota
+)
+
+// IntToSocketDest returns a socketdest based on integer input
+func IntToSocketDest(i int) SocketDest {
+	switch i {
+	case ToStdout.Int():
+		return ToStdout
+	case ToStderr.Int():
+		return ToStderr
+	case ToStdin.Int():
+		return ToStdin
+	case TerminalResize.Int():
+		return TerminalResize
+	case Quit.Int():
+		return Quit
+	default:
+		return ToStderr
+	}
+}
+
+// Int returns the integer representation of the socket dest
+func (sd SocketDest) Int() int {
+	return int(sd)
+}
+
+// VirtWriteCloser are writers for attach which include the dest
+// of the data
+type VirtWriteCloser struct {
+	writer *bufio.Writer
+	dest   SocketDest
+}
+
+// NewVirtWriteCloser is a constructor
+func NewVirtWriteCloser(w *bufio.Writer, dest SocketDest) VirtWriteCloser {
+	return VirtWriteCloser{w, dest}
+}
+
+// Close is a required method for a writecloser
+func (v VirtWriteCloser) Close() error {
+	return nil
+}
+
+// Write prepends a header to the input message.  The header is
+// 8bytes.  Position one contains the destination.  Positions
+// 5,6,7,8 are a big-endian encoded uint32 for len of the message.
+func (v VirtWriteCloser) Write(input []byte) (int, error) {
+	header := []byte{byte(v.dest), 0, 0, 0}
+	// Go makes us define the byte for big endian
+	mlen := make([]byte, 4)
+	binary.BigEndian.PutUint32(mlen, uint32(len(input)))
+	// append the message len to the header
+	msg := append(header, mlen...)
+	// append the message to the header
+	msg = append(msg, input...)
+	_, err := v.writer.Write(msg)
+	if err != nil {
+		return 0, err
+	}
+	err = v.writer.Flush()
+	return len(input), err
+}
+
+// Reader decodes the content that comes over the wire and directs it to the proper destination.
+func Reader(r *bufio.Reader, output, errput *os.File, input *io.PipeWriter, resize chan remotecommand.TerminalSize) error {
+	var saveb []byte
+	var eom int
+	for {
+		readb := make([]byte, 32*1024)
+		n, err := r.Read(readb)
+		// TODO, later may be worth checking in len of the read is 0
+		if err != nil {
+			return err
+		}
+		b := append(saveb, readb[0:n]...)
+		// no sense in reading less than the header len
+		for len(b) > 7 {
+			eom = int(binary.BigEndian.Uint32(b[4:8])) + 8
+			// The message and header are togther
+			if len(b) >= eom {
+				out := append([]byte{}, b[8:eom]...)
+
+				switch IntToSocketDest(int(b[0])) {
+				case ToStdout:
+					n, err := output.Write(out)
+					if err != nil {
+						return err
+					}
+					if n < len(out) {
+						return errors.New("short write error occurred on stdout")
+					}
+				case ToStderr:
+					n, err := errput.Write(out)
+					if err != nil {
+						return err
+					}
+					if n < len(out) {
+						return errors.New("short write error occurred on stderr")
+					}
+				case ToStdin:
+					n, err := input.Write(out)
+					if err != nil {
+						return err
+					}
+					if n < len(out) {
+						return errors.New("short write error occurred on stdin")
+					}
+				case TerminalResize:
+					// Resize events come over in bytes, need to be reserialized
+					resizeEvent := remotecommand.TerminalSize{}
+					if err := json.Unmarshal(out, &resizeEvent); err != nil {
+						return err
+					}
+					resize <- resizeEvent
+				case Quit:
+					return nil
+				}
+				b = b[eom:]
+			} else {
+				//	We do not have the header and full message, need to slurp again
+				saveb = b
+				break
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Also, you can now podman-remote run -it.  There are some bugs that need
to be ironed out but I would prefer to merge this so we can make both
progress on start and exec as well as the bugs.

* when doing podman-remote run -it foo /bin/bash, you have to press
enter to get the prompt to display. with the localized podman, we had to
teach it connect to the console first and then start the container so we
did not miss anything.

* when executing "exit" in the console, we get a hard lockup likely
because nobody knows what to do.

* custom detach keys are not supported

Signed-off-by: baude <bbaude@redhat.com>