### PR TITLE
Do not remove volumes when --rm removes a container

### DIFF
--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -585,7 +585,7 @@ Automatically remove the container when it exits. The default is *false*.
 
 Note that the container will not be removed when it could not be created or
 started successfully. This allows the user to inspect the container after
-failure. The `--rm` flag is incompatible with the `-d` flag.
+failure.
 
 **--rootfs**
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -607,7 +607,7 @@ Automatically remove the container when it exits. The default is *false*.
 
 Note that the container will not be removed when it could not be created or
 started successfully. This allows the user to inspect the container after
-failure. The `--rm` flag is incompatible with the `-d` flag.
+failure.
 
 **--rootfs**
 

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -413,7 +413,9 @@ func (r *LocalRuntime) Run(ctx context.Context, c *cliconfig.RunValues, exitCode
 	}
 
 	if c.IsSet("rm") {
-		r.Runtime.RemoveContainer(ctx, ctr, false, true)
+		if err := r.Runtime.RemoveContainer(ctx, ctr, false, false); err != nil {
+			logrus.Errorf("Error removing container %s: %v", ctr.ID(), err)
+		}
 	}
 
 	return exitCode, nil
@@ -965,8 +967,9 @@ func (r *LocalRuntime) CleanupContainers(ctx context.Context, cli *cliconfig.Cle
 	return ok, failures, nil
 }
 
+// Only used when cleaning up containers
 func removeContainer(ctx context.Context, ctr *libpod.Container, runtime *LocalRuntime) error {
-	if err := runtime.RemoveContainer(ctx, ctr, false, true); err != nil {
+	if err := runtime.RemoveContainer(ctx, ctr, false, false); err != nil {
 		return errors.Wrapf(err, "failed to cleanup and remove container %v", ctr.ID())
 	}
 	return nil


### PR DESCRIPTION
This duplicates Docker behavior for the `--rm` flag.

Fixes #3071