### PR TITLE
oci: fix race when the container exits before start returns

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1029,6 +1029,13 @@ func (c *Container) start() error {
 
 	c.state.State = ContainerStateRunning
 
+	// While we hold the lock, ensure the container is still running.
+	// The container could have already stopped by the time "$runtime start"
+	// exits and we mistakenly report it as "running".
+	if err := c.runtime.state.UpdateContainer(c); err != nil {
+		return err
+	}
+
 	if c.config.HealthCheckConfig != nil {
 		if err := c.updateHealthStatus(HealthCheckStarting); err != nil {
 			logrus.Error(err)


### PR DESCRIPTION
fix a race when the container process exits faster than we are
notified from the OCI runtime start command.  When it happens, the
cleanup process exits immediately as the container is reported as
running.  Do the check while we hold the lock, so we won't release it
with an invalid status.

Reproducer:
NOTIFY_SOCKET=/run/user/1000/notify podman run fedora sh -c ' echo hello'

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>