### PR TITLE
Add simple test to confirm bad command-line arguments

### DIFF
--- a/test/e2e/negative_test.go
+++ b/test/e2e/negative_test.go
@@ -1,0 +1,38 @@
+package integration
+
+import (
+	"os"
+
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman negative command-line", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest *PodmanTestIntegration
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanTestCreate(tempdir)
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+		f := CurrentGinkgoTestDescription()
+		processTestResult(f)
+
+	})
+
+	It("podman snuffleupagus exits non-zero", func() {
+		session := podmanTest.Podman([]string{"snuffleupagus"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+	})
+})


### PR DESCRIPTION
Someone found a bug in an earlier version related to what is tested here.  The problem was already fixed, this new test simply confirms it stays that way.