### PR TITLE
bats - various small updates

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -3,7 +3,7 @@
 load helpers
 
 @test "podman info - basic test" {
-    skip_if_remote
+    skip_if_remote "capitalization inconsistencies"
 
     run_podman info
 
@@ -28,7 +28,7 @@ RunRoot:
 }
 
 @test "podman info - json" {
-    skip_if_remote
+    skip_if_remote "capitalization inconsistencies"
 
     run_podman info --format=json
 

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -3,8 +3,6 @@
 load helpers
 
 @test "podman run - basic tests" {
-    skip_if_remote
-
     rand=$(random_string 30)
     tests="
 true              |   0 |

--- a/test/system/035-logs.bats
+++ b/test/system/035-logs.bats
@@ -6,8 +6,6 @@
 load helpers
 
 @test "podman logs - basic test" {
-    skip_if_remote
-
     rand_string=$(random_string 40)
 
     run_podman create $IMAGE echo $rand_string

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -6,7 +6,11 @@
 load helpers
 
 @test "podman build - basic test" {
-    skip_if_remote
+    if [[ "$PODMAN" =~ -remote ]]; then
+        if [ "$(id -u)" -ne 0 ]; then
+            skip "unreliable with podman-remote and rootless; #2972"
+        fi
+    fi
 
     rand_filename=$(random_string 20)
     rand_content=$(random_string 50)

--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -31,6 +31,12 @@ die() {
     echo "#| FAIL: $*"                                           >&2
     echo "#\\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" >&2
 
+    # Show permissions of directories from here on up
+    while expr "$path" : "/var/lib/containers" >/dev/null; do
+        echo "#|  $(ls -ld $path)"
+        path=$(dirname $path)
+    done
+
     exit 1
 }
 
@@ -65,8 +71,10 @@ EOF
 
     # get podman image and container storage directories
     run_podman info --format '{{.store.GraphRoot}}'
+    is "$output" "/var/lib/containers/storage" "GraphRoot in expected place"
     GRAPH_ROOT="$output"
     run_podman info --format '{{.store.RunRoot}}'
+    is "$output" "/var/run/containers/storage" "RunRoot in expected place"
     RUN_ROOT="$output"
 
     # The main test: find all world-writable files or directories underneath


### PR DESCRIPTION
- podman-remote:
  - enable log, run and build tests, they're working now
    - well, except build + rootless. Skip that one.
  - add explanation of why info test is skipped

- Giuseppe's permission test:
  - validate GraphRoot and RunRoot values
  - add verbose logging, to enable seeing full directory tree
    permissions on error

Signed-off-by: Ed Santiago <santiago@redhat.com>