### PR TITLE
varlink: fix usage message, URI is now optional

### DIFF
--- a/cmd/podman/varlink.go
+++ b/cmd/podman/varlink.go
@@ -29,7 +29,7 @@ var (
   Tools speaking varlink protocol can remotely manage pods, containers and images.
 `
 	_varlinkCommand = &cobra.Command{
-		Use:   "varlink [flags] URI",
+		Use:   "varlink [flags] [URI]",
 		Short: "Run varlink interface",
 		Long:  varlinkDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -68,7 +68,7 @@ func varlinkCmd(c *cliconfig.VarlinkValues) error {
 	args := c.InputArgs
 
 	if len(args) > 1 {
-		return errors.Errorf("too many arguments. you may optionally provide 1")
+		return errors.Errorf("too many arguments. You may optionally provide 1")
 	}
 
 	if len(args) > 0 {


### PR DESCRIPTION
38199f4c made the URI argument to podman-varlink optional.
Fix the usage message to indicate this.

Signed-off-by: Ed Santiago <santiago@redhat.com>