### PR TITLE
pull: special case all-tags semantics

### DIFF
--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -49,6 +49,8 @@ Image stored in local container/storage
 
 All tagged images in the repository will be pulled.
 
+Note: When using the all-tags flag, Podman will not iterate over the search registries in the containers-registries.conf(5) but will always use docker.io for unqualified image names.
+
 **--authfile**
 
 Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.


### PR DESCRIPTION
Supporting the all-tags semantics added some non-trivial code to the
pull command which does not make use of `registries.conf` and introduced
some regressions such as not adhering to the configured search registries.

Speacial case the all-tags flags to let existing users of all-tags
continue working while others can work again.  This implies that the
all-tags pull does not adhere to configured search registries while the
default (non-all-tags) pull does.

Note that this is a purely symptomaic fix.  A final solution should
include Buildah and the c/image library to avoid redundant and
error-prone code across the projects.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1701922
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>