### PR TITLE
Fix segfaults attribute to missing options

### DIFF
--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -17,6 +17,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			attachCommand.InputArgs = args
 			attachCommand.GlobalFlags = MainGlobalOpts
+			attachCommand.Remote = remoteclient
 			return attachCmd(&attachCommand)
 		},
 		Example: `podman attach ctrID

--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -39,6 +39,7 @@ var (
 			buildCommand.FromAndBudResults = &fromAndBudValues
 			buildCommand.LayerResults = &layerValues
 			buildCommand.NameSpaceResults = &namespaceValues
+			buildCommand.Remote = remoteclient
 			return buildCmd(&buildCommand)
 		},
 		Example: `podman build .

--- a/cmd/podman/checkpoint.go
+++ b/cmd/podman/checkpoint.go
@@ -23,6 +23,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			checkpointCommand.InputArgs = args
 			checkpointCommand.GlobalFlags = MainGlobalOpts
+			checkpointCommand.Remote = remoteclient
 			return checkpointCmd(&checkpointCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/cleanup.go
+++ b/cmd/podman/cleanup.go
@@ -24,6 +24,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cleanupCommand.InputArgs = args
 			cleanupCommand.GlobalFlags = MainGlobalOpts
+			cleanupCommand.Remote = remoteclient
 			return cleanupCmd(&cleanupCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/cliconfig/commands.go
+++ b/cmd/podman/cliconfig/commands.go
@@ -26,7 +26,9 @@ func (p *PodmanCommand) IsSet(opt string) bool {
 func (p *PodmanCommand) Bool(opt string) bool {
 	flag := p.Flags().Lookup(opt)
 	if flag == nil {
-		logrus.Errorf("Could not find flag %s", opt)
+		if !p.Remote {
+			logrus.Errorf("Could not find flag %s", opt)
+		}
 		return false
 	}
 	val, err := p.Flags().GetBool(opt)
@@ -40,7 +42,9 @@ func (p *PodmanCommand) Bool(opt string) bool {
 func (p *PodmanCommand) String(opt string) string {
 	flag := p.Flags().Lookup(opt)
 	if flag == nil {
-		logrus.Errorf("Could not find flag %s", opt)
+		if !p.Remote {
+			logrus.Errorf("Could not find flag %s", opt)
+		}
 		return ""
 	}
 	val, err := p.Flags().GetString(opt)
@@ -54,7 +58,9 @@ func (p *PodmanCommand) String(opt string) string {
 func (p *PodmanCommand) StringArray(opt string) []string {
 	flag := p.Flags().Lookup(opt)
 	if flag == nil {
-		logrus.Errorf("Could not find flag %s", opt)
+		if !p.Remote {
+			logrus.Errorf("Could not find flag %s", opt)
+		}
 		return []string{}
 	}
 	val, err := p.Flags().GetStringArray(opt)
@@ -68,7 +74,9 @@ func (p *PodmanCommand) StringArray(opt string) []string {
 func (p *PodmanCommand) StringSlice(opt string) []string {
 	flag := p.Flags().Lookup(opt)
 	if flag == nil {
-		logrus.Errorf("Could not find flag %s", opt)
+		if !p.Remote {
+			logrus.Errorf("Could not find flag %s", opt)
+		}
 		return []string{}
 	}
 	val, err := p.Flags().GetStringSlice(opt)
@@ -82,7 +90,9 @@ func (p *PodmanCommand) StringSlice(opt string) []string {
 func (p *PodmanCommand) Int(opt string) int {
 	flag := p.Flags().Lookup(opt)
 	if flag == nil {
-		logrus.Errorf("Could not find flag %s", opt)
+		if !p.Remote {
+			logrus.Errorf("Could not find flag %s", opt)
+		}
 		return 0
 	}
 	val, err := p.Flags().GetInt(opt)
@@ -96,7 +106,9 @@ func (p *PodmanCommand) Int(opt string) int {
 func (p *PodmanCommand) Uint(opt string) uint {
 	flag := p.Flags().Lookup(opt)
 	if flag == nil {
-		logrus.Errorf("Could not find flag %s", opt)
+		if !p.Remote {
+			logrus.Errorf("Could not find flag %s", opt)
+		}
 		return 0
 	}
 	val, err := p.Flags().GetUint(opt)
@@ -110,7 +122,9 @@ func (p *PodmanCommand) Uint(opt string) uint {
 func (p *PodmanCommand) Int64(opt string) int64 {
 	flag := p.Flags().Lookup(opt)
 	if flag == nil {
-		logrus.Errorf("Could not find flag %s", opt)
+		if !p.Remote {
+			logrus.Errorf("Could not find flag %s", opt)
+		}
 		return 0
 	}
 	val, err := p.Flags().GetInt64(opt)
@@ -124,7 +138,9 @@ func (p *PodmanCommand) Int64(opt string) int64 {
 func (p *PodmanCommand) Uint64(opt string) uint64 {
 	flag := p.Flags().Lookup(opt)
 	if flag == nil {
-		logrus.Errorf("Could not find flag %s", opt)
+		if !p.Remote {
+			logrus.Errorf("Could not find flag %s", opt)
+		}
 		return 0
 	}
 	val, err := p.Flags().GetUint64(opt)
@@ -138,7 +154,9 @@ func (p *PodmanCommand) Uint64(opt string) uint64 {
 func (p *PodmanCommand) Float64(opt string) float64 {
 	flag := p.Flags().Lookup(opt)
 	if flag == nil {
-		logrus.Errorf("Could not find flag %s", opt)
+		if !p.Remote {
+			logrus.Errorf("Could not find flag %s", opt)
+		}
 		return 0
 	}
 	val, err := p.Flags().GetFloat64(opt)

--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -8,6 +8,7 @@ type PodmanCommand struct {
 	*cobra.Command
 	InputArgs   []string
 	GlobalFlags MainFlags
+	Remote      bool
 }
 
 type MainFlags struct {

--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -28,6 +28,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			commitCommand.InputArgs = args
 			commitCommand.GlobalFlags = MainGlobalOpts
+			commitCommand.Remote = remoteclient
 			return commitCmd(&commitCommand)
 		},
 		Example: `podman commit -q --message "committing container to image" reverent_golick image-commited

--- a/cmd/podman/containers_prune.go
+++ b/cmd/podman/containers_prune.go
@@ -27,6 +27,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pruneContainersCommand.InputArgs = args
 			pruneContainersCommand.GlobalFlags = MainGlobalOpts
+			pruneContainersCommand.Remote = remoteclient
 			return pruneContainersCmd(&pruneContainersCommand)
 		},
 	}

--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -36,6 +36,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cpCommand.InputArgs = args
 			cpCommand.GlobalFlags = MainGlobalOpts
+			cpCommand.Remote = remoteclient
 			return cpCmd(&cpCommand)
 		},
 		Example: "[CONTAINER:]SRC_PATH [CONTAINER:]DEST_PATH",

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			createCommand.InputArgs = args
 			createCommand.GlobalFlags = MainGlobalOpts
+			createCommand.Remote = remoteclient
 			return createCmd(&createCommand)
 		},
 		Example: `podman create alpine ls

--- a/cmd/podman/diff.go
+++ b/cmd/podman/diff.go
@@ -43,6 +43,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			diffCommand.InputArgs = args
 			diffCommand.GlobalFlags = MainGlobalOpts
+			diffCommand.Remote = remoteclient
 			return diffCmd(&diffCommand)
 		},
 		Example: `podman diff imageID

--- a/cmd/podman/events.go
+++ b/cmd/podman/events.go
@@ -18,6 +18,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			eventsCommand.InputArgs = args
 			eventsCommand.GlobalFlags = MainGlobalOpts
+			eventsCommand.Remote = remoteclient
 			return eventsCmd(&eventsCommand)
 		},
 		Example: `podman events

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -26,6 +26,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			execCommand.InputArgs = args
 			execCommand.GlobalFlags = MainGlobalOpts
+			execCommand.Remote = remoteclient
 			return execCmd(&execCommand)
 		},
 		Example: `podman exec -it ctrID ls

--- a/cmd/podman/exists.go
+++ b/cmd/podman/exists.go
@@ -29,6 +29,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			imageExistsCommand.InputArgs = args
 			imageExistsCommand.GlobalFlags = MainGlobalOpts
+			imageExistsCommand.Remote = remoteclient
 			return imageExistsCmd(&imageExistsCommand)
 		},
 		Example: `podman image exists imageID
@@ -42,6 +43,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			containerExistsCommand.InputArgs = args
 			containerExistsCommand.GlobalFlags = MainGlobalOpts
+			containerExistsCommand.Remote = remoteclient
 			return containerExistsCmd(&containerExistsCommand)
 
 		},
@@ -56,6 +58,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podExistsCommand.InputArgs = args
 			podExistsCommand.GlobalFlags = MainGlobalOpts
+			podExistsCommand.Remote = remoteclient
 			return podExistsCmd(&podExistsCommand)
 		},
 		Example: `podman pod exists podID

--- a/cmd/podman/export.go
+++ b/cmd/podman/export.go
@@ -23,6 +23,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			exportCommand.InputArgs = args
 			exportCommand.GlobalFlags = MainGlobalOpts
+			exportCommand.Remote = remoteclient
 			return exportCmd(&exportCommand)
 		},
 		Example: `podman export ctrID > myCtr.tar

--- a/cmd/podman/generate_kube.go
+++ b/cmd/podman/generate_kube.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			containerKubeCommand.InputArgs = args
 			containerKubeCommand.GlobalFlags = MainGlobalOpts
+			containerKubeCommand.Remote = remoteclient
 			return generateKubeYAMLCmd(&containerKubeCommand)
 		},
 		Example: `podman generate kube ctrID

--- a/cmd/podman/healthcheck_run.go
+++ b/cmd/podman/healthcheck_run.go
@@ -20,6 +20,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			healthcheckRunCommand.InputArgs = args
 			healthcheckRunCommand.GlobalFlags = MainGlobalOpts
+			healthcheckRunCommand.Remote = remoteclient
 			return healthCheckCmd(&healthcheckRunCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/history.go
+++ b/cmd/podman/history.go
@@ -47,6 +47,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			historyCommand.InputArgs = args
 			historyCommand.GlobalFlags = MainGlobalOpts
+			historyCommand.Remote = remoteclient
 			return historyCmd(&historyCommand)
 		},
 	}

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -96,6 +96,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			imagesCommand.InputArgs = args
 			imagesCommand.GlobalFlags = MainGlobalOpts
+			imagesCommand.Remote = remoteclient
 			return imagesCmd(&imagesCommand)
 		},
 		Example: `podman images --format json

--- a/cmd/podman/images_prune.go
+++ b/cmd/podman/images_prune.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pruneImagesCommand.InputArgs = args
 			pruneImagesCommand.GlobalFlags = MainGlobalOpts
+			pruneImagesCommand.Remote = remoteclient
 			return pruneImagesCmd(&pruneImagesCommand)
 		},
 	}

--- a/cmd/podman/import.go
+++ b/cmd/podman/import.go
@@ -24,6 +24,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			importCommand.InputArgs = args
 			importCommand.GlobalFlags = MainGlobalOpts
+			importCommand.Remote = remoteclient
 			return importCmd(&importCommand)
 		},
 		Example: `podman import http://example.com/ctr.tar url-image

--- a/cmd/podman/info.go
+++ b/cmd/podman/info.go
@@ -28,6 +28,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			infoCommand.InputArgs = args
 			infoCommand.GlobalFlags = MainGlobalOpts
+			infoCommand.Remote = remoteclient
 			return infoCmd(&infoCommand)
 		},
 		Example: `podman info`,

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -33,6 +33,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inspectCommand.InputArgs = args
 			inspectCommand.GlobalFlags = MainGlobalOpts
+			inspectCommand.Remote = remoteclient
 			return inspectCmd(&inspectCommand)
 		},
 		Example: `podman inspect alpine

--- a/cmd/podman/kill.go
+++ b/cmd/podman/kill.go
@@ -20,6 +20,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			killCommand.InputArgs = args
 			killCommand.GlobalFlags = MainGlobalOpts
+			killCommand.Remote = remoteclient
 			return killCmd(&killCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/load.go
+++ b/cmd/podman/load.go
@@ -27,6 +27,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			loadCommand.InputArgs = args
 			loadCommand.GlobalFlags = MainGlobalOpts
+			loadCommand.Remote = remoteclient
 			return loadCmd(&loadCommand)
 		},
 	}

--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -27,6 +27,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			loginCommand.InputArgs = args
 			loginCommand.GlobalFlags = MainGlobalOpts
+			loginCommand.Remote = remoteclient
 			return loginCmd(&loginCommand)
 		},
 		Example: `podman login -u testuser -p testpassword localhost:5000

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -20,6 +20,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logoutCommand.InputArgs = args
 			logoutCommand.GlobalFlags = MainGlobalOpts
+			logoutCommand.Remote = remoteclient
 			return logoutCmd(&logoutCommand)
 		},
 		Example: `podman logout docker.io

--- a/cmd/podman/logs.go
+++ b/cmd/podman/logs.go
@@ -24,6 +24,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logsCommand.InputArgs = args
 			logsCommand.GlobalFlags = MainGlobalOpts
+			logsCommand.Remote = remoteclient
 			return logsCmd(&logsCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -110,6 +110,7 @@ func setupRootless(cmd *cobra.Command, args []string) error {
 		cmd,
 		args,
 		MainGlobalOpts,
+		remoteclient,
 	}
 	runtime, err := libpodruntime.GetRuntime(&podmanCmd)
 	if err != nil {

--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -31,6 +31,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			mountCommand.InputArgs = args
 			mountCommand.GlobalFlags = MainGlobalOpts
+			mountCommand.Remote = remoteclient
 			return mountCmd(&mountCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/pause.go
+++ b/cmd/podman/pause.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pauseCommand.InputArgs = args
 			pauseCommand.GlobalFlags = MainGlobalOpts
+			pauseCommand.Remote = remoteclient
 			return pauseCmd(&pauseCommand)
 		},
 		Example: `podman pause mywebserver

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -42,6 +42,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			playKubeCommand.InputArgs = args
 			playKubeCommand.GlobalFlags = MainGlobalOpts
+			playKubeCommand.Remote = remoteclient
 			return playKubeYAMLCmd(&playKubeCommand)
 		},
 		Example: `podman play kube demo.yml

--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -30,6 +30,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podCreateCommand.InputArgs = args
 			podCreateCommand.GlobalFlags = MainGlobalOpts
+			podCreateCommand.Remote = remoteclient
 			return podCreateCmd(&podCreateCommand)
 		},
 	}

--- a/cmd/podman/pod_inspect.go
+++ b/cmd/podman/pod_inspect.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podInspectCommand.InputArgs = args
 			podInspectCommand.GlobalFlags = MainGlobalOpts
+			podInspectCommand.Remote = remoteclient
 			return podInspectCmd(&podInspectCommand)
 		},
 		Example: `podman pod inspect podID`,

--- a/cmd/podman/pod_kill.go
+++ b/cmd/podman/pod_kill.go
@@ -24,6 +24,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podKillCommand.InputArgs = args
 			podKillCommand.GlobalFlags = MainGlobalOpts
+			podKillCommand.Remote = remoteclient
 			return podKillCmd(&podKillCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/pod_pause.go
+++ b/cmd/podman/pod_pause.go
@@ -21,6 +21,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podPauseCommand.InputArgs = args
 			podPauseCommand.GlobalFlags = MainGlobalOpts
+			podPauseCommand.Remote = remoteclient
 			return podPauseCmd(&podPauseCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/pod_ps.go
+++ b/cmd/podman/pod_ps.go
@@ -127,6 +127,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podPsCommand.InputArgs = args
 			podPsCommand.GlobalFlags = MainGlobalOpts
+			podPsCommand.Remote = remoteclient
 			return podPsCmd(&podPsCommand)
 		},
 	}

--- a/cmd/podman/pod_restart.go
+++ b/cmd/podman/pod_restart.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podRestartCommand.InputArgs = args
 			podRestartCommand.GlobalFlags = MainGlobalOpts
+			podRestartCommand.Remote = remoteclient
 			return podRestartCmd(&podRestartCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/pod_rm.go
+++ b/cmd/podman/pod_rm.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podRmCommand.InputArgs = args
 			podRmCommand.GlobalFlags = MainGlobalOpts
+			podRmCommand.Remote = remoteclient
 			return podRmCmd(&podRmCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/pod_start.go
+++ b/cmd/podman/pod_start.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podStartCommand.InputArgs = args
 			podStartCommand.GlobalFlags = MainGlobalOpts
+			podStartCommand.Remote = remoteclient
 			return podStartCmd(&podStartCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/pod_stats.go
+++ b/cmd/podman/pod_stats.go
@@ -29,6 +29,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podStatsCommand.InputArgs = args
 			podStatsCommand.GlobalFlags = MainGlobalOpts
+			podStatsCommand.Remote = remoteclient
 			return podStatsCmd(&podStatsCommand)
 		},
 		Example: `podman stats -a --no-stream

--- a/cmd/podman/pod_stop.go
+++ b/cmd/podman/pod_stop.go
@@ -23,6 +23,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podStopCommand.InputArgs = args
 			podStopCommand.GlobalFlags = MainGlobalOpts
+			podStopCommand.Remote = remoteclient
 			return podStopCmd(&podStopCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/pod_top.go
+++ b/cmd/podman/pod_top.go
@@ -28,6 +28,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podTopCommand.InputArgs = args
 			podTopCommand.GlobalFlags = MainGlobalOpts
+			podTopCommand.Remote = remoteclient
 			return podTopCmd(&podTopCommand)
 		},
 		Example: `podman top ctrID

--- a/cmd/podman/pod_unpause.go
+++ b/cmd/podman/pod_unpause.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podUnpauseCommand.InputArgs = args
 			podUnpauseCommand.GlobalFlags = MainGlobalOpts
+			podUnpauseCommand.Remote = remoteclient
 			return podUnpauseCmd(&podUnpauseCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/port.go
+++ b/cmd/podman/port.go
@@ -23,6 +23,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			portCommand.InputArgs = args
 			portCommand.GlobalFlags = MainGlobalOpts
+			portCommand.Remote = remoteclient
 			return portCmd(&portCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -161,6 +161,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			psCommand.InputArgs = args
 			psCommand.GlobalFlags = MainGlobalOpts
+			psCommand.Remote = remoteclient
 			return psCmd(&psCommand)
 		},
 		Example: `podman ps -a

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -32,6 +32,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pullCommand.InputArgs = args
 			pullCommand.GlobalFlags = MainGlobalOpts
+			pullCommand.Remote = remoteclient
 			return pullCmd(&pullCommand)
 		},
 		Example: `podman pull imageName
@@ -117,7 +118,7 @@ func pullCmd(c *cliconfig.PullValues) (retError error) {
 		DockerRegistryCreds: registryCreds,
 		DockerCertPath:      c.CertDir,
 	}
-	if c.Flag("tls-verify").Changed {
+	if c.IsSet("tls-verify") {
 		dockerRegistryOptions.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!c.TlsVerify)
 	}
 

--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -31,6 +31,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pushCommand.InputArgs = args
 			pushCommand.GlobalFlags = MainGlobalOpts
+			pushCommand.Remote = remoteclient
 			return pushCmd(&pushCommand)
 		},
 		Example: `podman push imageID docker://registry.example.com/repository:tag

--- a/cmd/podman/refresh.go
+++ b/cmd/podman/refresh.go
@@ -24,6 +24,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			refreshCommand.InputArgs = args
 			refreshCommand.GlobalFlags = MainGlobalOpts
+			refreshCommand.Remote = remoteclient
 			return refreshCmd(&refreshCommand)
 		},
 	}

--- a/cmd/podman/restart.go
+++ b/cmd/podman/restart.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			restartCommand.InputArgs = args
 			restartCommand.GlobalFlags = MainGlobalOpts
+			restartCommand.Remote = remoteclient
 			return restartCmd(&restartCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/restore.go
+++ b/cmd/podman/restore.go
@@ -23,6 +23,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			restoreCommand.InputArgs = args
 			restoreCommand.GlobalFlags = MainGlobalOpts
+			restoreCommand.Remote = remoteclient
 			return restoreCmd(&restoreCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rmCommand.InputArgs = args
 			rmCommand.GlobalFlags = MainGlobalOpts
+			rmCommand.Remote = remoteclient
 			return rmCmd(&rmCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -21,6 +21,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rmiCommand.InputArgs = args
 			rmiCommand.GlobalFlags = MainGlobalOpts
+			rmiCommand.Remote = remoteclient
 			return rmiCmd(&rmiCommand)
 		},
 		Example: `podman rmi imageID

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -19,6 +19,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runCommand.InputArgs = args
 			runCommand.GlobalFlags = MainGlobalOpts
+			runCommand.Remote = remoteclient
 			return runCmd(&runCommand)
 		},
 		Example: `podman run imageID ls -alF /etc

--- a/cmd/podman/runlabel.go
+++ b/cmd/podman/runlabel.go
@@ -30,6 +30,7 @@ Executes a command as described by a container image label.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runlabelCommand.InputArgs = args
 			runlabelCommand.GlobalFlags = MainGlobalOpts
+			runlabelCommand.Remote = remoteclient
 			return runlabelCmd(&runlabelCommand)
 		},
 		Example: `podman container runlabel run imageID

--- a/cmd/podman/save.go
+++ b/cmd/podman/save.go
@@ -33,6 +33,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			saveCommand.InputArgs = args
 			saveCommand.GlobalFlags = MainGlobalOpts
+			saveCommand.Remote = remoteclient
 			return saveCmd(&saveCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -29,6 +29,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			searchCommand.InputArgs = args
 			searchCommand.GlobalFlags = MainGlobalOpts
+			searchCommand.Remote = remoteclient
 			return searchCmd(&searchCommand)
 		},
 		Example: `podman search --filter=is-official --limit 3 alpine

--- a/cmd/podman/sign.go
+++ b/cmd/podman/sign.go
@@ -30,6 +30,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			signCommand.InputArgs = args
 			signCommand.GlobalFlags = MainGlobalOpts
+			signCommand.Remote = remoteclient
 			return signCmd(&signCommand)
 		},
 		Example: `podman sign --sign-by mykey imageID

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -25,6 +25,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			startCommand.InputArgs = args
 			startCommand.GlobalFlags = MainGlobalOpts
+			startCommand.Remote = remoteclient
 			return startCmd(&startCommand)
 		},
 		Example: `podman start --latest

--- a/cmd/podman/stats.go
+++ b/cmd/podman/stats.go
@@ -39,6 +39,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			statsCommand.InputArgs = args
 			statsCommand.GlobalFlags = MainGlobalOpts
+			statsCommand.Remote = remoteclient
 			return statsCmd(&statsCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -21,6 +21,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			stopCommand.InputArgs = args
 			stopCommand.GlobalFlags = MainGlobalOpts
+			stopCommand.Remote = remoteclient
 			return stopCmd(&stopCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/system_df.go
+++ b/cmd/podman/system_df.go
@@ -33,6 +33,7 @@ var (
 		Long:  dfSystemDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dfSystemCommand.GlobalFlags = MainGlobalOpts
+			dfSystemCommand.Remote = remoteclient
 			return dfSystemCmd(&dfSystemCommand)
 		},
 	}

--- a/cmd/podman/system_prune.go
+++ b/cmd/podman/system_prune.go
@@ -29,6 +29,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pruneSystemCommand.InputArgs = args
 			pruneSystemCommand.GlobalFlags = MainGlobalOpts
+			pruneSystemCommand.Remote = remoteclient
 			return pruneSystemCmd(&pruneSystemCommand)
 		},
 	}

--- a/cmd/podman/system_renumber.go
+++ b/cmd/podman/system_renumber.go
@@ -24,6 +24,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			renumberCommand.InputArgs = args
 			renumberCommand.GlobalFlags = MainGlobalOpts
+			renumberCommand.Remote = remoteclient
 			return renumberCmd(&renumberCommand)
 		},
 	}

--- a/cmd/podman/tag.go
+++ b/cmd/podman/tag.go
@@ -18,6 +18,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			tagCommand.InputArgs = args
 			tagCommand.GlobalFlags = MainGlobalOpts
+			tagCommand.Remote = remoteclient
 			return tagCmd(&tagCommand)
 		},
 		Example: `podman tag 0e3bbc2 fedora:latest

--- a/cmd/podman/top.go
+++ b/cmd/podman/top.go
@@ -39,6 +39,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			topCommand.InputArgs = args
 			topCommand.GlobalFlags = MainGlobalOpts
+			topCommand.Remote = remoteclient
 			return topCmd(&topCommand)
 		},
 		Example: `podman top ctrID

--- a/cmd/podman/tree.go
+++ b/cmd/podman/tree.go
@@ -29,6 +29,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			treeCommand.InputArgs = args
 			treeCommand.GlobalFlags = MainGlobalOpts
+			treeCommand.Remote = remoteclient
 			return treeCmd(&treeCommand)
 		},
 		Example: "podman image tree alpine:latest",

--- a/cmd/podman/trust_set_show.go
+++ b/cmd/podman/trust_set_show.go
@@ -29,6 +29,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			setTrustCommand.InputArgs = args
 			setTrustCommand.GlobalFlags = MainGlobalOpts
+			setTrustCommand.Remote = remoteclient
 			return setTrustCmd(&setTrustCommand)
 		},
 	}

--- a/cmd/podman/umount.go
+++ b/cmd/podman/umount.go
@@ -24,6 +24,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			umountCommand.InputArgs = args
 			umountCommand.GlobalFlags = MainGlobalOpts
+			umountCommand.Remote = remoteclient
 			return umountCmd(&umountCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/unpause.go
+++ b/cmd/podman/unpause.go
@@ -23,6 +23,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			unpauseCommand.InputArgs = args
 			unpauseCommand.GlobalFlags = MainGlobalOpts
+			unpauseCommand.Remote = remoteclient
 			return unpauseCmd(&unpauseCommand)
 		},
 		Example: `podman unpause ctrID

--- a/cmd/podman/version.go
+++ b/cmd/podman/version.go
@@ -23,6 +23,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			versionCommand.InputArgs = args
 			versionCommand.GlobalFlags = MainGlobalOpts
+			versionCommand.Remote = remoteclient
 			return versionCmd(&versionCommand)
 		},
 	}

--- a/cmd/podman/volume_create.go
+++ b/cmd/podman/volume_create.go
@@ -21,6 +21,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			volumeCreateCommand.InputArgs = args
 			volumeCreateCommand.GlobalFlags = MainGlobalOpts
+			volumeCreateCommand.Remote = remoteclient
 			return volumeCreateCmd(&volumeCreateCommand)
 		},
 		Example: `podman volume create myvol

--- a/cmd/podman/volume_inspect.go
+++ b/cmd/podman/volume_inspect.go
@@ -19,6 +19,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			volumeInspectCommand.InputArgs = args
 			volumeInspectCommand.GlobalFlags = MainGlobalOpts
+			volumeInspectCommand.Remote = remoteclient
 			return volumeInspectCmd(&volumeInspectCommand)
 		},
 		Example: `podman volume inspect myvol

--- a/cmd/podman/volume_ls.go
+++ b/cmd/podman/volume_ls.go
@@ -54,6 +54,7 @@ and the output format can be changed to JSON or a user specified Go template.`
 		RunE: func(cmd *cobra.Command, args []string) error {
 			volumeLsCommand.InputArgs = args
 			volumeLsCommand.GlobalFlags = MainGlobalOpts
+			volumeLsCommand.Remote = remoteclient
 			return volumeLsCmd(&volumeLsCommand)
 		},
 	}

--- a/cmd/podman/volume_prune.go
+++ b/cmd/podman/volume_prune.go
@@ -28,6 +28,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			volumePruneCommand.InputArgs = args
 			volumePruneCommand.GlobalFlags = MainGlobalOpts
+			volumePruneCommand.Remote = remoteclient
 			return volumePruneCmd(&volumePruneCommand)
 		},
 	}

--- a/cmd/podman/volume_rm.go
+++ b/cmd/podman/volume_rm.go
@@ -22,6 +22,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			volumeRmCommand.InputArgs = args
 			volumeRmCommand.GlobalFlags = MainGlobalOpts
+			volumeRmCommand.Remote = remoteclient
 			return volumeRmCmd(&volumeRmCommand)
 		},
 		Example: `podman volume rm myvol1 myvol2

--- a/cmd/podman/wait.go
+++ b/cmd/podman/wait.go
@@ -21,6 +21,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			waitCommand.InputArgs = args
 			waitCommand.GlobalFlags = MainGlobalOpts
+			waitCommand.Remote = remoteclient
 			return waitCmd(&waitCommand)
 		},
 		Example: `podman wait --latest


### PR DESCRIPTION
In cases where the remote client culls options to a command, we need to
be sure that the lookup for that flag does not result in a nil pointer.
To do so, we add a Remote attribute to the podman struct and then cli
helper funcs are now aware they are remote.

Signed-off-by: baude <bbaude@redhat.com>