### PR TITLE
Initial remote flag clean up

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -3,26 +3,18 @@ package main
 import (
 	"context"
 	"io"
-	"io/ioutil"
-	"log/syslog"
 	"os"
-	"runtime/pprof"
-	"strconv"
-	"strings"
 	"syscall"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
 	_ "github.com/containers/libpod/pkg/hooks/0.1.0"
 	"github.com/containers/libpod/pkg/rootless"
-	"github.com/containers/libpod/pkg/tracing"
 	"github.com/containers/libpod/version"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	lsyslog "github.com/sirupsen/logrus/hooks/syslog"
 	"github.com/spf13/cobra"
 )
 
@@ -89,40 +81,13 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.TraverseChildren = true
 	rootCmd.Version = version.Version
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.CGroupManager, "cgroup-manager", "", "Cgroup manager to use (cgroupfs or systemd, default systemd)")
-	// -c is deprecated due to conflict with -c on subcommands
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.CpuProfile, "cpu-profile", "", "Path for the cpu profiling results")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Config, "config", "", "Path of a libpod config file detailing container server configuration options")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.ConmonPath, "conmon", "", "Path of the conmon binary")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.NetworkCmdPath, "network-cmd-path", "", "Path to the command for configuring the network")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.CniConfigDir, "cni-config-dir", "", "Path of the configuration directory for CNI networks")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.DefaultMountsFile, "default-mounts-file", "", "Path to default mounts file")
-	rootCmd.PersistentFlags().MarkHidden("defaults-mount-file")
-	// Override default --help information of `--help` global flag
-	var dummyHelp bool
-	rootCmd.PersistentFlags().BoolVar(&dummyHelp, "help", false, "Help for podman")
-	rootCmd.PersistentFlags().StringSliceVar(&MainGlobalOpts.HooksDir, "hooks-dir", []string{}, "Set the OCI hooks directory path (may be set multiple times)")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.LogLevel, "log-level", "error", "Log messages above specified level: debug, info, warn, error, fatal or panic")
-	rootCmd.PersistentFlags().IntVar(&MainGlobalOpts.MaxWorks, "max-workers", 0, "The maximum number of workers for parallel operations")
-	rootCmd.PersistentFlags().MarkHidden("max-workers")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Namespace, "namespace", "", "Set the libpod namespace, used to create separate views of the containers and pods on the system")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Root, "root", "", "Path to the root directory in which data, including images, is stored")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Runroot, "runroot", "", "Path to the 'run directory' where all state information is stored")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Runtime, "runtime", "", "Path to the OCI-compatible binary used to run containers, default is /usr/bin/runc")
-	// -s is depracated due to conflict with -s on subcommands
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.StorageDriver, "storage-driver", "", "Select which storage driver is used to manage storage of images and containers (default is overlay)")
-	rootCmd.PersistentFlags().StringSliceVar(&MainGlobalOpts.StorageOpts, "storage-opt", []string{}, "Used to pass an option to the storage driver")
-	rootCmd.PersistentFlags().BoolVar(&MainGlobalOpts.Syslog, "syslog", false, "Output logging information to syslog as well as the console")
-
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.TmpDir, "tmpdir", "", "Path to the tmp directory")
-	rootCmd.PersistentFlags().BoolVar(&MainGlobalOpts.Trace, "trace", false, "Enable opentracing output")
 	// Override default --help information of `--version` global flag
 	var dummyVersion bool
 	rootCmd.PersistentFlags().BoolVar(&dummyVersion, "version", false, "Version for podman")
 	rootCmd.AddCommand(mainCommands...)
 	rootCmd.AddCommand(getMainCommands()...)
-
 }
+
 func initConfig() {
 	//	we can do more stuff in here.
 }
@@ -132,63 +97,16 @@ func before(cmd *cobra.Command, args []string) error {
 		logrus.Errorf(err.Error())
 		os.Exit(1)
 	}
-	if os.Geteuid() != 0 && cmd != _searchCommand && cmd != _versionCommand && !strings.HasPrefix(cmd.Use, "help") {
-		podmanCmd := cliconfig.PodmanCommand{
-			cmd,
-			args,
-			MainGlobalOpts,
-		}
-		runtime, err := libpodruntime.GetRuntime(&podmanCmd)
-		if err != nil {
-			return errors.Wrapf(err, "could not get runtime")
-		}
-		defer runtime.Shutdown(false)
-
-		ctrs, err := runtime.GetRunningContainers()
-		if err != nil {
-			logrus.Errorf(err.Error())
-			os.Exit(1)
-		}
-		var became bool
-		var ret int
-		if len(ctrs) == 0 {
-			became, ret, err = rootless.BecomeRootInUserNS()
-		} else {
-			for _, ctr := range ctrs {
-				data, err := ioutil.ReadFile(ctr.Config().ConmonPidFile)
-				if err != nil {
-					logrus.Errorf(err.Error())
-					os.Exit(1)
-				}
-				conmonPid, err := strconv.Atoi(string(data))
-				if err != nil {
-					logrus.Errorf(err.Error())
-					os.Exit(1)
-				}
-				became, ret, err = rootless.JoinUserAndMountNS(uint(conmonPid))
-				if err == nil {
-					break
-				}
-			}
-		}
-		if err != nil {
-			logrus.Errorf(err.Error())
-			os.Exit(1)
-		}
-		if became {
-			os.Exit(ret)
-		}
+	if err := setupRootless(cmd, args); err != nil {
+		return err
 	}
 
-	if MainGlobalOpts.Syslog {
-		hook, err := lsyslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
-		if err == nil {
-			logrus.AddHook(hook)
-		}
+	//	Set log level; if not log-level is provided, default to error
+	logLevel := MainGlobalOpts.LogLevel
+	if logLevel == "" {
+		logLevel = "error"
 	}
-
-	//	Set log level
-	level, err := logrus.ParseLevel(MainGlobalOpts.LogLevel)
+	level, err := logrus.ParseLevel(logLevel)
 	if err != nil {
 		return err
 	}
@@ -213,36 +131,11 @@ func before(cmd *cobra.Command, args []string) error {
 
 	// Be sure we can create directories with 0755 mode.
 	syscall.Umask(0022)
-
-	if cmd.Flag("cpu-profile").Changed {
-		f, err := os.Create(MainGlobalOpts.CpuProfile)
-		if err != nil {
-			return errors.Wrapf(err, "unable to create cpu profiling file %s",
-				MainGlobalOpts.CpuProfile)
-		}
-		pprof.StartCPUProfile(f)
-	}
-	if cmd.Flag("trace").Changed {
-		var tracer opentracing.Tracer
-		tracer, closer = tracing.Init("podman")
-		opentracing.SetGlobalTracer(tracer)
-
-		span = tracer.StartSpan("before-context")
-
-		Ctx = opentracing.ContextWithSpan(context.Background(), span)
-	}
-	return nil
+	return profileOn(cmd)
 }
 
 func after(cmd *cobra.Command, args []string) error {
-	if cmd.Flag("cpu-profile").Changed {
-		pprof.StopCPUProfile()
-	}
-	if cmd.Flag("trace").Changed {
-		span.Finish()
-		closer.Close()
-	}
-	return nil
+	return profileOff(cmd)
 }
 
 func main() {

--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -1,0 +1,155 @@
+// +build !remoteclient
+
+package main
+
+import (
+	"context"
+	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/containers/libpod/cmd/podman/libpodruntime"
+	"github.com/containers/libpod/pkg/rootless"
+	"io/ioutil"
+	"log/syslog"
+	"os"
+	"runtime/pprof"
+	"strconv"
+	"strings"
+
+	"github.com/containers/libpod/pkg/tracing"
+	"github.com/opentracing/opentracing-go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	lsyslog "github.com/sirupsen/logrus/hooks/syslog"
+	"github.com/spf13/cobra"
+)
+
+const remote = false
+
+func init() {
+
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.CGroupManager, "cgroup-manager", "", "Cgroup manager to use (cgroupfs or systemd, default systemd)")
+	// -c is deprecated due to conflict with -c on subcommands
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.CpuProfile, "cpu-profile", "", "Path for the cpu profiling results")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Config, "config", "", "Path of a libpod config file detailing container server configuration options")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.ConmonPath, "conmon", "", "Path of the conmon binary")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.NetworkCmdPath, "network-cmd-path", "", "Path to the command for configuring the network")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.CniConfigDir, "cni-config-dir", "", "Path of the configuration directory for CNI networks")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.DefaultMountsFile, "default-mounts-file", "", "Path to default mounts file")
+	rootCmd.PersistentFlags().MarkHidden("defaults-mount-file")
+	// Override default --help information of `--help` global flag
+	var dummyHelp bool
+	rootCmd.PersistentFlags().BoolVar(&dummyHelp, "help", false, "Help for podman")
+	rootCmd.PersistentFlags().StringSliceVar(&MainGlobalOpts.HooksDir, "hooks-dir", []string{}, "Set the OCI hooks directory path (may be set multiple times)")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.LogLevel, "log-level", "error", "Log messages above specified level: debug, info, warn, error, fatal or panic")
+	rootCmd.PersistentFlags().IntVar(&MainGlobalOpts.MaxWorks, "max-workers", 0, "The maximum number of workers for parallel operations")
+	rootCmd.PersistentFlags().MarkHidden("max-workers")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Namespace, "namespace", "", "Set the libpod namespace, used to create separate views of the containers and pods on the system")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Root, "root", "", "Path to the root directory in which data, including images, is stored")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Runroot, "runroot", "", "Path to the 'run directory' where all state information is stored")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Runtime, "runtime", "", "Path to the OCI-compatible binary used to run containers, default is /usr/bin/runc")
+	// -s is depracated due to conflict with -s on subcommands
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.StorageDriver, "storage-driver", "", "Select which storage driver is used to manage storage of images and containers (default is overlay)")
+	rootCmd.PersistentFlags().StringSliceVar(&MainGlobalOpts.StorageOpts, "storage-opt", []string{}, "Used to pass an option to the storage driver")
+	rootCmd.PersistentFlags().BoolVar(&MainGlobalOpts.Syslog, "syslog", false, "Output logging information to syslog as well as the console")
+
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.TmpDir, "tmpdir", "", "Path to the tmp directory")
+	rootCmd.PersistentFlags().BoolVar(&MainGlobalOpts.Trace, "trace", false, "Enable opentracing output")
+}
+
+func setSyslog() error {
+	if MainGlobalOpts.Syslog {
+		hook, err := lsyslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
+		if err == nil {
+			logrus.AddHook(hook)
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func profileOn(cmd *cobra.Command) error {
+	if cmd.Flag("cpu-profile").Changed {
+		f, err := os.Create(MainGlobalOpts.CpuProfile)
+		if err != nil {
+			return errors.Wrapf(err, "unable to create cpu profiling file %s",
+				MainGlobalOpts.CpuProfile)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			return err
+		}
+	}
+
+	if cmd.Flag("trace").Changed {
+		var tracer opentracing.Tracer
+		tracer, closer = tracing.Init("podman")
+		opentracing.SetGlobalTracer(tracer)
+
+		span = tracer.StartSpan("before-context")
+
+		Ctx = opentracing.ContextWithSpan(context.Background(), span)
+	}
+	return nil
+}
+
+func profileOff(cmd *cobra.Command) error {
+	if cmd.Flag("cpu-profile").Changed {
+		pprof.StopCPUProfile()
+	}
+	if cmd.Flag("trace").Changed {
+		span.Finish()
+		closer.Close()
+	}
+	return nil
+}
+
+func setupRootless(cmd *cobra.Command, args []string) error {
+	if os.Geteuid() == 0 || cmd == _searchCommand || cmd == _versionCommand || strings.HasPrefix(cmd.Use, "help") {
+		return nil
+	}
+	podmanCmd := cliconfig.PodmanCommand{
+		cmd,
+		args,
+		MainGlobalOpts,
+	}
+	runtime, err := libpodruntime.GetRuntime(&podmanCmd)
+	if err != nil {
+		return errors.Wrapf(err, "could not get runtime")
+	}
+	defer runtime.Shutdown(false)
+
+	ctrs, err := runtime.GetRunningContainers()
+	if err != nil {
+		logrus.Errorf(err.Error())
+		os.Exit(1)
+	}
+	var became bool
+	var ret int
+	if len(ctrs) == 0 {
+		became, ret, err = rootless.BecomeRootInUserNS()
+	} else {
+		for _, ctr := range ctrs {
+			data, err := ioutil.ReadFile(ctr.Config().ConmonPidFile)
+			if err != nil {
+				logrus.Errorf(err.Error())
+				os.Exit(1)
+			}
+			conmonPid, err := strconv.Atoi(string(data))
+			if err != nil {
+				logrus.Errorf(err.Error())
+				os.Exit(1)
+			}
+			became, ret, err = rootless.JoinUserAndMountNS(uint(conmonPid))
+			if err == nil {
+				break
+			}
+		}
+	}
+	if err != nil {
+		logrus.Errorf(err.Error())
+		os.Exit(1)
+	}
+	if became {
+		os.Exit(ret)
+	}
+	return nil
+}

--- a/cmd/podman/main_remote.go
+++ b/cmd/podman/main_remote.go
@@ -1,0 +1,43 @@
+// +build remoteclient
+
+package main
+
+import (
+	"os"
+
+	"github.com/containers/libpod/pkg/rootless"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const remote = true
+
+func init() {
+	//	remote client specific flags can go here.
+}
+
+func setSyslog() error {
+	return nil
+}
+
+func profileOn(cmd *cobra.Command) error {
+	return nil
+}
+
+func profileOff(cmd *cobra.Command) error {
+	return nil
+}
+
+func setupRootless(cmd *cobra.Command, args []string) error {
+	if rootless.IsRootless() {
+		became, ret, err := rootless.BecomeRootInUserNS()
+		if err != nil {
+			logrus.Errorf(err.Error())
+			os.Exit(1)
+		}
+		if became {
+			os.Exit(ret)
+		}
+	}
+	return nil
+}

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -46,12 +46,16 @@ func init() {
 	pullCommand.SetUsageTemplate(UsageTemplate())
 	flags := pullCommand.Flags()
 	flags.BoolVar(&pullCommand.AllTags, "all-tags", false, "All tagged images inthe repository will be pulled")
-	flags.StringVar(&pullCommand.Authfile, "authfile", "", "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringVar(&pullCommand.CertDir, "cert-dir", "", "`Pathname` of a directory containing TLS certificates and keys")
 	flags.StringVar(&pullCommand.Creds, "creds", "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
 	flags.BoolVarP(&pullCommand.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
-	flags.StringVar(&pullCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
-	flags.BoolVar(&pullCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+
+	// Disabled flags for the remote client
+	if !remote {
+		flags.StringVar(&pullCommand.Authfile, "authfile", "", "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")
+		flags.StringVar(&pullCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
+		flags.BoolVar(&pullCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+	}
 
 }
 

--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -45,16 +45,20 @@ func init() {
 	pushCommand.SetUsageTemplate(UsageTemplate())
 	flags := pushCommand.Flags()
 	flags.MarkHidden("signature-policy")
-	flags.StringVar(&pushCommand.Authfile, "authfile", "", "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringVar(&pushCommand.CertDir, "cert-dir", "", "`Pathname` of a directory containing TLS certificates and keys")
-	flags.BoolVar(&pushCommand.Compress, "compress", false, "Compress tarball image layers when pushing to a directory using the 'dir' transport. (default is same compression type as source)")
 	flags.StringVar(&pushCommand.Creds, "creds", "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
 	flags.StringVarP(&pushCommand.Format, "format", "f", "", "Manifest type (oci, v2s1, or v2s2) to use when pushing an image using the 'dir:' transport (default is manifest type of source)")
 	flags.BoolVarP(&pushCommand.Quiet, "quiet", "q", false, "Don't output progress information when pushing images")
 	flags.BoolVar(&pushCommand.RemoveSignatures, "remove-signatures", false, "Discard any pre-existing signatures in the image")
-	flags.StringVar(&pushCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
 	flags.StringVar(&pushCommand.SignBy, "sign-by", "", "Add a signature at the destination using the specified key")
-	flags.BoolVar(&pushCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+
+	// Disabled flags for the remote client
+	if !remote {
+		flags.StringVar(&pushCommand.Authfile, "authfile", "", "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")
+		flags.BoolVar(&pushCommand.Compress, "compress", false, "Compress tarball image layers when pushing to a directory using the 'dir' transport. (default is same compression type as source)")
+		flags.StringVar(&pushCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
+		flags.BoolVar(&pushCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+	}
 }
 
 func pushCmd(c *cliconfig.PushValues) error {


### PR DESCRIPTION
The remote client should not honor most of the local podman "global"
options.  Many of them are only applicable to where the podman backend
is actually running.

Also, removing some options for push and pull that also are not
applicable to the remote client environment.

Additionally, take some of the code from main and pop it into functions
that can be called whether local or not.  This helps the remote client
and darwin builds.

Signed-off-by: baude <bbaude@redhat.com>