### PR TITLE
remote-podman checkpoint and restore add to container submenu

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -39,13 +39,11 @@ func getImageSubCommands() []*cobra.Command {
 func getContainerSubCommands() []*cobra.Command {
 
 	return []*cobra.Command{
-		_checkpointCommand,
 		_cleanupCommand,
 		_commitCommand,
 		_execCommand,
 		_mountCommand,
 		_refreshCommand,
-		_restoreCommand,
 		_runlabelCommand,
 		_statsCommand,
 		_umountCommand,

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -51,6 +51,7 @@ var (
 	// Commands that are universally implemented.
 	containerCommands = []*cobra.Command{
 		_attachCommand,
+		_checkpointCommand,
 		_containerExistsCommand,
 		_contInspectSubCommand,
 		_diffCommand,
@@ -64,6 +65,7 @@ var (
 		_portCommand,
 		_pruneContainersCommand,
 		_restartCommand,
+		_restoreCommand,
 		_runCommand,
 		_rmCommand,
 		_startCommand,


### PR DESCRIPTION
the remote-podman checkpoint and restore commands were done some time
ago but for some reason not added to the container subcommand

Signed-off-by: baude <bbaude@redhat.com>