### PR TITLE
Ensure that start() in StartAndAttach() is locked

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -292,12 +292,14 @@ testing_task:
     setup_environment_script: '$SCRIPT_BASE/setup_environment.sh |& ${TIMESTAMP}'
     unit_test_script: '$SCRIPT_BASE/unit_test.sh |& ${TIMESTAMP}'
     integration_test_script: '$SCRIPT_BASE/integration_test.sh |& ${TIMESTAMP}'
+    ginkgo_node_logs_script: 'cat $CIRRUS_WORKING_DIR/test/e2e/ginkgo-node-*.log || echo "Ginkgo node logs not found"'
     audit_log_script: 'cat /var/log/audit/audit.log || cat /var/log/kern.log'
     journalctl_b_script: 'journalctl -b'
 
     on_failure:
         failed_master_script: '$CIRRUS_WORKING_DIR/$SCRIPT_BASE/notice_master_failure.sh'
         # Job has already failed, don't fail again and miss collecting data
+        failed_ginkgo_node_logs_script: 'cat $CIRRUS_WORKING_DIR/test/e2e/ginkgo-node-*.log || echo "Ginkgo node logs not found"'
         failed_audit_log_script: 'cat /var/log/audit/audit.log || cat /var/log/kern.log || echo "Uh oh, cat audit.log failed"'
         failed_journalctl_b_script: 'journalctl -b || echo "Uh oh, journalctl -b failed"'
 

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ localunit: test/goecho/goecho varlink_generate
 	./contrib/cirrus/lib.sh.t
 
 ginkgo:
-	ginkgo -v -tags "$(BUILDTAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes 3 test/e2e/.
+	ginkgo -v -tags "$(BUILDTAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes 3 -debug test/e2e/.
 
 ginkgo-remote:
 	ginkgo -v -tags "$(BUILDTAGS) remoteclient" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ popularized by Kubernetes.  Libpod also contains the Pod Manager tool `(Podman)`
 
 ## Overview and scope
 
-At a high level, the scope of libpod and podman is the following:
+At a high level, the scope of libpod and Podman is the following:
 
 * Support multiple image formats including the OCI and Docker image formats.
 * Support for multiple means to download images including trust & image verification.

--- a/libpod/container_attach_unsupported.go
+++ b/libpod/container_attach_unsupported.go
@@ -3,9 +3,11 @@
 package libpod
 
 import (
+	"sync"
+
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool) error {
+func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, wg *sync.WaitGroup) error {
 	return ErrNotImplemented
 }

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -40,15 +40,11 @@ var _ = Describe("Podman cp", func() {
 
 	It("podman cp file", func() {
 		path, err := os.Getwd()
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).To(BeNil())
 		filePath := filepath.Join(path, "cp_test.txt")
 		fromHostToContainer := []byte("copy from host to container")
 		err = ioutil.WriteFile(filePath, fromHostToContainer, 0644)
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"create", ALPINE, "cat", "foo"})
 		session.WaitWithDefaultTimeout()
@@ -69,15 +65,12 @@ var _ = Describe("Podman cp", func() {
 
 	It("podman cp file to dir", func() {
 		path, err := os.Getwd()
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).To(BeNil())
 		filePath := filepath.Join(path, "cp_test.txt")
 		fromHostToContainer := []byte("copy from host to container directory")
 		err = ioutil.WriteFile(filePath, fromHostToContainer, 0644)
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).To(BeNil())
+
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls", "foodir/"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -97,14 +90,10 @@ var _ = Describe("Podman cp", func() {
 
 	It("podman cp dir to dir", func() {
 		path, err := os.Getwd()
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).To(BeNil())
 		testDirPath := filepath.Join(path, "TestDir")
 		err = os.Mkdir(testDirPath, 0777)
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls", "/foodir"})
 		session.WaitWithDefaultTimeout()
@@ -124,19 +113,13 @@ var _ = Describe("Podman cp", func() {
 
 	It("podman cp stdin/stdout", func() {
 		path, err := os.Getwd()
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).To(BeNil())
 		testDirPath := filepath.Join(path, "TestDir")
 		err = os.Mkdir(testDirPath, 0777)
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).To(BeNil())
 		cmd := exec.Command("tar", "-zcvf", "file.tar.gz", testDirPath)
 		_, err = cmd.Output()
-		if err != nil {
-			os.Exit(1)
-		}
+		Expect(err).To(BeNil())
 
 		session := podmanTest.Podman([]string{"create", ALPINE, "ls", "foo"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
StartAndAttach() runs start() in a goroutine, which can allow it to fire after the caller returns - and thus, after the defer to unlock the container lock has fired.

The start() call _must_ occur while the container is locked, or else state inconsistencies may occur.

Fixes #3114