### PR TITLE
rootless: new function to join existing conmon processes

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -167,7 +167,7 @@ func (r *Runtime) newContainer(ctx context.Context, rSpec *spec.Spec, options ..
 	}()
 
 	if rootless.IsRootless() && ctr.config.ConmonPidFile == "" {
-		ctr.config.ConmonPidFile = filepath.Join(ctr.config.StaticDir, "conmon.pid")
+		ctr.config.ConmonPidFile = filepath.Join(ctr.state.RunDir, "conmon.pid")
 	}
 
 	// Go through named volumes and add them.

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -206,10 +206,10 @@ func enableLinger(pausePid string) {
 	}
 }
 
-// JoinUserAndMountNS re-exec podman in a new userNS and join the user and mount
+// joinUserAndMountNS re-exec podman in a new userNS and join the user and mount
 // namespace of the specified PID without looking up its parent.  Useful to join directly
 // the conmon process.
-func JoinUserAndMountNS(pid uint, pausePid string) (bool, int, error) {
+func joinUserAndMountNS(pid uint, pausePid string) (bool, int, error) {
 	enableLinger(pausePid)
 
 	if os.Geteuid() == 0 || os.Getenv("_CONTAINERS_USERNS_CONFIGURED") != "" {
@@ -357,7 +357,7 @@ func becomeRootInUserNS(pausePid, fileToRead string, fileOutput *os.File) (bool,
 		if err == nil {
 			pid, err := strconv.ParseUint(string(data), 10, 0)
 			if err == nil {
-				return JoinUserAndMountNS(uint(pid), "")
+				return joinUserAndMountNS(uint(pid), "")
 			}
 		}
 		return false, -1, errors.Wrapf(err, "error setting up the process")
@@ -480,5 +480,5 @@ func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []st
 		return false, 0, lastErr
 	}
 
-	return JoinUserAndMountNS(uint(pausePid), pausePidPath)
+	return joinUserAndMountNS(uint(pausePid), pausePidPath)
 }

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -36,3 +36,15 @@ func GetRootlessGID() int {
 func JoinUserAndMountNS(pid uint, pausePid string) (bool, int, error) {
 	return false, -1, errors.New("this function is not supported on this os")
 }
+
+// TryJoinFromFilePaths attempts to join the namespaces of the pid files in paths.
+// This is useful when there are already running containers and we
+// don't have a pause process yet.  We can use the paths to the conmon
+// processes to attempt joining their namespaces.
+// If needNewNamespace is set, the file is read from a temporary user
+// namespace, this is useful for containers that are running with a
+// different uidmap and the unprivileged user has no way to read the
+// file owned by the root in the container.
+func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []string) (bool, int, error) {
+	return false, -1, errors.New("this function is not supported on this os")
+}

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -29,14 +29,6 @@ func GetRootlessGID() int {
 	return -1
 }
 
-// JoinUserAndMountNS re-exec podman in a new userNS and join the user and mount
-// namespace of the specified PID without looking up its parent.  Useful to join directly
-// the conmon process.  It is a convenience function for JoinUserAndMountNSWithOpts
-// with a default configuration.
-func JoinUserAndMountNS(pid uint, pausePid string) (bool, int, error) {
-	return false, -1, errors.New("this function is not supported on this os")
-}
-
 // TryJoinFromFilePaths attempts to join the namespaces of the pid files in paths.
 // This is useful when there are already running containers and we
 // don't have a pause process yet.  We can use the paths to the conmon


### PR DESCRIPTION
move the logic for joining existing namespaces down to the rootless package.  In main_local we still retrieve the list of conmon pid files and use it from the rootless package.

In addition, create a temporary user namespace for reading these files, as the unprivileged user might not have enough privileges for reading the conmon pid file, for example when running with a different uidmap and root in the container is different than the rootless user.

Closes: https://github.com/containers/libpod/issues/3187

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>