### PR TITLE
remote: version: fix nil dereference

### DIFF
--- a/cmd/podman/version.go
+++ b/cmd/podman/version.go
@@ -70,7 +70,7 @@ func versionCmd(c *cliconfig.VersionValues) error {
 	if remote {
 		fmt.Fprintf(w, "\nService:\n")
 
-		runtime, err := adapter.GetRuntime(getContext(), nil)
+		runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 		if err != nil {
 			return errors.Wrapf(err, "could not get runtime")
 		}


### PR DESCRIPTION
Fix a nil dereference by passing the PodmanCommand to GetRuntime().

Fixes: #3145
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>