### PR TITLE
unshare: some cleanups and define CONTAINERS_{RUNROOT,GRAPHROOT}

### DIFF
--- a/cmd/podman/unshare.go
+++ b/cmd/podman/unshare.go
@@ -3,9 +3,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 
+	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/containers/libpod/cmd/podman/libpodruntime"
+	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -17,39 +21,59 @@ var (
 		Use:   "unshare [flags] [COMMAND [ARG]]",
 		Short: "Run a command in a modified user namespace",
 		Long:  unshareDescription,
-		RunE:  unshareCmd,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			unshareCommand.InputArgs = args
+			unshareCommand.GlobalFlags = MainGlobalOpts
+			return unshareCmd(&unshareCommand)
+		},
 		Example: `podman unshare id
   podman unshare cat /proc/self/uid_map,
   podman unshare podman-script.sh`,
 	}
+	unshareCommand cliconfig.PodmanCommand
 )
 
 func init() {
-	_unshareCommand.SetUsageTemplate(UsageTemplate())
+	unshareCommand.Command = _unshareCommand
+	unshareCommand.SetHelpTemplate(HelpTemplate())
+	unshareCommand.SetUsageTemplate(UsageTemplate())
 	flags := _unshareCommand.Flags()
 	flags.SetInterspersed(false)
 }
 
-func unshareEnv() []string {
-	return append(os.Environ(), "_CONTAINERS_USERNS_CONFIGURED=done")
+func unshareEnv(config *libpod.RuntimeConfig) []string {
+	return append(os.Environ(), "_CONTAINERS_USERNS_CONFIGURED=done",
+		fmt.Sprintf("CONTAINERS_GRAPHROOT=%s", config.StorageConfig.GraphRoot),
+		fmt.Sprintf("CONTAINERS_RUNROOT=%s", config.StorageConfig.RunRoot))
 }
 
 // unshareCmd execs whatever using the ID mappings that we want to use for ourselves
-func unshareCmd(c *cobra.Command, args []string) error {
+func unshareCmd(c *cliconfig.PodmanCommand) error {
+
 	if isRootless := rootless.IsRootless(); !isRootless {
 		return errors.Errorf("please use unshare with rootless")
 	}
 	// exec the specified command, if there is one
-	if len(args) < 1 {
+	if len(c.InputArgs) < 1 {
 		// try to exec the shell, if one's set
 		shell, shellSet := os.LookupEnv("SHELL")
 		if !shellSet {
 			return errors.Errorf("no command specified and no $SHELL specified")
 		}
-		args = []string{shell}
+		c.InputArgs = []string{shell}
 	}
-	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Env = unshareEnv()
+
+	runtime, err := libpodruntime.GetRuntime(getContext(), c)
+	if err != nil {
+		return err
+	}
+	runtimeConfig, err := runtime.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(c.InputArgs[0], c.InputArgs[1:]...)
+	cmd.Env = unshareEnv(runtimeConfig)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/docs/podman-unshare.1.md
+++ b/docs/podman-unshare.1.md
@@ -19,6 +19,11 @@ manually clearing storage and other data related to images and containers.
 It is also useful if you want to use the `podman mount` command.  If an unprivileged users wants to mount and work with a container, then they need to execute
 podman unshare.  Executing `podman mount` fails for unprivileged users unless the user is running inside a `podman unshare` session.
 
+The unshare session defines two environment variables:
+
+**CONTAINERS_GRAPHROOT** the path to the persistent containers data.
+**CONTAINERS_RUNROOT** the path to the volatile containers data.
+
 ## EXAMPLE
 
 ```


### PR DESCRIPTION
define two environment variables, that simplify the task of cleaning up the storage, as we can do something like:

podman unshare sh -c 'rm -rf $CONTAINERS_GRAPHROOT $CONTAINERS_RUNROOT'
