### PR TITLE
Fixup Flags

### DIFF
--- a/API.md
+++ b/API.md
@@ -131,9 +131,9 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func Ps(opts: PsOpts) PsContainer](#Ps)
 
-[func PullImage(name: string, certDir: string, creds: string, signaturePolicy: string, tlsVerify: ) MoreResponse](#PullImage)
+[func PullImage(name: string) MoreResponse](#PullImage)
 
-[func PushImage(name: string, tag: string, tlsverify: , signaturePolicy: string, creds: string, certDir: string, compress: bool, format: string, removeSignatures: bool, signBy: string) MoreResponse](#PushImage)
+[func PushImage(name: string, tag: string, compress: bool, format: string, removeSignatures: bool, signBy: string) MoreResponse](#PushImage)
 
 [func ReceiveFile(path: string, delete: bool) int](#ReceiveFile)
 
@@ -147,7 +147,7 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func RestartPod(name: string) string](#RestartPod)
 
-[func SearchImages(query: string, limit: , tlsVerify: , filter: ImageSearchFilter) ImageSearchResult](#SearchImages)
+[func SearchImages(query: string, limit: , filter: ImageSearchFilter) ImageSearchResult](#SearchImages)
 
 [func SendFile(type: string, length: int) string](#SendFile)
 
@@ -921,16 +921,15 @@ method Ps(opts: [PsOpts](#PsOpts)) [PsContainer](#PsContainer)</div>
 ### <a name="PullImage"></a>func PullImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
-method PullImage(name: [string](https://godoc.org/builtin#string), certDir: [string](https://godoc.org/builtin#string), creds: [string](https://godoc.org/builtin#string), signaturePolicy: [string](https://godoc.org/builtin#string), tlsVerify: [](#)) [MoreResponse](#MoreResponse)</div>
+method PullImage(name: [string](https://godoc.org/builtin#string)) [MoreResponse](#MoreResponse)</div>
 PullImage pulls an image from a repository to local storage.  After a successful pull, the image id and logs
 are returned as a [MoreResponse](#MoreResponse).  This connection also will handle a WantsMores request to send
 status as it occurs.
 ### <a name="PushImage"></a>func PushImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
-method PushImage(name: [string](https://godoc.org/builtin#string), tag: [string](https://godoc.org/builtin#string), tlsverify: [](#), signaturePolicy: [string](https://godoc.org/builtin#string), creds: [string](https://godoc.org/builtin#string), certDir: [string](https://godoc.org/builtin#string), compress: [bool](https://godoc.org/builtin#bool), format: [string](https://godoc.org/builtin#string), removeSignatures: [bool](https://godoc.org/builtin#bool), signBy: [string](https://godoc.org/builtin#string)) [MoreResponse](#MoreResponse)</div>
-PushImage takes three input arguments: the name or ID of an image, the fully-qualified destination name of the image,
-and a boolean as to whether tls-verify should be used (with false disabling TLS, not affecting the default behavior).
+method PushImage(name: [string](https://godoc.org/builtin#string), tag: [string](https://godoc.org/builtin#string), compress: [bool](https://godoc.org/builtin#bool), format: [string](https://godoc.org/builtin#string), removeSignatures: [bool](https://godoc.org/builtin#bool), signBy: [string](https://godoc.org/builtin#string)) [MoreResponse](#MoreResponse)</div>
+PushImage takes two input arguments: the name or ID of an image, the fully-qualified destination name of the image,
 It will return an [ImageNotFound](#ImageNotFound) error if
 the image cannot be found in local storage; otherwise it will return a [MoreResponse](#MoreResponse)
 ### <a name="ReceiveFile"></a>func ReceiveFile
@@ -1013,7 +1012,7 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.RestartPod '{"name": "135
 ### <a name="SearchImages"></a>func SearchImages
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
-method SearchImages(query: [string](https://godoc.org/builtin#string), limit: [](#), tlsVerify: [](#), filter: [ImageSearchFilter](#ImageSearchFilter)) [ImageSearchResult](#ImageSearchResult)</div>
+method SearchImages(query: [string](https://godoc.org/builtin#string), limit: [](#), filter: [ImageSearchFilter](#ImageSearchFilter)) [ImageSearchResult](#ImageSearchResult)</div>
 SearchImages searches available registries for images that contain the
 contents of "query" in their name. If "limit" is given, limits the amount of
 search results per registry.
@@ -1206,8 +1205,6 @@ remoteIntermediateCtrs [bool](https://godoc.org/builtin#bool)
 reportWriter [string](https://godoc.org/builtin#string)
 
 runtimeArgs [[]string](#[]string)
-
-signaturePolicyPath [string](https://godoc.org/builtin#string)
 
 squash [bool](https://godoc.org/builtin#bool)
 ### <a name="BuildOptions"></a>type BuildOptions
@@ -1908,19 +1905,11 @@ image [string](https://godoc.org/builtin#string)
 
 authfile [string](https://godoc.org/builtin#string)
 
-certDir [string](https://godoc.org/builtin#string)
-
-creds [string](https://godoc.org/builtin#string)
-
 display [bool](https://godoc.org/builtin#bool)
 
 name [string](https://godoc.org/builtin#string)
 
 pull [bool](https://godoc.org/builtin#bool)
-
-signaturePolicyPath [string](https://godoc.org/builtin#string)
-
-tlsVerify [](#)
 
 label [string](https://godoc.org/builtin#string)
 

--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -43,7 +43,7 @@ var (
 			return buildCmd(&buildCommand)
 		},
 		Example: `podman build .
-  podman build --cert-dir ~/auth --creds=username:password -t imageName -f Dockerfile.simple .
+  podman build --creds=username:password -t imageName -f Dockerfile.simple .
   podman build --layers --force-rm --tag imageName .`,
 	}
 )
@@ -72,6 +72,7 @@ func init() {
 	flags.AddFlagSet(&budFlags)
 	flags.AddFlagSet(&layerFlags)
 	flags.AddFlagSet(&fromAndBugFlags)
+	flags.MarkHidden("signature-policy")
 }
 
 func getDockerfiles(files []string) []string {

--- a/cmd/podman/load.go
+++ b/cmd/podman/load.go
@@ -40,8 +40,11 @@ func init() {
 	flags := loadCommand.Flags()
 	flags.StringVarP(&loadCommand.Input, "input", "i", "", "Read from specified archive file (default: stdin)")
 	flags.BoolVarP(&loadCommand.Quiet, "quiet", "q", false, "Suppress the output")
-	flags.StringVar(&loadCommand.SignaturePolicy, "signature-policy", "", "Pathname of signature policy file (not usually used)")
-
+	// Disabled flags for the remote client
+	if !remote {
+		flags.StringVar(&loadCommand.SignaturePolicy, "signature-policy", "", "Pathname of signature policy file (not usually used)")
+		flags.MarkHidden("signature-policy")
+	}
 }
 
 // loadCmd gets the image/file to be loaded from the command line

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -47,22 +47,28 @@ var (
 			playKubeCommand.Remote = remoteclient
 			return playKubeCmd(&playKubeCommand)
 		},
-		Example: `podman play kube demo.yml
-  podman play kube --cert-dir /mycertsdir --tls-verify=true --quiet myWebPod`,
+		Example: `podman play kube demo.yml`,
 	}
 )
 
 func init() {
+	if !remote {
+		_playKubeCommand.Example = fmt.Sprintf("%s\n  podman play kube --cert-dir /mycertsdir --tls-verify=true --quiet myWebPod", _playKubeCommand.Example)
+	}
 	playKubeCommand.Command = _playKubeCommand
 	playKubeCommand.SetHelpTemplate(HelpTemplate())
 	playKubeCommand.SetUsageTemplate(UsageTemplate())
 	flags := playKubeCommand.Flags()
-	flags.StringVar(&playKubeCommand.Authfile, "authfile", "", "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")
-	flags.StringVar(&playKubeCommand.CertDir, "cert-dir", "", "`Pathname` of a directory containing TLS certificates and keys")
 	flags.StringVar(&playKubeCommand.Creds, "creds", "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
 	flags.BoolVarP(&playKubeCommand.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
-	flags.StringVar(&playKubeCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
-	flags.BoolVar(&playKubeCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+	// Disabled flags for the remote client
+	if !remote {
+		flags.StringVar(&playKubeCommand.Authfile, "authfile", getAuthFile(""), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+		flags.StringVar(&playKubeCommand.CertDir, "cert-dir", "", "`Pathname` of a directory containing TLS certificates and keys")
+		flags.StringVar(&playKubeCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
+		flags.BoolVar(&playKubeCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+		flags.MarkHidden("signature-policy")
+	}
 }
 
 func playKubeCmd(c *cliconfig.KubePlayValues) error {

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -36,6 +36,8 @@ func init() {
 	flags.SetInterspersed(false)
 	flags.Bool("sig-proxy", true, "Proxy received signals to the process")
 	getCreateFlags(&runCommand.PodmanCommand)
+	markFlagHiddenForRemoteClient("authfile", flags)
+	flags.MarkHidden("signature-policy")
 }
 
 func runCmd(c *cliconfig.RunValues) error {

--- a/cmd/podman/search.go
+++ b/cmd/podman/search.go
@@ -43,12 +43,15 @@ func init() {
 	searchCommand.SetHelpTemplate(HelpTemplate())
 	searchCommand.SetUsageTemplate(UsageTemplate())
 	flags := searchCommand.Flags()
-	flags.StringVar(&searchCommand.Authfile, "authfile", "", "Path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json. Use REGISTRY_AUTH_FILE environment variable to override")
 	flags.StringSliceVarP(&searchCommand.Filter, "filter", "f", []string{}, "Filter output based on conditions provided (default [])")
 	flags.StringVar(&searchCommand.Format, "format", "", "Change the output format to a Go template")
 	flags.IntVar(&searchCommand.Limit, "limit", 0, "Limit the number of results")
 	flags.BoolVar(&searchCommand.NoTrunc, "no-trunc", false, "Do not truncate the output")
-	flags.BoolVar(&searchCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+	// Disabled flags for the remote client
+	if !remote {
+		flags.StringVar(&searchCommand.Authfile, "authfile", getAuthFile(""), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+		flags.BoolVar(&searchCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+	}
 }
 
 func searchCmd(c *cliconfig.SearchValues) error {
@@ -70,7 +73,7 @@ func searchCmd(c *cliconfig.SearchValues) error {
 		NoTrunc:  c.NoTrunc,
 		Limit:    c.Limit,
 		Filter:   *filter,
-		Authfile: getAuthFile(c.Authfile),
+		Authfile: c.Authfile,
 	}
 	if c.Flag("tls-verify").Changed {
 		searchOptions.InsecureSkipTLSVerify = types.NewOptionalBool(!c.TlsVerify)

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -414,7 +414,6 @@ type BuildInfo (
     remoteIntermediateCtrs: bool,
     reportWriter: string,
     runtimeArgs: []string,
-    signaturePolicyPath: string,
     squash: bool
 )
 
@@ -467,13 +466,9 @@ type PodContainerErrorData (
 type Runlabel(
     image: string,
     authfile: string,
-    certDir: string,
-    creds: string,
     display: bool,
     name: string,
     pull: bool,
-    signaturePolicyPath: string,
-    tlsVerify: ?bool,
     label: string,
     extraArgs: []string,
     opts: [string]string
@@ -759,11 +754,10 @@ method InspectImage(name: string) -> (image: string)
 # [ImageNotFound](#ImageNotFound) error is returned.
 method HistoryImage(name: string) -> (history: []ImageHistory)
 
-# PushImage takes three input arguments: the name or ID of an image, the fully-qualified destination name of the image,
-# and a boolean as to whether tls-verify should be used (with false disabling TLS, not affecting the default behavior).
+# PushImage takes two input arguments: the name or ID of an image, the fully-qualified destination name of the image,
 # It will return an [ImageNotFound](#ImageNotFound) error if
 # the image cannot be found in local storage; otherwise it will return a [MoreResponse](#MoreResponse)
-method PushImage(name: string, tag: string, tlsverify: ?bool, signaturePolicy: string, creds: string, certDir: string, compress: bool, format: string, removeSignatures: bool, signBy: string) -> (reply: MoreResponse)
+method PushImage(name: string, tag: string, compress: bool, format: string, removeSignatures: bool, signBy: string) -> (reply: MoreResponse)
 
 # TagImage takes the name or ID of an image in local storage as well as the desired tag name.  If the image cannot
 # be found, an [ImageNotFound](#ImageNotFound) error will be returned; otherwise, the ID of the image is returned on success.
@@ -784,7 +778,7 @@ method RemoveImage(name: string, force: bool) -> (image: string)
 # SearchImages searches available registries for images that contain the
 # contents of "query" in their name. If "limit" is given, limits the amount of
 # search results per registry.
-method SearchImages(query: string, limit: ?int, tlsVerify: ?bool, filter: ImageSearchFilter) -> (results: []ImageSearchResult)
+method SearchImages(query: string, limit: ?int, filter: ImageSearchFilter) -> (results: []ImageSearchResult)
 
 # DeleteUnusedImages deletes any images not associated with a container.  The IDs of the deleted images are returned
 # in a string array.
@@ -825,7 +819,7 @@ method ExportImage(name: string, destination: string, compress: bool, tags: []st
 # PullImage pulls an image from a repository to local storage.  After a successful pull, the image id and logs
 # are returned as a [MoreResponse](#MoreResponse).  This connection also will handle a WantsMores request to send
 # status as it occurs.
-method PullImage(name: string, certDir: string, creds: string, signaturePolicy: string, tlsVerify: ?bool) -> (reply: MoreResponse)
+method PullImage(name: string) -> (reply: MoreResponse)
 
 # CreatePod creates a new empty pod.  It uses a [PodCreate](#PodCreate) type for input.
 # On success, the ID of the newly created pod will be returned.

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -968,7 +968,7 @@ _podman_container() {
 	 export
 	 inspect
 	 kill
-	 ls
+	 list
 	 logs
 	 mount
 	 pause
@@ -979,6 +979,7 @@ _podman_container() {
 	 restore
 	 rm
 	 run
+	 runlabel
 	 start
 	 stats
 	 stop
@@ -1145,7 +1146,6 @@ _podman_build() {
      --runtime-flag
      --security-opt
      --shm-size
-     --signature-policy
      -t
      --tag
      --ulimit
@@ -1564,7 +1564,6 @@ _podman_pull() {
     --authfile
     --creds
     --cert-dir
-    --signature-policy
     "
     local boolean_options="
 	--all-tags
@@ -1655,7 +1654,6 @@ _podman_push() {
 	-h
 	--quiet
 	-q
-	--remove-signatures
 	--tls-verify
   "
 
@@ -1665,7 +1663,6 @@ _podman_push() {
     --cert-dir
     --creds
     --sign-by
-    --signature-policy
   "
 
     local all_options="$options_with_args $boolean_options"
@@ -2366,7 +2363,6 @@ _complete_() {
 _podman_load() {
     local options_with_args="
     --input -i
-    --signature-policy
     "
     local boolean_options="
 	 --help
@@ -2492,7 +2488,6 @@ _podman_play_kube() {
     --authfile
     --cert-dir
     --creds
-    --signature-policy
     "
 
     local boolean_options="
@@ -2535,7 +2530,6 @@ _podman_container_runlabel() {
      --cert-dir
      --creds
      --name
-     --signature-policy
     "
 
     local boolean_options="

--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -36,7 +36,7 @@ Note: this information is not present in Docker image formats, so it is discarde
 **--authfile** *path*
 
 Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -75,7 +75,7 @@ given.
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
 
 **--cgroup-parent**=""
 
@@ -354,12 +354,6 @@ Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater tha
 Unit is optional and can be `b` (bytes), `k` (kilobytes), `m`(megabytes), or `g` (gigabytes).
 If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
 
-**--signature-policy** *signaturepolicy*
-
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred.
-
 **--squash**
 
 Squash all of the new image's layers (including those inherited from a base image) into a single new layer.
@@ -378,7 +372,7 @@ Commands after the target stage will be skipped.
 
 **--tls-verify** *bool-value*
 
-Require HTTPS and verify certificates when talking to container registries (defaults to true).
+Require HTTPS and verify certificates when talking to container registries (defaults to true). (Not available for remote commands)
 
 **--ulimit**=*type*=*soft-limit*[:*hard-limit*]
 

--- a/docs/podman-container-runlabel.1.md
+++ b/docs/podman-container-runlabel.1.md
@@ -55,7 +55,7 @@ Any additional arguments will be appended to the command.
 **--authfile**
 
 Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -68,7 +68,7 @@ The runlabel command will not execute if --display is specified.
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
 
 **--creds**
 
@@ -92,17 +92,11 @@ Suppress output information when pulling images
 If a container exists of the default or given name, as needed it will be stopped, deleted and a new container will be
 created from this image.
 
-**--signature-policy="PATHNAME"**
-
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred
-
 **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
-TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf
+TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf (Not available for remote commands)
 
 ## Examples ##
 

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -40,6 +40,13 @@ error. It can even pretend to be a TTY (this is what most commandline
 executables expect) and pass along signals. The **-a** option can be set for
 each of stdin, stdout, and stderr.
 
+**--authfile**
+
+Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
+
+Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
+environment variable. `export REGISTRY_AUTH_FILE=path` (Not available for remote commands)
+
 **--blkio-weight**=*0*
 
 Block IO weight (relative weight) accepts a weight value between 10 and 1000.

--- a/docs/podman-load.1.md
+++ b/docs/podman-load.1.md
@@ -32,12 +32,6 @@ The remote client requires the use of this option.
 
 Suppress the progress output
 
-**--signature-policy="PATHNAME"**
-
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred
-
 **--help**, **-h**
 
 Print usage statement
@@ -49,7 +43,7 @@ $ podman load --quiet -i fedora.tar
 ```
 
 ```
-$ podman load -q --signature-policy /etc/containers/policy.json -i fedora.tar
+$ podman load -q -i fedora.tar
 ```
 
 ```

--- a/docs/podman-login.1.md
+++ b/docs/podman-login.1.md
@@ -35,7 +35,7 @@ Username for registry
 
 **--authfile**
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
+Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json (Not available for remote commands)
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -47,13 +47,13 @@ Return the logged-in user for the registry.  Return error if no login is found.
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
 
 **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
-TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
+TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf. (Not available for remote commands)
 
 **--help**, **-h**
 

--- a/docs/podman-logout.1.md
+++ b/docs/podman-logout.1.md
@@ -22,7 +22,7 @@ All the cached credentials can be removed by setting the **all** flag.
 
 **--authfile**
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
+Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json (Not available for remote commands)
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`

--- a/docs/podman-play-kube.1.md
+++ b/docs/podman-play-kube.1.md
@@ -11,7 +11,6 @@ podman-play-kube - Create pods and containers based on Kubernetes YAML
 [**--cert-dir**]
 [**--creds**]
 [***-q** | **--quiet**]
-[**--signature-policy**]
 [**--tls-verify**]
 kubernetes_input.yml
 
@@ -29,7 +28,7 @@ Note: HostPath volume types created by play kube will be given an SELinux privat
 **--authfile**
 
 Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -37,7 +36,7 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
 
 **--creds**
 
@@ -49,17 +48,11 @@ value can be entered.  The password is entered without echo.
 
 Suppress output information when pulling images
 
-**--signature-policy="PATHNAME"**
-
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred.
-
 **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
-TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
+TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf. (Not available for remote commands)
 
 **--help**, **-h**
 

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -54,7 +54,7 @@ Note: When using the all-tags flag, Podman will not iterate over the search regi
 **--authfile**
 
 Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -62,7 +62,7 @@ environment variable. `export REGISTRY_AUTH_FILE=path`
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
 
 **--creds**
 
@@ -74,17 +74,11 @@ value can be entered.  The password is entered without echo.
 
 Suppress output information when pulling images
 
-**--signature-policy="PATHNAME"**
-
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred
-
 **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
-TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
+TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf. (Not available for remote commands)
 
 **--help**, **-h**
 
@@ -93,7 +87,7 @@ Print usage statement
 ## EXAMPLES
 
 ```
-$ podman pull --signature-policy /etc/containers/policy.json alpine:latest
+$ podman pull alpine:latest
 Trying to pull registry.access.redhat.com/alpine:latest... Failed
 Trying to pull registry.fedoraproject.org/alpine:latest... Failed
 Trying to pull docker.io/library/alpine:latest...Getting image source signatures

--- a/docs/podman-push.1.md
+++ b/docs/podman-push.1.md
@@ -47,7 +47,7 @@ Image stored in local container/storage
 **--authfile**
 
 Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
-If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -61,7 +61,7 @@ value can be entered.  The password is entered without echo.
 **--cert-dir** *path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_.
+Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands) (Not available for remote commands)
 
 **--compress**
 
@@ -81,12 +81,6 @@ When writing the output image, suppress progress output
 
 Discard any pre-existing signatures in the image
 
-**--signature-policy="PATHNAME"**
-
-Pathname of a signature policy file to use.  It is not recommended that this
-option be used, as the default behavior of using the system-wide default policy
-(frequently */etc/containers/policy.json*) is most often preferred
-
 **--sign-by="KEY"**
 
 Add a signature at the destination using the specified key
@@ -95,7 +89,7 @@ Add a signature at the destination using the specified key
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used. If not specified,
-TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf.
+TLS verification will be used unless the target registry is listed as an insecure registry in registries.conf. (Not available for remote commands)
 
 ## EXAMPLE
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -54,6 +54,13 @@ error. It can even pretend to be a TTY (this is what most commandline
 executables expect) and pass along signals. The **-a** option can be set for
 each of stdin, stdout, and stderr.
 
+**--authfile**
+
+Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json (Not available for remote commands)
+
+Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
+environment variable. `export REGISTRY_AUTH_FILE=path`
+
 **--blkio-weight**=*0*
 
 Block IO weight (relative weight) accepts a weight value between 10 and 1000.

--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -27,7 +27,7 @@ Note, searching without a search term will only work for registries that impleme
 
 **--authfile**
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
+Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json (Not available for remote commands)
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path`
@@ -74,7 +74,7 @@ Do not truncate the output
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,
 then TLS verification will be used. If set to false, then TLS verification will not be used if needed. If not specified,
 default registries will be searched through (in /etc/containers/registries.conf), and TLS will be skipped if a default
-registry is listed in the insecure registries.
+registry is listed in the insecure registries. (Not available for remote commands)
 
 **--help**, **-h**
 

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -182,10 +182,7 @@ func (r *LocalRuntime) NewImageFromLocal(name string) (*ContainerImage, error) {
 // LoadFromArchiveReference creates an image from a local archive
 func (r *LocalRuntime) LoadFromArchiveReference(ctx context.Context, srcRef types.ImageReference, signaturePolicyPath string, writer io.Writer) ([]*ContainerImage, error) {
 	var iid string
-	// TODO We need to find a way to leak certDir, creds, and the tlsverify into this function, normally this would
-	// come from cli options but we don't want want those in here either.
-	tlsverify := true
-	reply, err := iopodman.PullImage().Send(r.Conn, varlink.More, srcRef.DockerReference().String(), "", "", signaturePolicyPath, &tlsverify)
+	reply, err := iopodman.PullImage().Send(r.Conn, varlink.More, srcRef.DockerReference().String())
 	if err != nil {
 		return nil, err
 	}
@@ -217,21 +214,7 @@ func (r *LocalRuntime) New(ctx context.Context, name, signaturePolicyPath, authf
 	if label != nil {
 		return nil, errors.New("the remote client function does not support checking a remote image for a label")
 	}
-	var (
-		tlsVerify    bool
-		tlsVerifyPtr *bool
-	)
-	if dockeroptions.DockerInsecureSkipTLSVerify == types.OptionalBoolFalse {
-		tlsVerify = true
-		tlsVerifyPtr = &tlsVerify
-
-	}
-	if dockeroptions.DockerInsecureSkipTLSVerify == types.OptionalBoolTrue {
-		tlsVerify = false
-		tlsVerifyPtr = &tlsVerify
-	}
-
-	reply, err := iopodman.PullImage().Send(r.Conn, varlink.More, name, dockeroptions.DockerCertPath, "", signaturePolicyPath, tlsVerifyPtr)
+	reply, err := iopodman.PullImage().Send(r.Conn, varlink.More, name)
 	if err != nil {
 		return nil, err
 	}
@@ -429,9 +412,8 @@ func (r *LocalRuntime) Build(ctx context.Context, c *cliconfig.BuildValues, opti
 		Quiet:                  options.Quiet,
 		RemoteIntermediateCtrs: options.RemoveIntermediateCtrs,
 		// ReportWriter:
-		RuntimeArgs:         options.RuntimeArgs,
-		SignaturePolicyPath: options.SignaturePolicyPath,
-		Squash:              options.Squash,
+		RuntimeArgs: options.RuntimeArgs,
+		Squash:      options.Squash,
 	}
 	// tar the file
 	outputFile, err := ioutil.TempFile("", "varlink_tar_send")
@@ -570,20 +552,7 @@ func (r *LocalRuntime) RemoveVolumes(ctx context.Context, c *cliconfig.VolumeRmV
 
 func (r *LocalRuntime) Push(ctx context.Context, srcName, destination, manifestMIMEType, authfile, signaturePolicyPath string, writer io.Writer, forceCompress bool, signingOptions image.SigningOptions, dockerRegistryOptions *image.DockerRegistryOptions, additionalDockerArchiveTags []reference.NamedTagged) error {
 
-	var (
-		tls       *bool
-		tlsVerify bool
-	)
-	if dockerRegistryOptions.DockerInsecureSkipTLSVerify == types.OptionalBoolTrue {
-		tlsVerify = false
-		tls = &tlsVerify
-	}
-	if dockerRegistryOptions.DockerInsecureSkipTLSVerify == types.OptionalBoolFalse {
-		tlsVerify = true
-		tls = &tlsVerify
-	}
-
-	reply, err := iopodman.PushImage().Send(r.Conn, varlink.More, srcName, destination, tls, signaturePolicyPath, "", dockerRegistryOptions.DockerCertPath, forceCompress, manifestMIMEType, signingOptions.RemoveSignatures, signingOptions.SignBy)
+	reply, err := iopodman.PushImage().Send(r.Conn, varlink.More, srcName, destination, forceCompress, manifestMIMEType, signingOptions.RemoveSignatures, signingOptions.SignBy)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Mark hidden all references to signature-policy
Default all uses of --authfile
Add --authfile support to podman run and podman create.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>