### PR TITLE
system: add new subcommand "migrate"

### DIFF
--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -47,7 +47,7 @@ func attachCmd(c *cliconfig.AttachValues) error {
 	if remoteclient && len(c.InputArgs) != 1 {
 		return errors.Errorf("attach requires the name or id of one running container")
 	}
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating runtime")
 	}

--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -206,7 +206,7 @@ func buildCmd(c *cliconfig.BuildValues) error {
 		dockerfiles = append(dockerfiles, filepath.Join(contextDir, "Dockerfile"))
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/checkpoint.go
+++ b/cmd/podman/checkpoint.go
@@ -54,7 +54,7 @@ func checkpointCmd(c *cliconfig.CheckpointValues) error {
 		return errors.New("checkpointing a container requires root")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/cleanup.go
+++ b/cmd/podman/cleanup.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 func cleanupCmd(c *cliconfig.CleanupValues) error {
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -581,6 +581,10 @@ type SystemRenumberValues struct {
 	PodmanCommand
 }
 
+type SystemMigrateValues struct {
+	PodmanCommand
+}
+
 type SystemDfValues struct {
 	PodmanCommand
 	Verbose bool

--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -77,6 +77,7 @@ func getSystemSubCommands() []*cobra.Command {
 		_pruneSystemCommand,
 		_renumberCommand,
 		_dfSystemCommand,
+		_migrateCommand,
 	}
 }
 

--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -52,7 +52,7 @@ func init() {
 }
 
 func commitCmd(c *cliconfig.CommitValues) error {
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/containers_prune.go
+++ b/cmd/podman/containers_prune.go
@@ -75,7 +75,7 @@ func pruneContainers(runtime *adapter.LocalRuntime, ctx context.Context, maxWork
 }
 
 func pruneContainersCmd(c *cliconfig.PruneContainersValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -58,7 +58,7 @@ func cpCmd(c *cliconfig.CpValues) error {
 		return errors.Errorf("you must provide a source path and a destination path")
 	}
 
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -52,7 +52,7 @@ func createCmd(c *cliconfig.CreateValues) error {
 		return err
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/diff.go
+++ b/cmd/podman/diff.go
@@ -87,7 +87,7 @@ func diffCmd(c *cliconfig.DiffValues) error {
 		return errors.Errorf("container, image, or layer name must be specified: podman diff [options [...]] ID-NAME")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/events.go
+++ b/cmd/podman/events.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 func eventsCmd(c *cliconfig.EventValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -68,7 +68,7 @@ func execCmd(c *cliconfig.ExecValues) error {
 		argStart = 0
 	}
 	cmd := args[argStart:]
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/exists.go
+++ b/cmd/podman/exists.go
@@ -86,7 +86,7 @@ func imageExistsCmd(c *cliconfig.ImageExistsValues) error {
 	if len(args) > 1 || len(args) < 1 {
 		return errors.New("you may only check for the existence of one image at a time")
 	}
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}
@@ -107,7 +107,7 @@ func containerExistsCmd(c *cliconfig.ContainerExistsValues) error {
 	if len(args) > 1 || len(args) < 1 {
 		return errors.New("you may only check for the existence of one container at a time")
 	}
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}
@@ -126,7 +126,7 @@ func podExistsCmd(c *cliconfig.PodExistsValues) error {
 	if len(args) > 1 || len(args) < 1 {
 		return errors.New("you may only check for the existence of one pod at a time")
 	}
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/export.go
+++ b/cmd/podman/export.go
@@ -41,7 +41,7 @@ func init() {
 
 // exportCmd saves a container to a tarball on disk
 func exportCmd(c *cliconfig.ExportValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/generate_kube.go
+++ b/cmd/podman/generate_kube.go
@@ -54,7 +54,7 @@ func generateKubeYAMLCmd(c *cliconfig.GenerateKubeValues) error {
 		return errors.Errorf("you must provide exactly one container|pod ID or name")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/healthcheck_run.go
+++ b/cmd/podman/healthcheck_run.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func healthCheckCmd(c *cliconfig.HealthCheckValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrap(err, "could not get runtime")
 	}

--- a/cmd/podman/history.go
+++ b/cmd/podman/history.go
@@ -67,7 +67,7 @@ func init() {
 }
 
 func historyCmd(c *cliconfig.HistoryValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -134,7 +134,7 @@ func imagesCmd(c *cliconfig.ImagesValues) error {
 		image       string
 	)
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "Could not get runtime")
 	}

--- a/cmd/podman/images_prune.go
+++ b/cmd/podman/images_prune.go
@@ -37,7 +37,7 @@ func init() {
 }
 
 func pruneImagesCmd(c *cliconfig.PruneImagesValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/import.go
+++ b/cmd/podman/import.go
@@ -45,7 +45,7 @@ func init() {
 }
 
 func importCmd(c *cliconfig.ImportValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/info.go
+++ b/cmd/podman/info.go
@@ -50,7 +50,7 @@ func infoCmd(c *cliconfig.InfoValues) error {
 	info := map[string]interface{}{}
 	remoteClientInfo := map[string]interface{}{}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -84,7 +84,7 @@ func inspectCmd(c *cliconfig.InspectValues) error {
 		return errors.Errorf("you cannot provide additional arguments with --latest")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/kill.go
+++ b/cmd/podman/kill.go
@@ -59,7 +59,7 @@ func killCmd(c *cliconfig.KillValues) error {
 		return err
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -1,6 +1,8 @@
 package libpodruntime
 
 import (
+	"context"
+
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/rootless"
@@ -10,21 +12,21 @@ import (
 )
 
 // GetRuntimeMigrate gets a libpod runtime that will perform a migration of existing containers
-func GetRuntimeMigrate(c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(c, false, true)
+func GetRuntimeMigrate(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
+	return getRuntime(ctx, c, false, true)
 }
 
 // GetRuntimeRenumber gets a libpod runtime that will perform a lock renumber
-func GetRuntimeRenumber(c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(c, true, false)
+func GetRuntimeRenumber(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
+	return getRuntime(ctx, c, true, false)
 }
 
 // GetRuntime generates a new libpod runtime configured by command line options
-func GetRuntime(c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(c, false, false)
+func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
+	return getRuntime(ctx, c, false, false)
 }
 
-func getRuntime(c *cliconfig.PodmanCommand, renumber bool, migrate bool) (*libpod.Runtime, error) {
+func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber bool, migrate bool) (*libpod.Runtime, error) {
 	options := []libpod.RuntimeOption{}
 	storageOpts := storage.StoreOptions{}
 	storageSet := false
@@ -75,6 +77,8 @@ func getRuntime(c *cliconfig.PodmanCommand, renumber bool, migrate bool) (*libpo
 	if renumber {
 		options = append(options, libpod.WithRenumber())
 	}
+
+	options = append(options, libpod.WithContext(ctx))
 
 	// Only set this if the user changes storage config on the command line
 	if storageSet {

--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -9,17 +9,22 @@ import (
 	"github.com/pkg/errors"
 )
 
+// GetRuntimeMigrate gets a libpod runtime that will perform a migration of existing containers
+func GetRuntimeMigrate(c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
+	return getRuntime(c, false, true)
+}
+
 // GetRuntimeRenumber gets a libpod runtime that will perform a lock renumber
 func GetRuntimeRenumber(c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(c, true)
+	return getRuntime(c, true, false)
 }
 
 // GetRuntime generates a new libpod runtime configured by command line options
 func GetRuntime(c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(c, false)
+	return getRuntime(c, false, false)
 }
 
-func getRuntime(c *cliconfig.PodmanCommand, renumber bool) (*libpod.Runtime, error) {
+func getRuntime(c *cliconfig.PodmanCommand, renumber bool, migrate bool) (*libpod.Runtime, error) {
 	options := []libpod.RuntimeOption{}
 	storageOpts := storage.StoreOptions{}
 	storageSet := false
@@ -62,6 +67,9 @@ func getRuntime(c *cliconfig.PodmanCommand, renumber bool) (*libpod.Runtime, err
 	if len(c.GlobalFlags.StorageOpts) > 0 {
 		storageSet = true
 		storageOpts.GraphDriverOptions = c.GlobalFlags.StorageOpts
+	}
+	if migrate {
+		options = append(options, libpod.WithMigrate())
 	}
 
 	if renumber {

--- a/cmd/podman/load.go
+++ b/cmd/podman/load.go
@@ -58,7 +58,7 @@ func loadCmd(c *cliconfig.LoadValues) error {
 		return errors.New("too many arguments. Requires exactly 1")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/logs.go
+++ b/cmd/podman/logs.go
@@ -64,7 +64,7 @@ func init() {
 func logsCmd(c *cliconfig.LogsValues) error {
 	var err error
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -112,7 +112,7 @@ func setupRootless(cmd *cobra.Command, args []string) error {
 		MainGlobalOpts,
 		remoteclient,
 	}
-	runtime, err := libpodruntime.GetRuntime(&podmanCmd)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &podmanCmd)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -103,7 +103,7 @@ func profileOff(cmd *cobra.Command) error {
 }
 
 func setupRootless(cmd *cobra.Command, args []string) error {
-	if os.Geteuid() == 0 || cmd == _searchCommand || cmd == _versionCommand || cmd == _mountCommand || strings.HasPrefix(cmd.Use, "help") {
+	if os.Geteuid() == 0 || cmd == _searchCommand || cmd == _versionCommand || cmd == _mountCommand || cmd == _migrateCommand || strings.HasPrefix(cmd.Use, "help") {
 		return nil
 	}
 	podmanCmd := cliconfig.PodmanCommand{

--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -61,7 +61,7 @@ type jsonMountPoint struct {
 }
 
 func mountCmd(c *cliconfig.MountValues) error {
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/pause.go
+++ b/cmd/podman/pause.go
@@ -43,7 +43,7 @@ func pauseCmd(c *cliconfig.PauseValues) error {
 		return errors.New("pause is not supported for rootless containers")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -75,7 +75,7 @@ func playKubeCmd(c *cliconfig.KubePlayValues) error {
 	}
 
 	ctx := getContext()
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(ctx, &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -62,7 +62,7 @@ func podCreateCmd(c *cliconfig.PodCreateValues) error {
 		podIdFile *os.File
 	)
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/pod_inspect.go
+++ b/cmd/podman/pod_inspect.go
@@ -49,7 +49,7 @@ func podInspectCmd(c *cliconfig.PodInspectValues) error {
 		return errors.Errorf("you must provide the name or id of a pod")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/pod_kill.go
+++ b/cmd/podman/pod_kill.go
@@ -49,7 +49,7 @@ func init() {
 
 // podKillCmd kills one or more pods with a signal
 func podKillCmd(c *cliconfig.PodKillValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/pod_pause.go
+++ b/cmd/podman/pod_pause.go
@@ -45,7 +45,7 @@ func init() {
 
 func podPauseCmd(c *cliconfig.PodPauseValues) error {
 	var lastError error
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/pod_ps.go
+++ b/cmd/podman/pod_ps.go
@@ -157,7 +157,7 @@ func podPsCmd(c *cliconfig.PodPsValues) error {
 		return errors.Wrapf(err, "error with flags passed")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/pod_restart.go
+++ b/cmd/podman/pod_restart.go
@@ -47,7 +47,7 @@ func init() {
 
 func podRestartCmd(c *cliconfig.PodRestartValues) error {
 	var lastError error
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/pod_rm.go
+++ b/cmd/podman/pod_rm.go
@@ -47,7 +47,7 @@ func init() {
 
 // podRmCmd deletes pods
 func podRmCmd(c *cliconfig.PodRmValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/pod_start.go
+++ b/cmd/podman/pod_start.go
@@ -45,7 +45,7 @@ func init() {
 }
 
 func podStartCmd(c *cliconfig.PodStartValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/pod_stats.go
+++ b/cmd/podman/pod_stats.go
@@ -78,7 +78,7 @@ func podStatsCmd(c *cliconfig.PodStatsValues) error {
 		all = true
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/pod_stop.go
+++ b/cmd/podman/pod_stop.go
@@ -47,7 +47,7 @@ func init() {
 }
 
 func podStopCmd(c *cliconfig.PodStopValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/pod_top.go
+++ b/cmd/podman/pod_top.go
@@ -67,7 +67,7 @@ func podTopCmd(c *cliconfig.PodTopValues) error {
 		return errors.Errorf("you must provide the name or id of a running pod")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/pod_unpause.go
+++ b/cmd/podman/pod_unpause.go
@@ -46,7 +46,7 @@ func init() {
 
 func podUnpauseCmd(c *cliconfig.PodUnpauseValues) error {
 	var lastError error
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/pods_prune.go
+++ b/cmd/podman/pods_prune.go
@@ -36,7 +36,7 @@ func init() {
 }
 
 func podPruneCmd(c *cliconfig.PodPruneValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/port.go
+++ b/cmd/podman/port.go
@@ -98,7 +98,7 @@ func portCmd(c *cliconfig.PortValues) error {
 		}
 	}
 
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -211,7 +211,7 @@ func psCmd(c *cliconfig.PsValues) error {
 		return errors.Wrapf(err, "error with flags passed")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/pull.go
+++ b/cmd/podman/pull.go
@@ -73,7 +73,7 @@ func pullCmd(c *cliconfig.PullValues) (retError error) {
 		defer span.Finish()
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -100,7 +100,7 @@ func pushCmd(c *cliconfig.PushValues) error {
 		registryCreds = creds
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not create runtime")
 	}

--- a/cmd/podman/refresh.go
+++ b/cmd/podman/refresh.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func refreshCmd(c *cliconfig.RefreshValues) error {
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/restart.go
+++ b/cmd/podman/restart.go
@@ -51,7 +51,7 @@ func restartCmd(c *cliconfig.RestartValues) error {
 		return errors.Wrapf(libpod.ErrInvalidArg, "you must provide at least one container name or ID")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/restore.go
+++ b/cmd/podman/restore.go
@@ -54,7 +54,7 @@ func restoreCmd(c *cliconfig.RestoreValues) error {
 		return errors.New("restoring a container requires root")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -48,7 +48,7 @@ func init() {
 
 // rmCmd removes one or more containers
 func rmCmd(c *cliconfig.RmValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -51,7 +51,7 @@ func rmiCmd(c *cliconfig.RmiValues) error {
 
 	ctx := getContext()
 	removeAll := c.All
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -48,7 +48,7 @@ func runCmd(c *cliconfig.RunValues) error {
 		return err
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/runlabel.go
+++ b/cmd/podman/runlabel.go
@@ -85,7 +85,7 @@ func runlabelCmd(c *cliconfig.RunlabelValues) error {
 	}
 
 	opts := make(map[string]string)
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/save.go
+++ b/cmd/podman/save.go
@@ -70,7 +70,7 @@ func saveCmd(c *cliconfig.SaveValues) error {
 		return errors.Errorf("need at least 1 argument")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not create runtime")
 	}

--- a/cmd/podman/sign.go
+++ b/cmd/podman/sign.go
@@ -56,7 +56,7 @@ func signCmd(c *cliconfig.SignValues) error {
 	if len(args) < 1 {
 		return errors.Errorf("at least one image name must be specified")
 	}
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not create runtime")
 	}

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -65,7 +65,7 @@ func startCmd(c *cliconfig.StartValues) error {
 		return errors.Wrapf(libpod.ErrInvalidArg, "you cannot use sig-proxy without --attach")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/stats.go
+++ b/cmd/podman/stats.go
@@ -88,7 +88,7 @@ func statsCmd(c *cliconfig.StatsValues) error {
 		return errors.Errorf("you must specify --all, --latest, or at least one container")
 	}
 
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -56,7 +56,7 @@ func stopCmd(c *cliconfig.StopValues) error {
 		defer span.Finish()
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/system_df.go
+++ b/cmd/podman/system_df.go
@@ -99,7 +99,7 @@ func init() {
 }
 
 func dfSystemCmd(c *cliconfig.SystemDfValues) error {
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "Could not get runtime")
 	}

--- a/cmd/podman/system_migrate.go
+++ b/cmd/podman/system_migrate.go
@@ -38,7 +38,7 @@ func migrateCmd(c *cliconfig.SystemMigrateValues) error {
 	// We need to pass one extra option to NewRuntime.
 	// This will inform the OCI runtime to start a migrate.
 	// That's controlled by the last argument to GetRuntime.
-	r, err := libpodruntime.GetRuntimeMigrate(&c.PodmanCommand)
+	r, err := libpodruntime.GetRuntimeMigrate(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error migrating containers")
 	}

--- a/cmd/podman/system_migrate.go
+++ b/cmd/podman/system_migrate.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/containers/libpod/cmd/podman/libpodruntime"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	migrateCommand     cliconfig.SystemMigrateValues
+	migrateDescription = `
+        podman system migrate
+
+        Migrate existing containers to a new version of Podman.
+`
+
+	_migrateCommand = &cobra.Command{
+		Use:   "migrate",
+		Args:  noSubArgs,
+		Short: "Migrate containers",
+		Long:  migrateDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			migrateCommand.InputArgs = args
+			migrateCommand.GlobalFlags = MainGlobalOpts
+			return migrateCmd(&migrateCommand)
+		},
+	}
+)
+
+func init() {
+	migrateCommand.Command = _migrateCommand
+	migrateCommand.SetHelpTemplate(HelpTemplate())
+	migrateCommand.SetUsageTemplate(UsageTemplate())
+}
+
+func migrateCmd(c *cliconfig.SystemMigrateValues) error {
+	// We need to pass one extra option to NewRuntime.
+	// This will inform the OCI runtime to start a migrate.
+	// That's controlled by the last argument to GetRuntime.
+	r, err := libpodruntime.GetRuntimeMigrate(&c.PodmanCommand)
+	if err != nil {
+		return errors.Wrapf(err, "error migrating containers")
+	}
+	if err := r.Shutdown(false); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/podman/system_prune.go
+++ b/cmd/podman/system_prune.go
@@ -72,7 +72,7 @@ Are you sure you want to continue? [y/N] `, volumeString)
 		}
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/system_renumber.go
+++ b/cmd/podman/system_renumber.go
@@ -40,7 +40,7 @@ func renumberCmd(c *cliconfig.SystemRenumberValues) error {
 	// We need to pass one extra option to NewRuntime.
 	// This will inform the OCI runtime to start a renumber.
 	// That's controlled by the last argument to GetRuntime.
-	r, err := libpodruntime.GetRuntimeRenumber(&c.PodmanCommand)
+	r, err := libpodruntime.GetRuntimeRenumber(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error renumbering locks")
 	}

--- a/cmd/podman/tag.go
+++ b/cmd/podman/tag.go
@@ -38,7 +38,7 @@ func tagCmd(c *cliconfig.TagValues) error {
 	if len(args) < 2 {
 		return errors.Errorf("image name and at least one new name must be specified")
 	}
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not create runtime")
 	}

--- a/cmd/podman/top.go
+++ b/cmd/podman/top.go
@@ -76,7 +76,7 @@ func topCmd(c *cliconfig.TopValues) error {
 		return errors.Errorf("you must provide the name or id of a running container")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/tree.go
+++ b/cmd/podman/tree.go
@@ -51,7 +51,7 @@ func treeCmd(c *cliconfig.TreeValues) error {
 		return errors.Errorf("you must provide at most 1 argument")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/trust_set_show.go
+++ b/cmd/podman/trust_set_show.go
@@ -74,7 +74,7 @@ File(s) must exist before using this command`)
 }
 
 func showTrustCmd(c *cliconfig.ShowTrustValues) error {
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not create runtime")
 	}
@@ -131,7 +131,7 @@ func showTrustCmd(c *cliconfig.ShowTrustValues) error {
 }
 
 func setTrustCmd(c *cliconfig.SetTrustValues) error {
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not create runtime")
 	}

--- a/cmd/podman/umount.go
+++ b/cmd/podman/umount.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 func umountCmd(c *cliconfig.UmountValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating runtime")
 	}

--- a/cmd/podman/unpause.go
+++ b/cmd/podman/unpause.go
@@ -42,7 +42,7 @@ func unpauseCmd(c *cliconfig.UnpauseValues) error {
 		return errors.New("unpause is not supported for rootless containers")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/varlink.go
+++ b/cmd/podman/varlink.go
@@ -55,7 +55,7 @@ func varlinkCmd(c *cliconfig.VarlinkValues) error {
 	timeout := time.Duration(c.Timeout) * time.Millisecond
 
 	// Create a single runtime for varlink
-	runtime, err := libpodruntime.GetRuntime(&c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/volume_create.go
+++ b/cmd/podman/volume_create.go
@@ -42,7 +42,7 @@ func init() {
 }
 
 func volumeCreateCmd(c *cliconfig.VolumeCreateValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/volume_inspect.go
+++ b/cmd/podman/volume_inspect.go
@@ -43,7 +43,7 @@ func volumeInspectCmd(c *cliconfig.VolumeInspectValues) error {
 		return errors.New("provide one or more volume names or use --all")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/volume_ls.go
+++ b/cmd/podman/volume_ls.go
@@ -72,7 +72,7 @@ func init() {
 }
 
 func volumeLsCmd(c *cliconfig.VolumeLsValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/volume_prune.go
+++ b/cmd/podman/volume_prune.go
@@ -63,7 +63,7 @@ func volumePrune(runtime *adapter.LocalRuntime, ctx context.Context) error {
 }
 
 func volumePruneCmd(c *cliconfig.VolumePruneValues) error {
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/volume_rm.go
+++ b/cmd/podman/volume_rm.go
@@ -47,7 +47,7 @@ func volumeRmCmd(c *cliconfig.VolumeRmValues) error {
 		return errors.New("choose either one or more volumes or all")
 	}
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/wait.go
+++ b/cmd/podman/wait.go
@@ -51,7 +51,7 @@ func waitCmd(c *cliconfig.WaitValues) error {
 	}
 	interval := time.Duration(c.Interval) * time.Millisecond
 
-	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating runtime")
 	}

--- a/docs/podman-system-migrate.1.md
+++ b/docs/podman-system-migrate.1.md
@@ -1,0 +1,21 @@
+% podman-system-migrate(1) podman
+
+## NAME
+podman\-system\-migrate - Migrate container to the latest version of podman
+
+## SYNOPSIS
+** podman system migrate**
+
+## DESCRIPTION
+** podman system migrate** migrates containers to the latest podman version.
+
+**podman system migrate** takes care of migrating existing containers to the latest version of podman if any change is necessary.
+
+## SYNOPSIS
+**podman system migrate**
+
+## SEE ALSO
+`podman(1)`, `libpod.conf(5)`
+
+# HISTORY
+April 2019, Originally compiled by Giuseppe Scrivano (gscrivan at redhat dot com)

--- a/docs/podman-system.1.md
+++ b/docs/podman-system.1.md
@@ -17,6 +17,7 @@ The system command allows you to manage the podman systems
 | info     | [podman-system-info(1)](podman-info.1.md)           | Displays Podman related system information.                                  |
 | prune    | [podman-system-prune(1)](podman-system-prune.1.md)  | Remove all unused data                                                       |
 | renumber | [podman-system-renumber(1)](podman-system-renumber.1.md)| Migrate lock numbers to handle a change in maximum number of locks.      |
+| migrate  | [podman-system-migrate(1)](podman-system-migrate.1.md)| Migrate existing containers to a new podman version.                       |
 
 ## SEE ALSO
 podman(1)

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"context"
 	"net"
 	"os"
 	"path/filepath"
@@ -462,6 +463,19 @@ func WithShmDir(dir string) CtrCreateOption {
 		}
 
 		ctr.config.ShmDir = dir
+		return nil
+	}
+}
+
+// WithContext sets the context to use.
+func WithContext(ctx context.Context) RuntimeOption {
+	return func(rt *Runtime) error {
+		if rt.valid {
+			return ErrRuntimeFinalized
+		}
+
+		rt.ctx = ctx
+
 		return nil
 	}
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -436,6 +436,22 @@ func WithRenumber() RuntimeOption {
 	}
 }
 
+// WithMigrate instructs libpod to perform a lock migrateing while
+// initializing. This will handle migrations from early versions of libpod with
+// file locks to newer versions with SHM locking, as well as changes in the
+// number of configured locks.
+func WithMigrate() RuntimeOption {
+	return func(rt *Runtime) error {
+		if rt.valid {
+			return ErrRuntimeFinalized
+		}
+
+		rt.doMigrate = true
+
+		return nil
+	}
+}
+
 // Container Creation Options
 
 // WithShmDir sets the directory that should be mounted on /dev/shm.

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -111,6 +112,8 @@ type Runtime struct {
 
 	// mechanism to read and write even logs
 	eventer events.Eventer
+
+	ctx context.Context
 }
 
 // OCIRuntimePath contains information about an OCI runtime.

--- a/libpod/runtime_migrate.go
+++ b/libpod/runtime_migrate.go
@@ -1,7 +1,6 @@
 package libpod
 
 import (
-	"context"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -39,7 +38,7 @@ func (r *Runtime) migrate() error {
 	}
 
 	for _, ctr := range runningContainers {
-		if err := ctr.Start(context.Background(), true); err != nil {
+		if err := ctr.Start(r.ctx, true); err != nil {
 			logrus.Errorf("error restarting container %s", ctr.ID())
 		}
 	}

--- a/libpod/runtime_migrate.go
+++ b/libpod/runtime_migrate.go
@@ -1,0 +1,48 @@
+package libpod
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func (r *Runtime) migrate() error {
+	runningContainers, err := r.GetRunningContainers()
+	if err != nil {
+		return err
+	}
+
+	allCtrs, err := r.state.AllContainers()
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("stopping all containers")
+	for _, ctr := range runningContainers {
+		logrus.Infof("stopping %s", ctr.ID())
+		if err := ctr.Stop(); err != nil {
+			return errors.Wrapf(err, "cannot stop container %s", ctr.ID())
+		}
+	}
+
+	for _, ctr := range allCtrs {
+		oldLocation := filepath.Join(ctr.state.RunDir, "conmon.pid")
+		if ctr.config.ConmonPidFile == oldLocation {
+			logrus.Infof("changing conmon PID file for %s", ctr.ID())
+			ctr.config.ConmonPidFile = filepath.Join(ctr.config.StaticDir, "conmon.pid")
+			if err := r.state.RewriteContainerConfig(ctr, ctr.config); err != nil {
+				return errors.Wrapf(err, "error rewriting config for container %s", ctr.ID())
+			}
+		}
+	}
+
+	for _, ctr := range runningContainers {
+		if err := ctr.Start(context.Background(), true); err != nil {
+			logrus.Errorf("error restarting container %s", ctr.ID())
+		}
+	}
+
+	return nil
+}

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -57,8 +57,8 @@ type Volume struct {
 type VolumeFilter func(*Volume) bool
 
 // GetRuntime returns a LocalRuntime struct with the actual runtime embedded in it
-func GetRuntime(c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
-	runtime, err := libpodruntime.GetRuntime(c)
+func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
+	runtime, err := libpodruntime.GetRuntime(ctx, c)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -46,7 +46,7 @@ type LocalRuntime struct {
 }
 
 // GetRuntime returns a LocalRuntime struct with the actual runtime embedded in it
-func GetRuntime(c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
+func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
 	runtime := RemoteRuntime{}
 	conn, err := runtime.Connect()
 	if err != nil {


### PR DESCRIPTION
it is useful to migrate existing containers to a new version of
podman.  Currently, it is needed to migrate rootless containers that
were created with podman <= 1.2 to a newer version which requires all
containers to be running in the same user namespace.

Closes: https://github.com/containers/libpod/issues/2935

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>