### PR TITLE
create: fix segfault if container name already exists

### DIFF
--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -257,7 +257,10 @@ func (r *LocalRuntime) Log(c *cliconfig.LogsValues, options *libpod.LogOptions) 
 func (r *LocalRuntime) CreateContainer(ctx context.Context, c *cliconfig.CreateValues) (string, error) {
 	results := shared.NewIntermediateLayer(&c.PodmanCommand, false)
 	ctr, _, err := shared.CreateContainer(ctx, &results, r.Runtime)
-	return ctr.ID(), err
+	if err != nil {
+		return "", err
+	}
+	return ctr.ID(), nil
 }
 
 // Run a libpod container

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -70,6 +70,17 @@ var _ = Describe("Podman create", func() {
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 	})
 
+	It("podman create using existing name", func() {
+		session := podmanTest.Podman([]string{"create", "--name=foo", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+
+		session = podmanTest.Podman([]string{"create", "--name=foo", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(125))
+	})
+
 	It("podman create adds annotation", func() {
 		session := podmanTest.Podman([]string{"create", "--annotation", "HELLO=WORLD", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
do not try to use ctr if there was an error.  It fixes a segfault when
there is already a container with the same name.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>