### PR TITLE
Fixes for podman-remote run and attach

### DIFF
--- a/API.md
+++ b/API.md
@@ -3,7 +3,7 @@ Podman Service Interface and API description.  The master version of this docume
 in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in the upstream libpod repository.
 ## Index
 
-[func Attach(name: string) ](#Attach)
+[func Attach(name: string, detachKeys: string, start: bool) ](#Attach)
 
 [func AttachControl(name: string) ](#AttachControl)
 
@@ -119,6 +119,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func PodStateData(name: string) string](#PodStateData)
 
+[func Ps(opts: PsOpts) PsContainer](#Ps)
+
 [func PullImage(name: string, certDir: string, creds: string, signaturePolicy: string, tlsVerify: ) MoreResponse](#PullImage)
 
 [func PushImage(name: string, tag: string, tlsverify: , signaturePolicy: string, creds: string, certDir: string, compress: bool, format: string, removeSignatures: bool, signBy: string) MoreResponse](#PushImage)
@@ -225,6 +227,10 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [type PodmanInfo](#PodmanInfo)
 
+[type PsContainer](#PsContainer)
+
+[type PsOpts](#PsOpts)
+
 [type Runlabel](#Runlabel)
 
 [type Sockets](#Sockets)
@@ -261,8 +267,9 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 ### <a name="Attach"></a>func Attach
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
-method Attach(name: [string](https://godoc.org/builtin#string)) </div>
-
+method Attach(name: [string](https://godoc.org/builtin#string), detachKeys: [string](https://godoc.org/builtin#string), start: [bool](https://godoc.org/builtin#bool)) </div>
+Attach takes the name or ID of a container and sets up a the ability to remotely attach to its console. The start
+bool is whether you wish to start the container in question first.
 ### <a name="AttachControl"></a>func AttachControl
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -857,6 +864,11 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.PausePod '{"name": "fooba
 method PodStateData(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
 PodStateData returns inspectr level information of a given pod in string form.  This call is for
 development of Podman only and generally should not be used.
+### <a name="Ps"></a>func Ps
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method Ps(opts: [PsOpts](#PsOpts)) [PsContainer](#PsContainer)</div>
+
 ### <a name="PullImage"></a>func PullImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -1749,6 +1761,82 @@ insecure_registries [[]string](#[]string)
 store [InfoStore](#InfoStore)
 
 podman [InfoPodmanBinary](#InfoPodmanBinary)
+### <a name="PsContainer"></a>type PsContainer
+
+
+
+id [string](https://godoc.org/builtin#string)
+
+image [string](https://godoc.org/builtin#string)
+
+command [string](https://godoc.org/builtin#string)
+
+created [string](https://godoc.org/builtin#string)
+
+ports [string](https://godoc.org/builtin#string)
+
+names [string](https://godoc.org/builtin#string)
+
+isInfra [bool](https://godoc.org/builtin#bool)
+
+status [string](https://godoc.org/builtin#string)
+
+state [string](https://godoc.org/builtin#string)
+
+pidNum [int](https://godoc.org/builtin#int)
+
+rootFsSize [int](https://godoc.org/builtin#int)
+
+rwSize [int](https://godoc.org/builtin#int)
+
+pod [string](https://godoc.org/builtin#string)
+
+createdAt [string](https://godoc.org/builtin#string)
+
+exitedAt [string](https://godoc.org/builtin#string)
+
+startedAt [string](https://godoc.org/builtin#string)
+
+labels [map[string]](#map[string])
+
+nsPid [string](https://godoc.org/builtin#string)
+
+cgroup [string](https://godoc.org/builtin#string)
+
+ipc [string](https://godoc.org/builtin#string)
+
+mnt [string](https://godoc.org/builtin#string)
+
+net [string](https://godoc.org/builtin#string)
+
+pidNs [string](https://godoc.org/builtin#string)
+
+user [string](https://godoc.org/builtin#string)
+
+uts [string](https://godoc.org/builtin#string)
+
+mounts [string](https://godoc.org/builtin#string)
+### <a name="PsOpts"></a>type PsOpts
+
+
+
+all [bool](https://godoc.org/builtin#bool)
+
+filters [](#)
+
+last [](#)
+
+latest [](#)
+
+noTrunc [](#)
+
+pod [](#)
+
+quiet [](#)
+
+sort [](#)
+
+sync [](#)
 ### <a name="Runlabel"></a>type Runlabel
 
 Runlabel describes the required input for container runlabel

--- a/cmd/podman/cliconfig/commands.go
+++ b/cmd/podman/cliconfig/commands.go
@@ -1,6 +1,8 @@
 package cliconfig
 
-import "github.com/sirupsen/logrus"
+import (
+	"github.com/sirupsen/logrus"
+)
 
 // GlobalIsSet is a compatibility method for urfave
 func (p *PodmanCommand) GlobalIsSet(opt string) bool {

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -66,7 +66,7 @@ func createCmd(c *cliconfig.CreateValues) error {
 }
 
 func createInit(c *cliconfig.PodmanCommand) error {
-	if c.Bool("trace") {
+	if !remote && c.Bool("trace") {
 		span, _ := opentracing.StartSpanFromContext(Ctx, "createInit")
 		defer span.Finish()
 	}

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func runCmd(c *cliconfig.RunValues) error {
-	if c.Bool("trace") {
+	if !remote && c.Bool("trace") {
 		span, _ := opentracing.StartSpanFromContext(Ctx, "runCmd")
 		defer span.Finish()
 	}

--- a/cmd/podman/run_test.go
+++ b/cmd/podman/run_test.go
@@ -83,7 +83,7 @@ func getRuntimeSpec(c *cliconfig.PodmanCommand) (*spec.Spec, error) {
 		createConfig, err := parseCreateOpts(c, runtime, "alpine", generateAlpineImageData())
 	*/
 	ctx := getContext()
-	genericResults := shared.NewIntermediateLayer(c)
+	genericResults := shared.NewIntermediateLayer(c, false)
 	createConfig, err := shared.ParseCreateOpts(ctx, &genericResults, nil, "alpine", generateAlpineImageData())
 	if err != nil {
 		return nil, err

--- a/cmd/podman/shared/intermediate.go
+++ b/cmd/podman/shared/intermediate.go
@@ -360,7 +360,7 @@ func newCRStringArray(c *cliconfig.PodmanCommand, flag string) CRStringArray {
 }
 
 // NewIntermediateLayer creates a GenericCLIResults from a create or run cli-command
-func NewIntermediateLayer(c *cliconfig.PodmanCommand) GenericCLIResults {
+func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIResults {
 	m := make(map[string]GenericCLIResult)
 
 	m["add-host"] = newCRStringSlice(c, "add-host")
@@ -458,8 +458,10 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand) GenericCLIResults {
 	m["volumes-from"] = newCRStringSlice(c, "volumes-from")
 	m["workdir"] = newCRString(c, "workdir")
 	// global flag
-	m["trace"] = newCRBool(c, "trace")
-	m["syslog"] = newCRBool(c, "syslog")
+	if !remote {
+		m["trace"] = newCRBool(c, "trace")
+		m["syslog"] = newCRBool(c, "syslog")
+	}
 
 	return GenericCLIResults{m, c.InputArgs}
 }

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -658,7 +658,9 @@ method PauseContainer(name: string) -> (container: string)
 # See also [PauseContainer](#PauseContainer).
 method UnpauseContainer(name: string) -> (container: string)
 
-method Attach(name: string) -> ()
+# Attach takes the name or ID of a container and sets up a the ability to remotely attach to its console. The start
+# bool is whether you wish to start the container in question first.
+method Attach(name: string, detachKeys: string, start: bool) -> ()
 
 method AttachControl(name: string) -> ()
 

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -255,14 +255,14 @@ func (r *LocalRuntime) Log(c *cliconfig.LogsValues, options *libpod.LogOptions) 
 
 // CreateContainer creates a libpod container
 func (r *LocalRuntime) CreateContainer(ctx context.Context, c *cliconfig.CreateValues) (string, error) {
-	results := shared.NewIntermediateLayer(&c.PodmanCommand)
+	results := shared.NewIntermediateLayer(&c.PodmanCommand, false)
 	ctr, _, err := shared.CreateContainer(ctx, &results, r.Runtime)
 	return ctr.ID(), err
 }
 
 // Run a libpod container
 func (r *LocalRuntime) Run(ctx context.Context, c *cliconfig.RunValues, exitCode int) (int, error) {
-	results := shared.NewIntermediateLayer(&c.PodmanCommand)
+	results := shared.NewIntermediateLayer(&c.PodmanCommand, false)
 
 	ctr, createConfig, err := shared.CreateContainer(ctx, &results, r.Runtime)
 	if err != nil {


### PR DESCRIPTION
Fixes the ability to run (create,start) a container and attach to its
console correctly.  We can now also exit from the console without
hanging the remote client.

Signed-off-by: baude <bbaude@redhat.com>