### PR TITLE
podman-remote container commands

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -49,8 +49,6 @@ func getContainerSubCommands() []*cobra.Command {
 		_cleanupCommand,
 		_commitCommand,
 		_execCommand,
-		_exportCommand,
-		_killCommand,
 		_mountCommand,
 		_pauseCommand,
 		_portCommand,
@@ -58,7 +56,6 @@ func getContainerSubCommands() []*cobra.Command {
 		_refreshCommand,
 		_restartCommand,
 		_restoreCommand,
-		_rmCommand,
 		_runlabelCommand,
 		_startCommand,
 		_statsCommand,
@@ -66,7 +63,6 @@ func getContainerSubCommands() []*cobra.Command {
 		_topCommand,
 		_umountCommand,
 		_unpauseCommand,
-		_waitCommand,
 	}
 }
 

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -54,10 +54,14 @@ var (
 		_containerExistsCommand,
 		_contInspectSubCommand,
 		_diffCommand,
+		_exportCommand,
 		_createCommand,
+		_killCommand,
 		_listSubCommand,
 		_logsCommand,
 		_runCommand,
+		_rmCommand,
+		_waitCommand,
 	}
 )
 


### PR DESCRIPTION
Several container commands were ported to the remote client but had not
been updated on the container submenu yet.

Signed-off-by: baude <bbaude@redhat.com>