### PR TITLE
Add connection information to podman-remote info

### DIFF
--- a/cmd/podman/info.go
+++ b/cmd/podman/info.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/containers/libpod/version"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -60,7 +61,16 @@ func infoCmd(c *cliconfig.InfoValues) error {
 	if err != nil {
 		return errors.Wrapf(err, "error getting info")
 	}
+
 	if runtime.Remote {
+		endpoint, err := runtime.RemoteEndpoint()
+		if err != nil {
+			logrus.Errorf("Failed to obtain server connection: %s", err.Error())
+		} else {
+			remoteClientInfo["Connection"] = endpoint.Connection
+			remoteClientInfo["Connection Type"] = endpoint.Type.String()
+		}
+
 		remoteClientInfo["RemoteAPI Version"] = version.RemoteAPIVersion
 		remoteClientInfo["Podman Version"] = version.Version
 		remoteClientInfo["OS Arch"] = fmt.Sprintf("%s/%s", rt.GOOS, rt.GOARCH)

--- a/pkg/adapter/client.go
+++ b/pkg/adapter/client.go
@@ -10,44 +10,56 @@ import (
 	"github.com/varlink/go/varlink"
 )
 
-type VarlinkConnectionInfo struct {
-	RemoteUserName string
-	RemoteHost     string
-	VarlinkAddress string
-}
+var remoteEndpoint *Endpoint
 
-// Connect provides a varlink connection
-func (r RemoteRuntime) Connect() (*varlink.Connection, error) {
-	var (
-		err        error
-		connection *varlink.Connection
-	)
-
-	logLevel := r.cmd.LogLevel
+func (r RemoteRuntime) RemoteEndpoint() (remoteEndpoint *Endpoint, err error) {
+	if remoteEndpoint == nil {
+		remoteEndpoint = &Endpoint{Unknown, ""}
+	} else {
+		return remoteEndpoint, nil
+	}
 
 	// I'm leaving this here for now as a document of the birdge format.  It can be removed later once the bridge
 	// function is more flushed out.
-	//bridge := `ssh -T root@192.168.122.1 "/usr/bin/varlink -A '/usr/bin/podman varlink \$VARLINK_ADDRESS' bridge"`
+	// bridge := `ssh -T root@192.168.122.1 "/usr/bin/varlink -A '/usr/bin/podman varlink \$VARLINK_ADDRESS' bridge"`
 	if len(r.cmd.RemoteHost) > 0 {
 		// The user has provided a remote host endpoint
 		if len(r.cmd.RemoteUserName) < 1 {
 			return nil, errors.New("you must provide a username when providing a remote host name")
 		}
-		bridge := fmt.Sprintf(`ssh -T %s@%s /usr/bin/varlink -A \'/usr/bin/podman --log-level=%s varlink \\\$VARLINK_ADDRESS\' bridge`, r.cmd.RemoteUserName, r.cmd.RemoteHost, logLevel)
-		connection, err = varlink.NewBridge(bridge)
+		remoteEndpoint.Type = BridgeConnection
+		remoteEndpoint.Connection = fmt.Sprintf(
+			`ssh -T %s@%s /usr/bin/varlink -A \'/usr/bin/podman --log-level=%s varlink \\\$VARLINK_ADDRESS\' bridge`,
+			r.cmd.RemoteUserName, r.cmd.RemoteHost, r.cmd.LogLevel)
+
 	} else if bridge := os.Getenv("PODMAN_VARLINK_BRIDGE"); bridge != "" {
-		connection, err = varlink.NewBridge(bridge)
+		remoteEndpoint.Type = BridgeConnection
+		remoteEndpoint.Connection = bridge
 	} else {
 		address := os.Getenv("PODMAN_VARLINK_ADDRESS")
 		if address == "" {
 			address = DefaultAddress
 		}
-		connection, err = varlink.NewConnection(address)
+		remoteEndpoint.Type = DirectConnection
+		remoteEndpoint.Connection = address
 	}
+	return
+}
+
+// Connect provides a varlink connection
+func (r RemoteRuntime) Connect() (*varlink.Connection, error) {
+	ep, err := r.RemoteEndpoint()
 	if err != nil {
 		return nil, err
 	}
-	return connection, nil
+
+	switch ep.Type {
+	case DirectConnection:
+		return varlink.NewConnection(ep.Connection)
+	case BridgeConnection:
+		return varlink.NewBridge(ep.Connection)
+	}
+	return nil, errors.New(fmt.Sprintf("Unable to determine type of varlink connection: %s", ep.Connection))
 }
 
 // RefreshConnection is used to replace the current r.Conn after things like

--- a/pkg/adapter/client_config.go
+++ b/pkg/adapter/client_config.go
@@ -2,3 +2,35 @@ package adapter
 
 // DefaultAddress is the default address of the varlink socket
 const DefaultAddress = "unix:/run/podman/io.podman"
+
+// EndpointType declares the type of server connection
+type EndpointType int
+
+// Enum of connection types
+const (
+	Unknown          = iota - 1 // Unknown connection type
+	BridgeConnection            // BridgeConnection proxy connection via ssh
+	DirectConnection            // DirectConnection socket connection to server
+)
+
+// String prints ASCII string for EndpointType
+func (e EndpointType) String() string {
+	// declare an array of strings
+	// ... operator counts how many
+	// items in the array (7)
+	names := [...]string{
+		"BridgeConnection",
+		"DirectConnection",
+	}
+
+	if e < BridgeConnection || e > DirectConnection {
+		return "Unknown"
+	}
+	return names[e]
+}
+
+// Endpoint type and connection string to use
+type Endpoint struct {
+	Type       EndpointType
+	Connection string
+}

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -398,3 +398,8 @@ func (r *LocalRuntime) GetPodsByStatus(statuses []string) ([]*libpod.Pod, error)
 func (r *LocalRuntime) GetVersion() (libpod.Version, error) {
 	return libpod.GetVersion()
 }
+
+// RemoteEndpoint resolve interface requirement
+func (r *LocalRuntime) RemoteEndpoint() (*Endpoint, error) {
+	return nil, errors.New("RemoteEndpoint() not implemented for local connection")
+}


### PR DESCRIPTION
Refactor client code to break out building connection string from
making the connection.

Example:

client:
  Connection: unix:/run/podman/io.podman
  Connection Type: DirectConnection
  .
  :

Signed-off-by: Jhon Honce <jhonce@redhat.com>