### PR TITLE
use imagecaches for local tests

### DIFF
--- a/test/e2e/attach_test.go
+++ b/test/e2e/attach_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Podman attach", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Podman checkpoint", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 		// Check if the runtime implements checkpointing. Currently only
 		// runc's checkpoint/restore implementation is supported.
 		cmd := exec.Command(podmanTest.OCIRuntime, "checkpoint", "-h")
@@ -221,7 +221,6 @@ var _ = Describe("Podman checkpoint", func() {
 	})
 
 	It("podman checkpoint container with established tcp connections", func() {
-		podmanTest.RestoreArtifact(redis)
 		session := podmanTest.Podman([]string{"run", "-it", "--security-opt", "seccomp=unconfined", "-d", redis})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman commit", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -7,4 +7,5 @@ var (
 	infra         = "k8s.gcr.io/pause:3.1"
 	BB            = "docker.io/library/busybox:latest"
 	healthcheck   = "docker.io/libpod/alpine_healthcheck:latest"
+	ImageCacheDir = "/tmp/podman/imagecachedir"
 )

--- a/test/e2e/config_amd64.go
+++ b/test/e2e/config_amd64.go
@@ -1,7 +1,9 @@
 package integration
 
 var (
+	STORAGE_FS               = "vfs"
 	STORAGE_OPTIONS          = "--storage-driver vfs"
+	ROOTLESS_STORAGE_FS      = "vfs"
 	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"
 	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, registry, infra, labels, healthcheck}
 	nginx                    = "quay.io/libpod/alpine_nginx:latest"

--- a/test/e2e/config_ppc64le.go
+++ b/test/e2e/config_ppc64le.go
@@ -1,7 +1,9 @@
 package integration
 
 var (
+	STORAGE_FS               = "overlay"
 	STORAGE_OPTIONS          = "--storage-driver overlay"
+	ROOTLESS_STORAGE_FS      = "vfs"
 	ROOTLESS_STORAGE_OPTIONS = "--storage-driver vfs"
 	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, infra, labels}
 	nginx                    = "quay.io/libpod/alpine_nginx-ppc64le:latest"

--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 		// Cleanup the CNI networks used by the tests
 		os.RemoveAll("/var/lib/cni/networks/podman")
 	})

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman create", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Podman diff", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Podman events", func() {
 			os.Exit(1)
 		}
 		podmanTest = PodmanTestCreate(tempdir)
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman exec", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {
@@ -123,7 +123,6 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec with user only in container", func() {
-		podmanTest.RestoreArtifact(fedoraMinimal)
 		testUser := "test123"
 		setup := podmanTest.Podman([]string{"run", "--name", "test1", "-d", fedoraMinimal, "sleep", "60"})
 		setup.WaitWithDefaultTimeout()

--- a/test/e2e/exists_test.go
+++ b/test/e2e/exists_test.go
@@ -48,7 +48,6 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session.ExitCode()).To(Equal(1))
 	})
 	It("podman container exists in local storage by name", func() {
-		SkipIfRemote()
 		setup := podmanTest.RunTopContainer("foobar")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
@@ -58,7 +57,6 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 	It("podman container exists in local storage by container ID", func() {
-		SkipIfRemote()
 		setup := podmanTest.RunTopContainer("")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
@@ -69,7 +67,6 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 	It("podman container exists in local storage by short container ID", func() {
-		SkipIfRemote()
 		setup := podmanTest.RunTopContainer("")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
@@ -80,14 +77,12 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 	It("podman container does not exist in local storage", func() {
-		SkipIfRemote()
 		session := podmanTest.Podman([]string{"container", "exists", "foobar"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(1))
 	})
 
 	It("podman pod exists in local storage by name", func() {
-		SkipIfRemote()
 		setup, rc, _ := podmanTest.CreatePod("foobar")
 		setup.WaitWithDefaultTimeout()
 		Expect(rc).To(Equal(0))
@@ -97,7 +92,6 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 	It("podman pod exists in local storage by container ID", func() {
-		SkipIfRemote()
 		setup, rc, podID := podmanTest.CreatePod("")
 		setup.WaitWithDefaultTimeout()
 		Expect(rc).To(Equal(0))
@@ -107,7 +101,6 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 	It("podman pod exists in local storage by short container ID", func() {
-		SkipIfRemote()
 		setup, rc, podID := podmanTest.CreatePod("")
 		setup.WaitWithDefaultTimeout()
 		Expect(rc).To(Equal(0))
@@ -117,6 +110,7 @@ var _ = Describe("Podman image|container exists", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 	It("podman pod does not exist in local storage", func() {
+		// The exit code for non-existing pod is incorrect (125 vs 1)
 		SkipIfRemote()
 		session := podmanTest.Podman([]string{"pod", "exists", "foobar"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/export_test.go
+++ b/test/e2e/export_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Podman export", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman generate kube", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Podman generate systemd", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -24,7 +24,8 @@ var _ = Describe("Podman healthcheck run", func() {
 			os.Exit(1)
 		}
 		podmanTest = PodmanTestCreate(tempdir)
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.Setup()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {
@@ -42,7 +43,6 @@ var _ = Describe("Podman healthcheck run", func() {
 	})
 
 	It("podman healthcheck on valid container", func() {
-		podmanTest.RestoreArtifact(healthcheck)
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", healthcheck})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -63,7 +63,6 @@ var _ = Describe("Podman healthcheck run", func() {
 	})
 
 	It("podman healthcheck on stopped container", func() {
-		podmanTest.RestoreArtifact(healthcheck)
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", healthcheck, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/history_test.go
+++ b/test/e2e/history_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman history", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman images", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {
@@ -44,14 +44,15 @@ var _ = Describe("Podman images", func() {
 	})
 
 	It("podman images with no images prints header", func() {
-		rmi := podmanTest.Podman([]string{"rmi", "-a"})
+		rmi := podmanTest.PodmanNoCache([]string{"rmi", "-a"})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"images"})
+		session := podmanTest.PodmanNoCache([]string{"images"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(1))
+		Expect(session.LineInOutputContains("REPOSITORY")).To(BeTrue())
 	})
 
 	It("podman image List", func() {
@@ -65,15 +66,16 @@ var _ = Describe("Podman images", func() {
 
 	It("podman images with multiple tags", func() {
 		// tag "docker.io/library/alpine:latest" to "foo:{a,b,c}"
-		session := podmanTest.Podman([]string{"tag", ALPINE, "foo:a", "foo:b", "foo:c"})
+		podmanTest.RestoreAllArtifacts()
+		session := podmanTest.PodmanNoCache([]string{"tag", ALPINE, "foo:a", "foo:b", "foo:c"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		// tag "foo:c" to "bar:{a,b}"
-		session = podmanTest.Podman([]string{"tag", "foo:c", "bar:a", "bar:b"})
+		session = podmanTest.PodmanNoCache([]string{"tag", "foo:c", "bar:a", "bar:b"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		// check all previous and the newly tagged images
-		session = podmanTest.Podman([]string{"images"})
+		session = podmanTest.PodmanNoCache([]string{"images"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session.LineInOutputContainsTag("docker.io/library/alpine", "latest")
@@ -83,7 +85,7 @@ var _ = Describe("Podman images", func() {
 		session.LineInOutputContainsTag("foo", "c")
 		session.LineInOutputContainsTag("bar", "a")
 		session.LineInOutputContainsTag("bar", "b")
-		session = podmanTest.Podman([]string{"images", "-qn"})
+		session = podmanTest.PodmanNoCache([]string{"images", "-qn"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(BeNumerically("==", 2))
@@ -119,19 +121,20 @@ var _ = Describe("Podman images", func() {
 	})
 
 	It("podman images filter by image name", func() {
-		session := podmanTest.Podman([]string{"images", "-q", ALPINE})
+		podmanTest.RestoreAllArtifacts()
+		session := podmanTest.PodmanNoCache([]string{"images", "-q", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(1))
 
-		session = podmanTest.Podman([]string{"tag", ALPINE, "foo:a"})
+		session = podmanTest.PodmanNoCache([]string{"tag", ALPINE, "foo:a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"tag", BB, "foo:b"})
+		session = podmanTest.PodmanNoCache([]string{"tag", BB, "foo:b"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"images", "-q", "foo"})
+		session = podmanTest.PodmanNoCache([]string{"images", "-q", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(2))
@@ -141,24 +144,25 @@ var _ = Describe("Podman images", func() {
 		if podmanTest.RemoteTest {
 			Skip("Does not work on remote client")
 		}
-		result := podmanTest.Podman([]string{"images", "-q", "-f", "reference=docker.io*"})
+		podmanTest.RestoreAllArtifacts()
+		result := podmanTest.PodmanNoCache([]string{"images", "-q", "-f", "reference=docker.io*"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(len(result.OutputToStringArray())).To(Equal(2))
 
-		retapline := podmanTest.Podman([]string{"images", "-f", "reference=a*pine"})
+		retapline := podmanTest.PodmanNoCache([]string{"images", "-f", "reference=a*pine"})
 		retapline.WaitWithDefaultTimeout()
 		Expect(retapline.ExitCode()).To(Equal(0))
 		Expect(len(retapline.OutputToStringArray())).To(Equal(2))
 		Expect(retapline.LineInOutputContains("alpine"))
 
-		retapline = podmanTest.Podman([]string{"images", "-f", "reference=alpine"})
+		retapline = podmanTest.PodmanNoCache([]string{"images", "-f", "reference=alpine"})
 		retapline.WaitWithDefaultTimeout()
 		Expect(retapline.ExitCode()).To(Equal(0))
 		Expect(len(retapline.OutputToStringArray())).To(Equal(2))
 		Expect(retapline.LineInOutputContains("alpine"))
 
-		retnone := podmanTest.Podman([]string{"images", "-q", "-f", "reference=bogus"})
+		retnone := podmanTest.PodmanNoCache([]string{"images", "-q", "-f", "reference=bogus"})
 		retnone.WaitWithDefaultTimeout()
 		Expect(retnone.ExitCode()).To(Equal(0))
 		Expect(len(retnone.OutputToStringArray())).To(Equal(0))
@@ -182,14 +186,15 @@ RUN apk update && apk add man
 		if podmanTest.RemoteTest {
 			Skip("Does not work on remote client")
 		}
-		rmi := podmanTest.Podman([]string{"rmi", "busybox"})
+		podmanTest.RestoreAllArtifacts()
+		rmi := podmanTest.PodmanNoCache([]string{"rmi", "busybox"})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 
 		dockerfile := `FROM docker.io/library/alpine:latest
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
-		result := podmanTest.Podman([]string{"images", "-q", "-f", "after=docker.io/library/alpine:latest"})
+		result := podmanTest.PodmanNoCache([]string{"images", "-q", "-f", "after=docker.io/library/alpine:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(len(result.OutputToStringArray())).To(Equal(0))
@@ -199,14 +204,15 @@ RUN apk update && apk add man
 		if podmanTest.RemoteTest {
 			Skip("Does not work on remote client")
 		}
-		rmi := podmanTest.Podman([]string{"image", "rm", "busybox"})
+		podmanTest.RestoreAllArtifacts()
+		rmi := podmanTest.PodmanNoCache([]string{"image", "rm", "busybox"})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 
 		dockerfile := `FROM docker.io/library/alpine:latest
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
-		result := podmanTest.Podman([]string{"image", "list", "-q", "-f", "after=docker.io/library/alpine:latest"})
+		result := podmanTest.PodmanNoCache([]string{"image", "list", "-q", "-f", "after=docker.io/library/alpine:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(len(result.OutputToStringArray())).To(Equal(0))
@@ -282,18 +288,19 @@ RUN apk update && apk add man
 		if podmanTest.RemoteTest {
 			Skip("Does not work on remote client")
 		}
+		podmanTest.RestoreAllArtifacts()
 		dockerfile := `FROM docker.io/library/alpine:latest
 RUN mkdir hello
 RUN touch test.txt
 ENV foo=bar
 `
 		podmanTest.BuildImage(dockerfile, "test", "true")
-		session := podmanTest.Podman([]string{"images"})
+		session := podmanTest.PodmanNoCache([]string{"images"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(4))
 
-		session2 := podmanTest.Podman([]string{"images", "--all"})
+		session2 := podmanTest.PodmanNoCache([]string{"images", "--all"})
 		session2.WaitWithDefaultTimeout()
 		Expect(session2.ExitCode()).To(Equal(0))
 		Expect(len(session2.OutputToStringArray())).To(Equal(6))

--- a/test/e2e/import_test.go
+++ b/test/e2e/import_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman import", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {
@@ -62,14 +62,11 @@ var _ = Describe("Podman import", func() {
 		export.WaitWithDefaultTimeout()
 		Expect(export.ExitCode()).To(Equal(0))
 
-		importImage := podmanTest.Podman([]string{"import", outfile})
+		importImage := podmanTest.PodmanNoCache([]string{"import", outfile})
 		importImage.WaitWithDefaultTimeout()
 		Expect(importImage.ExitCode()).To(Equal(0))
 
-		results := podmanTest.Podman([]string{"images", "-q"})
-		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
-		Expect(len(results.OutputToStringArray())).To(Equal(3))
+		Expect(podmanTest.ImageExistsInMainStore(importImage.OutputToString())).To(BeTrue())
 	})
 
 	It("podman import with message flag", func() {

--- a/test/e2e/init_test.go
+++ b/test/e2e/init_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman init", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Podman inspect", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman kill", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -38,7 +39,11 @@ var _ = Describe("Podman load", func() {
 	It("podman load input flag", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", "-o", outfile, ALPINE})
+		images := podmanTest.PodmanNoCache([]string{"images"})
+		images.WaitWithDefaultTimeout()
+		fmt.Println(images.OutputToStringArray())
+
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 
@@ -46,7 +51,7 @@ var _ = Describe("Podman load", func() {
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"load", "-i", outfile})
+		result := podmanTest.PodmanNoCache([]string{"load", "-i", outfile})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 	})
@@ -54,7 +59,7 @@ var _ = Describe("Podman load", func() {
 	It("podman load compressed tar file", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", "-o", outfile, ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 
@@ -62,11 +67,11 @@ var _ = Describe("Podman load", func() {
 		Expect(compress.ExitCode()).To(Equal(0))
 		outfile = outfile + ".gz"
 
-		rmi := podmanTest.Podman([]string{"rmi", ALPINE})
+		rmi := podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"load", "-i", outfile})
+		result := podmanTest.PodmanNoCache([]string{"load", "-i", outfile})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 	})
@@ -74,15 +79,15 @@ var _ = Describe("Podman load", func() {
 	It("podman load oci-archive image", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", "-o", outfile, "--format", "oci-archive", ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, "--format", "oci-archive", ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 
-		rmi := podmanTest.Podman([]string{"rmi", ALPINE})
+		rmi := podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"load", "-i", outfile})
+		result := podmanTest.PodmanNoCache([]string{"load", "-i", outfile})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 	})
@@ -90,15 +95,15 @@ var _ = Describe("Podman load", func() {
 	It("podman load oci-archive with signature", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", "-o", outfile, "--format", "oci-archive", ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, "--format", "oci-archive", ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 
-		rmi := podmanTest.Podman([]string{"rmi", ALPINE})
+		rmi := podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"load", "--signature-policy", "/etc/containers/policy.json", "-i", outfile})
+		result := podmanTest.PodmanNoCache([]string{"load", "--signature-policy", "/etc/containers/policy.json", "-i", outfile})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 	})
@@ -106,15 +111,15 @@ var _ = Describe("Podman load", func() {
 	It("podman load with quiet flag", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", "-o", outfile, ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 
-		rmi := podmanTest.Podman([]string{"rmi", ALPINE})
+		rmi := podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"load", "-q", "-i", outfile})
+		result := podmanTest.PodmanNoCache([]string{"load", "-q", "-i", outfile})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 	})
@@ -122,7 +127,7 @@ var _ = Describe("Podman load", func() {
 	It("podman load directory", func() {
 		outdir := filepath.Join(podmanTest.TempDir, "alpine")
 
-		save := podmanTest.Podman([]string{"save", "--format", "oci-dir", "-o", outdir, ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "--format", "oci-dir", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 
@@ -136,7 +141,7 @@ var _ = Describe("Podman load", func() {
 	})
 
 	It("podman load bogus file", func() {
-		save := podmanTest.Podman([]string{"load", "-i", "foobar.tar"})
+		save := podmanTest.PodmanNoCache([]string{"load", "-i", "foobar.tar"})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).ToNot(Equal(0))
 	})
@@ -148,75 +153,75 @@ var _ = Describe("Podman load", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 		alpVersion := "docker.io/library/alpine:3.2"
 
-		pull := podmanTest.Podman([]string{"pull", alpVersion})
+		pull := podmanTest.PodmanNoCache([]string{"pull", alpVersion})
 		pull.WaitWithDefaultTimeout()
 		Expect(pull.ExitCode()).To(Equal(0))
 
-		save := podmanTest.Podman([]string{"save", "-o", outfile, ALPINE, alpVersion})
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, ALPINE, alpVersion})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 
-		rmi := podmanTest.Podman([]string{"rmi", ALPINE, alpVersion})
+		rmi := podmanTest.PodmanNoCache([]string{"rmi", ALPINE, alpVersion})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"load", "-i", outfile})
+		result := podmanTest.PodmanNoCache([]string{"load", "-i", outfile})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 
-		inspect := podmanTest.Podman([]string{"inspect", ALPINE})
+		inspect := podmanTest.PodmanNoCache([]string{"inspect", ALPINE})
 		inspect.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
-		inspect = podmanTest.Podman([]string{"inspect", alpVersion})
+		inspect = podmanTest.PodmanNoCache([]string{"inspect", alpVersion})
 		inspect.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 	})
 
 	It("podman load localhost registry from scratch", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "load_test.tar.gz")
-		setup := podmanTest.Podman([]string{"tag", ALPINE, "hello:world"})
+		setup := podmanTest.PodmanNoCache([]string{"tag", ALPINE, "hello:world"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		setup = podmanTest.Podman([]string{"save", "-o", outfile, "--format", "oci-archive", "hello:world"})
+		setup = podmanTest.PodmanNoCache([]string{"save", "-o", outfile, "--format", "oci-archive", "hello:world"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		setup = podmanTest.Podman([]string{"rmi", "hello:world"})
+		setup = podmanTest.PodmanNoCache([]string{"rmi", "hello:world"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		load := podmanTest.Podman([]string{"load", "-i", outfile})
+		load := podmanTest.PodmanNoCache([]string{"load", "-i", outfile})
 		load.WaitWithDefaultTimeout()
 		Expect(load.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"images", "hello:world"})
+		result := podmanTest.PodmanNoCache([]string{"images", "hello:world"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.LineInOutputContains("docker")).To(Not(BeTrue()))
 		Expect(result.LineInOutputContains("localhost")).To(BeTrue())
 	})
 
 	It("podman load localhost registry from scratch and :latest", func() {
+		podmanTest.RestoreArtifact(fedoraMinimal)
 		outfile := filepath.Join(podmanTest.TempDir, "load_test.tar.gz")
-		podmanTest.RestoreArtifact("fedora-minimal:latest")
 
-		setup := podmanTest.Podman([]string{"tag", "fedora-minimal", "hello"})
+		setup := podmanTest.PodmanNoCache([]string{"tag", "fedora-minimal", "hello"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		setup = podmanTest.Podman([]string{"save", "-o", outfile, "--format", "oci-archive", "hello"})
+		setup = podmanTest.PodmanNoCache([]string{"save", "-o", outfile, "--format", "oci-archive", "hello"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		setup = podmanTest.Podman([]string{"rmi", "hello"})
+		setup = podmanTest.PodmanNoCache([]string{"rmi", "hello"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		load := podmanTest.Podman([]string{"load", "-i", outfile})
+		load := podmanTest.PodmanNoCache([]string{"load", "-i", outfile})
 		load.WaitWithDefaultTimeout()
 		Expect(load.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"images", "hello:latest"})
+		result := podmanTest.PodmanNoCache([]string{"images", "hello:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.LineInOutputContains("docker")).To(Not(BeTrue()))
 		Expect(result.LineInOutputContains("localhost")).To(BeTrue())
@@ -225,23 +230,23 @@ var _ = Describe("Podman load", func() {
 	It("podman load localhost registry from dir", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "load")
 
-		setup := podmanTest.Podman([]string{"tag", BB, "hello:world"})
+		setup := podmanTest.PodmanNoCache([]string{"tag", BB, "hello:world"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		setup = podmanTest.Podman([]string{"save", "-o", outfile, "--format", "oci-dir", "hello:world"})
+		setup = podmanTest.PodmanNoCache([]string{"save", "-o", outfile, "--format", "oci-dir", "hello:world"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		setup = podmanTest.Podman([]string{"rmi", "hello:world"})
+		setup = podmanTest.PodmanNoCache([]string{"rmi", "hello:world"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		load := podmanTest.Podman([]string{"load", "-i", outfile})
+		load := podmanTest.PodmanNoCache([]string{"load", "-i", outfile})
 		load.WaitWithDefaultTimeout()
 		Expect(load.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"images", "load:latest"})
+		result := podmanTest.PodmanNoCache([]string{"images", "load:latest"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.LineInOutputContains("docker")).To(Not(BeTrue()))
 		Expect(result.LineInOutputContains("localhost")).To(BeTrue())
@@ -250,17 +255,17 @@ var _ = Describe("Podman load", func() {
 	It("podman load xz compressed image", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "bb.tar")
 
-		save := podmanTest.Podman([]string{"save", "-o", outfile, BB})
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, BB})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 		session := SystemExec("xz", []string{outfile})
 		Expect(session.ExitCode()).To(Equal(0))
 
-		rmi := podmanTest.Podman([]string{"rmi", BB})
+		rmi := podmanTest.PodmanNoCache([]string{"rmi", BB})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"load", "-i", outfile + ".xz"})
+		result := podmanTest.PodmanNoCache([]string{"load", "-i", outfile + ".xz"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 	})

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Podman logs", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman mount", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman namespaces", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Podman pause", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {
@@ -249,7 +249,6 @@ var _ = Describe("Podman pause", func() {
 	})
 
 	It("Pause a bunch of running containers", func() {
-		podmanTest.RestoreArtifact(nginx)
 		for i := 0; i < 3; i++ {
 			name := fmt.Sprintf("test%d", i)
 			run := podmanTest.Podman([]string{"run", "-dt", "--name", name, nginx})
@@ -277,7 +276,6 @@ var _ = Describe("Podman pause", func() {
 	})
 
 	It("Unpause a bunch of running containers", func() {
-		podmanTest.RestoreArtifact(nginx)
 		for i := 0; i < 3; i++ {
 			name := fmt.Sprintf("test%d", i)
 			run := podmanTest.Podman([]string{"run", "-dt", "--name", name, nginx})

--- a/test/e2e/pod_create_test.go
+++ b/test/e2e/pod_create_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman pod create", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -25,8 +25,7 @@ var _ = Describe("Podman pod create", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
-		podmanTest.RestoreArtifact(infra)
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {
@@ -113,12 +112,10 @@ var _ = Describe("Podman pod create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		podmanTest.RestoreArtifact(nginx)
 		session = podmanTest.Podman([]string{"run", "-d", "--pod", podID, nginx})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		podmanTest.RestoreArtifact(fedoraMinimal)
 		session = podmanTest.Podman([]string{"run", "--pod", podID, fedoraMinimal, "curl", "localhost:80"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -138,7 +135,6 @@ var _ = Describe("Podman pod create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		podmanTest.RestoreArtifact(fedoraMinimal)
 		session = podmanTest.Podman([]string{"run", "--pod", podID, fedoraMinimal, "/bin/sh", "-c", "'touch /dev/shm/hi'"})
 		session.WaitWithDefaultTimeout()
 		if session.ExitCode() != 0 {
@@ -216,7 +212,6 @@ var _ = Describe("Podman pod create", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		podmanTest.RestoreArtifact(nginx)
 		session = podmanTest.Podman([]string{"run", "-d", "--pod", podID, nginx})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/pod_inspect_test.go
+++ b/test/e2e/pod_inspect_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman pod inspect", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_kill_test.go
+++ b/test/e2e/pod_kill_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Podman pod kill", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_pause_test.go
+++ b/test/e2e/pod_pause_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman pod pause", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_pod_namespaces.go
+++ b/test/e2e/pod_pod_namespaces.go
@@ -25,8 +25,7 @@ var _ = Describe("Podman pod create", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
-		podmanTest.RestoreArtifact(infra)
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_prune_test.go
+++ b/test/e2e/pod_prune_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman pod prune", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman ps", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_restart_test.go
+++ b/test/e2e/pod_restart_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman pod restart", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_rm_test.go
+++ b/test/e2e/pod_rm_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Podman pod rm", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_start_test.go
+++ b/test/e2e/pod_start_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman pod start", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_stats_test.go
+++ b/test/e2e/pod_stats_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman pod stats", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_stop_test.go
+++ b/test/e2e/pod_stop_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman pod stop", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pod_top_test.go
+++ b/test/e2e/pod_top_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Podman top", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/port_test.go
+++ b/test/e2e/port_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Podman port", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {
@@ -49,7 +49,6 @@ var _ = Describe("Podman port", func() {
 	})
 
 	It("podman port  -l nginx", func() {
-		podmanTest.RestoreArtifact(nginx)
 		session := podmanTest.Podman([]string{"run", "-dt", "-P", nginx})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -62,7 +61,6 @@ var _ = Describe("Podman port", func() {
 	})
 
 	It("podman container port  -l nginx", func() {
-		podmanTest.RestoreArtifact(nginx)
 		session := podmanTest.Podman([]string{"container", "run", "-dt", "-P", nginx})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -75,7 +73,6 @@ var _ = Describe("Podman port", func() {
 	})
 
 	It("podman port -l port nginx", func() {
-		podmanTest.RestoreArtifact(nginx)
 		session := podmanTest.Podman([]string{"run", "-dt", "-P", nginx})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -88,7 +85,6 @@ var _ = Describe("Podman port", func() {
 	})
 
 	It("podman port -a nginx", func() {
-		podmanTest.RestoreArtifact(nginx)
 		session := podmanTest.Podman([]string{"run", "-dt", "-P", nginx})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Podman prune", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {
@@ -77,11 +77,12 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman image prune unused images", func() {
-		prune := podmanTest.Podman([]string{"image", "prune", "-a"})
+		podmanTest.RestoreAllArtifacts()
+		prune := podmanTest.PodmanNoCache([]string{"image", "prune", "-a"})
 		prune.WaitWithDefaultTimeout()
 		Expect(prune.ExitCode()).To(Equal(0))
 
-		images := podmanTest.Podman([]string{"images", "-aq"})
+		images := podmanTest.PodmanNoCache([]string{"images", "-aq"})
 		images.WaitWithDefaultTimeout()
 		// all images are unused, so they all should be deleted!
 		Expect(len(images.OutputToStringArray())).To(Equal(0))
@@ -89,12 +90,13 @@ var _ = Describe("Podman prune", func() {
 
 	It("podman system image prune unused images", func() {
 		SkipIfRemote()
+		podmanTest.RestoreAllArtifacts()
 		podmanTest.BuildImage(pruneImage, "alpine_bash:latest", "true")
-		prune := podmanTest.Podman([]string{"system", "prune", "-a", "--force"})
+		prune := podmanTest.PodmanNoCache([]string{"system", "prune", "-a", "--force"})
 		prune.WaitWithDefaultTimeout()
 		Expect(prune.ExitCode()).To(Equal(0))
 
-		images := podmanTest.Podman([]string{"images", "-aq"})
+		images := podmanTest.PodmanNoCache([]string{"images", "-aq"})
 		images.WaitWithDefaultTimeout()
 		// all images are unused, so they all should be deleted!
 		Expect(len(images.OutputToStringArray())).To(Equal(0))

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Podman ps", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -28,7 +28,6 @@ var _ = Describe("Podman pull", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
 	})
 
 	AfterEach(func() {
@@ -39,132 +38,135 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull from docker a not existing image", func() {
-		session := podmanTest.Podman([]string{"pull", "ibetthisdoesntexistthere:foo"})
+		session := podmanTest.PodmanNoCache([]string{"pull", "ibetthisdoesntexistthere:foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
 
 	It("podman pull from docker with tag", func() {
-		session := podmanTest.Podman([]string{"pull", "busybox:glibc"})
+		session := podmanTest.PodmanNoCache([]string{"pull", "busybox:glibc"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", "busybox:glibc"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "busybox:glibc"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	It("podman pull from docker without tag", func() {
-		session := podmanTest.Podman([]string{"pull", "busybox"})
+		session := podmanTest.PodmanNoCache([]string{"pull", "busybox"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", "busybox"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "busybox"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	It("podman pull from alternate registry with tag", func() {
-		session := podmanTest.Podman([]string{"pull", nginx})
+		session := podmanTest.PodmanNoCache([]string{"pull", nginx})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", nginx})
+		session = podmanTest.PodmanNoCache([]string{"rmi", nginx})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	It("podman pull from alternate registry without tag", func() {
-		session := podmanTest.Podman([]string{"pull", "quay.io/libpod/alpine_nginx"})
+		session := podmanTest.PodmanNoCache([]string{"pull", "quay.io/libpod/alpine_nginx"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", "quay.io/libpod/alpine_nginx"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "quay.io/libpod/alpine_nginx"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	It("podman pull by digest", func() {
-		session := podmanTest.Podman([]string{"pull", "alpine@sha256:1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe"})
+		session := podmanTest.PodmanNoCache([]string{"pull", "alpine@sha256:1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", "alpine:none"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "alpine:none"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	It("podman pull bogus image", func() {
-		session := podmanTest.Podman([]string{"pull", "umohnani/get-started"})
+		session := podmanTest.PodmanNoCache([]string{"pull", "umohnani/get-started"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
 
 	It("podman pull from docker-archive", func() {
+		podmanTest.RestoreArtifact(ALPINE)
 		tarfn := filepath.Join(podmanTest.TempDir, "alp.tar")
-		session := podmanTest.Podman([]string{"save", "-o", tarfn, "alpine"})
+		session := podmanTest.PodmanNoCache([]string{"save", "-o", tarfn, "alpine"})
 		session.WaitWithDefaultTimeout()
 
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"rmi", "alpine"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"pull", fmt.Sprintf("docker-archive:%s", tarfn)})
+		session = podmanTest.PodmanNoCache([]string{"pull", fmt.Sprintf("docker-archive:%s", tarfn)})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"rmi", "alpine"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	It("podman pull from oci-archive", func() {
+		podmanTest.RestoreArtifact(ALPINE)
 		tarfn := filepath.Join(podmanTest.TempDir, "oci-alp.tar")
-		session := podmanTest.Podman([]string{"save", "--format", "oci-archive", "-o", tarfn, "alpine"})
+		session := podmanTest.PodmanNoCache([]string{"save", "--format", "oci-archive", "-o", tarfn, "alpine"})
 		session.WaitWithDefaultTimeout()
 
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"rmi", "alpine"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"pull", fmt.Sprintf("oci-archive:%s", tarfn)})
+		session = podmanTest.PodmanNoCache([]string{"pull", fmt.Sprintf("oci-archive:%s", tarfn)})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"rmi", "alpine"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	It("podman pull from local directory", func() {
+		podmanTest.RestoreArtifact(ALPINE)
 		dirpath := filepath.Join(podmanTest.TempDir, "alpine")
 		os.MkdirAll(dirpath, os.ModePerm)
 		imgPath := fmt.Sprintf("dir:%s", dirpath)
 
-		session := podmanTest.Podman([]string{"push", "alpine", imgPath})
+		session := podmanTest.PodmanNoCache([]string{"push", "alpine", imgPath})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"rmi", "alpine"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"pull", imgPath})
+		session = podmanTest.PodmanNoCache([]string{"pull", imgPath})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"rmi", "alpine"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	It("podman pull check quiet", func() {
 		podmanTest.RestoreArtifact(ALPINE)
-		setup := podmanTest.Podman([]string{"images", ALPINE, "-q", "--no-trunc"})
+		setup := podmanTest.PodmanNoCache([]string{"images", ALPINE, "-q", "--no-trunc"})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 		shortImageId := strings.Split(setup.OutputToString(), ":")[1]
 
-		rmi := podmanTest.Podman([]string{"rmi", ALPINE})
+		rmi := podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 
-		pull := podmanTest.Podman([]string{"pull", "-q", ALPINE})
+		pull := podmanTest.PodmanNoCache([]string{"pull", "-q", ALPINE})
 		pull.WaitWithDefaultTimeout()
 		Expect(pull.ExitCode()).To(Equal(0))
 
@@ -172,17 +174,17 @@ var _ = Describe("Podman pull", func() {
 	})
 
 	It("podman pull check all tags", func() {
-		session := podmanTest.Podman([]string{"pull", "--all-tags", "alpine"})
+		session := podmanTest.PodmanNoCache([]string{"pull", "--all-tags", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.LineInOuputStartsWith("Pulled Images:")).To(BeTrue())
 
-		session = podmanTest.Podman([]string{"images"})
+		session = podmanTest.PodmanNoCache([]string{"images"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 4))
 
-		rmi := podmanTest.Podman([]string{"rmi", "-a", "-f"})
+		rmi := podmanTest.PodmanNoCache([]string{"rmi", "-a", "-f"})
 		rmi.WaitWithDefaultTimeout()
 		Expect(rmi.ExitCode()).To(Equal(0))
 	})

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -38,22 +38,18 @@ var _ = Describe("Podman push", func() {
 	})
 
 	It("podman push to containers/storage", func() {
-		session := podmanTest.Podman([]string{"push", ALPINE, "containers-storage:busybox:test"})
+		session := podmanTest.PodmanNoCache([]string{"push", ALPINE, "containers-storage:busybox:test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", ALPINE})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-
-		session = podmanTest.Podman([]string{"rmi", "busybox:test"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
 	It("podman push to dir", func() {
 		bbdir := filepath.Join(podmanTest.TempDir, "busybox")
-		session := podmanTest.Podman([]string{"push", "--remove-signatures", ALPINE,
+		session := podmanTest.PodmanNoCache([]string{"push", "--remove-signatures", ALPINE,
 			fmt.Sprintf("dir:%s", bbdir)})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -65,8 +61,7 @@ var _ = Describe("Podman push", func() {
 		}
 		lock := GetPortLock("5000")
 		defer lock.Unlock()
-		podmanTest.RestoreArtifact(registry)
-		session := podmanTest.Podman([]string{"run", "-d", "--name", "registry", "-p", "5000:5000", registry, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
+		session := podmanTest.PodmanNoCache([]string{"run", "-d", "--name", "registry", "-p", "5000:5000", registry, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -74,7 +69,7 @@ var _ = Describe("Podman push", func() {
 			Skip("Can not start docker registry.")
 		}
 
-		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
+		push := podmanTest.PodmanNoCache([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Equal(0))
 	})
@@ -106,8 +101,7 @@ var _ = Describe("Podman push", func() {
 		}
 		lock := GetPortLock("5000")
 		defer lock.Unlock()
-		podmanTest.RestoreArtifact(registry)
-		session := podmanTest.Podman([]string{"run", "--entrypoint", "htpasswd", registry, "-Bbn", "podmantest", "test"})
+		session := podmanTest.PodmanNoCache([]string{"run", "--entrypoint", "htpasswd", registry, "-Bbn", "podmantest", "test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -117,7 +111,7 @@ var _ = Describe("Podman push", func() {
 		f.WriteString(session.OutputToString())
 		f.Sync()
 
-		session = podmanTest.Podman([]string{"run", "-d", "-p", "5000:5000", "--name", "registry", "-v",
+		session = podmanTest.PodmanNoCache([]string{"run", "-d", "-p", "5000:5000", "--name", "registry", "-v",
 			strings.Join([]string{authPath, "/auth"}, ":"), "-e", "REGISTRY_AUTH=htpasswd", "-e",
 			"REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm", "-e", "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd",
 			"-v", strings.Join([]string{certPath, "/certs"}, ":"), "-e", "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt",
@@ -129,36 +123,36 @@ var _ = Describe("Podman push", func() {
 			Skip("Can not start docker registry.")
 		}
 
-		session = podmanTest.Podman([]string{"logs", "registry"})
+		session = podmanTest.PodmanNoCache([]string{"logs", "registry"})
 		session.WaitWithDefaultTimeout()
 
-		push := podmanTest.Podman([]string{"push", "--creds=podmantest:test", ALPINE, "localhost:5000/tlstest"})
+		push := podmanTest.PodmanNoCache([]string{"push", "--creds=podmantest:test", ALPINE, "localhost:5000/tlstest"})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Not(Equal(0)))
 
-		push = podmanTest.Podman([]string{"push", "--creds=podmantest:test", "--tls-verify=false", ALPINE, "localhost:5000/tlstest"})
+		push = podmanTest.PodmanNoCache([]string{"push", "--creds=podmantest:test", "--tls-verify=false", ALPINE, "localhost:5000/tlstest"})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Equal(0))
 
 		setup := SystemExec("cp", []string{filepath.Join(certPath, "domain.crt"), "/etc/containers/certs.d/localhost:5000/ca.crt"})
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		push = podmanTest.Podman([]string{"push", "--creds=podmantest:wrongpasswd", ALPINE, "localhost:5000/credstest"})
+		push = podmanTest.PodmanNoCache([]string{"push", "--creds=podmantest:wrongpasswd", ALPINE, "localhost:5000/credstest"})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Not(Equal(0)))
 
-		push = podmanTest.Podman([]string{"push", "--creds=podmantest:test", "--cert-dir=fakedir", ALPINE, "localhost:5000/certdirtest"})
+		push = podmanTest.PodmanNoCache([]string{"push", "--creds=podmantest:test", "--cert-dir=fakedir", ALPINE, "localhost:5000/certdirtest"})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Not(Equal(0)))
 
-		push = podmanTest.Podman([]string{"push", "--creds=podmantest:test", ALPINE, "localhost:5000/defaultflags"})
+		push = podmanTest.PodmanNoCache([]string{"push", "--creds=podmantest:test", ALPINE, "localhost:5000/defaultflags"})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Equal(0))
 	})
 
 	It("podman push to docker-archive", func() {
 		tarfn := filepath.Join(podmanTest.TempDir, "alp.tar")
-		session := podmanTest.Podman([]string{"push", ALPINE,
+		session := podmanTest.PodmanNoCache([]string{"push", ALPINE,
 			fmt.Sprintf("docker-archive:%s:latest", tarfn)})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -177,7 +171,7 @@ var _ = Describe("Podman push", func() {
 			Skip("Docker is not available")
 		}
 
-		session := podmanTest.Podman([]string{"push", ALPINE, "docker-daemon:alpine:podmantest"})
+		session := podmanTest.PodmanNoCache([]string{"push", ALPINE, "docker-daemon:alpine:podmantest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -191,7 +185,7 @@ var _ = Describe("Podman push", func() {
 
 	It("podman push to oci-archive", func() {
 		tarfn := filepath.Join(podmanTest.TempDir, "alp.tar")
-		session := podmanTest.Podman([]string{"push", ALPINE,
+		session := podmanTest.PodmanNoCache([]string{"push", ALPINE,
 			fmt.Sprintf("oci-archive:%s:latest", tarfn)})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -208,7 +202,7 @@ var _ = Describe("Podman push", func() {
 		setup := SystemExec("ostree", []string{strings.Join([]string{"--repo=", ostreePath}, ""), "init"})
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"push", ALPINE, strings.Join([]string{"ostree:alp@", ostreePath}, "")})
+		session := podmanTest.PodmanNoCache([]string{"push", ALPINE, strings.Join([]string{"ostree:alp@", ostreePath}, "")})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -216,7 +210,7 @@ var _ = Describe("Podman push", func() {
 
 	It("podman push to docker-archive no reference", func() {
 		tarfn := filepath.Join(podmanTest.TempDir, "alp.tar")
-		session := podmanTest.Podman([]string{"push", ALPINE,
+		session := podmanTest.PodmanNoCache([]string{"push", ALPINE,
 			fmt.Sprintf("docker-archive:%s", tarfn)})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -224,7 +218,7 @@ var _ = Describe("Podman push", func() {
 
 	It("podman push to oci-archive no reference", func() {
 		ociarc := filepath.Join(podmanTest.TempDir, "alp-oci")
-		session := podmanTest.Podman([]string{"push", ALPINE,
+		session := podmanTest.PodmanNoCache([]string{"push", ALPINE,
 			fmt.Sprintf("oci-archive:%s", ociarc)})
 
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Podman restart", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman rm", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -41,14 +41,14 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi with fq name", func() {
-		session := podmanTest.Podman([]string{"rmi", ALPINE})
+		session := podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 	})
 
 	It("podman rmi with short name", func() {
-		session := podmanTest.Podman([]string{"rmi", "alpine"})
+		session := podmanTest.PodmanNoCache([]string{"rmi", "alpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -56,9 +56,9 @@ var _ = Describe("Podman rmi", func() {
 
 	It("podman rmi all images", func() {
 		podmanTest.PullImages([]string{nginx})
-		session := podmanTest.Podman([]string{"rmi", "-a"})
+		session := podmanTest.PodmanNoCache([]string{"rmi", "-a"})
 		session.WaitWithDefaultTimeout()
-		images := podmanTest.Podman([]string{"images"})
+		images := podmanTest.PodmanNoCache([]string{"images"})
 		images.WaitWithDefaultTimeout()
 		fmt.Println(images.OutputToStringArray())
 		Expect(session.ExitCode()).To(Equal(0))
@@ -67,22 +67,22 @@ var _ = Describe("Podman rmi", func() {
 
 	It("podman rmi all images forcibly with short options", func() {
 		podmanTest.PullImages([]string{nginx})
-		session := podmanTest.Podman([]string{"rmi", "-fa"})
+		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 	})
 
 	It("podman rmi tagged image", func() {
-		setup := podmanTest.Podman([]string{"images", "-q", ALPINE})
+		setup := podmanTest.PodmanNoCache([]string{"images", "-q", ALPINE})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"tag", "alpine", "foo:bar", "foo"})
+		session := podmanTest.PodmanNoCache([]string{"tag", "alpine", "foo:bar", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"images", "-q", "foo"})
+		result := podmanTest.PodmanNoCache([]string{"images", "-q", "foo"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 
@@ -90,95 +90,95 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi image with tags by ID cannot be done without force", func() {
-		setup := podmanTest.Podman([]string{"images", "-q", ALPINE})
+		setup := podmanTest.PodmanNoCache([]string{"images", "-q", ALPINE})
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 		alpineId := setup.OutputToString()
 
-		session := podmanTest.Podman([]string{"tag", "alpine", "foo:bar", "foo"})
+		session := podmanTest.PodmanNoCache([]string{"tag", "alpine", "foo:bar", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
 		// Trying without --force should fail
-		result := podmanTest.Podman([]string{"rmi", alpineId})
+		result := podmanTest.PodmanNoCache([]string{"rmi", alpineId})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).ToNot(Equal(0))
 
 		// With --force it should work
-		resultForce := podmanTest.Podman([]string{"rmi", "-f", alpineId})
+		resultForce := podmanTest.PodmanNoCache([]string{"rmi", "-f", alpineId})
 		resultForce.WaitWithDefaultTimeout()
 		Expect(resultForce.ExitCode()).To(Equal(0))
 	})
 
 	It("podman rmi image that is a parent of another image", func() {
 		SkipIfRemote()
-		session := podmanTest.Podman([]string{"rmi", "-fa"})
+		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"run", "--name", "c_test", ALPINE, "true"})
+		session = podmanTest.PodmanNoCache([]string{"run", "--name", "c_test", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"commit", "-q", "c_test", "test"})
+		session = podmanTest.PodmanNoCache([]string{"commit", "-q", "c_test", "test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rm", "c_test"})
+		session = podmanTest.PodmanNoCache([]string{"rm", "c_test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", ALPINE})
+		session = podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"images", "-q"})
+		session = podmanTest.PodmanNoCache([]string{"images", "-q"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(1))
 
-		session = podmanTest.Podman([]string{"images", "-q", "-a"})
+		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(2))
 		untaggedImg := session.OutputToStringArray()[1]
 
-		session = podmanTest.Podman([]string{"rmi", "-f", untaggedImg})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "-f", untaggedImg})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
 
 	It("podman rmi image that is created from another named imaged", func() {
 		SkipIfRemote()
-		session := podmanTest.Podman([]string{"rmi", "-fa"})
+		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"create", "--name", "c_test1", ALPINE, "true"})
+		session = podmanTest.PodmanNoCache([]string{"create", "--name", "c_test1", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"commit", "-q", "c_test1", "test1"})
+		session = podmanTest.PodmanNoCache([]string{"commit", "-q", "c_test1", "test1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"create", "--name", "c_test2", "test1", "true"})
+		session = podmanTest.PodmanNoCache([]string{"create", "--name", "c_test2", "test1", "true"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"commit", "-q", "c_test2", "test2"})
+		session = podmanTest.PodmanNoCache([]string{"commit", "-q", "c_test2", "test2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rm", "-a"})
+		session = podmanTest.PodmanNoCache([]string{"rm", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", "test2"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "test2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"images", "-q"})
+		session = podmanTest.PodmanNoCache([]string{"images", "-q"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(2))
@@ -186,7 +186,7 @@ var _ = Describe("Podman rmi", func() {
 
 	It("podman rmi with cached images", func() {
 		SkipIfRemote()
-		session := podmanTest.Podman([]string{"rmi", "-fa"})
+		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -205,51 +205,51 @@ var _ = Describe("Podman rmi", func() {
 		`
 		podmanTest.BuildImage(dockerfile, "test2", "true")
 
-		session = podmanTest.Podman([]string{"images", "-q", "-a"})
+		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		numOfImages := len(session.OutputToStringArray())
 
-		session = podmanTest.Podman([]string{"rmi", "test2"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "test2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"images", "-q", "-a"})
+		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(numOfImages - len(session.OutputToStringArray())).To(Equal(2))
 
-		session = podmanTest.Podman([]string{"rmi", "test"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"images", "-q", "-a"})
+		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(1))
 
 		podmanTest.BuildImage(dockerfile, "test3", "true")
 
-		session = podmanTest.Podman([]string{"rmi", ALPINE})
+		session = podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", "test3"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "test3"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"images", "-q", "-a"})
+		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToString())).To(Equal(0))
 	})
 
 	It("podman rmi -a with no images should be exit 0", func() {
-		session := podmanTest.Podman([]string{"rmi", "-fa"})
+		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session2 := podmanTest.Podman([]string{"rmi", "-fa"})
+		session2 := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session2.WaitWithDefaultTimeout()
 		Expect(session2.ExitCode()).To(Equal(0))
 	})
@@ -265,12 +265,12 @@ RUN find $LOCAL
 
 `
 		podmanTest.BuildImage(dockerfile, "test", "true")
-		session := podmanTest.Podman([]string{"rmi", "-a"})
+		session := podmanTest.PodmanNoCache([]string{"rmi", "-a"})
 		session.WaitWithDefaultTimeout()
 		fmt.Println(session.OutputToString())
 		Expect(session.ExitCode()).To(Equal(0))
 
-		images := podmanTest.Podman([]string{"images", "-aq"})
+		images := podmanTest.PodmanNoCache([]string{"images", "-aq"})
 		images.WaitWithDefaultTimeout()
 		Expect(images.ExitCode()).To(Equal(0))
 		Expect(len(images.OutputToStringArray())).To(Equal(0))
@@ -279,7 +279,7 @@ RUN find $LOCAL
 	// Don't rerun all tests; just assume that if we get that diagnostic,
 	// we're getting rmi
 	It("podman image rm is the same as rmi", func() {
-		session := podmanTest.Podman([]string{"image", "rm"})
+		session := podmanTest.PodmanNoCache([]string{"image", "rm"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(125))
 		Expect(session.LineInOutputContains("image name or ID must be specified"))

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreArtifact(fedoraMinimal)
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_cleanup_test.go
+++ b/test/e2e/run_cleanup_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman run exit", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.RestoreArtifact(ALPINE)
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman run cpu", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman run device", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman run dns", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_entrypoint_test.go
+++ b/test/e2e/run_entrypoint_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman run entrypoint", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreArtifact(ALPINE)
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_exit_test.go
+++ b/test/e2e/run_exit_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman run exit", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_memory_test.go
+++ b/test/e2e/run_memory_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman run memory", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman run networking", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {
@@ -78,7 +78,6 @@ var _ = Describe("Podman run networking", func() {
 	})
 
 	It("podman run network expose ports in image metadata", func() {
-		podmanTest.RestoreArtifact(nginx)
 		session := podmanTest.Podman([]string{"create", "-dt", "-P", nginx})
 		session.Wait(90)
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/run_ns_test.go
+++ b/test/e2e/run_ns_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman run ns", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreArtifact(fedoraMinimal)
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_passwd_test.go
+++ b/test/e2e/run_passwd_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman run passwd", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_privileged_test.go
+++ b/test/e2e/run_privileged_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman privileged container tests", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_restart_test.go
+++ b/test/e2e/run_restart_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman run restart containers", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_selinux_test.go
+++ b/test/e2e/run_selinux_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman run", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 		if !selinux.GetEnabled() {
 			Skip("SELinux not enabled")
 		}

--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 		}
 		podmanTest = PodmanTestCreate(tmpdir)
 		podmanTest.Setup()
-		podmanTest.RestoreArtifact(fedoraMinimal)
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Podman run with --ip flag", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 		// Cleanup the CNI networks used by the tests
 		os.RemoveAll("/var/lib/cni/networks/podman")
 	})

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Podman UserNS support", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Podman run with volumes", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -37,7 +37,7 @@ var _ = Describe("podman container runlabel", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Podman save", func() {
 	It("podman save output flag", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", "-o", outfile, ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 	})
@@ -45,7 +45,7 @@ var _ = Describe("Podman save", func() {
 	It("podman save oci flag", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", "-o", outfile, "--format", "oci-archive", ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, "--format", "oci-archive", ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 	})
@@ -54,7 +54,7 @@ var _ = Describe("Podman save", func() {
 		Skip("Pipe redirection in ginkgo probably wont work")
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", ALPINE, ">", outfile})
+		save := podmanTest.PodmanNoCache([]string{"save", ALPINE, ">", outfile})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 	})
@@ -62,7 +62,7 @@ var _ = Describe("Podman save", func() {
 	It("podman save quiet flag", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", "-q", "-o", outfile, ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "-q", "-o", outfile, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 	})
@@ -70,7 +70,7 @@ var _ = Describe("Podman save", func() {
 	It("podman save bogus image", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "alpine.tar")
 
-		save := podmanTest.Podman([]string{"save", "-o", outfile, "FOOBAR"})
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, "FOOBAR"})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Not(Equal(0)))
 	})
@@ -81,7 +81,7 @@ var _ = Describe("Podman save", func() {
 		}
 		outdir := filepath.Join(podmanTest.TempDir, "save")
 
-		save := podmanTest.Podman([]string{"save", "--format", "oci-dir", "-o", outdir, ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "--format", "oci-dir", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 	})
@@ -92,7 +92,7 @@ var _ = Describe("Podman save", func() {
 		}
 		outdir := filepath.Join(podmanTest.TempDir, "save")
 
-		save := podmanTest.Podman([]string{"save", "--format", "docker-dir", "-o", outdir, ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "--format", "docker-dir", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 	})
@@ -103,7 +103,7 @@ var _ = Describe("Podman save", func() {
 		}
 		outdir := filepath.Join(podmanTest.TempDir, "save")
 
-		save := podmanTest.Podman([]string{"save", "--compress", "--format", "docker-dir", "-o", outdir, ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "--compress", "--format", "docker-dir", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Equal(0))
 	})
@@ -111,7 +111,7 @@ var _ = Describe("Podman save", func() {
 	It("podman save bad filename", func() {
 		outdir := filepath.Join(podmanTest.TempDir, "save:colon")
 
-		save := podmanTest.Podman([]string{"save", "--compress", "--format", "docker-dir", "-o", outdir, ALPINE})
+		save := podmanTest.PodmanNoCache([]string{"save", "--compress", "--format", "docker-dir", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
 		Expect(save.ExitCode()).To(Not(Equal(0)))
 	})

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -75,8 +75,8 @@ registries = ['{{.Host}}:{{.Port}}']`
 
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
+		podmanTest.SeedImages()
 
-		podmanTest.RestoreAllArtifacts()
 	})
 
 	AfterEach(func() {
@@ -168,7 +168,6 @@ registries = ['{{.Host}}:{{.Port}}']`
 		lock := GetPortLock(registryEndpoints[0].Port)
 		defer lock.Unlock()
 
-		podmanTest.RestoreArtifact(registry)
 		fakereg := podmanTest.Podman([]string{"run", "-d", "--name", "registry",
 			"-p", fmt.Sprintf("%s:5000", registryEndpoints[0].Port),
 			registry, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
@@ -196,7 +195,6 @@ registries = ['{{.Host}}:{{.Port}}']`
 		}
 		lock := GetPortLock(registryEndpoints[3].Port)
 		defer lock.Unlock()
-		podmanTest.RestoreArtifact(registry)
 		registry := podmanTest.Podman([]string{"run", "-d", "--name", "registry3",
 			"-p", fmt.Sprintf("%s:5000", registryEndpoints[3].Port), registry,
 			"/entrypoint.sh", "/etc/docker/registry/config.yml"})
@@ -207,11 +205,12 @@ registries = ['{{.Host}}:{{.Port}}']`
 			Skip("Can not start docker registry.")
 		}
 
+		podmanTest.RestoreArtifact(ALPINE)
 		image := fmt.Sprintf("%s/my-alpine", registryEndpoints[3].Address())
-		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
+		push := podmanTest.PodmanNoCache([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Equal(0))
-		search := podmanTest.Podman([]string{"search", image, "--tls-verify=false"})
+		search := podmanTest.PodmanNoCache([]string{"search", image, "--tls-verify=false"})
 		search.WaitWithDefaultTimeout()
 
 		Expect(search.ExitCode()).To(Equal(0))
@@ -225,7 +224,6 @@ registries = ['{{.Host}}:{{.Port}}']`
 
 		lock := GetPortLock(registryEndpoints[4].Port)
 		defer lock.Unlock()
-		podmanTest.RestoreArtifact(registry)
 		registry := podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%s:5000", registryEndpoints[4].Port),
 			"--name", "registry4", registry, "/entrypoint.sh", "/etc/docker/registry/config.yml"})
 		registry.WaitWithDefaultTimeout()
@@ -235,8 +233,9 @@ registries = ['{{.Host}}:{{.Port}}']`
 			Skip("Can not start docker registry.")
 		}
 
+		podmanTest.RestoreArtifact(ALPINE)
 		image := fmt.Sprintf("%s/my-alpine", registryEndpoints[4].Address())
-		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
+		push := podmanTest.PodmanNoCache([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Equal(0))
 
@@ -246,7 +245,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
 		ioutil.WriteFile(fmt.Sprintf("%s/registry4.conf", tempdir), buffer.Bytes(), 0644)
 
-		search := podmanTest.Podman([]string{"search", image})
+		search := podmanTest.PodmanNoCache([]string{"search", image})
 		search.WaitWithDefaultTimeout()
 
 		Expect(search.ExitCode()).To(Equal(0))
@@ -264,7 +263,6 @@ registries = ['{{.Host}}:{{.Port}}']`
 		}
 		lock := GetPortLock(registryEndpoints[5].Port)
 		defer lock.Unlock()
-		podmanTest.RestoreArtifact(registry)
 		registry := podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%s:5000", registryEndpoints[5].Port),
 			"--name", "registry5", registry})
 		registry.WaitWithDefaultTimeout()
@@ -274,8 +272,9 @@ registries = ['{{.Host}}:{{.Port}}']`
 			Skip("Can not start docker registry.")
 		}
 
+		podmanTest.RestoreArtifact(ALPINE)
 		image := fmt.Sprintf("%s/my-alpine", registryEndpoints[5].Address())
-		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
+		push := podmanTest.PodmanNoCache([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Equal(0))
 
@@ -284,7 +283,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
 		ioutil.WriteFile(fmt.Sprintf("%s/registry5.conf", tempdir), buffer.Bytes(), 0644)
 
-		search := podmanTest.Podman([]string{"search", image, "--tls-verify=true"})
+		search := podmanTest.PodmanNoCache([]string{"search", image, "--tls-verify=true"})
 		search.WaitWithDefaultTimeout()
 
 		Expect(search.ExitCode()).To(Equal(0))
@@ -302,7 +301,6 @@ registries = ['{{.Host}}:{{.Port}}']`
 		}
 		lock := GetPortLock(registryEndpoints[6].Port)
 		defer lock.Unlock()
-		podmanTest.RestoreArtifact(registry)
 		registry := podmanTest.Podman([]string{"run", "-d", "-p", fmt.Sprintf("%s:5000", registryEndpoints[6].Port),
 			"--name", "registry6", registry})
 		registry.WaitWithDefaultTimeout()
@@ -312,8 +310,9 @@ registries = ['{{.Host}}:{{.Port}}']`
 			Skip("Can not start docker registry.")
 		}
 
+		podmanTest.RestoreArtifact(ALPINE)
 		image := fmt.Sprintf("%s/my-alpine", registryEndpoints[6].Address())
-		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
+		push := podmanTest.PodmanNoCache([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, image})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Equal(0))
 
@@ -322,7 +321,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
 		ioutil.WriteFile(fmt.Sprintf("%s/registry6.conf", tempdir), buffer.Bytes(), 0644)
 
-		search := podmanTest.Podman([]string{"search", image})
+		search := podmanTest.PodmanNoCache([]string{"search", image})
 		search.WaitWithDefaultTimeout()
 
 		Expect(search.ExitCode()).To(Equal(0))
@@ -343,7 +342,6 @@ registries = ['{{.Host}}:{{.Port}}']`
 		lock8 := GetPortLock("6000")
 		defer lock8.Unlock()
 
-		podmanTest.RestoreArtifact(registry)
 		registryLocal := podmanTest.Podman([]string{"run", "-d", "--net=host", "-p", fmt.Sprintf("%s:5000", registryEndpoints[7].Port),
 			"--name", "registry7", registry})
 		registryLocal.WaitWithDefaultTimeout()
@@ -361,7 +359,8 @@ registries = ['{{.Host}}:{{.Port}}']`
 			Skip("Can not start docker registry.")
 		}
 
-		push := podmanTest.Podman([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:6000/my-alpine"})
+		podmanTest.RestoreArtifact(ALPINE)
+		push := podmanTest.PodmanNoCache([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:6000/my-alpine"})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Equal(0))
 
@@ -371,7 +370,7 @@ registries = ['{{.Host}}:{{.Port}}']`
 		podmanTest.setRegistriesConfigEnv(buffer.Bytes())
 		ioutil.WriteFile(fmt.Sprintf("%s/registry8.conf", tempdir), buffer.Bytes(), 0644)
 
-		search := podmanTest.Podman([]string{"search", "my-alpine"})
+		search := podmanTest.PodmanNoCache([]string{"search", "my-alpine"})
 		search.WaitWithDefaultTimeout()
 
 		Expect(search.ExitCode()).To(Equal(0))

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman start", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Podman stats", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Podman stop", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/system_df_test.go
+++ b/test/e2e/system_df_test.go
@@ -25,7 +25,8 @@ var _ = Describe("podman system df", func() {
 			os.Exit(1)
 		}
 		podmanTest = PodmanTestCreate(tempdir)
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.Setup()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {
@@ -55,7 +56,7 @@ var _ = Describe("podman system df", func() {
 		images := strings.Fields(session.OutputToStringArray()[1])
 		containers := strings.Fields(session.OutputToStringArray()[2])
 		volumes := strings.Fields(session.OutputToStringArray()[3])
-		Expect(images[1]).To(Equal("2"))
+		Expect(images[1]).To(Equal("9"))
 		Expect(containers[1]).To(Equal("2"))
 		Expect(volumes[2]).To(Equal("1"))
 	})

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Podman systemd", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 		systemd_unit_file = `[Unit]
 Description=redis container
 [Service]

--- a/test/e2e/tag_test.go
+++ b/test/e2e/tag_test.go
@@ -33,11 +33,11 @@ var _ = Describe("Podman tag", func() {
 	})
 
 	It("podman tag shortname:latest", func() {
-		session := podmanTest.Podman([]string{"tag", ALPINE, "foobar:latest"})
+		session := podmanTest.PodmanNoCache([]string{"tag", ALPINE, "foobar:latest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		results := podmanTest.Podman([]string{"inspect", "foobar:latest"})
+		results := podmanTest.PodmanNoCache([]string{"inspect", "foobar:latest"})
 		results.WaitWithDefaultTimeout()
 		Expect(results.ExitCode()).To(Equal(0))
 		inspectData := results.InspectImageJSON()
@@ -46,11 +46,11 @@ var _ = Describe("Podman tag", func() {
 	})
 
 	It("podman tag shortname", func() {
-		session := podmanTest.Podman([]string{"tag", ALPINE, "foobar"})
+		session := podmanTest.PodmanNoCache([]string{"tag", ALPINE, "foobar"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		results := podmanTest.Podman([]string{"inspect", "foobar:latest"})
+		results := podmanTest.PodmanNoCache([]string{"inspect", "foobar:latest"})
 		results.WaitWithDefaultTimeout()
 		Expect(results.ExitCode()).To(Equal(0))
 		inspectData := results.InspectImageJSON()
@@ -59,11 +59,11 @@ var _ = Describe("Podman tag", func() {
 	})
 
 	It("podman tag shortname:tag", func() {
-		session := podmanTest.Podman([]string{"tag", ALPINE, "foobar:new"})
+		session := podmanTest.PodmanNoCache([]string{"tag", ALPINE, "foobar:new"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		results := podmanTest.Podman([]string{"inspect", "foobar:new"})
+		results := podmanTest.PodmanNoCache([]string{"inspect", "foobar:new"})
 		results.WaitWithDefaultTimeout()
 		Expect(results.ExitCode()).To(Equal(0))
 		inspectData := results.InspectImageJSON()
@@ -72,15 +72,15 @@ var _ = Describe("Podman tag", func() {
 	})
 
 	It("podman tag shortname image no tag", func() {
-		session := podmanTest.Podman([]string{"tag", ALPINE, "foobar"})
+		session := podmanTest.PodmanNoCache([]string{"tag", ALPINE, "foobar"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		results := podmanTest.Podman([]string{"tag", "foobar", "barfoo"})
+		results := podmanTest.PodmanNoCache([]string{"tag", "foobar", "barfoo"})
 		results.WaitWithDefaultTimeout()
 		Expect(results.ExitCode()).To(Equal(0))
 
-		verify := podmanTest.Podman([]string{"inspect", "barfoo"})
+		verify := podmanTest.PodmanNoCache([]string{"inspect", "barfoo"})
 		verify.WaitWithDefaultTimeout()
 		Expect(verify.ExitCode()).To(Equal(0))
 	})

--- a/test/e2e/top_test.go
+++ b/test/e2e/top_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman top", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/tree_test.go
+++ b/test/e2e/tree_test.go
@@ -22,7 +22,8 @@ var _ = Describe("Podman image tree", func() {
 			os.Exit(1)
 		}
 		podmanTest = PodmanTestCreate(tempdir)
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.Setup()
+		podmanTest.RestoreArtifact(BB)
 	})
 
 	AfterEach(func() {
@@ -36,7 +37,7 @@ var _ = Describe("Podman image tree", func() {
 		if podmanTest.RemoteTest {
 			Skip("Does not work on remote client")
 		}
-		session := podmanTest.Podman([]string{"pull", "docker.io/library/busybox:latest"})
+		session := podmanTest.PodmanNoCache([]string{"pull", "docker.io/library/busybox:latest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -47,17 +48,17 @@ ENV foo=bar
 `
 		podmanTest.BuildImage(dockerfile, "test:latest", "true")
 
-		session = podmanTest.Podman([]string{"image", "tree", "test:latest"})
+		session = podmanTest.PodmanNoCache([]string{"image", "tree", "test:latest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"image", "tree", "--whatrequires", "docker.io/library/busybox:latest"})
+		session = podmanTest.PodmanNoCache([]string{"image", "tree", "--whatrequires", "docker.io/library/busybox:latest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"rmi", "test:latest"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "test:latest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"rmi", "docker.io/library/busybox:latest"})
+		session = podmanTest.PodmanNoCache([]string{"rmi", "docker.io/library/busybox:latest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})

--- a/test/e2e/trust_test.go
+++ b/test/e2e/trust_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Podman trust", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/unshare_test.go
+++ b/test/e2e/unshare_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Podman unshare", func() {
 		podmanTest.CgroupManager = "cgroupfs"
 		podmanTest.StorageOptions = ROOTLESS_STORAGE_OPTIONS
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -27,6 +27,7 @@ var _ = Describe("Podman version", func() {
 		podmanTest.Cleanup()
 		f := CurrentGinkgoTestDescription()
 		processTestResult(f)
+		podmanTest.SeedImages()
 
 	})
 

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman volume create", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/volume_inspect_test.go
+++ b/test/e2e/volume_inspect_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman volume inspect", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman volume ls", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Podman volume prune", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/volume_rm_test.go
+++ b/test/e2e/volume_rm_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman volume rm", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/wait_test.go
+++ b/test/e2e/wait_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Podman wait", func() {
 		}
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
-		podmanTest.RestoreAllArtifacts()
+		podmanTest.SeedImages()
 	})
 
 	AfterEach(func() {

--- a/test/utils/podmantest_test.go
+++ b/test/utils/podmantest_test.go
@@ -23,7 +23,7 @@ var _ = Describe("PodmanTest test", func() {
 		FakeOutputs["check"] = []string{"check"}
 		os.Setenv("HOOK_OPTION", "hook_option")
 		env := os.Environ()
-		session := podmanTest.PodmanAsUserBase([]string{"check"}, 1000, 1000, "", env)
+		session := podmanTest.PodmanAsUserBase([]string{"check"}, 1000, 1000, "", env, true)
 		os.Unsetenv("HOOK_OPTION")
 		session.WaitWithDefaultTimeout()
 		Expect(session.Command.Process).ShouldNot(BeNil())


### PR DESCRIPTION
when doing localized tests (not varlink), we can use secondary image
stores as read-only image caches.  this cuts down on test time
significantly because each test does not need to restore the images from
a tarball.

Signed-off-by: baude <bbaude@redhat.com>