### PR TITLE
ps: now works with --size and nonroot

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -205,10 +205,6 @@ func psCmd(c *cliconfig.PsValues) error {
 		span, _ := opentracing.StartSpanFromContext(Ctx, "psCmd")
 		defer span.Finish()
 	}
-	// TODO disable when single rootless userns merges
-	if c.Bool("size") && os.Geteuid() != 0 {
-		return errors.New("the --size option is not presently supported without root")
-	}
 
 	var watch bool
 


### PR DESCRIPTION
Revert the error check from #2832. This is not strictly
necessary, since 'podman ps --size' now works perfectly
fine in nonroot because some recent change (Giuseppe's,
presumably) masked os.Geteuid() return 0... but removing
for maintainability's sake.

Signed-off-by: Ed Santiago <santiago@redhat.com>