### PR TITLE
userns: prevent /sys/kernel/* paths in the container

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -500,6 +500,7 @@ func blockAccessToKernelFilesystems(config *CreateConfig, g *generate.Generator)
 			"/proc/scsi",
 			"/sys/firmware",
 			"/sys/fs/selinux",
+			"/sys/kernel",
 		} {
 			g.AddLinuxMaskedPaths(mp)
 		}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -132,6 +132,9 @@ func CreateConfigToOCISpec(config *CreateConfig) (*spec.Spec, error) { //nolint
 			Options:     []string{"rprivate", "nosuid", "noexec", "nodev", r, "rbind"},
 		}
 		g.AddMount(sysMnt)
+		if !config.Privileged && isRootless {
+			g.AddLinuxMaskedPaths("/sys/kernel")
+		}
 	}
 	if isRootless {
 		nGids, err := getAvailableGids()
@@ -500,7 +503,6 @@ func blockAccessToKernelFilesystems(config *CreateConfig, g *generate.Generator)
 			"/proc/scsi",
 			"/sys/firmware",
 			"/sys/fs/selinux",
-			"/sys/kernel",
 		} {
 			g.AddLinuxMaskedPaths(mp)
 		}

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -31,4 +31,12 @@ echo $rand        |   0 | $rand
     done < <(parse_table "$tests")
 }
 
+@test "podman run - uidmapping has no /sys/kernel mounts" {
+      run_podman $expected_rc run --uidmapping 0:100:10000 $IMAGE mount | grep /sys/kernel
+      is "$output" "" "podman run $cmd - output"
+
+      run_podman $expected_rc run --net host --uidmapping 0:100:10000 $IMAGE mount | grep /sys/kernel
+      is "$output" "" "podman run $cmd - output"
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
when we run in a user namespace, there are cases where we have not
enough privileges to mount a fresh sysfs on /sys.  To circumvent this
limitation, we rbind /sys from the host.  This carries inside of the
container also some mounts we probably don't want to.  We are also
limited by the kernel to use rbind instead of bind, as allowing a bind
would uncover paths that were not previously visible.

This is a slimmed down version of the intermediate mount namespace
logic we had before, where we only set /sys to slave, so the umounts
done to the storage by the cleanup process are propagated back to the
host.  We also don't setup any new directory, so there is no
additional cleanup to do.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>