### PR TITLE
Add variable for global flags to runlabel

### DIFF
--- a/cmd/podman/runlabel.go
+++ b/cmd/podman/runlabel.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/image"
+	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/libpod/utils"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -145,7 +146,8 @@ func runlabelCmd(c *cliconfig.RunlabelValues) error {
 		return errors.Errorf("%s does not have a label of %s", runlabelImage, label)
 	}
 
-	cmd, env, err := shared.GenerateRunlabelCommand(runLabel, imageName, c.Name, opts, extraArgs)
+	globalOpts := util.GetGlobalOpts(c)
+	cmd, env, err := shared.GenerateRunlabelCommand(runLabel, imageName, c.Name, opts, extraArgs, globalOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -883,7 +883,7 @@ func GetRunlabel(label string, runlabelImage string, ctx context.Context, runtim
 }
 
 // GenerateRunlabelCommand generates the command that will eventually be execucted by podman
-func GenerateRunlabelCommand(runLabel, imageName, name string, opts map[string]string, extraArgs []string) ([]string, []string, error) {
+func GenerateRunlabelCommand(runLabel, imageName, name string, opts map[string]string, extraArgs []string, globalOpts string) ([]string, []string, error) {
 	// If no name is provided, we use the image's basename instead
 	if name == "" {
 		baseName, err := image.GetImageBaseName(imageName)
@@ -896,7 +896,7 @@ func GenerateRunlabelCommand(runLabel, imageName, name string, opts map[string]s
 	if len(extraArgs) > 0 {
 		runLabel = fmt.Sprintf("%s %s", runLabel, strings.Join(extraArgs, " "))
 	}
-	cmd, err := GenerateCommand(runLabel, imageName, name)
+	cmd, err := GenerateCommand(runLabel, imageName, name, globalOpts)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "unable to generate command")
 	}

--- a/cmd/podman/shared/funcs.go
+++ b/cmd/podman/shared/funcs.go
@@ -41,7 +41,7 @@ func substituteCommand(cmd string) (string, error) {
 }
 
 // GenerateCommand takes a label (string) and converts it to an executable command
-func GenerateCommand(command, imageName, name string) ([]string, error) {
+func GenerateCommand(command, imageName, name, globalOpts string) ([]string, error) {
 	var (
 		newCommand []string
 	)
@@ -79,6 +79,8 @@ func GenerateCommand(command, imageName, name string) ([]string, error) {
 			newArg = fmt.Sprintf("NAME=%s", name)
 		case "$NAME":
 			newArg = name
+		case "$GLOBAL_OPTS":
+			newArg = globalOpts
 		default:
 			newArg = arg
 		}

--- a/cmd/podman/shared/funcs_test.go
+++ b/cmd/podman/shared/funcs_test.go
@@ -20,7 +20,7 @@ var (
 func TestGenerateCommand(t *testing.T) {
 	inputCommand := "docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo \"hello world\""
 	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo hello world"
-	newCommand, err := GenerateCommand(inputCommand, "foo", "bar")
+	newCommand, err := GenerateCommand(inputCommand, "foo", "bar", "")
 	assert.Nil(t, err)
 	assert.Equal(t, "hello world", newCommand[11])
 	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
@@ -83,7 +83,7 @@ func TestGenerateCommandCheckSubstitution(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		newCommand, err := GenerateCommand(test.input, "foo", "bar")
+		newCommand, err := GenerateCommand(test.input, "foo", "bar", "")
 		if test.shouldFail {
 			assert.NotNil(t, err)
 		} else {
@@ -96,14 +96,14 @@ func TestGenerateCommandCheckSubstitution(t *testing.T) {
 func TestGenerateCommandPath(t *testing.T) {
 	inputCommand := "docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
 	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
-	newCommand, _ := GenerateCommand(inputCommand, "foo", "bar")
+	newCommand, _ := GenerateCommand(inputCommand, "foo", "bar", "")
 	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
 }
 
 func TestGenerateCommandNoSetName(t *testing.T) {
 	inputCommand := "docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
 	correctCommand := "/proc/self/exe run -it --name foo -e NAME=foo -e IMAGE=foo foo echo install"
-	newCommand, err := GenerateCommand(inputCommand, "foo", "")
+	newCommand, err := GenerateCommand(inputCommand, "foo", "", "")
 	assert.Nil(t, err)
 	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
 }
@@ -111,7 +111,7 @@ func TestGenerateCommandNoSetName(t *testing.T) {
 func TestGenerateCommandNoName(t *testing.T) {
 	inputCommand := "docker run -it -e IMAGE=IMAGE IMAGE echo install"
 	correctCommand := "/proc/self/exe run -it -e IMAGE=foo foo echo install"
-	newCommand, err := GenerateCommand(inputCommand, "foo", "")
+	newCommand, err := GenerateCommand(inputCommand, "foo", "", "")
 	assert.Nil(t, err)
 	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
 }
@@ -119,7 +119,7 @@ func TestGenerateCommandNoName(t *testing.T) {
 func TestGenerateCommandAlreadyPodman(t *testing.T) {
 	inputCommand := "podman run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
 	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
-	newCommand, err := GenerateCommand(inputCommand, "foo", "bar")
+	newCommand, err := GenerateCommand(inputCommand, "foo", "bar", "")
 	assert.Nil(t, err)
 	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
 }

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -728,7 +728,7 @@ func (i *LibpodAPI) ContainerRunlabel(call iopodman.VarlinkCall, input iopodman.
 		return call.ReplyErrorOccurred(fmt.Sprintf("%s does not contain the label %s", input.Image, input.Label))
 	}
 
-	cmd, env, err := shared.GenerateRunlabelCommand(runLabel, imageName, input.Name, input.Opts, input.ExtraArgs)
+	cmd, env, err := shared.GenerateRunlabelCommand(runLabel, imageName, input.Name, input.Opts, input.ExtraArgs, "")
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}


### PR DESCRIPTION
close #2399 
use $GLOBAL_OPTS to pass global flags to the runlabel command.
Signed-off-by: Qi Wang <qiwan@redhat.com>