### PR TITLE
container: drop rootless check

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -299,7 +299,7 @@ func (c *Container) setupStorage(ctx context.Context) error {
 		return errors.Wrapf(err, "error creating container storage")
 	}
 
-	if !rootless.IsRootless() && (len(c.config.IDMappings.UIDMap) != 0 || len(c.config.IDMappings.GIDMap) != 0) {
+	if len(c.config.IDMappings.UIDMap) != 0 || len(c.config.IDMappings.GIDMap) != 0 {
 		if err := os.Chown(containerInfo.RunDir, c.RootUID(), c.RootGID()); err != nil {
 			return err
 		}


### PR DESCRIPTION
we don't need to treat the rootless case differently now that we use a
single user namespace.

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>