### PR TITLE
Refactor of 'podman prune' to better support remote

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -159,7 +159,7 @@ type PruneContainersValues struct {
 	Force bool
 }
 
-type PrunePodsValues struct {
+type PodPruneValues struct {
 	PodmanCommand
 	Force bool
 }

--- a/cmd/podman/pods_prune.go
+++ b/cmd/podman/pods_prune.go
@@ -1,19 +1,15 @@
 package main
 
 import (
-	"context"
-
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var (
-	prunePodsCommand     cliconfig.PrunePodsValues
-	prunePodsDescription = `
+	podPruneCommand     cliconfig.PodPruneValues
+	podPruneDescription = `
 	podman pod prune
 
 	Removes all exited pods
@@ -22,62 +18,30 @@ var (
 		Use:   "prune",
 		Args:  noSubArgs,
 		Short: "Remove all stopped pods",
-		Long:  prunePodsDescription,
+		Long:  podPruneDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			prunePodsCommand.InputArgs = args
-			prunePodsCommand.GlobalFlags = MainGlobalOpts
-			return prunePodsCmd(&prunePodsCommand)
+			podPruneCommand.InputArgs = args
+			podPruneCommand.GlobalFlags = MainGlobalOpts
+			return podPruneCmd(&podPruneCommand)
 		},
 	}
 )
 
 func init() {
-	prunePodsCommand.Command = _prunePodsCommand
-	prunePodsCommand.SetHelpTemplate(HelpTemplate())
-	prunePodsCommand.SetUsageTemplate(UsageTemplate())
-	flags := prunePodsCommand.Flags()
-	flags.BoolVarP(&prunePodsCommand.Force, "force", "f", false, "Force removal of a running pods.  The default is false")
+	podPruneCommand.Command = _prunePodsCommand
+	podPruneCommand.SetHelpTemplate(HelpTemplate())
+	podPruneCommand.SetUsageTemplate(UsageTemplate())
+	flags := podPruneCommand.Flags()
+	flags.BoolVarP(&podPruneCommand.Force, "force", "f", false, "Force removal of a running pods.  The default is false")
 }
 
-func prunePods(runtime *adapter.LocalRuntime, ctx context.Context, maxWorkers int, force bool) error {
-	var deleteFuncs []shared.ParallelWorkerInput
-
-	states := []string{shared.PodStateStopped, shared.PodStateExited}
-	delPods, err := runtime.GetPodsByStatus(states)
-	if err != nil {
-		return err
-	}
-	if len(delPods) < 1 {
-		return nil
-	}
-	for _, pod := range delPods {
-		p := pod
-		f := func() error {
-			return runtime.RemovePod(ctx, p, force, force)
-		}
-
-		deleteFuncs = append(deleteFuncs, shared.ParallelWorkerInput{
-			ContainerID:  p.ID(),
-			ParallelFunc: f,
-		})
-	}
-	// Run the parallel funcs
-	deleteErrors, errCount := shared.ParallelExecuteWorkerPool(maxWorkers, deleteFuncs)
-	return printParallelOutput(deleteErrors, errCount)
-}
-
-func prunePodsCmd(c *cliconfig.PrunePodsValues) error {
+func podPruneCmd(c *cliconfig.PodPruneValues) error {
 	runtime, err := adapter.GetRuntime(&c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}
 	defer runtime.Shutdown(false)
 
-	maxWorkers := shared.Parallelize("rm")
-	if c.GlobalIsSet("max-workers") {
-		maxWorkers = c.GlobalFlags.MaxWorks
-	}
-	logrus.Debugf("Setting maximum workers to %d", maxWorkers)
-
-	return prunePods(runtime, getContext(), maxWorkers, c.Bool("force"))
+	ok, failures, err := runtime.PrunePods(getContext(), c)
+	return printCmdResults(ok, failures)
 }

--- a/cmd/podman/system_prune.go
+++ b/cmd/podman/system_prune.go
@@ -82,13 +82,21 @@ Are you sure you want to continue? [y/N] `, volumeString)
 	ctx := getContext()
 	fmt.Println("Deleted Containers")
 	lasterr := pruneContainers(runtime, ctx, rmWorkers, false, false)
+
 	fmt.Println("Deleted Pods")
-	if err := prunePods(runtime, ctx, rmWorkers, true); err != nil {
+	pruneValues := cliconfig.PodPruneValues{
+		PodmanCommand: c.PodmanCommand,
+		Force:         c.Force,
+	}
+	ok, failures, err := runtime.PrunePods(ctx, &pruneValues)
+	if err != nil {
 		if lasterr != nil {
 			logrus.Errorf("%q", lasterr)
 		}
 		lasterr = err
 	}
+	printCmdResults(ok, failures)
+
 	if c.Bool("volumes") {
 		fmt.Println("Deleted Volumes")
 		err := volumePrune(runtime, getContext())

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -99,6 +99,18 @@ type remoteContainer struct {
 	state   *libpod.ContainerState
 }
 
+// Pod ...
+type Pod struct {
+	remotepod
+}
+
+type remotepod struct {
+	config     *libpod.PodConfig
+	state      *libpod.PodInspectState
+	containers []libpod.PodContainerInfo
+	Runtime    *LocalRuntime
+}
+
 type VolumeFilter func(*Volume) bool
 
 // Volume is embed for libpod volumes

--- a/test/e2e/pod_prune_test.go
+++ b/test/e2e/pod_prune_test.go
@@ -1,0 +1,78 @@
+// +build !remoteclient
+
+package integration
+
+import (
+	"os"
+
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman pod prune", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest *PodmanTestIntegration
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanTestCreate(tempdir)
+		podmanTest.Setup()
+		podmanTest.RestoreAllArtifacts()
+	})
+
+	AfterEach(func() {
+		podmanTest.CleanupPod()
+		f := CurrentGinkgoTestDescription()
+		processTestResult(f)
+
+	})
+
+	It("podman pod prune empty pod", func() {
+		_, ec, _ := podmanTest.CreatePod("")
+		Expect(ec).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"pod", "prune"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+	})
+
+	It("podman pod prune doesn't remove a pod with a container", func() {
+		_, ec, podid := podmanTest.CreatePod("")
+		Expect(ec).To(Equal(0))
+
+		_, ec2, _ := podmanTest.RunLsContainerInPod("", podid)
+		Expect(ec2).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"pod", "prune"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(125))
+
+		result = podmanTest.Podman([]string{"ps", "-qa"})
+		result.WaitWithDefaultTimeout()
+		Expect(len(result.OutputToStringArray())).To(Equal(1))
+	})
+
+	It("podman pod prune -f does remove a running container", func() {
+		_, ec, podid := podmanTest.CreatePod("")
+		Expect(ec).To(Equal(0))
+
+		session := podmanTest.RunTopContainerInPod("", podid)
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"pod", "prune", "-f"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		result = podmanTest.Podman([]string{"ps", "-q"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.OutputToString()).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
* Push iterations into the service not the client
* Add e2e tests
* Refactor to use new frameworks

Signed-off-by: Jhon Honce <jhonce@redhat.com>