### PR TITLE
Fix remote-client testing reports

### DIFF
--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -584,7 +584,10 @@ func (r *LocalRuntime) Attach(ctx context.Context, c *cliconfig.AttachValues) er
 	}
 	inputStream := os.Stdin
 	if c.NoStdin {
-		inputStream = nil
+		inputStream, err = os.Open(os.DevNull)
+		if err != nil {
+			return err
+		}
 	}
 	errChan, err := r.attach(ctx, inputStream, os.Stdout, c.InputArgs[0], false, c.DetachKeys)
 	if err != nil {


### PR DESCRIPTION
Ensure when using remote attach --no-stdin a mock device is used to
prevent stdin and not nil.  This fixes issue #3009.

When starting a container with the remote client, if the container is
already running and the user asks to attach, we should just attach.
This fixes issue #3011

Signed-off-by: baude <bbaude@redhat.com>