### PR TITLE
Create Dockerfiles for podmanimage

### DIFF
--- a/contrib/podmanimage/README.md
+++ b/contrib/podmanimage/README.md
@@ -1,0 +1,44 @@
+![PODMAN logo](logo/podman-logo-source.svg)
+
+# podmanimage
+
+## Overview
+
+This directory contains the Dockerfiles necessary to create the three podmanimage container
+images that are housed on quay.io under the podman account.  All three repositories where
+the images live are public and can be pulled without credentials.  These container images are secured and the
+resulting containers can run safely with privileges within the container.  The container images are built
+using the latest Fedora and then Podman is installed into them:
+
+  * quay.io/podman/stable - This image is built using the latest stable version of Podman in a Fedora based container.  Built with podman/stable/Dockerfile.
+  * quay.io/podman/upstream - This image is built using the latest code found in this GitHub repository.  When someone creates a commit and pushes it, the image is created.  Due to that the image changes frequently and is not guaranteed to be stable.  Built with podmanimage/upstream/Dockerfile.
+  * quay.io/podman/testing - This image is built using the latest version of Podman that is or was in updates testing for Fedora.  At times this may be the same as the stable image.  This container image will primarily be used by the development teams for verification testing when a new package is created.  Built with podmanimage/testing/Dockerfile.
+
+## Sample Usage
+
+
+```
+podman pull docker://quay.io/podman/stable:latest
+
+podman run --privileged stable podman version
+
+# Create a directory on the host to mount the container's
+# /var/lib/container directory to so containers can be
+# run within the container.
+mkdir /var/lib/mycontainer
+
+# Run the image detached using the host's network in a container name
+# podmanctr, turn off label and seccomp confinement in the container
+# and then do a little shell hackery to keep the container up and running.
+podman run --detach --name=podmanctr --net=host --security-opt label=disable --security-opt seccomp=unconfined --device /dev/fuse:rw -v /var/lib/mycontainer:/var/lib/containers:Z --privileged  stable sh -c 'while true ;do wait; done'
+
+podman exec -it  podmanctr /bin/sh
+
+# Now inside of the container
+
+podman pull alpine
+
+podman images
+
+exit
+```

--- a/contrib/podmanimage/stable/Dockerfile
+++ b/contrib/podmanimage/stable/Dockerfile
@@ -1,0 +1,26 @@
+# stable/Dockerfile
+#
+# Build a Podman container image from the latest
+# stable version of Podman on the Fedoras Updates System.
+# https://bodhi.fedoraproject.org/updates/?search=podman
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+#
+FROM fedora:latest
+
+# Don't include container-selinux and remove
+# directories used by dnf that are just taking
+# up space.
+RUN yum -y install podman fuse-overlayfs --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+
+# Adjust libpod.conf to write logging to a file
+RUN sed -i 's/events_logger = "journald"/events_logger = "file"/g' /usr/share/containers/libpod.conf
+
+# Set up environment variables to note that this is
+# not starting with usernamespace and default to
+# isolate the filesystem with chroot.
+ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot

--- a/contrib/podmanimage/testing/Dockerfile
+++ b/contrib/podmanimage/testing/Dockerfile
@@ -1,0 +1,28 @@
+# testing/Dockerfile
+#
+# Build a Podman image using the latest
+# version of Podman that is in updates-testing
+# on the Fedoras Updates System.  At times this
+# may be the same the latest stable version.
+# https://bodhi.fedoraproject.org/updates/?search=podman
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+#
+FROM fedora:latest
+
+# Don't include container-selinux and remove
+# directories used by dnf that are just taking
+# up space.
+RUN yum -y install podman fuse-overlayfs --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+
+# Adjust libpod.conf to write logging to a file
+RUN sed -i 's/events_logger = "journald"/events_logger = "file"/g' /usr/share/containers/libpod.conf
+
+# Set up environment variables to note that this is
+# not starting with usernamespace and default to
+# isolate the filesystem with chroot.
+ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot

--- a/contrib/podmanimage/upstream/Dockerfile
+++ b/contrib/podmanimage/upstream/Dockerfile
@@ -1,0 +1,78 @@
+# git/Dockerfile
+#
+# Build a Podman container image from the latest
+# upstream version of Podman on GitHub.
+# https://github.com/containers/libpod
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+# The containers created by this image also come with a
+# Podman development environment in /root/podman.
+#
+FROM fedora:latest
+ENV GOPATH=/root/podman
+
+# Install the software required to build Podman.
+# Then create a directory and clone from the Podman
+# GitHub repository, make and install Podman
+# to the container.
+# Finally remove the podman directory and a few other packages
+# that are needed for building but not running Podman
+RUN dnf -y install --exclude container-selinux \
+     --enablerepo=updates-testing \
+     atomic-registries \
+     btrfs-progs-devel \
+     conmon \
+     containernetworking-cni \
+     device-mapper-devel \
+     git \
+     glib2-devel \
+     glibc-devel \
+     glibc-static \
+     go \
+     golang-github-cpuguy83-go-md2man \
+     gpgme-devel \
+     iptables \
+     libassuan-devel \
+     libgpg-error-devel \
+     libseccomp-devel \
+     libselinux-devel \
+     make \
+     ostree-devel \
+     pkgconfig \
+     runc \
+     fuse-overlayfs \
+     fuse3 \
+     containers-common; \
+     mkdir /root/podman; \
+     git clone https://github.com/containers/libpod /root/podman/src/github.com/containers/libpod; \
+     cd /root/podman/src/github.com/containers/libpod; \
+     make BUILDTAGS="selinux seccomp"; \
+     make install PREFIX=/usr; \
+     cd /root/podman; \
+     git clone https://github.com/containers/conmon; \
+     cd conmon; \
+     make; \
+     install -D -m 755 bin/conmon /usr/libexec/podman/conmon; \
+     git clone https://github.com/containernetworking/plugins.git $GOPATH/src/github.com/containernetworking/plugins; \
+     cd $GOPATH/src/github.com/containernetworking/plugins; \
+     ./build_linux.sh; \
+     mkdir -p /usr/libexec/cni; \
+     cp bin/* /usr/libexec/cni; \
+     mkdir -p /etc/cni/net.d; \
+     curl -qsSL https://raw.githubusercontent.com/containers/libpod/master/cni/87-podman-bridge.conflist | sudo tee /etc/cni/net.d/99-loopback.conf; \
+     mkdir -p /usr/share/containers; \
+     cp $GOPATH/podman/src/github.com/containers/libpod/libpod.conf /usr/share/containers; \
+     # Adjust libpod.conf to write logging to a file
+     sed -i 's/events_logger = "journald"/events_logger = "file"/g' /usr/share/containers/libpod.conf; \
+     rm -rf /root/podman/*; \
+     dnf -y remove bats git golang go-md2man make; \
+     dnf clean all;
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+
+# Set up environment variables to note that this is
+# not starting with usernamespace and default to
+# isolate the filesystem with chroot.
+ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot

--- a/install.md
+++ b/install.md
@@ -273,7 +273,7 @@ First, ensure that the go version that is found first on the $PATH (in case you 
 git clone https://github.com/containers/libpod/ $GOPATH/src/github.com/containers/libpod
 cd $GOPATH/src/github.com/containers/libpod
 make BUILDTAGS="selinux seccomp"
-sudo make install PREFIX=
+sudo make install PREFIX=/usr
 ```
 
 #### Build Tags


### PR DESCRIPTION
The Dockerfiles necessary to create the stable, testing and upstream container images
on quay.io/user/podman.  Once this is commited, I will set up those images
such that they will be built with every git commit.

stable - Latest Fedora release image
testing - Latest release on bohdi Fedora testing
upstream - Latest version in upstream podman

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>