### PR TITLE
Add podman pod prune

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -159,6 +159,11 @@ type PruneContainersValues struct {
 	Force bool
 }
 
+type PrunePodsValues struct {
+	PodmanCommand
+	Force bool
+}
+
 type ImportValues struct {
 	PodmanCommand
 	Change  []string

--- a/cmd/podman/pod.go
+++ b/cmd/podman/pod.go
@@ -24,6 +24,7 @@ var podSubCommands = []*cobra.Command{
 	_podInspectCommand,
 	_podKillCommand,
 	_podPauseCommand,
+	_prunePodsCommand,
 	_podPsCommand,
 	_podRestartCommand,
 	_podRmCommand,

--- a/cmd/podman/pods_prune.go
+++ b/cmd/podman/pods_prune.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/shared"
-	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -43,15 +42,8 @@ func init() {
 func prunePods(runtime *adapter.LocalRuntime, ctx context.Context, maxWorkers int, force bool) error {
 	var deleteFuncs []shared.ParallelWorkerInput
 
-	filter := func(p *libpod.Pod) bool {
-		state, err := shared.GetPodStatus(p)
-		// pod states should be the same
-		if state == shared.PodStateStopped || (state == shared.PodStateExited && err == nil) {
-			return true
-		}
-		return false
-	}
-	delPods, err := runtime.Pods(filter)
+	states := []string{shared.PodStateStopped, shared.PodStateExited}
+	delPods, err := runtime.GetPodsByStatus(states)
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/pods_prune.go
+++ b/cmd/podman/pods_prune.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+
+	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/containers/libpod/cmd/podman/shared"
+	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/pkg/adapter"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	prunePodsCommand     cliconfig.PrunePodsValues
+	prunePodsDescription = `
+	podman pod prune
+
+	Removes all exited pods
+`
+	_prunePodsCommand = &cobra.Command{
+		Use:   "prune",
+		Args:  noSubArgs,
+		Short: "Remove all stopped pods",
+		Long:  prunePodsDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			prunePodsCommand.InputArgs = args
+			prunePodsCommand.GlobalFlags = MainGlobalOpts
+			return prunePodsCmd(&prunePodsCommand)
+		},
+	}
+)
+
+func init() {
+	prunePodsCommand.Command = _prunePodsCommand
+	prunePodsCommand.SetHelpTemplate(HelpTemplate())
+	prunePodsCommand.SetUsageTemplate(UsageTemplate())
+	flags := prunePodsCommand.Flags()
+	flags.BoolVarP(&prunePodsCommand.Force, "force", "f", false, "Force removal of a running pods.  The default is false")
+}
+
+func prunePods(runtime *adapter.LocalRuntime, ctx context.Context, maxWorkers int, force bool) error {
+	var deleteFuncs []shared.ParallelWorkerInput
+
+	filter := func(p *libpod.Pod) bool {
+		state, err := shared.GetPodStatus(p)
+		// pod states should be the same
+		if state == shared.PodStateStopped || (state == shared.PodStateExited && err == nil) {
+			return true
+		}
+		return false
+	}
+	delPods, err := runtime.Pods(filter)
+	if err != nil {
+		return err
+	}
+	if len(delPods) < 1 {
+		return nil
+	}
+	for _, pod := range delPods {
+		p := pod
+		f := func() error {
+			return runtime.RemovePod(ctx, p, force, force)
+		}
+
+		deleteFuncs = append(deleteFuncs, shared.ParallelWorkerInput{
+			ContainerID:  p.ID(),
+			ParallelFunc: f,
+		})
+	}
+	// Run the parallel funcs
+	deleteErrors, errCount := shared.ParallelExecuteWorkerPool(maxWorkers, deleteFuncs)
+	return printParallelOutput(deleteErrors, errCount)
+}
+
+func prunePodsCmd(c *cliconfig.PrunePodsValues) error {
+	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	if err != nil {
+		return errors.Wrapf(err, "could not get runtime")
+	}
+	defer runtime.Shutdown(false)
+
+	maxWorkers := shared.Parallelize("rm")
+	if c.GlobalIsSet("max-workers") {
+		maxWorkers = c.GlobalFlags.MaxWorks
+	}
+	logrus.Debugf("Setting maximum workers to %d", maxWorkers)
+
+	return prunePods(runtime, getContext(), maxWorkers, c.Bool("force"))
+}

--- a/cmd/podman/shared/pod.go
+++ b/cmd/podman/shared/pod.go
@@ -10,12 +10,12 @@ import (
 )
 
 const (
-	stopped = "Stopped"
-	running = "Running"
-	paused  = "Paused"
-	exited  = "Exited"
-	errored = "Error"
-	created = "Created"
+	PodStateStopped = "Stopped"
+	PodStateRunning = "Running"
+	PodStatePaused  = "Paused"
+	PodStateExited  = "Exited"
+	PodStateErrored = "Error"
+	PodStateCreated = "Created"
 )
 
 // GetPodStatus determines the status of the pod based on the
@@ -24,7 +24,7 @@ const (
 func GetPodStatus(pod *libpod.Pod) (string, error) {
 	ctrStatuses, err := pod.Status()
 	if err != nil {
-		return errored, err
+		return PodStateErrored, err
 	}
 	return CreatePodStatusResults(ctrStatuses)
 }
@@ -32,44 +32,44 @@ func GetPodStatus(pod *libpod.Pod) (string, error) {
 func CreatePodStatusResults(ctrStatuses map[string]libpod.ContainerStatus) (string, error) {
 	ctrNum := len(ctrStatuses)
 	if ctrNum == 0 {
-		return created, nil
+		return PodStateCreated, nil
 	}
 	statuses := map[string]int{
-		stopped: 0,
-		running: 0,
-		paused:  0,
-		created: 0,
-		errored: 0,
+		PodStateStopped: 0,
+		PodStateRunning: 0,
+		PodStatePaused:  0,
+		PodStateCreated: 0,
+		PodStateErrored: 0,
 	}
 	for _, ctrStatus := range ctrStatuses {
 		switch ctrStatus {
 		case libpod.ContainerStateExited:
 			fallthrough
 		case libpod.ContainerStateStopped:
-			statuses[stopped]++
+			statuses[PodStateStopped]++
 		case libpod.ContainerStateRunning:
-			statuses[running]++
+			statuses[PodStateRunning]++
 		case libpod.ContainerStatePaused:
-			statuses[paused]++
+			statuses[PodStatePaused]++
 		case libpod.ContainerStateCreated, libpod.ContainerStateConfigured:
-			statuses[created]++
+			statuses[PodStateCreated]++
 		default:
-			statuses[errored]++
+			statuses[PodStateErrored]++
 		}
 	}
 
-	if statuses[running] > 0 {
-		return running, nil
-	} else if statuses[paused] == ctrNum {
-		return paused, nil
-	} else if statuses[stopped] == ctrNum {
-		return exited, nil
-	} else if statuses[stopped] > 0 {
-		return stopped, nil
-	} else if statuses[errored] > 0 {
-		return errored, nil
+	if statuses[PodStateRunning] > 0 {
+		return PodStateRunning, nil
+	} else if statuses[PodStatePaused] == ctrNum {
+		return PodStatePaused, nil
+	} else if statuses[PodStateStopped] == ctrNum {
+		return PodStateExited, nil
+	} else if statuses[PodStateStopped] > 0 {
+		return PodStateStopped, nil
+	} else if statuses[PodStateErrored] > 0 {
+		return PodStateErrored, nil
 	}
-	return created, nil
+	return PodStateCreated, nil
 }
 
 // GetNamespaceOptions transforms a slice of kernel namespaces

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -1053,6 +1053,9 @@ method TopPod(pod: string, latest: bool, descriptors: []string) -> (stats: []str
 # ~~~
 method GetPodStats(name: string) -> (pod: string, containers: []ContainerStats)
 
+# GetPodsByStatus searches for pods whose status is included in statuses
+method GetPodsByStatus(statuses: []string) -> (pods: []string)
+
 # ImageExists talks a full or partial image ID or name and returns an int as to whether
 # the image exists in local storage. An int result of 0 means the image does exist in
 # local storage; whereas 1 indicates the image does not exists in local storage.

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2740,6 +2740,22 @@ _podman_pod_ps() {
   __podman_pod_ps
 }
 
+_podman_pod_prune() {
+    local options_with_args="
+    "
+
+    local boolean_options="
+     -f
+     -h
+	 --help
+  "
+    case "$cur" in
+	-*)
+	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+	    ;;
+    esac
+}
+
 _podman_pod_restart() {
   local options_with_args="
   "

--- a/docs/podman-container-prune.1.md
+++ b/docs/podman-container-prune.1.md
@@ -1,4 +1,4 @@
-% PODMAN(1) Podman Man Pages
+% podman-container-prune (1)
 % Brent Baude
 % December 2018
 # NAME

--- a/docs/podman-pod-prune.1.md
+++ b/docs/podman-pod-prune.1.md
@@ -1,0 +1,29 @@
+% % podman-pod-prune (1)
+% Peter Hunt
+% April 2019
+# NAME
+podman-pod-prune - Remove all stopped pods
+
+# SYNOPSIS
+**podman pod prune** [*-h*|*--help*]
+
+# DESCRIPTION
+**podman pod prune** removes all stopped pods from local storage.
+
+## Examples ##
+
+Remove all stopped pods from local storage
+```
+$ sudo podman pod prune
+22b8813332948064b6566370088c5e0230eeaf15a58b1c5646859fd9fc364fe7
+2afb26869fe5beab979c234afb75c7506063cd4655b1a73557c9d583ff1aebe9
+49161ad2a722cf18722f0e17199a9e840703a17d1158cdeda502b6d54080f674
+5ca429f37fb83a9f54eea89e3a9102b7780a6e6ae5f132db0672da551d862c4a
+6bb06573787efb8b0675bc88ebf8361f1a56d3ac7922d1a6436d8f59ffd955f1
+```
+
+## SEE ALSO
+podman-pod(1), podman-pod-ps(1), podman-pod-rm(1)
+
+# HISTORY
+April 2019, Originally compiled by Peter Hunt (pehunt at redhat dot com)

--- a/docs/podman-pod.1.md
+++ b/docs/podman-pod.1.md
@@ -11,21 +11,22 @@ podman pod is a set of subcommands that manage pods, or groups of containers.
 
 ## SUBCOMMANDS
 
-| Command | Man Page                                          | Description                                                                    |
-| ------- | ------------------------------------------------- | ------------------------------------------------------------------------------ |
-| create  | [podman-pod-create(1)](podman-pod-create.1.md)    | Create a new pod.                                                              |
-| exists  | [podman-pod-exists(1)](podman-pod-exists.1.md)    | Check if a pod exists in local storage.                                        |
-| inspect | [podman-pod-inspect(1)](podman-pod-inspect.1.md)  | Displays information describing a pod.                                         |
-| kill    | [podman-pod-kill(1)](podman-pod-kill.1.md)        | Kill the main process of each container in pod.                                |
-| pause   | [podman-pod-pause(1)](podman-pod-pause.1.md)      | Pause one or more pods.                                                        |
-| ps      | [podman-pod-ps(1)](podman-pod-ps.1.md)            | Prints out information about pods.                                             |
-| restart | [podman-pod-restart(1)](podman-pod-restart.1.md)  | Restart one or more pods.                                                      |
-| rm      | [podman-pod-rm(1)](podman-pod-rm.1.md)            | Remove one or more pods.                                                       |
-| start   | [podman-pod-start(1)](podman-pod-start.1.md)      | Start one or more pods.                                                        |
-| stats   | [podman-pod-stats(1)](podman-pod-stats.1.md)      | Display live stream resource usage stats for containers in one or more pods.   |
-| stop    | [podman-pod-stop(1)](podman-pod-stop.1.md)        | Stop one or more pods.                                                         |
-| top     | [podman-pod-top(1)](podman-pod-top.1.md)          | Display the running processes of containers in a pod.                          |
-| unpause | [podman-pod-unpause(1)](podman-pod-unpause.1.md)  | Unpause one or more pods.                                                      |
+| Command | Man Page                                                 | Description                                                                    |
+| ------- | -------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| create  | [podman-pod-create(1)](podman-pod-create.1.md)           | Create a new pod.                                                              |
+| exists  | [podman-pod-exists(1)](podman-pod-exists.1.md)           | Check if a pod exists in local storage.                                        |
+| inspect | [podman-pod-inspect(1)](podman-pod-inspect.1.md)         | Displays information describing a pod.                                         |
+| kill    | [podman-pod-kill(1)](podman-pod-kill.1.md)               | Kill the main process of each container in pod.                                |
+| pause   | [podman-pod-pause(1)](podman-pod-pause.1.md)             | Pause one or more pods.                                                        |
+| prune   | [podman-container-prune(1)](podman-container-prune.1.md) | Remove all stopped containers from local storage.                        |
+| ps      | [podman-pod-ps(1)](podman-pod-ps.1.md)                   | Prints out information about pods.                                             |
+| restart | [podman-pod-restart(1)](podman-pod-restart.1.md)         | Restart one or more pods.                                                      |
+| rm      | [podman-pod-rm(1)](podman-pod-rm.1.md)                   | Remove one or more pods.                                                       |
+| start   | [podman-pod-start(1)](podman-pod-start.1.md)             | Start one or more pods.                                                        |
+| stats   | [podman-pod-stats(1)](podman-pod-stats.1.md)             | Display live stream resource usage stats for containers in one or more pods.   |
+| stop    | [podman-pod-stop(1)](podman-pod-stop.1.md)               | Stop one or more pods.                                                         |
+| top     | [podman-pod-top(1)](podman-pod-top.1.md)                 | Display the running processes of containers in a pod.                          |
+| unpause | [podman-pod-unpause(1)](podman-pod-unpause.1.md)         | Unpause one or more pods.                                                      |
 
 ## SEE ALSO
 podman(1)

--- a/docs/podman-system-prune.1.md
+++ b/docs/podman-system-prune.1.md
@@ -11,7 +11,7 @@ podman\-system\-prune - Remove all unused container, image and volume data
 [**-volumes**|**--v**]
 
 ## DESCRIPTION
-**podman system prune** removes all unused containers, (both dangling and unreferenced) from local storage and optionally, volumes.
+**podman system prune** removes all unused containers (both dangling and unreferenced), pods and optionally, volumes from local storage.
 
 With the `all` option, you can delete all unused images.  Unused images are dangling images as well as any image that does not have any containers based on it.
 
@@ -31,7 +31,7 @@ Do not prompt for confirmation
 Prune volumes not used by at least one container
 
 ## SEE ALSO
-podman(1), podman-image-prune(1), podman-container-prune(1), podman-volume-prune(1)
+podman(1), podman-image-prune(1), podman-container-prune(1), podman-pod-prune(1), podman-volume-prune(1)
 
 # HISTORY
 February 2019, Originally compiled by Dan Walsh (dwalsh at redhat dot com)

--- a/pkg/adapter/pods.go
+++ b/pkg/adapter/pods.go
@@ -38,7 +38,7 @@ func (r *LocalRuntime) RemovePods(ctx context.Context, cli *cliconfig.PodRmValue
 	}
 
 	for _, p := range pods {
-		if err := r.RemovePod(ctx, p, cli.Force, cli.Force); err != nil {
+		if err := r.Runtime.RemovePod(ctx, p, cli.Force, cli.Force); err != nil {
 			errs = append(errs, err)
 		} else {
 			podids = append(podids, p.ID())

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -527,6 +527,24 @@ func (r *LocalRuntime) RemoveContainer(ctx context.Context, c *libpod.Container,
 	return libpod.ErrNotImplemented
 }
 
+// Pods retrieves all pods
+// Filters can be provided which will determine which pods are included in the
+// output. Multiple filters are handled by ANDing their output, so only pods
+// matching all filters are returned
+func (r *LocalRuntime) Pods(filters ...libpod.PodFilter) ([]*libpod.Pod, error) {
+	return nil, libpod.ErrNotImplemented
+}
+
+// RemovePod removes a pod
+// If removeCtrs is specified, containers will be removed
+// Otherwise, a pod that is not empty will return an error and not be removed
+// If force is specified with removeCtrs, all containers will be stopped before
+// being removed
+// Otherwise, the pod will not be removed if any containers are running
+func (r *LocalRuntime) RemovePod(ctx context.Context, p *libpod.Pod, removeCtrs, force bool) error {
+	return libpod.ErrNotImplemented
+}
+
 // CreateVolume creates a volume over a varlink connection for the remote client
 func (r *LocalRuntime) CreateVolume(ctx context.Context, c *cliconfig.VolumeCreateValues, labels, opts map[string]string) (string, error) {
 	cvOpts := iopodman.VolumeCreateOpts{

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -527,24 +527,6 @@ func (r *LocalRuntime) RemoveContainer(ctx context.Context, c *libpod.Container,
 	return libpod.ErrNotImplemented
 }
 
-// Pods retrieves all pods
-// Filters can be provided which will determine which pods are included in the
-// output. Multiple filters are handled by ANDing their output, so only pods
-// matching all filters are returned
-func (r *LocalRuntime) Pods(filters ...libpod.PodFilter) ([]*libpod.Pod, error) {
-	return nil, libpod.ErrNotImplemented
-}
-
-// RemovePod removes a pod
-// If removeCtrs is specified, containers will be removed
-// Otherwise, a pod that is not empty will return an error and not be removed
-// If force is specified with removeCtrs, all containers will be stopped before
-// being removed
-// Otherwise, the pod will not be removed if any containers are running
-func (r *LocalRuntime) RemovePod(ctx context.Context, p *libpod.Pod, removeCtrs, force bool) error {
-	return libpod.ErrNotImplemented
-}
-
 // CreateVolume creates a volume over a varlink connection for the remote client
 func (r *LocalRuntime) CreateVolume(ctx context.Context, c *cliconfig.VolumeCreateValues, labels, opts map[string]string) (string, error) {
 	cvOpts := iopodman.VolumeCreateOpts{

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -14,7 +14,7 @@ LABEL RUN podman --version
 RUN apk update
 RUN apk add bash`
 
-var _ = Describe("Podman rm", func() {
+var _ = Describe("Podman prune", func() {
 	var (
 		tempdir    string
 		err        error
@@ -101,4 +101,37 @@ var _ = Describe("Podman rm", func() {
 		Expect(len(images.OutputToStringArray())).To(Equal(0))
 	})
 
+	It("podman system prune pods", func() {
+		SkipIfRemote()
+
+		session := podmanTest.Podman([]string{"pod", "create"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"pod", "create"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"pod", "start", "-l"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"pod", "stop", "-l"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		pods := podmanTest.Podman([]string{"pod", "ps"})
+		pods.WaitWithDefaultTimeout()
+		Expect(pods.ExitCode()).To(Equal(0))
+		Expect(len(pods.OutputToStringArray())).To(Equal(3))
+
+		prune := podmanTest.Podman([]string{"system", "prune", "-f"})
+		prune.WaitWithDefaultTimeout()
+		Expect(prune.ExitCode()).To(Equal(0))
+
+		pods = podmanTest.Podman([]string{"pod", "ps"})
+		pods.WaitWithDefaultTimeout()
+		Expect(pods.ExitCode()).To(Equal(0))
+		Expect(len(pods.OutputToStringArray())).To(Equal(2))
+	})
 })


### PR DESCRIPTION
podman system prune would leave pods be, and not prune them if they were stopped.
Fix this by adding a `podman pod prune` command that prunes stopped pods similarly to containers.

Signed-off-by: Peter Hunt <pehunt@redhat.com>