### PR TITLE
add varlink bridge

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -32,6 +32,10 @@ type MainFlags struct {
 	CpuProfile string
 	LogLevel   string
 	TmpDir     string
+
+	RemoteUserName string
+	RemoteHost     string
+	VarlinkAddress string
 }
 
 type AttachValues struct {

--- a/cmd/podman/main_remote.go
+++ b/cmd/podman/main_remote.go
@@ -9,7 +9,11 @@ import (
 const remote = true
 
 func init() {
-	//	remote client specific flags can go here.
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.RemoteUserName, "username", "", "username on the remote host")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.RemoteHost, "remote-host", "", "remote host")
+	// TODO maybe we allow the altering of this for bridge connections?
+	//rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.VarlinkAddress, "varlink-address", adapter.DefaultAddress, "address of the varlink socket")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.LogLevel, "log-level", "error", "Log messages above specified level: debug, info, warn, error, fatal or panic")
 }
 
 func setSyslog() error {

--- a/cmd/podman/shared/intermediate_varlink.go
+++ b/cmd/podman/shared/intermediate_varlink.go
@@ -3,8 +3,6 @@
 package shared
 
 import (
-	"fmt"
-
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/pkg/rootless"
@@ -209,7 +207,6 @@ func boolFromVarlink(v *bool, flagName string, defaultValue bool) CRBool {
 		cr.Val = defaultValue
 		cr.Changed = false
 	} else {
-		fmt.Println(flagName, cr.Val)
 		cr.Val = *v
 		cr.Changed = true
 	}

--- a/docs/podman-varlink.1.md
+++ b/docs/podman-varlink.1.md
@@ -7,8 +7,10 @@ podman\-varlink - Runs the varlink backend interface
 **podman varlink** [*options*] *uri*
 
 ## DESCRIPTION
-Starts the varlink service listening on *uri* that allows varlink clients to interact with podman.  This should generally be done
-with systemd.  See _Configuration_ below.
+Starts the varlink service listening on *uri* that allows varlink clients to interact with podman.  If no *uri* is provided, a default
+URI will be used depending on the user calling the varlink service.  The default for the root user is `unix:/run/podman/io.podman`. Regular
+users will have a default *uri* of `$XDG_RUNTIME_DIR/podman/io.podman`.  For example, `unix:/run/user/1000/podman/io.podman`
+The varlink service should generally be done with systemd.  See _Configuration_ below.
 
 ## GLOBAL OPTIONS
 
@@ -23,16 +25,23 @@ second. A value of `0` means no timeout and the session will not expire.
 
 ## EXAMPLES
 
-Run the podman varlink service manually and accept the default timeout.
+Run the podman varlink service accepting all default options.
 
 ```
-$ podman varlink unix:/run/podman/io.podman
+$ podman varlink
+```
+
+
+Run the podman varlink service with an alternate URI and accept the default timeout.
+
+```
+$ podman varlink unix:/tmp/io.podman
 ```
 
 Run the podman varlink service manually with a 5 second timeout.
 
 ```
-$ podman varlink --timeout 5000 unix:/run/podman/io.podman
+$ podman varlink --timeout 5000
 ```
 
 ## CONFIGURATION

--- a/pkg/adapter/client.go
+++ b/pkg/adapter/client.go
@@ -3,30 +3,45 @@
 package adapter
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"github.com/pkg/errors"
 	"github.com/varlink/go/varlink"
 )
 
-// DefaultAddress is the default address of the varlink socket
-const DefaultAddress = "unix:/run/podman/io.podman"
+type VarlinkConnectionInfo struct {
+	RemoteUserName string
+	RemoteHost     string
+	VarlinkAddress string
+}
 
 // Connect provides a varlink connection
 func (r RemoteRuntime) Connect() (*varlink.Connection, error) {
-	var err error
-	var connection *varlink.Connection
-	if bridge := os.Getenv("PODMAN_VARLINK_BRIDGE"); bridge != "" {
-		logrus.Infof("Connecting with varlink bridge")
-		logrus.Debugf("%s", bridge)
+	var (
+		err        error
+		connection *varlink.Connection
+	)
+
+	logLevel := r.cmd.LogLevel
+
+	// I'm leaving this here for now as a document of the birdge format.  It can be removed later once the bridge
+	// function is more flushed out.
+	//bridge := `ssh -T root@192.168.122.1 "/usr/bin/varlink -A '/usr/bin/podman varlink \$VARLINK_ADDRESS' bridge"`
+	if len(r.cmd.RemoteHost) > 0 {
+		// The user has provided a remote host endpoint
+		if len(r.cmd.RemoteUserName) < 1 {
+			return nil, errors.New("you must provide a username when providing a remote host name")
+		}
+		bridge := fmt.Sprintf(`ssh -T %s@%s /usr/bin/varlink -A \'/usr/bin/podman --log-level=%s varlink \\\$VARLINK_ADDRESS\' bridge`, r.cmd.RemoteUserName, r.cmd.RemoteHost, logLevel)
+		connection, err = varlink.NewBridge(bridge)
+	} else if bridge := os.Getenv("PODMAN_VARLINK_BRIDGE"); bridge != "" {
 		connection, err = varlink.NewBridge(bridge)
 	} else {
 		address := os.Getenv("PODMAN_VARLINK_ADDRESS")
 		if address == "" {
 			address = DefaultAddress
 		}
-		logrus.Infof("Connecting with varlink address")
-		logrus.Debugf("%s", address)
 		connection, err = varlink.NewConnection(address)
 	}
 	if err != nil {

--- a/pkg/adapter/client_config.go
+++ b/pkg/adapter/client_config.go
@@ -1,0 +1,4 @@
+package adapter
+
+// DefaultAddress is the default address of the varlink socket
+const DefaultAddress = "unix:/run/podman/io.podman"

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -38,6 +38,7 @@ type RemoteImageRuntime struct{}
 type RemoteRuntime struct {
 	Conn   *varlink.Connection
 	Remote bool
+	cmd    cliconfig.MainFlags
 }
 
 // LocalRuntime describes a typical libpod runtime
@@ -47,17 +48,17 @@ type LocalRuntime struct {
 
 // GetRuntime returns a LocalRuntime struct with the actual runtime embedded in it
 func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
-	runtime := RemoteRuntime{}
+	runtime := RemoteRuntime{
+		Remote: true,
+		cmd:    c.GlobalFlags,
+	}
 	conn, err := runtime.Connect()
 	if err != nil {
 		return nil, err
 	}
-
+	runtime.Conn = conn
 	return &LocalRuntime{
-		&RemoteRuntime{
-			Conn:   conn,
-			Remote: true,
-		},
+		&runtime,
 	}, nil
 }
 

--- a/pkg/varlinkapi/attach.go
+++ b/pkg/varlinkapi/attach.go
@@ -60,6 +60,7 @@ func (i *LibpodAPI) Attach(call iopodman.VarlinkCall, name string, detachKeys st
 	if !start && state != libpod.ContainerStateRunning {
 		return call.ReplyErrorOccurred("container must be running to attach")
 	}
+	call.Reply(nil)
 	reader, writer, _, pw, streams := setupStreams(call)
 
 	go func() {

--- a/pkg/varlinkapi/system.go
+++ b/pkg/varlinkapi/system.go
@@ -86,15 +86,18 @@ func (i *LibpodAPI) GetInfo(call iopodman.VarlinkCall) error {
 		Graph_status:         graphStatus,
 	}
 
-	registriesInterface := info[2].Data["registries"]
-	insecureRegistriesInterface := info[3].Data["registries"]
-	if registriesInterface != nil {
-		registries = registriesInterface.([]string)
+	if len(info) > 2 {
+		registriesInterface := info[2].Data["registries"]
+		if registriesInterface != nil {
+			registries = registriesInterface.([]string)
+		}
 	}
-	if insecureRegistriesInterface != nil {
-		insecureRegistries = insecureRegistriesInterface.([]string)
+	if len(info) > 3 {
+		insecureRegistriesInterface := info[3].Data["registries"]
+		if insecureRegistriesInterface != nil {
+			insecureRegistries = insecureRegistriesInterface.([]string)
+		}
 	}
-
 	podmanInfo.Store = infoStore
 	podmanInfo.Podman = pmaninfo
 	podmanInfo.Registries = registries

--- a/vendor.conf
+++ b/vendor.conf
@@ -93,8 +93,8 @@ k8s.io/api kubernetes-1.10.13-beta.0 https://github.com/kubernetes/api
 k8s.io/apimachinery kubernetes-1.10.13-beta.0 https://github.com/kubernetes/apimachinery
 k8s.io/client-go kubernetes-1.10.13-beta.0 https://github.com/kubernetes/client-go
 github.com/mrunalp/fileutils 7d4729fb36185a7c1719923406c9d40e54fb93c7
-github.com/varlink/go 64e07fabffa33e385817b41971cf2674f692f391
 github.com/containers/buildah v1.8.2
+github.com/varlink/go 0f1d566d194b9d6d48e0d47c5e4d822628919066
 # TODO: Gotty has not been updated since 2012. Can we find replacement?
 github.com/Nvveen/Gotty cd527374f1e5bff4938207604a14f2e38a9cf512
 github.com/fsouza/go-dockerclient v1.3.0

--- a/vendor/github.com/varlink/go/varlink/bridge.go
+++ b/vendor/github.com/varlink/go/varlink/bridge.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"io"
 	"net"
+	"os"
 	"os/exec"
 )
 
@@ -30,12 +31,13 @@ func (p PipeCon) Close() error {
 	return nil
 }
 
-// NewConnection returns a new connection to the given address.
-func NewBridge(bridge string) (*Connection, error) {
+// NewBridgeWithStderr returns a new connection with the given bridge.
+func NewBridgeWithStderr(bridge string, stderr io.Writer) (*Connection, error) {
 	//var err error
 
 	c := Connection{}
 	cmd := exec.Command("sh", "-c", bridge)
+	cmd.Stderr = stderr
 	r, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -55,4 +57,9 @@ func NewBridge(bridge string) (*Connection, error) {
 	}
 
 	return &c, nil
+}
+
+// NewBridge returns a new connection with the given bridge.
+func NewBridge(bridge string) (*Connection, error) {
+	return NewBridgeWithStderr(bridge, os.Stderr)
 }

--- a/vendor/github.com/varlink/go/varlink/bridge_windows.go
+++ b/vendor/github.com/varlink/go/varlink/bridge_windows.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"net"
+	"os"
 	"os/exec"
 )
 
@@ -28,12 +29,13 @@ func (p PipeCon) Close() error {
 	return nil
 }
 
-// NewConnection returns a new connection to the given address.
-func NewBridge(bridge string) (*Connection, error) {
+// NewBridgeWithStderr returns a new connection with the given bridge.
+func NewBridgeWithStderr(bridge string, stderr io.Writer) (*Connection, error) {
 	//var err error
 
 	c := Connection{}
 	cmd := exec.Command("cmd", "/C", bridge)
+	cmd.Stderr = stderr
 	r, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -53,4 +55,9 @@ func NewBridge(bridge string) (*Connection, error) {
 	}
 
 	return &c, nil
+}
+
+// NewBridge returns a new connection with the given bridge.
+func NewBridge(bridge string) (*Connection, error) {
+	return NewBridgeWithStderr(bridge, os.Stderr)
 }


### PR DESCRIPTION
allow the user to define a remote host and remote username for their
remote podman sessions.  this is then feed to the varlink "bridge" as
the ssh credentials and endpoint.

Signed-off-by: baude <bbaude@redhat.com>