### PR TITLE
Clean up after play kube failure

### DIFF
--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -238,7 +238,13 @@ func playKubeYAMLCmd(c *cliconfig.KubePlayValues, ctx context.Context, runtime *
 
 	// We've now successfully converted this YAML into a pod
 	// print our pod and containers, signifying we succeeded
-	fmt.Println(pod.ID())
+	fmt.Printf("Pod:\n%s\n", pod.ID())
+	if len(containers) == 1 {
+		fmt.Printf("Container:\n")
+	}
+	if len(containers) > 1 {
+		fmt.Printf("Containers:\n")
+	}
 	for _, ctr := range containers {
 		fmt.Println(ctr.ID())
 	}


### PR DESCRIPTION
Before, we would half create a pod in play kube and error out if we fail.
Rather, let's clean up after our failure so the user doesn't have to delete the pod themselves.

Signed-off-by: Peter Hunt <pehunt@redhat.com>