### PR TITLE
Fix podman command --change CMD

### DIFF
--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -42,7 +42,7 @@ func init() {
 	commitCommand.SetHelpTemplate(HelpTemplate())
 	commitCommand.SetUsageTemplate(UsageTemplate())
 	flags := commitCommand.Flags()
-	flags.StringSliceVarP(&commitCommand.Change, "change", "c", []string{}, fmt.Sprintf("Apply the following possible instructions to the created image (default []): %s", strings.Join(libpod.ChangeCmds, " | ")))
+	flags.StringArrayVarP(&commitCommand.Change, "change", "c", []string{}, fmt.Sprintf("Apply the following possible instructions to the created image (default []): %s", strings.Join(libpod.ChangeCmds, " | ")))
 	flags.StringVarP(&commitCommand.Format, "format", "f", "oci", "`Format` of the image manifest and metadata")
 	flags.StringVarP(&commitCommand.Message, "message", "m", "", "Set commit message for imported image")
 	flags.StringVarP(&commitCommand.Author, "author", "a", "", "Set the author for the image committed")
@@ -83,6 +83,9 @@ func commitCmd(c *cliconfig.CommitValues) error {
 	if c.Flag("change").Changed {
 		for _, change := range c.Change {
 			splitChange := strings.Split(strings.ToUpper(change), "=")
+			if len(splitChange) == 1 {
+				splitChange = strings.Split(strings.ToUpper(change), " ")
+			}
 			if !util.StringInSlice(splitChange[0], libpod.ChangeCmds) {
 				return errors.Errorf("invalid syntax for --change: %s", change)
 			}


### PR DESCRIPTION
Currently in Docker if you commit with --change 'CMD a b c'
The command that gets added is

[/bin/sh -c "a b c"]

If you commit --change 'CMD ["a","b","c"]'

You get
[a b c]

This patch set makes podman match this behaviour.

Similar change required for Entrypoint.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>