### PR TITLE
docs: Fix typo for "healthcheck"

### DIFF
--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -259,7 +259,7 @@ The following example maps uids 0-2000 in the container to the uids 30000-31999 
 
 Add additional groups to run as
 
-**--healthchech**=""
+**--healthcheck**=""
 
 Set or alter a healthcheck for a container.  The value must be of the format of:
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -267,7 +267,7 @@ The example maps gids 0-2000 in the container to the gids 30000-31999 on the hos
 
 Add additional groups to run as
 
-**--healthchech**=""
+**--healthcheck**=""
 
 Set or alter a healthcheck for a container.  The value must be of the format of:
 


### PR DESCRIPTION
Just spotted while reading the manpage for something else.