### PR TITLE
Fix libpod.conf option ordering

### DIFF
--- a/libpod.conf
+++ b/libpod.conf
@@ -99,6 +99,10 @@ num_locks = 2048
 # Uncomment to change location from this default.
 #volume_path = "/var/lib/containers/storage/volumes"
 
+# Selects which logging mechanism to use for Podman events.  Valid values
+# are `journald` or `file`.
+# events_logger = "journald"
+
 # Default OCI runtime
 runtime = "runc"
 
@@ -114,6 +118,8 @@ runc = [
 	    "/usr/lib/cri-o-runc/sbin/runc"
 ]
 
-# Selects which logging mechanism to use for Podman events.  Valid values
-# are `journald` or `file`.
-# events_logger = "journald"
+# The [runtimes] table MUST be the last thing in this file.
+# (Unless another table is added)
+# TOML does not provide a way to end a table other than a further table being
+# defined, so every key hereafter will be part of [runtimes] and not the main
+# config.


### PR DESCRIPTION
Adding the journald configuration broke decoding the default libpod.conf, because it was after the [runtimes] table (and was being interpreted as a member of the table, and not the larger config). We can't easily fix this on the TOML side, so our best bet is to move it above the table and add a comment to try and make sure this doesn't happen again.