### PR TITLE
rootless: cleanups

### DIFF
--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -103,7 +103,7 @@ func profileOff(cmd *cobra.Command) error {
 }
 
 func setupRootless(cmd *cobra.Command, args []string) error {
-	if os.Geteuid() == 0 || cmd == _searchCommand || cmd == _versionCommand || strings.HasPrefix(cmd.Use, "help") {
+	if os.Geteuid() == 0 || cmd == _searchCommand || cmd == _versionCommand || cmd == _mountCommand || strings.HasPrefix(cmd.Use, "help") {
 		return nil
 	}
 	podmanCmd := cliconfig.PodmanCommand{

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -19,7 +19,6 @@ import (
 	ann "github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/inspect"
 	ns "github.com/containers/libpod/pkg/namespaces"
-	"github.com/containers/libpod/pkg/rootless"
 	cc "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/docker/docker/pkg/signal"
@@ -392,16 +391,6 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 	}
 	if c.IsSet("pod") {
 		if strings.HasPrefix(originalPodName, "new:") {
-			if rootless.IsRootless() {
-				// To create a new pod, we must immediately create the userns.
-				became, ret, err := rootless.BecomeRootInUserNS()
-				if err != nil {
-					return nil, err
-				}
-				if became {
-					os.Exit(ret)
-				}
-			}
 			// pod does not exist; lets make it
 			var podOptions []libpod.PodCreateOption
 			podOptions = append(podOptions, libpod.WithPodName(podName), libpod.WithInfraContainer(), libpod.WithPodCgroups())

--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -51,29 +51,3 @@ func markFlagHiddenForRemoteClient(flagName string, flags *pflag.FlagSet) {
 		flags.MarkHidden(flagName)
 	}
 }
-
-// TODO: remove when adapter package takes over this functionality
-// func joinContainerOrCreateRootlessUserNS(runtime *libpod.Runtime, ctr *libpod.Container) (bool, int, error) {
-// 	if os.Geteuid() == 0 {
-// 		return false, 0, nil
-// 	}
-// 	s, err := ctr.State()
-// 	if err != nil {
-// 		return false, -1, err
-// 	}
-// 	opts := rootless.Opts{
-// 		Argument: ctr.ID(),
-// 	}
-// 	if s == libpod.ContainerStateRunning || s == libpod.ContainerStatePaused {
-// 		data, err := ioutil.ReadFile(ctr.Config().ConmonPidFile)
-// 		if err != nil {
-// 			return false, -1, errors.Wrapf(err, "cannot read conmon PID file %q", ctr.Config().ConmonPidFile)
-// 		}
-// 		conmonPid, err := strconv.Atoi(string(data))
-// 		if err != nil {
-// 			return false, -1, errors.Wrapf(err, "cannot parse PID %q", data)
-// 		}
-// 		return rootless.JoinDirectUserAndMountNSWithOpts(uint(conmonPid), &opts)
-// 	}
-// 	return rootless.BecomeRootInUserNSWithOpts(&opts)
-// }

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -311,46 +311,6 @@ func (r *LocalRuntime) HealthCheck(c *cliconfig.HealthCheckValues) (libpod.Healt
 	return r.Runtime.HealthCheck(c.InputArgs[0])
 }
 
-// JoinOrCreateRootlessPod joins the specified pod if it is running or it creates a new user namespace
-// if the pod is stopped
-// func (r *LocalRuntime) JoinOrCreateRootlessPod(pod *Pod) (bool, int, error) {
-// 	if os.Geteuid() == 0 {
-// 		return false, 0, nil
-// 	}
-// 	opts := rootless.Opts{
-// 		Argument: pod.ID(),
-// 	}
-//
-// 	inspect, err := pod.Inspect()
-// 	if err != nil {
-// 		return false, 0, err
-// 	}
-// 	for _, ctr := range inspect.Containers {
-// 		prevCtr, err := r.LookupContainer(ctr.ID)
-// 		if err != nil {
-// 			return false, -1, err
-// 		}
-// 		s, err := prevCtr.State()
-// 		if err != nil {
-// 			return false, -1, err
-// 		}
-// 		if s != libpod.ContainerStateRunning && s != libpod.ContainerStatePaused {
-// 			continue
-// 		}
-// 		data, err := ioutil.ReadFile(prevCtr.Config().ConmonPidFile)
-// 		if err != nil {
-// 			return false, -1, errors.Wrapf(err, "cannot read conmon PID file %q", prevCtr.Config().ConmonPidFile)
-// 		}
-// 		conmonPid, err := strconv.Atoi(string(data))
-// 		if err != nil {
-// 			return false, -1, errors.Wrapf(err, "cannot parse PID %q", data)
-// 		}
-// 		return rootless.JoinDirectUserAndMountNSWithOpts(uint(conmonPid), &opts)
-// 	}
-//
-// 	return rootless.BecomeRootInUserNSWithOpts(&opts)
-// }
-
 // Events is a wrapper to libpod to obtain libpod/podman events
 func (r *LocalRuntime) Events(c *cliconfig.EventValues) error {
 	var (


### PR DESCRIPTION
remove some dead code and fix a regression where we don't report correctly if are trying to use "mount" with something different than "vfs"