### PR TITLE
Docker compat: fix JSON key capitalization in `podman inspect`

### DIFF
--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -146,7 +146,7 @@ type Data struct {
 
 // ContainerInspectData handles the data used when inspecting a container
 type ContainerInspectData struct {
-	ID              string                 `json:"ID"`
+	ID              string                 `json:"Id"`
 	Created         time.Time              `json:"Created"`
 	Path            string                 `json:"Path"`
 	Args            []string               `json:"Args"`


### PR DESCRIPTION
The JSON output of `podman inspect <container>` has a key with name `ID`, whereas
the JSON output of `docker inspect <container>` has a key with name `Id`.

An attempted fix for this discrepancy was committed in https://github.com/containers/libpod/pull/306. This made `podman inspect --format '{{.Id}}' <container>` work correctly by substituting `{{.Id}} -> {{.ID}}` internally when present in the `--format` arg.

However this fix is inadequate because it does not also change the name of the key in the full JSON output (e.g. when no `--format` is specified). This causes problems for tooling which does not specify a `--format` and instead parses the full JSON output itself.

Contrived example:
```
$ podman inspect --format '{{.Id}}' foobar  # works fine
1baec244c4ad57ac2437981f686aef0e774420a775bd531b0737e472ce0eacee

$ podman inspect foobar | jq '.[].Id'    # fails because it's still called ID in the json
null
```
(The Jenkins "Docker pipeline" plugin works this way and is currently incompatible with podman for this reason.)

This PR changes the JSON tag in the appropriate struct so the correct name is used when marshaled for output.

This also makes the behaviour of `podman inspect <container>` consistent with `podman inspect <image>`, which already uses the Docker-compatible key `Id`.