### PR TITLE
Add different exit codes in rm, rmi and inspect commands

### DIFF
--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -67,7 +67,7 @@ func rmCmd(c *cliconfig.RmValues) error {
 	}
 
 	if len(failures) > 0 {
-		exitCode = 125
+		exitCode = 2
 	}
 
 	return printCmdResults(ok, failures)

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -74,6 +74,7 @@ func rmiCmd(c *cliconfig.RmiValues) error {
 				fmt.Printf("A container associated with containers/storage, i.e. via Buildah, CRI-O, etc., may be associated with this image: %-12.12s\n", img.ID())
 			}
 			if !adapter.IsImageNotFound(err) {
+				exitCode = 2
 				failureCnt++
 			}
 			if lastError != nil {

--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -62,7 +62,8 @@ podman rm -f --latest
 ## Exit Status
 **_0_** if all specified containers removed
 **_1_** if one of the specified containers did not exist, and no other failures
-**_125_** if command fails for a reason other then an container did not exist
+**_2_** if one of the specified containers is paused or running
+**_125_** if the command fails for a reason other than container did not exist or is paused/running
 
 ## SEE ALSO
 podman(1), podman-image-rm(1)

--- a/docs/podman-rmi.1.md
+++ b/docs/podman-rmi.1.md
@@ -43,7 +43,8 @@ podman rmi -a -f
 ## Exit Status
 **_0_** if all specified images removed
 **_1_** if one of the specified images did not exist, and no other failures
-**_125_** if command fails for a reason other then an image did not exist
+**_2_** if one of the specified images has child images or is being used by a container
+**_125_** if the command fails for a reason other than an image did not exist or is in use
 
 ## SEE ALSO
 podman(1)

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Podman rm", func() {
 
 		result := podmanTest.Podman([]string{"rm", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(125))
+		Expect(result.ExitCode()).To(Equal(2))
 	})
 
 	It("podman rm created container", func() {

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Podman rmi", func() {
 
 		session = podmanTest.Podman([]string{"rmi", "-f", untaggedImg})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session.ExitCode()).To(Equal(2))
 	})
 
 	It("podman rmi image that is created from another named imaged", func() {


### PR DESCRIPTION
Currently, the inspect command does not return any specific exit code when something goes wrong and rm/rmi commands only return 1 when specified container/image does not exist. In order for [toolbox](https://github.com/debarshiray/toolbox) to be able to give more specific error messages when image/container couldn't be removed, we need separate exit codes. 

In this PR, I modified the inspect command so that it returns 1 when the specified image/container was not found (consistent with exit code 1 in rm/rmi). The rm command returns 2 when the specified container is paused or running and the rmi command returns 2 when the specified image has child images or is being used by a container. 

Feel free to suggest any other exit codes if the ones I chose are unsuitable. Also, this is my first contribution here, so please excuse any silly mistakes.

Signed-off-by: Ondrej Zoder <ozoder@redhat.com>