### PR TITLE
Apparmor fixes

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -70,6 +71,10 @@ func createInit(c *cliconfig.PodmanCommand) error {
 	if !remote && c.Bool("trace") {
 		span, _ := opentracing.StartSpanFromContext(Ctx, "createInit")
 		defer span.Finish()
+	}
+
+	if c.IsSet("privileged") && c.IsSet("security-opt") {
+		logrus.Warn("setting security options with --privileged has no effect")
 	}
 
 	// Docker-compatibility: the "-h" flag for run/create is reserved for

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containers/libpod/pkg/lookup"
 	"github.com/containers/libpod/pkg/resolvconf"
 	"github.com/containers/libpod/pkg/rootless"
-	"github.com/cyphar/filepath-securejoin"
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/user"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -188,11 +188,13 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 	}
 
 	// Apply AppArmor checks and load the default profile if needed.
-	updatedProfile, err := apparmor.CheckProfileAndLoadDefault(c.config.Spec.Process.ApparmorProfile)
-	if err != nil {
-		return nil, err
+	if !c.config.Privileged {
+		updatedProfile, err := apparmor.CheckProfileAndLoadDefault(c.config.Spec.Process.ApparmorProfile)
+		if err != nil {
+			return nil, err
+		}
+		g.SetProcessApparmorProfile(updatedProfile)
 	}
-	g.SetProcessApparmorProfile(updatedProfile)
 
 	if err := c.makeBindMounts(); err != nil {
 		return nil, err

--- a/test/test_podman_baseline.sh
+++ b/test/test_podman_baseline.sh
@@ -504,6 +504,16 @@ EOF
         echo "failed"
     fi
 
+    #Expected to pass (as root with --privileged).
+    #Note that the profile should not be loaded letting the mount succeed.
+    podman run --privileged docker.io/library/alpine:latest sh -c "mkdir tmp2; mount --bind tmp tmp2"
+    rc=$?
+    echo -n "root with specified AppArmor profile but --privileged: "
+    if [ $rc == 0 ]; then
+        echo "passed"
+    else
+        echo "failed"
+    fi
     #Expected to fail (as rootless)
     sudo -u "#1000" podman run --security-opt apparmor=$aaProfile docker.io/library/alpine:latest echo hello
     rc=$?


### PR DESCRIPTION
- don't load/set the aa profile when initializing the container
- add a baseline test to avoid regressing on privileged containers