### PR TITLE
Add `NewRuntimeFromRuntimeConfig` libpod API

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -358,6 +358,33 @@ func NewRuntimeFromConfig(userConfigPath string, options ...RuntimeOption) (runt
 	return newRuntimeFromConfig(userConfigPath, options...)
 }
 
+// NewRuntimeFromRuntimeConfig creates a new container runtime for the provided
+// RuntimeConfig. It assumes that every config field is set and will error if
+// the runtime creation fails.
+func NewRuntimeFromRuntimeConfig(config *RuntimeConfig) (*Runtime, error) {
+	runtime := &Runtime{
+		config: config,
+		configuredFrom: &runtimeConfiguredFrom{
+			storageGraphDriverSet: true,
+			storageGraphRootSet:   true,
+			storageRunRootSet:     true,
+			libpodStaticDirSet:    true,
+			libpodTmpDirSet:       true,
+			volPathSet:            true,
+			conmonPath:            true,
+			conmonEnvVars:         true,
+			ociRuntimes:           true,
+			runtimePath:           true,
+			cniPluginDir:          true,
+			noPivotRoot:           true,
+		},
+	}
+	if err := makeRuntime(runtime); err != nil {
+		return nil, err
+	}
+	return runtime, nil
+}
+
 func newRuntimeFromConfig(userConfigPath string, options ...RuntimeOption) (runtime *Runtime, err error) {
 	runtime = new(Runtime)
 	runtime.config = new(RuntimeConfig)


### PR DESCRIPTION
Hey, please see this PR as part of a proposal in *how to use libpod within cri-o*.

The commit introduces a new libpod API function to be able to initialize the runtime from a non-file-based configuration. Projects like CRI-O will now have the possibility to reuse their existing config within libpod.

My plan would be to add a `*libpod.Runtime` to the CRI-O server, to directly use it for operations like pulling images. This is the completely other way around approach than migrating from the lowest possible level like [libpod/libpod/storage.go](https://github.com/containers/libpod/blob/7141f972700ed454438d8539dd0bec79c0b61cf4/libpod/storage.go). WDYT?

/cc @mrunalp @rhatdan @vrothberg 

Relates to #2791