### PR TITLE
Add `systemd` build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,23 @@ SHAREDIR_CONTAINERS ?= ${PREFIX}/share/containers
 ETCDIR ?= ${DESTDIR}/etc
 TMPFILESDIR ?= ${PREFIX}/lib/tmpfiles.d
 SYSTEMDDIR ?= ${PREFIX}/lib/systemd/system
-BUILDTAGS ?= seccomp $(shell hack/btrfs_tag.sh) $(shell hack/btrfs_installed_tag.sh) $(shell hack/ostree_tag.sh) $(shell hack/selinux_tag.sh) $(shell hack/apparmor_tag.sh) varlink exclude_graphdriver_devicemapper
+BUILDTAGS ?= \
+	$(shell hack/apparmor_tag.sh) \
+	$(shell hack/btrfs_installed_tag.sh) \
+	$(shell hack/btrfs_tag.sh) \
+	$(shell hack/ostree_tag.sh) \
+	$(shell hack/selinux_tag.sh) \
+	$(shell hack/systemd_tag.sh) \
+	exclude_graphdriver_devicemapper \
+	seccomp \
+	varlink
+
+ifeq (,$(findstring systemd,$(BUILDTAGS)))
+$(warning \
+	Podman is being compiled without the systemd build tag.\
+	Install libsystemd for journald support)
+endif
+
 BUILDTAGS_CROSS ?= containers_image_openpgp containers_image_ostree_stub exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay
 ifneq (,$(findstring varlink,$(BUILDTAGS)))
 	PODMAN_VARLINK_DEPENDENCIES = cmd/podman/varlink/iopodman.go

--- a/hack/systemd_tag.sh
+++ b/hack/systemd_tag.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+if pkg-config --exists libsystemd; then
+    echo systemd
+fi

--- a/libpod.conf
+++ b/libpod.conf
@@ -116,4 +116,4 @@ runc = [
 
 # Selects which logging mechanism to use for Podman events.  Valid values
 # are `journald` or `file`.
-events_logger = "journald"
+# events_logger = "journald"

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -10,6 +10,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrNoJournaldLogging indicates that there is no journald logging
+// supported (requires libsystemd)
+var ErrNoJournaldLogging = errors.New("No support for journald logging")
+
 // String returns a string representation of EventerType
 func (et EventerType) String() string {
 	if et == LogFile {

--- a/libpod/events/events_linux.go
+++ b/libpod/events/events_linux.go
@@ -8,12 +8,14 @@ import (
 )
 
 // NewEventer creates an eventer based on the eventer type
-func NewEventer(options EventerOptions) (Eventer, error) {
-	var eventer Eventer
+func NewEventer(options EventerOptions) (eventer Eventer, err error) {
 	logrus.Debugf("Initializing event backend %s", options.EventerType)
 	switch strings.ToUpper(options.EventerType) {
 	case strings.ToUpper(Journald.String()):
-		eventer = EventJournalD{options}
+		eventer, err = newEventJournalD(options)
+		if err != nil {
+			return nil, errors.Wrapf(err, "eventer creation")
+		}
 	case strings.ToUpper(LogFile.String()):
 		eventer = EventLogFile{options}
 	default:

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -1,3 +1,5 @@
+// +build systemd
+
 package events
 
 import (
@@ -13,6 +15,11 @@ import (
 // EventJournalD is the journald implementation of an eventer
 type EventJournalD struct {
 	options EventerOptions
+}
+
+// newEventJournalD creates a new journald Eventer
+func newEventJournalD(options EventerOptions) (Eventer, error) {
+	return EventJournalD{options}, nil
 }
 
 // Write to journald

--- a/libpod/events/journal_unsupported.go
+++ b/libpod/events/journal_unsupported.go
@@ -1,0 +1,8 @@
+// +build !systemd
+
+package events
+
+// newEventJournalD always returns an error if libsystemd not found
+func newEventJournalD(options EventerOptions) (Eventer, error) {
+	return nil, ErrNoJournaldLogging
+}


### PR DESCRIPTION
If the systemd development files are not present on the system which
builds podman, then `podman events` will error on runtime creation.

This commit mainly exists because projects which depend on libpod
would not need the podman event support and therefore do not need to
rely on the systemd headers.

Closes #3079
