### PR TITLE
Remove old crio reference from man pages

### DIFF
--- a/docs/podman-export.1.md
+++ b/docs/podman-export.1.md
@@ -37,7 +37,7 @@ $ podman export > redis-container.tar 883504668ec465463bc0fe7e63d53154ac3b696ea8
 ```
 
 ## SEE ALSO
-podman(1), podman-import(1), crio(8)
+podman(1), podman-import(1)
 
 ## HISTORY
 August 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-history.1.md
+++ b/docs/podman-history.1.md
@@ -90,7 +90,7 @@ $ podman history --format json debian
 ```
 
 ## SEE ALSO
-podman(1), crio(8)
+podman(1)
 
 ## HISTORY
 July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-image-tree.1.md
+++ b/docs/podman-image-tree.1.md
@@ -82,7 +82,7 @@ Image Layers
 
 
 ## SEE ALSO
-podman(1), crio(8)
+podman(1)
 
 ## HISTORY
 Feb 2019, Originally compiled by Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>

--- a/docs/podman-import.1.md
+++ b/docs/podman-import.1.md
@@ -83,7 +83,7 @@ db65d991f3bbf7f31ed1064db9a6ced7652e3f8166c4736aa9133dadd3c7acb3
 ```
 
 ## SEE ALSO
-podman(1), podman-export(1), crio(8)
+podman(1), podman-export(1)
 
 ## HISTORY
 November 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-info.1.md
+++ b/docs/podman-info.1.md
@@ -148,4 +148,4 @@ map[registries:[docker.io quay.io registry.fedoraproject.org registry.access.red
 ```
 
 ## SEE ALSO
-podman(1), containers-registries.conf(5), containers-storage.conf(5), crio(8)
+podman(1), containers-registries.conf(5), containers-storage.conf(5)

--- a/docs/podman-load.1.md
+++ b/docs/podman-load.1.md
@@ -77,7 +77,7 @@ Loaded image:  registry.fedoraproject.org/fedora:latest
 ```
 
 ## SEE ALSO
-podman(1), podman-save(1), podman-tag(1), crio(8)
+podman(1), podman-save(1), podman-tag(1)
 
 ## HISTORY
 July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-login.1.md
+++ b/docs/podman-login.1.md
@@ -101,7 +101,7 @@ Login Succeeded!
 ```
 
 ## SEE ALSO
-podman(1), podman-logout(1), crio(8)
+podman(1), podman-logout(1)
 
 ## HISTORY
 August 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-logout.1.md
+++ b/docs/podman-logout.1.md
@@ -53,7 +53,7 @@ Remove login credentials for all registries
 ```
 
 ## SEE ALSO
-podman(1), podman-login(1), crio(8)
+podman(1), podman-login(1)
 
 ## HISTORY
 August 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-ps.1.md
+++ b/docs/podman-ps.1.md
@@ -166,7 +166,7 @@ CONTAINER ID  IMAGE                            COMMAND    CREATED        STATUS 
 Print a list of containers
 
 ## SEE ALSO
-podman(1), crio(8)
+podman(1)
 
 ## HISTORY
 August 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -146,7 +146,7 @@ Storing signatures
 	registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-podman(1), podman-push(1), podman-login(1), containers-registries.conf(5), crio(8)
+podman(1), podman-push(1), podman-login(1), containers-registries.conf(5)
 
 ## HISTORY
 July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-push.1.md
+++ b/docs/podman-push.1.md
@@ -144,4 +144,4 @@ Storing signatures
 ```
 
 ## SEE ALSO
-podman(1), podman-pull(1), podman-login(1), crio(8)
+podman(1), podman-pull(1), podman-login(1)

--- a/docs/podman-save.1.md
+++ b/docs/podman-save.1.md
@@ -91,7 +91,7 @@ Storing signatures
 ```
 
 ## SEE ALSO
-podman(1), podman-load(1), crio(8)
+podman(1), podman-load(1)
 
 ## HISTORY
 July 2017, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -149,7 +149,7 @@ Note: This works only with registries that implement the v2 API. If tried with a
 	registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
 ## SEE ALSO
-podman(1), containers-registries.conf(5), crio(8)
+podman(1), containers-registries.conf(5)
 
 ## HISTORY
 January 2018, Originally compiled by Urvashi Mohnani <umohnani@redhat.com>

--- a/docs/podman-tag.1.md
+++ b/docs/podman-tag.1.md
@@ -28,7 +28,7 @@ $ podman tag httpd myregistryhost:5000/fedora/httpd:v2
 
 
 ## SEE ALSO
-podman(1), crio(8)
+podman(1)
 
 ## HISTORY
 July 2017, Originally compiled by Ryan Cole <rycole@redhat.com>

--- a/docs/podman-version.1.md
+++ b/docs/podman-version.1.md
@@ -39,7 +39,7 @@ $ podman version --format '{{.Version}}'
 ```
 
 ## SEE ALSO
-podman(1), crio(8)
+podman(1)
 
 ## HISTORY
 November 2018, Added --format flag by Tomas Tomecek <ttomecek@redhat.com>

--- a/docs/podman-wait.1.md
+++ b/docs/podman-wait.1.md
@@ -40,7 +40,7 @@ $ podman wait mywebserver myftpserver
 ```
 
 ## SEE ALSO
-podman(1), crio(8)
+podman(1)
 
 ## HISTORY
 September 2017, Originally compiled by Brent Baude<bbaude@redhat.com>

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -237,7 +237,7 @@ Images are pulled under `XDG_DATA_HOME` when specified, otherwise in the home di
 Currently the slirp4netns package is required to be installed to create a network device, otherwise rootless containers need to run in the network namespace of the host.
 
 ## SEE ALSO
-`containers-mounts.conf(5)`, `containers-registries.conf(5)`, `containers-storage.conf(5)`, `buildah(1)`, `crio(8)`, `libpod.conf(5)`, `oci-hooks(5)`, `policy.json(5)`, `subuid(5)`, `subgid(5)`, `slirp4netns(1)`
+`containers-mounts.conf(5)`, `containers-registries.conf(5)`, `containers-storage.conf(5)`, `buildah(1)`, `libpod.conf(5)`, `oci-hooks(5)`, `policy.json(5)`, `subuid(5)`, `subgid(5)`, `slirp4netns(1)`
 
 ## HISTORY
 Dec 2016, Originally compiled by Dan Walsh <dwalsh@redhat.com>


### PR DESCRIPTION
Seems like we have some old references to crio man pages left
over in the docs, since we don't mention crio in man pages
we should not be referencing the man page in the see-also.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>