### PR TITLE
fix podman-remote ps --ns

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -497,7 +497,7 @@ func psDisplay(c *cliconfig.PsValues, runtime *adapter.LocalRuntime) error {
 
 		} else {
 			// Print namespace information
-			ns := shared.GetNamespaces(container.Pid)
+			ns := runtime.GetNamespaces(container)
 			fmt.Fprintf(w, "\n%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s", container.ID, container.Names, container.Pid, ns.Cgroup, ns.IPC, ns.MNT, ns.NET, ns.PIDNS, ns.User, ns.UTS)
 		}
 

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -1022,3 +1022,8 @@ func (r *LocalRuntime) GenerateSystemd(c *cliconfig.GenerateSystemdValues) (stri
 	}
 	return systemdgen.CreateSystemdUnitAsString(name, ctr.ID(), c.RestartPolicy, ctr.Config().StaticDir, timeout)
 }
+
+// GetNamespaces returns namespace information about a container for PS
+func (r *LocalRuntime) GetNamespaces(container shared.PsContainerOutput) *shared.Namespace {
+	return shared.GetNamespaces(container.Pid)
+}

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -961,3 +961,18 @@ func (r *LocalRuntime) Port(c *cliconfig.PortValues) ([]*Container, error) {
 func (r *LocalRuntime) GenerateSystemd(c *cliconfig.GenerateSystemdValues) (string, error) {
 	return iopodman.GenerateSystemd().Call(r.Conn, c.InputArgs[0], c.RestartPolicy, int64(c.StopTimeout), c.Name)
 }
+
+// GetNamespaces returns namespace information about a container for PS
+func (r *LocalRuntime) GetNamespaces(container shared.PsContainerOutput) *shared.Namespace {
+	ns := shared.Namespace{
+		PID:    container.PID,
+		Cgroup: container.Cgroup,
+		IPC:    container.IPC,
+		MNT:    container.MNT,
+		NET:    container.NET,
+		PIDNS:  container.PIDNS,
+		User:   container.User,
+		UTS:    container.UTS,
+	}
+	return &ns
+}


### PR DESCRIPTION
the namespace for the remote client was being incorrectly derived from
the "remote" client.

fixes: #2938

Signed-off-by: baude <bbaude@redhat.com>