### PR TITLE
Add OCI Spec Path to `podman inspect` JSON

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -92,6 +92,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *inspect.Data)
 		HostnamePath:    hostnamePath,
 		HostsPath:       hostsPath,
 		StaticDir:       config.StaticDir,
+		OCISpecPath:     c.state.ConfigPath,
 		LogPath:         config.LogPath,
 		ConmonPidFile:   config.ConmonPidFile,
 		Name:            config.Name,

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -158,6 +158,7 @@ type ContainerInspectData struct {
 	HostnamePath    string                 `json:"HostnamePath"`
 	HostsPath       string                 `json:"HostsPath"`
 	StaticDir       string                 `json:"StaticDir"`
+	OCISpecPath     string                 `json:"OCISpecPath,omitempty"`
 	LogPath         string                 `json:"LogPath"`
 	ConmonPidFile   string                 `json:"ConmonPidFile"`
 	Name            string                 `json:"Name"`


### PR DESCRIPTION
This is OmitEmpty, so I'll only be shown if the spec exists (IE, the container has been created in runc).