### PR TITLE
set default event logger based on build tags

### DIFF
--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -12,6 +12,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// DefaultEventerType is journald when systemd is available
+const DefaultEventerType = Journald
+
 // EventJournalD is the journald implementation of an eventer
 type EventJournalD struct {
 	options EventerOptions

--- a/libpod/events/journal_unsupported.go
+++ b/libpod/events/journal_unsupported.go
@@ -2,6 +2,9 @@
 
 package events
 
+// DefaultEventerType is logfile when systemd is not present
+const DefaultEventerType = LogFile
+
 // newEventJournalD always returns an error if libsystemd not found
 func newEventJournalD(options EventerOptions) (Eventer, error) {
 	return nil, ErrNoJournaldLogging

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -304,7 +304,7 @@ func defaultRuntimeConfig() (RuntimeConfig, error) {
 		EnablePortReservation: true,
 		EnableLabeling:        true,
 		NumLocks:              2048,
-		EventsLogger:          "journald",
+		EventsLogger:          events.DefaultEventerType.String(),
 	}, nil
 }
 


### PR DESCRIPTION
once the default event logger was removed from libpod.conf, we need to
set the default based on whether the systemd build tag is used or not.

Signed-off-by: baude <bbaude@redhat.com>