### PR TITLE
Fix a 'generate kube' bug on ctrs with named volumes

### DIFF
--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -217,7 +217,7 @@ func playKubeYAMLCmd(c *cliconfig.KubePlayValues, ctx context.Context, runtime *
 		if err != nil {
 			return pod, err
 		}
-		createConfig, err := kubeContainerToCreateConfig(ctx, container, runtime, newImage, namespaces, volumes)
+		createConfig, err := kubeContainerToCreateConfig(ctx, container, runtime, newImage, namespaces, volumes, pod.ID())
 		if err != nil {
 			return pod, err
 		}
@@ -274,7 +274,7 @@ func getPodPorts(containers []v1.Container) []ocicni.PortMapping {
 }
 
 // kubeContainerToCreateConfig takes a v1.Container and returns a createconfig describing a container
-func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container, runtime *libpod.Runtime, newImage *image.Image, namespaces map[string]string, volumes map[string]string) (*createconfig.CreateConfig, error) {
+func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container, runtime *libpod.Runtime, newImage *image.Image, namespaces map[string]string, volumes map[string]string, podID string) (*createconfig.CreateConfig, error) {
 	var (
 		containerConfig createconfig.CreateConfig
 	)
@@ -287,6 +287,8 @@ func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container
 	containerConfig.Name = containerYAML.Name
 	containerConfig.Tty = containerYAML.TTY
 	containerConfig.WorkDir = containerYAML.WorkingDir
+
+	containerConfig.Pod = podID
 
 	imageData, _ := newImage.Inspect(ctx)
 

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -220,7 +220,6 @@ func containerToV1Container(c *Container) (v1.Container, error) {
 			return kubeContainer, err
 		}
 		kubeContainer.VolumeMounts = volumes
-		//return kubeContainer, errors.Wrapf(ErrNotImplemented, "volume names")
 	}
 
 	envVariables, err := libpodEnvVarsToKubeEnvVars(c.config.Spec.Process.Env)

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -220,12 +220,12 @@ func containerToV1Container(c *Container) (v1.Container, error) {
 			return kubeContainer, err
 		}
 		kubeContainer.VolumeMounts = volumes
-		return kubeContainer, errors.Wrapf(ErrNotImplemented, "volume names")
+		//return kubeContainer, errors.Wrapf(ErrNotImplemented, "volume names")
 	}
 
 	envVariables, err := libpodEnvVarsToKubeEnvVars(c.config.Spec.Process.Env)
 	if err != nil {
-		return kubeContainer, nil
+		return kubeContainer, err
 	}
 
 	portmappings, err := c.PortMappings()
@@ -234,7 +234,7 @@ func containerToV1Container(c *Container) (v1.Container, error) {
 	}
 	ports, err := ocicniPortMappingToContainerPort(portmappings)
 	if err != nil {
-		return kubeContainer, nil
+		return kubeContainer, err
 	}
 
 	containerCommands := c.Command()
@@ -345,7 +345,7 @@ func libpodMountsToKubeVolumeMounts(c *Container) ([]v1.VolumeMount, error) {
 	for _, hostSourcePath := range c.config.UserVolumes {
 		vm, err := generateKubeVolumeMount(hostSourcePath, c.config.Spec.Mounts)
 		if err != nil {
-			return vms, err
+			continue
 		}
 		vms = append(vms, vm)
 	}


### PR DESCRIPTION
Also, restore some errors that were being ignored.

Comment out an error line because I'm not actually sure what it's doing and why it's there, but we were hitting it on occasion.