### PR TITLE
adding additional apt-get update, needed for ubuntu install

### DIFF
--- a/install.md
+++ b/install.md
@@ -57,6 +57,7 @@ sudo yum module install -y container-tools:1.0
 sudo apt-get update -qq
 sudo apt-get install -qq -y software-properties-common
 sudo add-apt-repository -y ppa:projectatomic/ppa
+sudo apt-get update -qq
 sudo apt-get -qq -y install podman
 ```
 


### PR DESCRIPTION
Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

For the Ubuntu install instructions, we need one more additional apt-get update before podman can be installed:

```bash
sudo apt-get update -qq
sudo apt-get install -qq -y software-properties-common
sudo add-apt-repository -y ppa:projectatomic/ppa
sudo apt-get update -qq
sudo apt-get -qq -y install podman
```

Without the update, we would just be adding the repository but not actually updating the package lists, so podman isn't found:

```bash
9$ sudo add-apt-repository -y ppa:projectatomic/ppa
gpg: keyring `/tmp/tmp9ltltsqg/secring.gpg' created
gpg: keyring `/tmp/tmp9ltltsqg/pubring.gpg' created
gpg: requesting key 7AD8C79D from hkp server keyserver.ubuntu.com
gpg: /tmp/tmp9ltltsqg/trustdb.gpg: trustdb created
gpg: key 7AD8C79D: public key "Launchpad PPA for Project Atomic" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
OK
```
```bash
$ sudo apt-get -qq -y install podman
E: Unable to locate package podman
```

The additional update fixes that :) Notice projectatomic in the ones hit:

```bash
$ sudo apt-get update
Hit:1 http://us.archive.ubuntu.com/ubuntu xenial InRelease
Ign:2 http://dl.google.com/linux/chrome/deb stable InRelease        
Hit:3 http://us.archive.ubuntu.com/ubuntu xenial-updates InRelease                            
Hit:4 http://dl.google.com/linux/chrome/deb stable Release                                    
Get:5 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]                    
Hit:6 http://ppa.launchpad.net/git-core/ppa/ubuntu xenial InRelease               
Hit:7 https://repo.skype.com/deb stable InRelease                                                             
Hit:8 https://apt.dockerproject.org/repo ubuntu-xenial InRelease                                              
Hit:10 http://ppa.launchpad.net/obsproject/obs-studio/ubuntu xenial InRelease                                 
Hit:11 http://ppa.launchpad.net/peek-developers/stable/ubuntu xenial InRelease                                 
Hit:12 https://packagecloud.io/slacktechnologies/slack/debian jessie InRelease 
Get:13 http://ppa.launchpad.net/projectatomic/ppa/ubuntu xenial InRelease [24.3 kB]
Hit:14 http://ppa.launchpad.net/ubuntuhandbook1/audacity/ubuntu xenial InRelease
Hit:15 http://ppa.launchpad.net/webupd8team/java/ubuntu xenial InRelease       
Get:16 http://ppa.launchpad.net/projectatomic/ppa/ubuntu xenial/main amd64 Packages [2,904 B]
Get:17 http://ppa.launchpad.net/projectatomic/ppa/ubuntu xenial/main i386 Packages [2,908 B]
Get:18 http://ppa.launchpad.net/projectatomic/ppa/ubuntu xenial/main Translation-en [1,360 B]
Fetched 141 kB in 4s (30.6 kB/s)                    
Reading package lists... Done
```
And then the install is successful.
```bash
$ sudo apt-get -qq -y install podman
Selecting previously unselected package conmon.
(Reading database ... 454928 files and directories currently installed.)
Preparing to unpack .../conmon_0-1~dev~ubuntu16.04~ppa2_amd64.deb ...
Unpacking conmon (0-1~dev~ubuntu16.04~ppa2) ...
Selecting previously unselected package containers-golang.
Preparing to unpack .../containers-golang_0.1-1~dev~ubuntu16.04~ppa1_all.deb ...
Unpacking containers-golang (0.1-1~dev~ubuntu16.04~ppa1) ...
Selecting previously unselected package containers-common.
Preparing to unpack .../containers-common_0.1.36-1~dev~ubuntu16.04.2~ppa10_all.deb ...
Unpacking containers-common (0.1.36-1~dev~ubuntu16.04.2~ppa10) ...
Selecting previously unselected package containernetworking-plugins.
Preparing to unpack .../containernetworking-plugins_0.7.3-1~ubuntu16.04.2~ppa2_amd64.deb ...
Unpacking containernetworking-plugins (0.7.3-1~ubuntu16.04.2~ppa2) ...
Selecting previously unselected package cri-o-runc.
Preparing to unpack .../cri-o-runc_1.0.0-rc6-1~ubuntu16.04.2~ppa77_amd64.deb ...
Unpacking cri-o-runc (1.0.0-rc6-1~ubuntu16.04.2~ppa77) ...
Selecting previously unselected package podman.
Preparing to unpack .../podman_1.3.0-1~ubuntu16.04.2~ppa8_amd64.deb ...
Unpacking podman (1.3.0-1~ubuntu16.04.2~ppa8) ...
Processing triggers for man-db (2.7.5-1) ...
Setting up conmon (0-1~dev~ubuntu16.04~ppa2) ...
Setting up containers-golang (0.1-1~dev~ubuntu16.04~ppa1) ...
Setting up containers-common (0.1.36-1~dev~ubuntu16.04.2~ppa10) ...
Setting up containernetworking-plugins (0.7.3-1~ubuntu16.04.2~ppa2) ...
Setting up cri-o-runc (1.0.0-rc6-1~ubuntu16.04.2~ppa77) ...
Setting up podman (1.3.0-1~ubuntu16.04.2~ppa8) ...
$ which podman
/usr/local/bin/podman
```