### PR TITLE
Output name of process on runlabel command

### DIFF
--- a/cmd/podman/runlabel.go
+++ b/cmd/podman/runlabel.go
@@ -152,7 +152,7 @@ func runlabelCmd(c *cliconfig.RunlabelValues) error {
 		return err
 	}
 	if !c.Quiet {
-		fmt.Printf("command: %s\n", strings.Join(cmd, " "))
+		fmt.Printf("command: %s\n", strings.Join(append([]string{os.Args[0]}, cmd[1:]...), " "))
 		if c.Display {
 			return nil
 		}


### PR DESCRIPTION
From the logic in [funcs.go](https://github.com/containers/libpod/blob/a7809fabe508e26c527490e700a1703ef923bd3b/cmd/podman/shared/funcs.go#L17-L24), it looks like `/proc/self/exe` is used to ensure no further indirection.
However, this also shows up in the debug output:

```
$ podman container runlabel -p pod quay.io/baude/demodb:latest

command: /proc/self/exe run --pod new:demodb -P -e MYSQL_ROOT_PASSWORD=x -dt quay.io/baude/demodb:latest
```

This isn't as helpful since the command cannot be copy-pasted and reused.

This patch is a dead-simple swap-in for the current process name during the debug log.