### PR TITLE
new uidmap BATS test: fix

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -32,11 +32,15 @@ echo $rand        |   0 | $rand
 }
 
 @test "podman run - uidmapping has no /sys/kernel mounts" {
-      run_podman $expected_rc run --uidmapping 0:100:10000 $IMAGE mount | grep /sys/kernel
-      is "$output" "" "podman run $cmd - output"
+    skip_if_rootless "cannot umount as rootless"
 
-      run_podman $expected_rc run --net host --uidmapping 0:100:10000 $IMAGE mount | grep /sys/kernel
-      is "$output" "" "podman run $cmd - output"
+    run_podman run --rm --uidmap 0:100:10000 $IMAGE mount
+    run grep /sys/kernel <(echo "$output")
+    is "$output" "" "unwanted /sys/kernel in 'mount' output"
+
+    run_podman run --rm --net host --uidmap 0:100:10000 $IMAGE mount
+    run grep /sys/kernel <(echo "$output")
+    is "$output" "" "unwanted /sys/kernel in 'mount' output (with --net=host)"
 }
 
 # vim: filetype=sh


### PR DESCRIPTION
Various problems, one of which was causing the test to fail
completely (otherwise I wouldn't have caught the others):

- option is --uidmap, not --uidmapping
- run_podman cannot be piped (| grep /sys/kernel). That's
  an unfortunate limitation of BATS. Any invocation of 'run'
  saves results to $output, which then has to be tested
  in a separate step.
  - do so.
- remove "$expected_rc", that looks like a copy/paste bug
  from a few lines above.

We really need to get these tests running in CI.

Signed-off-by: Ed Santiago <santiago@redhat.com>