### PR TITLE
Add VarlinkCall.RequiresUpgrade() type and method

### DIFF
--- a/pkg/varlinkapi/config.go
+++ b/pkg/varlinkapi/config.go
@@ -21,3 +21,7 @@ func New(cli *cliconfig.PodmanCommand, runtime *libpod.Runtime) *iopodman.Varlin
 	lp := LibpodAPI{Cli: cli.Command, Runtime: runtime}
 	return iopodman.VarlinkNew(&lp)
 }
+
+type VarlinkCall struct {
+	*iopodman.VarlinkCall
+}

--- a/pkg/varlinkapi/transfers.go
+++ b/pkg/varlinkapi/transfers.go
@@ -15,58 +15,61 @@ import (
 
 // SendFile allows a client to send a file to the varlink server
 func (i *LibpodAPI) SendFile(call iopodman.VarlinkCall, ftype string, length int64) error {
-	if !call.WantsUpgrade() {
-		return call.ReplyErrorOccurred("client must use upgraded connection to send files")
+	varlink := VarlinkCall{&call}
+	if err := varlink.RequiresUpgrade(); err != nil {
+		return varlink.ReplyErrorOccurred(err.Error())
 	}
 
 	outputFile, err := ioutil.TempFile("", "varlink_send")
 	if err != nil {
-		return call.ReplyErrorOccurred(err.Error())
+		return varlink.ReplyErrorOccurred(err.Error())
 	}
 	defer outputFile.Close()
 
-	if err = call.ReplySendFile(outputFile.Name()); err != nil {
-		return call.ReplyErrorOccurred(err.Error())
+	if err = varlink.ReplySendFile(outputFile.Name()); err != nil {
+		return varlink.ReplyErrorOccurred(err.Error())
 	}
 
 	writer := bufio.NewWriter(outputFile)
 	defer writer.Flush()
 
-	reader := call.Call.Reader
+	reader := varlink.Call.Reader
 	if _, err := io.CopyN(writer, reader, length); err != nil {
 		return err
 	}
 
 	logrus.Debugf("successfully received %s", outputFile.Name())
 	// Send an ACK to the client
-	call.Call.Writer.WriteString(fmt.Sprintf("%s:", outputFile.Name()))
-	call.Call.Writer.Flush()
+	varlink.Call.Writer.WriteString(fmt.Sprintf("%s:", outputFile.Name()))
+	varlink.Call.Writer.Flush()
 	return nil
 
 }
 
 // ReceiveFile allows the varlink server to send a file to a client
 func (i *LibpodAPI) ReceiveFile(call iopodman.VarlinkCall, filepath string, delete bool) error {
-	if !call.WantsUpgrade() {
-		return call.ReplyErrorOccurred("client must use upgraded connection to send files")
+	varlink := VarlinkCall{&call}
+	if err := varlink.RequiresUpgrade(); err != nil {
+		return varlink.ReplyErrorOccurred(err.Error())
 	}
+
 	fs, err := os.Open(filepath)
 	if err != nil {
-		return call.ReplyErrorOccurred(err.Error())
+		return varlink.ReplyErrorOccurred(err.Error())
 	}
 	fileInfo, err := fs.Stat()
 	if err != nil {
-		return call.ReplyErrorOccurred(err.Error())
+		return varlink.ReplyErrorOccurred(err.Error())
 	}
 
 	// Send the file length down to client
 	// Varlink connection upraded
-	if err = call.ReplyReceiveFile(fileInfo.Size()); err != nil {
-		return call.ReplyErrorOccurred(err.Error())
+	if err = varlink.ReplyReceiveFile(fileInfo.Size()); err != nil {
+		return varlink.ReplyErrorOccurred(err.Error())
 	}
 
 	reader := bufio.NewReader(fs)
-	_, err = reader.WriteTo(call.Writer)
+	_, err = reader.WriteTo(varlink.Writer)
 	if err != nil {
 		return err
 	}
@@ -75,5 +78,5 @@ func (i *LibpodAPI) ReceiveFile(call iopodman.VarlinkCall, filepath string, dele
 			return err
 		}
 	}
-	return call.Writer.Flush()
+	return varlink.Writer.Flush()
 }

--- a/pkg/varlinkapi/util.go
+++ b/pkg/varlinkapi/util.go
@@ -13,6 +13,11 @@ import (
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrUpgradedConnectionRequired = errors.New("peer must use upgraded connection for operation")
 )
 
 // getContext returns a non-nil, empty context
@@ -193,5 +198,15 @@ func makePsOpts(inOpts iopodman.PsOpts) shared.PsOptions {
 		Sort:      derefString(inOpts.Sort),
 		Namespace: true,
 		Sync:      derefBool(inOpts.Sync),
+	}
+}
+
+// RequiresUpgrade tests if varlink connection has been marked for upgrade.
+func (v *VarlinkCall) RequiresUpgrade() error {
+	if v.WantsUpgrade() {
+		// A nil is sent to the peer as required by the varlink protocol.
+		return v.Reply(nil)
+	} else {
+		return ErrUpgradedConnectionRequired
 	}
 }


### PR DESCRIPTION
Type varlinkapi.VarlinkCall currently only used as receiver for
RequiresUpgrade() future helpers could be added to this type.

RequiresUpgrade() verifies caller has given correct options to the call
for the given operation.

Signed-off-by: Jhon Honce <jhonce@redhat.com>