### PR TITLE
make remote resize channel buffered

### DIFF
--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -561,7 +561,7 @@ func (r *LocalRuntime) attach(ctx context.Context, stdin, stdout *os.File, cid s
 	if err != nil {
 		return nil, err
 	}
-	resize := make(chan remotecommand.TerminalSize)
+	resize := make(chan remotecommand.TerminalSize, 5)
 	haveTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))
 
 	// Check if we are attached to a terminal. If we are, generate resize


### PR DESCRIPTION
when doing any sort of attach to a container, a sigwinch is sent
followed by a resize event.  this is fine for the local client but when
doing things over the varlink, the first sigwinch is wiped out by the
immediate resize event and is therefore lost.  by making the channel
buffered, both events are processed after the varlink connection is
established.

Signed-off-by: baude <bbaude@redhat.com>