### PR TITLE
rootless: fix top huser and hgroup

### DIFF
--- a/libpod/container_top_linux.go
+++ b/libpod/container_top_linux.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/psgo"
 	"github.com/pkg/errors"
 )
@@ -47,7 +48,9 @@ func (c *Container) GetContainerPidInformation(descriptors []string) ([]string, 
 	//       filters on the data.  We need to change the API here and the
 	//       varlink API to return a [][]string if we want to make use of
 	//       filtering.
-	psgoOutput, err := psgo.JoinNamespaceAndProcessInfo(pid, descriptors)
+	opts := psgo.JoinNamespaceOpts{FillMappings: rootless.IsRootless()}
+
+	psgoOutput, err := psgo.JoinNamespaceAndProcessInfoWithOptions(pid, descriptors, &opts)
 	if err != nil {
 		return nil, err
 	}

--- a/libpod/pod_top_linux.go
+++ b/libpod/pod_top_linux.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/psgo"
 )
 
@@ -43,7 +44,8 @@ func (p *Pod) GetPodPidInformation(descriptors []string) ([]string, error) {
 	//       filters on the data.  We need to change the API here and the
 	//       varlink API to return a [][]string if we want to make use of
 	//       filtering.
-	output, err := psgo.JoinNamespaceAndProcessInfoByPids(pids, descriptors)
+	opts := psgo.JoinNamespaceOpts{FillMappings: rootless.IsRootless()}
+	output, err := psgo.JoinNamespaceAndProcessInfoByPidsWithOptions(pids, descriptors, &opts)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/vbauerster/mpb v3.3.4
 github.com/mattn/go-isatty v0.0.4
 github.com/VividCortex/ewma v1.1.1
 github.com/containers/storage v1.12.7
-github.com/containers/psgo v1.2.1
+github.com/containers/psgo v1.3.0
 github.com/coreos/go-systemd v14
 github.com/coreos/pkg v4
 github.com/cri-o/ocicni 0c180f981b27ef6036fa5be29bcb4dd666e406eb

--- a/vendor/github.com/containers/psgo/internal/proc/ns.go
+++ b/vendor/github.com/containers/psgo/internal/proc/ns.go
@@ -15,9 +15,19 @@
 package proc
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
+
+	"github.com/pkg/errors"
 )
+
+type IDMap struct {
+	ContainerID int
+	HostID      int
+	Size        int
+}
 
 // ParsePIDNamespace returns the content of /proc/$pid/ns/pid.
 func ParsePIDNamespace(pid string) (string, error) {
@@ -35,4 +45,35 @@ func ParseUserNamespace(pid string) (string, error) {
 		return "", err
 	}
 	return userNS, nil
+}
+
+// ReadMappings reads the user namespace mappings at the specified path
+func ReadMappings(path string) ([]IDMap, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot open %s", path)
+	}
+	defer file.Close()
+
+	mappings := []IDMap{}
+
+	buf := bufio.NewReader(file)
+	for {
+		line, _, err := buf.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				return mappings, nil
+			}
+			return nil, errors.Wrapf(err, "cannot read line from %s", path)
+		}
+		if line == nil {
+			return mappings, nil
+		}
+
+		containerID, hostID, size := 0, 0, 0
+		if _, err := fmt.Sscanf(string(line), "%d %d %d", &containerID, &hostID, &size); err != nil {
+			return nil, errors.Wrapf(err, "cannot parse %s", string(line))
+		}
+		mappings = append(mappings, IDMap{ContainerID: containerID, HostID: hostID, Size: size})
+	}
 }

--- a/vendor/github.com/containers/psgo/internal/process/process.go
+++ b/vendor/github.com/containers/psgo/internal/process/process.go
@@ -45,7 +45,7 @@ type Process struct {
 	Hgroup string
 }
 
-// LookupGID returns the textual group ID, if it can be optained, or the
+// LookupGID returns the textual group ID, if it can be obtained, or the
 // decimal representation otherwise.
 func LookupGID(gid string) (string, error) {
 	gidNum, err := strconv.Atoi(gid)
@@ -59,7 +59,7 @@ func LookupGID(gid string) (string, error) {
 	return g.Name, nil
 }
 
-// LookupUID return the textual user ID, if it can be optained, or the decimal
+// LookupUID return the textual user ID, if it can be obtained, or the decimal
 // representation otherwise.
 func LookupUID(uid string) (string, error) {
 	uidNum, err := strconv.Atoi(uid)


### PR DESCRIPTION
when running in rootless mode, be sure psgo is honoring the user namespace settings for huser and hgroup.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
