### PR TITLE
Add new exit codes to rm & rmi for running containers & dependencies

### DIFF
--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -67,7 +67,7 @@ func rmCmd(c *cliconfig.RmValues) error {
 	}
 
 	if len(failures) > 0 {
-		exitCode = 125
+		exitCode = 2
 	}
 
 	return printCmdResults(ok, failures)

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -74,6 +74,7 @@ func rmiCmd(c *cliconfig.RmiValues) error {
 				fmt.Printf("A container associated with containers/storage, i.e. via Buildah, CRI-O, etc., may be associated with this image: %-12.12s\n", img.ID())
 			}
 			if !adapter.IsImageNotFound(err) {
+				exitCode = 2
 				failureCnt++
 			}
 			if lastError != nil {

--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -62,7 +62,8 @@ podman rm -f --latest
 ## Exit Status
 **_0_** if all specified containers removed
 **_1_** if one of the specified containers did not exist, and no other failures
-**_125_** if command fails for a reason other then an container did not exist
+**_2_** if one of the specified containers is paused or running
+**_125_** if the command fails for a reason other than container did not exist or is paused/running
 
 ## SEE ALSO
 podman(1), podman-image-rm(1)

--- a/docs/podman-rmi.1.md
+++ b/docs/podman-rmi.1.md
@@ -43,7 +43,8 @@ podman rmi -a -f
 ## Exit Status
 **_0_** if all specified images removed
 **_1_** if one of the specified images did not exist, and no other failures
-**_125_** if command fails for a reason other then an image did not exist
+**_2_** if one of the specified images has child images or is being used by a container
+**_125_** if the command fails for a reason other than an image did not exist or is in use
 
 ## SEE ALSO
 podman(1)

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Podman checkpoint", func() {
 
 		result = podmanTest.Podman([]string{"rm", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(125))
+		Expect(result.ExitCode()).To(Equal(2))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		result = podmanTest.Podman([]string{"rm", "-f", cid})

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Podman pause", func() {
 		result = podmanTest.Podman([]string{"rm", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result.ExitCode()).To(Equal(125))
+		Expect(result.ExitCode()).To(Equal(2))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring(pausedState))
 
@@ -179,7 +179,7 @@ var _ = Describe("Podman pause", func() {
 
 		result = podmanTest.Podman([]string{"rm", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(125))
+		Expect(result.ExitCode()).To(Equal(2))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 
 		result = podmanTest.Podman([]string{"rm", "-f", cid})

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Podman rm", func() {
 
 		result := podmanTest.Podman([]string{"rm", cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(125))
+		Expect(result.ExitCode()).To(Equal(2))
 	})
 
 	It("podman rm created container", func() {

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Podman rmi", func() {
 
 		session = podmanTest.Podman([]string{"rmi", "-f", untaggedImg})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session.ExitCode()).To(Equal(2))
 	})
 
 	It("podman rmi image that is created from another named imaged", func() {


### PR DESCRIPTION
This enables programs and scripts wrapping the podman command to handle
'podman rm' and 'podman rmi' failures caused by paused or running
containers or due to images having other child images or dependent
containers. These errors are common enough that it makes sense to have
a more machine readable way of detecting them than parsing the standard
error output.

Signed-off-by: Ondrej Zoder <ozoder@redhat.com>

(fixups for #2945)