### PR TITLE
enable podman remote top

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -21,7 +21,6 @@ func getMainCommands() []*cobra.Command {
 		_refreshCommand,
 		_searchCommand,
 		_statsCommand,
-		_topCommand,
 	}
 
 	if len(_varlinkCommand.Use) > 0 {
@@ -53,7 +52,6 @@ func getContainerSubCommands() []*cobra.Command {
 		_runlabelCommand,
 		_statsCommand,
 		_stopCommand,
-		_topCommand,
 		_umountCommand,
 	}
 }

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -64,6 +64,7 @@ var (
 		_runCommand,
 		_rmCommand,
 		_startCommand,
+		_topCommand,
 		_unpauseCommand,
 		_waitCommand,
 	}

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -57,6 +57,7 @@ var mainCommands = []*cobra.Command{
 	_saveCommand,
 	_stopCommand,
 	_tagCommand,
+	_topCommand,
 	_umountCommand,
 	_unpauseCommand,
 	_versionCommand,

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -524,6 +524,8 @@ method Ps(opts: PsOpts) -> (containers: []PsContainer)
 
 method GetContainersByStatus(status: []string) -> (containerS: []Container)
 
+method Top (nameOrID: string, descriptors: []string) -> (top: []string)
+
 # GetContainer returns information about a single container.  If a container
 # with the given id doesn't exist, a [ContainerNotFound](#ContainerNotFound)
 # error will be returned.  See also [ListContainers](ListContainers) and

--- a/libpod/container_top_linux.go
+++ b/libpod/container_top_linux.go
@@ -7,7 +7,21 @@ import (
 	"strings"
 
 	"github.com/containers/psgo"
+	"github.com/pkg/errors"
 )
+
+// Top gathers statistics about the running processes in a container. It returns a
+// []string for output
+func (c *Container) Top(descriptors []string) ([]string, error) {
+	conStat, err := c.State()
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to look up state for %s", c.ID())
+	}
+	if conStat != ContainerStateRunning {
+		return nil, errors.Errorf("top can only be used on running containers")
+	}
+	return c.GetContainerPidInformation(descriptors)
+}
 
 // GetContainerPidInformation returns process-related data of all processes in
 // the container.  The output data can be controlled via the `descriptors`

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -766,3 +766,23 @@ func (r *LocalRuntime) Restart(ctx context.Context, c *cliconfig.RestartValues) 
 	}
 	return pool.Run()
 }
+
+// Top display the running processes of a container
+func (r *LocalRuntime) Top(cli *cliconfig.TopValues) ([]string, error) {
+	var (
+		descriptors []string
+		container   *libpod.Container
+		err         error
+	)
+	if cli.Latest {
+		descriptors = cli.InputArgs
+		container, err = r.Runtime.GetLatestContainer()
+	} else {
+		descriptors = cli.InputArgs[1:]
+		container, err = r.Runtime.LookupContainer(cli.InputArgs[0])
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to lookup requested container")
+	}
+	return container.Top(descriptors)
+}

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -832,3 +832,23 @@ func (r *LocalRuntime) Restart(ctx context.Context, c *cliconfig.RestartValues) 
 	}
 	return ok, failures, nil
 }
+
+// Top display the running processes of a container
+func (r *LocalRuntime) Top(cli *cliconfig.TopValues) ([]string, error) {
+	var (
+		ctr         *Container
+		err         error
+		descriptors []string
+	)
+	if cli.Latest {
+		ctr, err = r.GetLatestContainer()
+		descriptors = cli.InputArgs
+	} else {
+		ctr, err = r.LookupContainer(cli.InputArgs[0])
+		descriptors = cli.InputArgs[1:]
+	}
+	if err != nil {
+		return nil, err
+	}
+	return iopodman.Top().Call(r.Conn, ctr.ID(), descriptors)
+}

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -733,3 +733,16 @@ func newPodmanLogLine(line *libpod.LogLine) iopodman.LogLine {
 		Cid:          line.CID,
 	}
 }
+
+// Top displays information about a container's running processes
+func (i *LibpodAPI) Top(call iopodman.VarlinkCall, nameOrID string, descriptors []string) error {
+	ctr, err := i.Runtime.LookupContainer(nameOrID)
+	if err != nil {
+		return call.ReplyContainerNotFound(ctr.ID(), err.Error())
+	}
+	topInfo, err := ctr.Top(descriptors)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyTop(topInfo)
+}


### PR DESCRIPTION
add the ability for the remote client to display a container's running
processes.

Signed-off-by: baude <bbaude@redhat.com>