### PR TITLE
Add --include-volumes flag to 'podman commit'

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -88,12 +88,13 @@ type CheckpointValues struct {
 
 type CommitValues struct {
 	PodmanCommand
-	Change  []string
-	Format  string
-	Message string
-	Author  string
-	Pause   bool
-	Quiet   bool
+	Change         []string
+	Format         string
+	Message        string
+	Author         string
+	Pause          bool
+	Quiet          bool
+	IncludeVolumes bool
 }
 
 type ContainersPrune struct {

--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -2,19 +2,19 @@ package main
 
 import (
 	"fmt"
-	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/spf13/cobra"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/containers/buildah"
 	"github.com/containers/image/manifest"
+	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -47,7 +47,7 @@ func init() {
 	flags.StringVarP(&commitCommand.Author, "author", "a", "", "Set the author for the image committed")
 	flags.BoolVarP(&commitCommand.Pause, "pause", "p", false, "Pause container during commit")
 	flags.BoolVarP(&commitCommand.Quiet, "quiet", "q", false, "Suppress output")
-
+	flags.BoolVar(&commitCommand.IncludeVolumes, "include-volumes", false, "Include container volumes as image volumes")
 }
 
 func commitCmd(c *cliconfig.CommitValues) error {
@@ -109,11 +109,12 @@ func commitCmd(c *cliconfig.CommitValues) error {
 		PreferredManifestType: mimeType,
 	}
 	options := libpod.ContainerCommitOptions{
-		CommitOptions: coptions,
-		Pause:         c.Pause,
-		Message:       c.Message,
-		Changes:       c.Change,
-		Author:        c.Author,
+		CommitOptions:  coptions,
+		Pause:          c.Pause,
+		IncludeVolumes: c.IncludeVolumes,
+		Message:        c.Message,
+		Changes:        c.Change,
+		Author:         c.Author,
 	}
 	newImage, err := ctr.Commit(getContext(), reference, options)
 	if err != nil {

--- a/docs/podman-commit.1.md
+++ b/docs/podman-commit.1.md
@@ -39,6 +39,10 @@ not specifically set, the default format used is _oci_.
 
 Write the image ID to the file.
 
+**--include-volumes**
+
+Include in the committed image any volumes added to the container by the `--volume` or `--mount` options to the `podman create` and `podman run` commands.
+
 **--message, -m**
 
 Set commit message for committed image.  The message field is not supported in _oci_ format.

--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -20,10 +20,11 @@ import (
 //libpod
 type ContainerCommitOptions struct {
 	buildah.CommitOptions
-	Pause   bool
-	Author  string
-	Message string
-	Changes []string
+	Pause          bool
+	IncludeVolumes bool
+	Author         string
+	Message        string
+	Changes        []string
 }
 
 // ChangeCmds is the list of valid Changes commands to passed to the Commit call
@@ -113,9 +114,11 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 	// User
 	importBuilder.SetUser(c.User())
 	// Volumes
-	for _, v := range c.config.UserVolumes {
-		if v != "" {
-			importBuilder.AddVolume(v)
+	if options.IncludeVolumes {
+		for _, v := range c.config.UserVolumes {
+			if v != "" {
+				importBuilder.AddVolume(v)
+			}
 		}
 	}
 	// Workdir

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -131,12 +131,29 @@ var _ = Describe("Podman commit", func() {
 		Expect(check.ExitCode()).To(Equal(0))
 	})
 
-	It("podman commit with volume mounts", func() {
+	It("podman commit with volumes mounts and no include-volumes", func() {
 		s := podmanTest.Podman([]string{"run", "--name", "test1", "-v", "/tmp:/foo", "alpine", "date"})
 		s.WaitWithDefaultTimeout()
 		Expect(s.ExitCode()).To(Equal(0))
 
 		c := podmanTest.Podman([]string{"commit", "test1", "newimage"})
+		c.WaitWithDefaultTimeout()
+		Expect(c.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", "newimage"})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(Equal(0))
+		image := inspect.InspectImageJSON()
+		_, ok := image[0].Config.Volumes["/foo"]
+		Expect(ok).To(BeFalse())
+	})
+
+	It("podman commit with volume mounts and --include-volumes", func() {
+		s := podmanTest.Podman([]string{"run", "--name", "test1", "-v", "/tmp:/foo", "alpine", "date"})
+		s.WaitWithDefaultTimeout()
+		Expect(s.ExitCode()).To(Equal(0))
+
+		c := podmanTest.Podman([]string{"commit", "--include-volumes", "test1", "newimage"})
 		c.WaitWithDefaultTimeout()
 		Expect(c.ExitCode()).To(Equal(0))
 


### PR DESCRIPTION
The 'docker commit' will never include a container's volumes when committing, without an explicit request through '--change'.

Podman, however, defaulted to including user volumes as image volumes.

Make this behavior depend on a new flag, '--include-volumes', and make the default behavior match Docker.