### PR TITLE
image: rework parent/child/history matching

### DIFF
--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -243,7 +243,7 @@ func getImagesTemplateOutput(ctx context.Context, images []*adapter.ContainerIma
 		// If all is false and the image doesn't have a name, check to see if the top layer of the image is a parent
 		// to another image's top layer. If it is, then it is an intermediate image so don't print out if the --all flag
 		// is not set.
-		isParent, err := img.IsParent()
+		isParent, err := img.IsParent(ctx)
 		if err != nil {
 			logrus.Errorf("error checking if image is a parent %q: %v", img.ID(), err)
 		}

--- a/cmd/podman/images_prune.go
+++ b/cmd/podman/images_prune.go
@@ -45,7 +45,7 @@ func pruneImagesCmd(c *cliconfig.PruneImagesValues) error {
 
 	// Call prune; if any cids are returned, print them and then
 	// return err in case an error also came up
-	pruneCids, err := runtime.PruneImages(c.All)
+	pruneCids, err := runtime.PruneImages(getContext(), c.All)
 	if len(pruneCids) > 0 {
 		for _, cid := range pruneCids {
 			fmt.Println(cid)

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -97,7 +97,7 @@ func rmiCmd(c *cliconfig.RmiValues) error {
 				return errors.New("unable to delete all images; re-run the rmi command again.")
 			}
 			for _, i := range imagesToDelete {
-				isParent, err := i.IsParent()
+				isParent, err := i.IsParent(ctx)
 				if err != nil {
 					return err
 				}

--- a/cmd/podman/system_df.go
+++ b/cmd/podman/system_df.go
@@ -201,7 +201,7 @@ func imageUniqueSize(ctx context.Context, images []*image.Image) (map[string]uin
 	for _, img := range images {
 		parentImg := img
 		for {
-			next, err := parentImg.GetParent()
+			next, err := parentImg.GetParent(ctx)
 			if err != nil {
 				return nil, errors.Wrapf(err, "error getting parent of image %s", parentImg.ID())
 			}
@@ -246,11 +246,11 @@ func getImageDiskUsage(ctx context.Context, images []*image.Image, imageUsedbyCi
 
 		unreclaimableSize += imageUsedSize(img, imgUniqueSizeMap, imageUsedbyCintainerMap, imageUsedbyActiveContainerMap)
 
-		isParent, err := img.IsParent()
+		isParent, err := img.IsParent(ctx)
 		if err != nil {
 			return imageDiskUsage, err
 		}
-		parent, err := img.GetParent()
+		parent, err := img.GetParent(ctx)
 		if err != nil {
 			return imageDiskUsage, errors.Wrapf(err, "error getting parent of image %s", img.ID())
 		}
@@ -437,11 +437,11 @@ func getImageVerboseDiskUsage(ctx context.Context, images []*image.Image, images
 		return imagesVerboseDiskUsage, errors.Wrapf(err, "error getting unique size of images")
 	}
 	for _, img := range images {
-		isParent, err := img.IsParent()
+		isParent, err := img.IsParent(ctx)
 		if err != nil {
 			return imagesVerboseDiskUsage, errors.Wrapf(err, "error checking if %s is a parent images", img.ID())
 		}
-		parent, err := img.GetParent()
+		parent, err := img.GetParent(ctx)
 		if err != nil {
 			return imagesVerboseDiskUsage, errors.Wrapf(err, "error getting parent of image %s", img.ID())
 		}

--- a/cmd/podman/system_prune.go
+++ b/cmd/podman/system_prune.go
@@ -110,7 +110,7 @@ Are you sure you want to continue? [y/N] `, volumeString)
 
 	// Call prune; if any cids are returned, print them and then
 	// return err in case an error also came up
-	pruneCids, err := runtime.PruneImages(c.All)
+	pruneCids, err := runtime.PruneImages(ctx, c.All)
 	if len(pruneCids) > 0 {
 		fmt.Println("Deleted Images")
 		for _, cid := range pruneCids {

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -353,8 +353,8 @@ func (i *Image) TopLayer() string {
 // outside the context of images
 // TODO: the force param does nothing as of now. Need to move container
 // handling logic here eventually.
-func (i *Image) Remove(force bool) error {
-	parent, err := i.GetParent()
+func (i *Image) Remove(ctx context.Context, force bool) error {
+	parent, err := i.GetParent(ctx)
 	if err != nil {
 		return err
 	}
@@ -363,11 +363,11 @@ func (i *Image) Remove(force bool) error {
 	}
 	i.newImageEvent(events.Remove)
 	for parent != nil {
-		nextParent, err := parent.GetParent()
+		nextParent, err := parent.GetParent(ctx)
 		if err != nil {
 			return err
 		}
-		children, err := parent.GetChildren()
+		children, err := parent.GetChildren(ctx)
 		if err != nil {
 			return err
 		}
@@ -1006,8 +1006,8 @@ func splitString(input string) string {
 // IsParent goes through the layers in the store and checks if i.TopLayer is
 // the parent of any other layer in store. Double check that image with that
 // layer exists as well.
-func (i *Image) IsParent() (bool, error) {
-	children, err := i.GetChildren()
+func (i *Image) IsParent(ctx context.Context) (bool, error) {
+	children, err := i.GetChildren(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -1015,7 +1015,7 @@ func (i *Image) IsParent() (bool, error) {
 }
 
 // GetParent returns the image ID of the parent. Return nil if a parent is not found.
-func (i *Image) GetParent() (*Image, error) {
+func (i *Image) GetParent(ctx context.Context) (*Image, error) {
 	images, err := i.imageruntime.GetImages()
 	if err != nil {
 		return nil, err
@@ -1033,7 +1033,7 @@ func (i *Image) GetParent() (*Image, error) {
 }
 
 // GetChildren returns a list of the imageIDs that depend on the image
-func (i *Image) GetChildren() ([]string, error) {
+func (i *Image) GetChildren(ctx context.Context) ([]string, error) {
 	var children []string
 	images, err := i.imageruntime.GetImages()
 	if err != nil {

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -139,7 +139,7 @@ func TestImage_New(t *testing.T) {
 		newImage, err := ir.New(context.Background(), img, "", "", writer, nil, SigningOptions{}, false, nil)
 		assert.NoError(t, err)
 		assert.NotEqual(t, newImage.ID(), "")
-		err = newImage.Remove(false)
+		err = newImage.Remove(context.Background(), false)
 		assert.NoError(t, err)
 	}
 

--- a/libpod/image/prune.go
+++ b/libpod/image/prune.go
@@ -1,6 +1,8 @@
 package image
 
 import (
+	"context"
+
 	"github.com/containers/libpod/libpod/events"
 	"github.com/pkg/errors"
 )
@@ -34,14 +36,14 @@ func (ir *Runtime) GetPruneImages(all bool) ([]*Image, error) {
 
 // PruneImages prunes dangling and optionally all unused images from the local
 // image store
-func (ir *Runtime) PruneImages(all bool) ([]string, error) {
+func (ir *Runtime) PruneImages(ctx context.Context, all bool) ([]string, error) {
 	var prunedCids []string
 	pruneImages, err := ir.GetPruneImages(all)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get images to prune")
 	}
 	for _, p := range pruneImages {
-		if err := p.Remove(true); err != nil {
+		if err := p.Remove(ctx, true); err != nil {
 			return nil, errors.Wrap(err, "failed to prune image")
 		}
 		defer p.newImageEvent(events.Prune)

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -57,7 +57,7 @@ func (r *Runtime) RemoveImage(ctx context.Context, img *image.Image, force bool)
 		}
 	}
 
-	hasChildren, err := img.IsParent()
+	hasChildren, err := img.IsParent(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -82,12 +82,12 @@ func (r *Runtime) RemoveImage(ctx context.Context, img *image.Image, force bool)
 		// reponames and no force is applied, we error out.
 		return "", fmt.Errorf("unable to delete %s (must force) - image is referred to in multiple tags", img.ID())
 	}
-	err = img.Remove(force)
+	err = img.Remove(ctx, force)
 	if err != nil && errors.Cause(err) == storage.ErrImageUsedByContainer {
 		if errStorage := r.rmStorageContainers(force, img); errStorage == nil {
 			// Containers associated with the image should be deleted now,
 			// let's try removing the image again.
-			err = img.Remove(force)
+			err = img.Remove(ctx, force)
 		} else {
 			err = errStorage
 		}

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -119,8 +119,8 @@ func (r *LocalRuntime) RemoveImage(ctx context.Context, img *ContainerImage, for
 }
 
 // PruneImages is wrapper into PruneImages within the image pkg
-func (r *LocalRuntime) PruneImages(all bool) ([]string, error) {
-	return r.ImageRuntime().PruneImages(all)
+func (r *LocalRuntime) PruneImages(ctx context.Context, all bool) ([]string, error) {
+	return r.ImageRuntime().PruneImages(ctx, all)
 }
 
 // Export is a wrapper to container export to a tarfile

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -256,7 +256,7 @@ func (r *LocalRuntime) New(ctx context.Context, name, signaturePolicyPath, authf
 // IsParent goes through the layers in the store and checks if i.TopLayer is
 // the parent of any other layer in store. Double check that image with that
 // layer exists as well.
-func (ci *ContainerImage) IsParent() (bool, error) {
+func (ci *ContainerImage) IsParent(context.Context) (bool, error) {
 	return ci.remoteImage.isParent, nil
 }
 
@@ -338,7 +338,7 @@ func (ci *ContainerImage) History(ctx context.Context) ([]*image.History, error)
 }
 
 // PruneImages is the wrapper call for a remote-client to prune images
-func (r *LocalRuntime) PruneImages(all bool) ([]string, error) {
+func (r *LocalRuntime) PruneImages(ctx context.Context, all bool) ([]string, error) {
 	return iopodman.ImagesPrune().Call(r.Conn, all)
 }
 

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -4,6 +4,7 @@ package varlinkapi
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -49,7 +50,7 @@ func (i *LibpodAPI) ListImages(call iopodman.VarlinkCall) error {
 		}
 
 		size, _ := image.Size(getContext())
-		isParent, err := image.IsParent()
+		isParent, err := image.IsParent(context.TODO())
 		if err != nil {
 			return call.ReplyErrorOccurred(err.Error())
 		}
@@ -503,7 +504,7 @@ func (i *LibpodAPI) DeleteUnusedImages(call iopodman.VarlinkCall) error {
 			return call.ReplyErrorOccurred(err.Error())
 		}
 		if len(containers) == 0 {
-			if err := img.Remove(false); err != nil {
+			if err := img.Remove(context.TODO(), false); err != nil {
 				return call.ReplyErrorOccurred(err.Error())
 			}
 			deletedImages = append(deletedImages, img.ID())
@@ -739,7 +740,7 @@ func (i *LibpodAPI) ContainerRunlabel(call iopodman.VarlinkCall, input iopodman.
 
 // ImagesPrune ....
 func (i *LibpodAPI) ImagesPrune(call iopodman.VarlinkCall, all bool) error {
-	prunedImages, err := i.Runtime.ImageRuntime().PruneImages(all)
+	prunedImages, err := i.Runtime.ImageRuntime().PruneImages(context.TODO(), all)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}


### PR DESCRIPTION
Rework our expectations of how images that are derived from each other look, so that we don't assume that an image that's derived from a base image always adds layers relative to that base image.