### PR TITLE
Fix a typo in release notes, and bump README version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Libpod provides a library for applications looking to use the Container Pod concept,
 popularized by Kubernetes.  Libpod also contains the Pod Manager tool `(Podman)`. Podman manages pods, containers, container images, and container volumes.
 
-* [Latest Version: 1.2.0](https://github.com/containers/libpod/releases/latest)
+* [Latest Version: 1.3.1](https://github.com/containers/libpod/releases/latest)
 * [Continuous Integration:](contrib/cirrus/README.md) [![Build Status](https://api.cirrus-ci.com/github/containers/libpod.svg)](https://cirrus-ci.com/github/containers/libpod/master)
 
 ## Overview and scope

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,7 +23,7 @@
 
 ## 1.3.0
 ### Features
-- Podman now supports container restart policies! The `--restart-policy` flag on `podman create` and `podman run` allows containers to be restarted after they exit. Please note that Podman cannot restart containers after a system reboot - for that, see our next feature
+- Podman now supports container restart policies! The `--restart` flag on `podman create` and `podman run` allows containers to be restarted after they exit. Please note that Podman cannot restart containers after a system reboot - for that, see our next feature
 - Podman `podman generate systemd` command was added to generate systemd unit files for managing Podman containers
 - The `podman runlabel` command now allows a `$GLOBAL_OPTS` variable, which will be populated by global options passed to the `podman runlabel` command, allowing custom storage configurations to be passed into containers run with `runlabel` ([#2399](https://github.com/containers/libpod/issues/2399))
 - The `podman play kube` command now allows `File` and `FileOrCreate` volumes


### PR DESCRIPTION
I wrote the wrong flag for restart policy in the release notes for 1.3.0 - `--restart` is the correct one, not `--restart-policy`