### PR TITLE
Remove conmon from fedora install instructions

### DIFF
--- a/install.md
+++ b/install.md
@@ -91,7 +91,6 @@ Fedora, CentOS, RHEL, and related distributions:
 sudo yum install -y \
   atomic-registries \
   btrfs-progs-devel \
-  conmon \
   containernetworking-cni \
   device-mapper-devel \
   git \


### PR DESCRIPTION
conmon package is no longer available, remove from
install.md.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>