### PR TITLE
util: fix race condition in WaitForFile

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -289,8 +289,8 @@ func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir 
 	chWait := make(chan error)
 	go func() {
 		chWait <- execCmd.Wait()
+		close(chWait)
 	}()
-	defer close(chWait)
 
 	pidFile := c.execPidPath(sessionID)
 	// 60 second seems a reasonable time to wait


### PR DESCRIPTION
enable polling also when using inotify.  It is generally useful to
have it as under high load inotify can lose notifications.  It also
solves a race condition where the file is created while the watcher
is configured and it'd wait until the timeout and fail.

Closes: https://github.com/containers/libpod/issues/2942

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>