### PR TITLE
install.remote should be separate for install.bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,14 +259,17 @@ changelog: ## Generate changelog
 	$(shell cat $(TMPFILE) >> changelog.txt)
 	$(shell rm $(TMPFILE))
 
-install: .gopathok install.bin install.man install.cni install.systemd  ## Install binaries to system locations
+install: .gopathok install.bin install.remote install.man install.cni install.systemd  ## Install binaries to system locations
+
+install.remote:
+	install ${SELINUXOPT} -d -m 755 $(BINDIR)
+	install ${SELINUXOPT} -m 755 bin/podman-remote $(BINDIR)/podman-remote
+	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(BINDIR)/podman bin/podman-remote
 
 install.bin:
 	install ${SELINUXOPT} -d -m 755 $(BINDIR)
 	install ${SELINUXOPT} -m 755 bin/podman $(BINDIR)/podman
-	install ${SELINUXOPT} -m 755 bin/podman-remote $(BINDIR)/podman-remote
 	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(BINDIR)/podman bin/podman
-	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(BINDIR)/podman bin/podman-remote
 
 install.man: docs
 	install ${SELINUXOPT} -d -m 755 $(MANDIR)/man1

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -389,6 +389,7 @@ popd
 install -dp %{buildroot}%{_unitdir}
 PODMAN_VERSION=%{version} %{__make} PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir} \
         install.bin \
+        install.remote \
         install.man \
         install.cni \
         install.systemd \


### PR DESCRIPTION
For people who want to install podman remote or podman
only we need to separate out the two install commands.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>