### PR TITLE
When superceding mounts, check for opposite types

### DIFF
--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -104,4 +104,18 @@ var _ = Describe("Podman run with volumes", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(125))
 	})
+
+	It("podman run with conflict between image volume and user mount succeeds", func() {
+		podmanTest.RestoreArtifact(redis)
+		mountPath := filepath.Join(podmanTest.TempDir, "secrets")
+		err := os.Mkdir(mountPath, 0755)
+		Expect(err).To(BeNil())
+		testFile := filepath.Join(mountPath, "test1")
+		f, err := os.Create(testFile)
+		f.Close()
+		Expect(err).To(BeNil())
+		session := podmanTest.Podman([]string{"run", "-v", fmt.Sprintf("%s:/data", mountPath), redis, "ls", "/data/test1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
When we supercede low-priority mounts and volumes (image volumes, and volumes sourced from --volumes-from) with higher-priority ones (the --volume and --mount flags), we always replaced lower-priority mounts of the same type (e.g. a user mount to /tmp/test1 would supercede a volumes-from mount to the same destination). However, we did not supercede the opposite type - a named volume from image volumes at /tmp/test1 would be allowed to remain and create a conflict, preventing container creation.

Solve this by destroying opposite types before merging (we can't do it in the same loop, as then named volumes, which go second, might trample changes made by mounts).

Fixes #3174