### PR TITLE
podman-remote stop

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -51,7 +51,6 @@ func getContainerSubCommands() []*cobra.Command {
 		_restoreCommand,
 		_runlabelCommand,
 		_statsCommand,
-		_stopCommand,
 		_umountCommand,
 	}
 }

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -64,6 +64,7 @@ var (
 		_runCommand,
 		_rmCommand,
 		_startCommand,
+		_stopCommand,
 		_topCommand,
 		_unpauseCommand,
 		_waitCommand,


### PR DESCRIPTION
add stop to the container subcommands for the remote client. the stop
function is already done.  this is a graphical change only.

Signed-off-by: baude <bbaude@redhat.com>