### PR TITLE
Minor fix splitting env vars in podman-commit

### DIFF
--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -99,7 +99,7 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 	// Should we store the ENV we actually want in the spec separately?
 	if c.config.Spec.Process != nil {
 		for _, e := range c.config.Spec.Process.Env {
-			splitEnv := strings.Split(e, "=")
+			splitEnv := strings.SplitN(e, "=", 2)
 			importBuilder.SetEnv(splitEnv[0], splitEnv[1])
 		}
 	}


### PR DESCRIPTION
`string.Split()` splits into slice of size greater than 2
which may result in loss of environment variables

fixes #3132
