### PR TITLE
Bool switches dont need values

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -83,7 +83,7 @@ var MainGlobalOpts cliconfig.MainFlags
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.TraverseChildren = true
+	rootCmd.TraverseChildren = false
 	rootCmd.Version = version.Version
 	// Override default --help information of `--version` global flag
 	var dummyVersion bool


### PR DESCRIPTION
We want the persistent options for the podman command to not require a
true|false value when used.  That is to say, --syslog should set to
true when the default is false.

Signed-off-by: baude <bbaude@redhat.com>