### PR TITLE
Add information when running `podman version` on client

### DIFF
--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -5,11 +5,12 @@ package adapter
 import (
 	"bufio"
 	"context"
-	"github.com/containers/libpod/cmd/podman/shared"
 	"io"
 	"io/ioutil"
 	"os"
 	"text/template"
+
+	"github.com/containers/libpod/cmd/podman/shared"
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/imagebuildah"
@@ -391,4 +392,9 @@ func (r *LocalRuntime) GetPodsByStatus(statuses []string) ([]*libpod.Pod, error)
 	}
 
 	return pods, nil
+}
+
+// GetVersion is an alias to satisfy interface{}
+func (r *LocalRuntime) GetVersion() (libpod.Version, error) {
+	return libpod.GetVersion()
 }

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
 	"os"
 	"strings"
 	"text/template"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/containers/buildah/imagebuildah"
 	"github.com/containers/image/docker/reference"
@@ -414,19 +415,19 @@ func (r *LocalRuntime) Build(ctx context.Context, c *cliconfig.BuildValues, opti
 		Compression:           string(options.Compression),
 		DefaultsMountFilePath: options.DefaultMountsFilePath,
 		Dockerfiles:           dockerfiles,
-		//Err: string(options.Err),
+		// Err: string(options.Err),
 		ForceRmIntermediateCtrs: options.ForceRmIntermediateCtrs,
 		Iidfile:                 options.IIDFile,
 		Label:                   options.Labels,
 		Layers:                  options.Layers,
 		Nocache:                 options.NoCache,
-		//Out:
+		// Out:
 		Output:                 options.Output,
 		OutputFormat:           options.OutputFormat,
 		PullPolicy:             options.PullPolicy.String(),
 		Quiet:                  options.Quiet,
 		RemoteIntermediateCtrs: options.RemoveIntermediateCtrs,
-		//ReportWriter:
+		// ReportWriter:
 		RuntimeArgs:         options.RuntimeArgs,
 		SignaturePolicyPath: options.SignaturePolicyPath,
 		Squash:              options.Squash,
@@ -610,7 +611,7 @@ func (r *LocalRuntime) InspectVolumes(ctx context.Context, c *cliconfig.VolumeIn
 	return varlinkVolumeToVolume(r, reply), nil
 }
 
-//Volumes returns a slice of adapter.volumes based on information about libpod
+// Volumes returns a slice of adapter.volumes based on information about libpod
 // volumes over a varlink connection
 func (r *LocalRuntime) Volumes(ctx context.Context) ([]*Volume, error) {
 	reply, err := iopodman.GetVolumes().Call(r.Conn, []string{}, true)
@@ -905,4 +906,30 @@ func (r *LocalRuntime) GetContainersByContext(all bool, latest bool, namesOrIDs 
 		containers = append(containers, ctr)
 	}
 	return containers, nil
+}
+
+// GetVersion returns version information from service
+func (r *LocalRuntime) GetVersion() (libpod.Version, error) {
+	version, goVersion, gitCommit, built, osArch, apiVersion, err := iopodman.GetVersion().Call(r.Conn)
+	if err != nil {
+		return libpod.Version{}, errors.Wrapf(err, "Unable to obtain server version information")
+	}
+
+	var buildTime int64
+	if built != "" {
+		t, err := time.Parse(time.RFC3339, built)
+		if err != nil {
+			return libpod.Version{}, nil
+		}
+		buildTime = t.Unix()
+	}
+
+	return libpod.Version{
+		RemoteAPIVersion: apiVersion,
+		Version:          version,
+		GoVersion:        goVersion,
+		GitCommit:        gitCommit,
+		Built:            buildTime,
+		OsArch:           osArch,
+	}, nil
 }

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -31,6 +31,7 @@ var _ = Describe("Podman version", func() {
 	})
 
 	It("podman version", func() {
+		SkipIfRemote()
 		session := podmanTest.Podman([]string{"version"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -38,6 +39,7 @@ var _ = Describe("Podman version", func() {
 	})
 
 	It("podman version --format json", func() {
+		SkipIfRemote()
 		session := podmanTest.Podman([]string{"version", "--format", "json"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -45,6 +47,7 @@ var _ = Describe("Podman version", func() {
 	})
 
 	It("podman version --format json", func() {
+		SkipIfRemote()
 		session := podmanTest.Podman([]string{"version", "--format", "{{ json .}}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -52,6 +55,7 @@ var _ = Describe("Podman version", func() {
 	})
 
 	It("podman version --format GO template", func() {
+		SkipIfRemote()
 		session := podmanTest.Podman([]string{"version", "--format", "{{ .Version }}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))


### PR DESCRIPTION
* Include service version information and headers

```
$ ./podman-remote-darwin version
Client:
Version:            1.3.1-dev
RemoteAPI Version:  1
Go Version:         go1.12.2
Git Commit:         64d1a357e8299c5fcecd4141091424419111cdee-dirty
Built:              Wed May  8 10:28:56 2019
OS/Arch:            darwin/amd64

Service:
Version:            1.3.1-dev
RemoteAPI Version:  1
Go Version:         go1.12.2
Git Commit:         64d1a357e8299c5fcecd4141091424419111cdee-dirty
Built:              Wed May  8 10:20:55 2019
OS/Arch:            linux/amd64
```


Signed-off-by: Jhon Honce <jhonce@redhat.com>