### PR TITLE
network: raise a clearer error when using CNI

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/libpod/pkg/firewall"
 	"github.com/containers/libpod/pkg/inspect"
 	"github.com/containers/libpod/pkg/netns"
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -100,6 +101,9 @@ func (r *Runtime) configureNetNS(ctr *Container, ctrNS ns.NetNS) ([]*cnitypes.Re
 
 // Create and configure a new network namespace for a container
 func (r *Runtime) createNetNS(ctr *Container) (n ns.NetNS, q []*cnitypes.Result, err error) {
+	if rootless.IsRootless() {
+		return nil, nil, errors.New("cannot configure a new network namespace in rootless mode, only --network=slirp4netns is supported")
+	}
 	ctrNS, err := netns.NewNS()
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "error creating network namespace for container %s", ctr.ID())


### PR DESCRIPTION
print a clearer error message when an unprivileged user attempts to
create a network using CNI.

Closes: https://github.com/containers/libpod/issues/3118

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>