### PR TITLE
Revert "rootless: set controlling terminal for podman in the userns"

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -16,8 +16,6 @@
 #include <sys/types.h>
 #include <sys/prctl.h>
 #include <dirent.h>
-#include <termios.h>
-#include <sys/ioctl.h>
 
 static const char *_max_user_namespaces = "/proc/sys/user/max_user_namespaces";
 static const char *_unprivileged_user_namespaces = "/proc/sys/kernel/unprivileged_userns_clone";
@@ -179,11 +177,6 @@ reexec_userns_join (int userns, int mountns)
       fprintf (stderr, "cannot prctl(PR_SET_PDEATHSIG): %s\n", strerror (errno));
       _exit (EXIT_FAILURE);
     }
-
-  if (isatty (1) && ioctl (1, TIOCSCTTY, 0) == -1) {
-      fprintf (stderr, "cannot ioctl(TIOCSCTTY): %s\n", strerror (errno));
-      _exit (EXIT_FAILURE);
-  }
 
   if (setns (userns, 0) < 0)
     {


### PR DESCRIPTION
This reverts commit 531514e8231e7f42efb7e7992d62e516f9577363.

Closes: https://github.com/containers/libpod/issues/2926

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>