### PR TITLE
Use GetContainer instead of LookupContainer for full ID

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -614,7 +614,7 @@ func (c *Container) NewNetNS() bool {
 func (c *Container) PortMappings() ([]ocicni.PortMapping, error) {
 	// First check if the container belongs to a network namespace (like a pod)
 	if len(c.config.NetNsCtr) > 0 {
-		netNsCtr, err := c.runtime.LookupContainer(c.config.NetNsCtr)
+		netNsCtr, err := c.runtime.GetContainer(c.config.NetNsCtr)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to lookup network namespace for container %s", c.ID())
 		}

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -676,7 +676,7 @@ func (c *Container) getAllDependencies(visited map[string]*Container) error {
 	}
 	for _, depID := range depIDs {
 		if _, ok := visited[depID]; !ok {
-			dep, err := c.runtime.state.LookupContainer(depID)
+			dep, err := c.runtime.state.Container(depID)
 			if err != nil {
 				return err
 			}

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -69,7 +69,7 @@ func (p *Pod) getInfraContainer() (*Container, error) {
 	if err != nil {
 		return nil, err
 	}
-	return p.runtime.LookupContainer(infraID)
+	return p.runtime.GetContainer(infraID)
 }
 
 // GenerateKubeServiceFromV1Pod creates a v1 service object from a v1 pod object

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -547,16 +547,6 @@ func (r *Runtime) GetLatestContainer() (*Container, error) {
 	return ctrs[lastCreatedIndex], nil
 }
 
-// Export is the libpod portion of exporting a container to a tar file
-func (r *Runtime) Export(name string, path string) error {
-	ctr, err := r.LookupContainer(name)
-	if err != nil {
-		return err
-	}
-	return ctr.Export(path)
-
-}
-
 // RemoveContainersFromStorage attempt to remove containers from storage that do not exist in libpod database
 func (r *Runtime) RemoveContainersFromStorage(ctrs []string) {
 	for _, i := range ctrs {


### PR DESCRIPTION
All IDs in libpod are stored as a full container ID. We can get a container by full ID faster with GetContainer (which directly retrieves) than LookupContainer (which finds a match, then retrieves). No reason to use Lookup when we have full IDs present and available.