### PR TITLE
Move open tracing in main

### DIFF
--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -43,9 +43,6 @@ func attachCmd(c *cliconfig.AttachValues) error {
 	if len(c.InputArgs) > 1 || (len(c.InputArgs) == 0 && !c.Latest) {
 		return errors.Errorf("attach requires the name or id of one running container or the latest flag")
 	}
-	if remoteclient && len(c.InputArgs) != 1 {
-		return errors.Errorf("attach requires the name or id of one running container")
-	}
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating runtime")

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -42,11 +41,6 @@ func init() {
 }
 
 func createCmd(c *cliconfig.CreateValues) error {
-	if c.Bool("trace") {
-		span, _ := opentracing.StartSpanFromContext(Ctx, "createCmd")
-		defer span.Finish()
-	}
-
 	if err := createInit(&c.PodmanCommand); err != nil {
 		return err
 	}
@@ -66,11 +60,6 @@ func createCmd(c *cliconfig.CreateValues) error {
 }
 
 func createInit(c *cliconfig.PodmanCommand) error {
-	if !remote && c.Bool("trace") {
-		span, _ := opentracing.StartSpanFromContext(Ctx, "createInit")
-		defer span.Finish()
-	}
-
 	// Docker-compatibility: the "-h" flag for run/create is reserved for
 	// the hostname (see https://github.com/containers/libpod/issues/1367).
 

--- a/cmd/podman/kill.go
+++ b/cmd/podman/kill.go
@@ -4,7 +4,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/docker/docker/pkg/signal"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -46,11 +45,6 @@ func init() {
 
 // killCmd kills one or more containers with a signal
 func killCmd(c *cliconfig.KillValues) error {
-	if c.Bool("trace") {
-		span, _ := opentracing.StartSpanFromContext(Ctx, "killCmd")
-		defer span.Finish()
-	}
-
 	// Check if the signalString provided by the user is valid
 	// Invalid signals will return err
 	killSignal, err := signal.ParseSignal(c.Signal)

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/version"
 	"github.com/containers/storage/pkg/reexec"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -23,7 +22,6 @@ import (
 var (
 	exitCode = 125
 	Ctx      context.Context
-	span     opentracing.Span
 	closer   io.Closer
 )
 
@@ -71,6 +69,12 @@ var rootCmd = &cobra.Command{
 	},
 	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 		return after(cmd, args)
+	},
+	PreRun: func(cmd *cobra.Command, args []string) {
+		startTrace()
+	},
+	PostRun: func(cmd *cobra.Command, args []string) {
+		stopTrace()
 	},
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -24,6 +24,8 @@ import (
 
 const remote = false
 
+var span opentracing.Span
+
 func init() {
 
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.CGroupManager, "cgroup-manager", "", "Cgroup manager to use (cgroupfs or systemd, default systemd)")
@@ -152,4 +154,13 @@ func setupRootless(cmd *cobra.Command, args []string) error {
 		os.Exit(ret)
 	}
 	return nil
+}
+func startTrace() {
+	if MainGlobalOpts.Trace {
+		span, _ = opentracing.StartSpanFromContext(Ctx, "stopCmd")
+	}
+}
+
+func stopTrace() {
+	defer span.Finish()
 }

--- a/cmd/podman/main_remote.go
+++ b/cmd/podman/main_remote.go
@@ -41,3 +41,6 @@ func setupRootless(cmd *cobra.Command, args []string) error {
 	}
 	return nil
 }
+
+func startTrace() {}
+func stopTrace()  {}

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/docker/go-units"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/fields"
@@ -197,11 +196,6 @@ func init() {
 }
 
 func psCmd(c *cliconfig.PsValues) error {
-	if c.Bool("trace") {
-		span, _ := opentracing.StartSpanFromContext(Ctx, "psCmd")
-		defer span.Finish()
-	}
-
 	var watch bool
 
 	if c.Watch > 0 {

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/containers/libpod/pkg/util"
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -67,11 +66,6 @@ func pullCmd(c *cliconfig.PullValues) (retError error) {
 			exitCode = 1
 		}
 	}()
-	if c.Bool("trace") {
-		span, _ := opentracing.StartSpanFromContext(Ctx, "pullCmd")
-		defer span.Finish()
-	}
-
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 
 	if err != nil {

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -38,11 +37,6 @@ func init() {
 }
 
 func runCmd(c *cliconfig.RunValues) error {
-	if !remote && c.Bool("trace") {
-		span, _ := opentracing.StartSpanFromContext(Ctx, "runCmd")
-		defer span.Finish()
-	}
-
 	if err := createInit(&c.PodmanCommand); err != nil {
 		return err
 	}

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -28,7 +28,6 @@ import (
 	"github.com/google/shlex"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -39,11 +38,6 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		err         error
 		cidFile     *os.File
 	)
-	if c.Bool("trace") {
-		span, _ := opentracing.StartSpanFromContext(ctx, "createContainer")
-		defer span.Finish()
-	}
-
 	rtc, err := runtime.GetConfig()
 	if err != nil {
 		return nil, nil, err

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -8,7 +8,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/adapter"
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -47,11 +46,6 @@ func init() {
 }
 
 func startCmd(c *cliconfig.StartValues) error {
-	if c.Bool("trace") {
-		span, _ := opentracing.StartSpanFromContext(Ctx, "startCmd")
-		defer span.Finish()
-	}
-
 	args := c.InputArgs
 	if len(args) < 1 && !c.Latest {
 		return errors.Errorf("you must provide at least one container name or id")

--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -4,7 +4,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/adapter"
-	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -48,11 +47,6 @@ func init() {
 func stopCmd(c *cliconfig.StopValues) error {
 	if c.Flag("timeout").Changed && c.Flag("time").Changed {
 		return errors.New("the --timeout and --time flags are mutually exclusive")
-	}
-
-	if c.Bool("trace") {
-		span, _ := opentracing.StartSpanFromContext(Ctx, "stopCmd")
-		defer span.Finish()
 	}
 
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)


### PR DESCRIPTION
To make the calls to the opentracing utilities more efficient, the start
and stop of the trace are now run in pre and post run routines of cobra
when enabled.

Fixes: #2937

Signed-off-by: baude <bbaude@redhat.com>