### PR TITLE
oci: fix umount of /sys/kernel

### DIFF
--- a/libpod/oci_linux.go
+++ b/libpod/oci_linux.go
@@ -133,7 +133,7 @@ func (r *OCIRuntime) createContainer(ctr *Container, cgroupParent string, restor
 							continue
 						}
 						err = unix.Unmount(m.Mountpoint, 0)
-						if err != nil {
+						if err != nil && !os.IsNotExist(err) {
 							return errors.Wrapf(err, "cannot unmount %s", m.Mountpoint)
 						}
 					}


### PR DESCRIPTION
if the mount was already umounted as part of the cleanup (i.e. being a
submount), the umount would fail.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>