### PR TITLE
rootless: allow resource isolation with cgroup v2

### DIFF
--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -107,7 +107,11 @@ func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber bool, 
 	if c.Flags().Changed("cgroup-manager") {
 		options = append(options, libpod.WithCgroupManager(c.GlobalFlags.CGroupManager))
 	} else {
-		if rootless.IsRootless() {
+		unified, err := util.IsCgroup2UnifiedMode()
+		if err != nil {
+			return nil, err
+		}
+		if rootless.IsRootless() && !unified {
 			options = append(options, libpod.WithCgroupManager("cgroupfs"))
 		}
 	}

--- a/cmd/podman/shared/create_cli.go
+++ b/cmd/podman/shared/create_cli.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/shared/parse"
 	cc "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/libpod/pkg/sysinfo"
+	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -76,6 +77,12 @@ func addWarning(warnings []string, msg string) []string {
 
 func verifyContainerResources(config *cc.CreateConfig, update bool) ([]string, error) {
 	warnings := []string{}
+
+	cgroup2, err := util.IsCgroup2UnifiedMode()
+	if err != nil || cgroup2 {
+		return warnings, err
+	}
+
 	sysInfo := sysinfo.New(true)
 
 	// memory subsystem checks and adjustments

--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -11,8 +11,32 @@ import (
 	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 )
+
+const (
+	_cgroup2SuperMagic = 0x63677270
+)
+
+var (
+	isUnifiedOnce sync.Once
+	isUnified     bool
+	isUnifiedErr  error
+)
+
+// IsCgroup2UnifiedMode returns whether we are running in cgroup 2 unified mode.
+func IsCgroup2UnifiedMode() (bool, error) {
+	isUnifiedOnce.Do(func() {
+		var st syscall.Statfs_t
+		if err := syscall.Statfs("/sys/fs/cgroup", &st); err != nil {
+			isUnified, isUnifiedErr = false, err
+		} else {
+			isUnified, isUnifiedErr = st.Type == _cgroup2SuperMagic, nil
+		}
+	})
+	return isUnified, isUnifiedErr
+}
 
 // GetRootlessRuntimeDir returns the runtime directory when running as non root
 func GetRootlessRuntimeDir() (string, error) {

--- a/pkg/util/utils_windows.go
+++ b/pkg/util/utils_windows.go
@@ -10,3 +10,8 @@ import (
 func GetRootlessRuntimeDir() (string, error) {
 	return "", errors.New("this function is not implemented for windows")
 }
+
+// IsCgroup2UnifiedMode returns whether we are running in cgroup 2 unified mode.
+func IsCgroup2UnifiedMode() (bool, error) {
+	return false, errors.New("this function is not implemented for windows")
+}


### PR DESCRIPTION
this is not adding any support for cgroup v2.  It is only used to avoid some early errors when attempting to use cgroup v2 for rootless users.

Depends on:

- https://github.com/cri-o/cri-o/pull/2356
- https://github.com/giuseppe/crun (master)

with the updated versions of conmon and crun, on a Fedora 30 configured with cgroup v2 unified mode, I can:

```
$ podman --runtime /usr/bin/crun run --memory=100M \
   --rm fedora sh -c 'cat $(cat /proc/self/cgroup | sed -e"s|0::|/sys/fs/cgroup|")/memory.max'
 104857600


```
