### PR TITLE
man: podman-mount: only vfs in rootless mode

### DIFF
--- a/docs/podman-mount.1.md
+++ b/docs/podman-mount.1.md
@@ -13,6 +13,8 @@ accessed from the host, and returns its location.
 If you execute the command without any arguments, the tool will list all of the
 currently mounted containers.
 
+Note that when running in rootless mode, the mount command only works with the vfs storage driver.
+
 ## RETURN VALUE
 The location of the mounted file system.  On error an empty string and errno is
 returned.


### PR DESCRIPTION
Document that rootless podman-mount only works with vfs.  The error
message from podman-mount only states that the current driver != vfs
does not work.  The man page seems a proper place to tell users what is
supported.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>