### PR TITLE
rootless: force resources to be nil on cgroup v1

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -357,6 +357,10 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 		if addedResources && !cgroup2 {
 			return nil, errors.New("invalid configuration, cannot set resources with rootless containers not using cgroups v2 unified mode")
 		}
+		if !cgroup2 {
+			// Force the resources block to be empty instead of having default values.
+			configSpec.Linux.Resources = &spec.LinuxResources{}
+		}
 	}
 
 	// Make sure that the bind mounts keep options like nosuid, noexec, nodev.


### PR DESCRIPTION
force the resources block to be empty instead of having default
values.

Regression introduced by 8e88461511e81d2327e4c1a1315bb58fda1827ca

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>