### PR TITLE
BATS tests: start supporting podman-remote

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -3,6 +3,8 @@
 load helpers
 
 @test "podman info - basic test" {
+    skip_if_remote
+
     run_podman info
 
     expected_keys="
@@ -26,6 +28,8 @@ RunRoot:
 }
 
 @test "podman info - json" {
+    skip_if_remote
+
     run_podman info --format=json
 
     expr_nvr="[a-z0-9-]\\\+-[a-z0-9.]\\\+-[a-z0-9]\\\+\."

--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -25,11 +25,12 @@ load helpers
 
 
 @test "podman images - json" {
+    # 'created': podman includes fractional seconds, podman-remote does not
     tests="
 names[0]   | $PODMAN_TEST_IMAGE_FQN
 id         |        [0-9a-f]\\\{64\\\}
 digest     | sha256:[0-9a-f]\\\{64\\\}
-created    | [0-9-]\\\+T[0-9:]\\\+\\\.[0-9]\\\+Z
+created    | [0-9-]\\\+T[0-9:.]\\\+Z
 size       | [0-9]\\\+
 "
 

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -87,6 +87,8 @@ function check_help() {
 
 
 @test "podman help - basic tests" {
+    skip_if_remote
+
     # Called with no args -- start with 'podman --help'. check_help() will
     # recurse for any subcommands.
     check_help

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -3,6 +3,8 @@
 load helpers
 
 @test "podman run - basic tests" {
+    skip_if_remote
+
     rand=$(random_string 30)
     tests="
 true              |   0 |

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -6,6 +6,8 @@
 load helpers
 
 @test "podman logs - basic test" {
+    skip_if_remote
+
     rand_string=$(random_string 40)
 
     run_podman create $IMAGE echo $rand_string

--- a/test/system/060-mount.bats
+++ b/test/system/060-mount.bats
@@ -6,6 +6,7 @@ load helpers
 @test "podman mount - basic test" {
     # Only works with root (FIXME: does it work with rootless + vfs?)
     skip_if_rootless "mount does not work rootless"
+    skip_if_remote
 
     f_path=/tmp/tmpfile_$(random_string 8)
     f_content=$(random_string 30)

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -6,6 +6,8 @@
 load helpers
 
 @test "podman build - basic test" {
+    skip_if_remote
+
     rand_filename=$(random_string 20)
     rand_content=$(random_string 50)
 

--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -6,6 +6,8 @@
 load helpers
 
 @test "podman exec - basic test" {
+    skip_if_remote
+
     rand_filename=$(random_string 20)
     rand_content=$(random_string 50)
 

--- a/test/system/110-history.bats
+++ b/test/system/110-history.bats
@@ -24,7 +24,7 @@ load helpers
 @test "podman history - json" {
     tests="
 id        | [0-9a-f]\\\{64\\\}
-created   | [0-9-]\\\+T[0-9:]\\\+\\\.[0-9]\\\+Z
+created   | [0-9-]\\\+T[0-9:.]\\\+Z
 size      | -\\\?[0-9]\\\+
 "
 

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -7,6 +7,7 @@ load helpers
 
 @test "podman container storage is not accessible by unprivileged users" {
     skip_if_rootless "test meaningless without suid"
+    skip_if_remote
 
     run_podman run --name c_uidmap   --uidmap 0:10000:10000 $IMAGE true
     run_podman run --name c_uidmap_v --uidmap 0:10000:10000 -v foo:/foo $IMAGE true

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -225,6 +225,16 @@ function skip_if_rootless() {
     skip "${1:-not applicable under rootless podman}"
 }
 
+####################
+#  skip_if_remote  #  ...with an optional message
+####################
+function skip_if_remote() {
+    if [[ ! "$PODMAN" =~ -remote ]]; then
+        return
+    fi
+
+    skip "${1:-test does not work with podman-remote}"
+}
 
 #########
 #  die  #  Abort with helpful message


### PR DESCRIPTION
podman-remote now supports rm! That's what we needed to start
running BATS tests.

Although most tests don't actually work, some do, and maybe
the rest will start working over time. For now, disable them.

The only significant difference found is that podman-remote
strips fractional seconds from timestamps in JSON output.
Probably not something worth caring about.

Signed-off-by: Ed Santiago <santiago@redhat.com>