### PR TITLE
Revert "Add VarlinkCall.RequiresUpgrade() type and method"

### DIFF
--- a/pkg/varlinkapi/config.go
+++ b/pkg/varlinkapi/config.go
@@ -21,7 +21,3 @@ func New(cli *cliconfig.PodmanCommand, runtime *libpod.Runtime) *iopodman.Varlin
 	lp := LibpodAPI{Cli: cli.Command, Runtime: runtime}
 	return iopodman.VarlinkNew(&lp)
 }
-
-type VarlinkCall struct {
-	*iopodman.VarlinkCall
-}

--- a/pkg/varlinkapi/util.go
+++ b/pkg/varlinkapi/util.go
@@ -13,11 +13,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/storage/pkg/archive"
-	"github.com/pkg/errors"
-)
-
-var (
-	ErrUpgradedConnectionRequired = errors.New("peer must use upgraded connection for operation")
 )
 
 // getContext returns a non-nil, empty context
@@ -198,15 +193,5 @@ func makePsOpts(inOpts iopodman.PsOpts) shared.PsOptions {
 		Sort:      derefString(inOpts.Sort),
 		Namespace: true,
 		Sync:      derefBool(inOpts.Sync),
-	}
-}
-
-// RequiresUpgrade tests if varlink connection has been marked for upgrade.
-func (v *VarlinkCall) RequiresUpgrade() error {
-	if v.WantsUpgrade() {
-		// A nil is sent to the peer as required by the varlink protocol.
-		return v.Reply(nil)
-	} else {
-		return ErrUpgradedConnectionRequired
 	}
 }


### PR DESCRIPTION
This reverts commit bd3154fcf6a48b37cfde5d9b1226900cd863c0d9.

Commit in question may be breaking upstream CI.

Don't merge this yet, just testing to see if this commit was the one that caused the break on master