### PR TITLE
Fix COPR builds to start working again

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -66,6 +66,7 @@ BuildRequires: libselinux-devel
 BuildRequires: ostree-devel
 BuildRequires: pkgconfig
 BuildRequires: make
+BuildRequires: systemd-devel
 Requires: runc
 Requires: skopeo-containers
 Requires: containernetworking-plugins >= 0.6.0-3


### PR DESCRIPTION
We now need systemd in the root of the COPR build for podman.

Signed-off-by: baude <bbaude@redhat.com>