### PR TITLE
fix bug dest path of copying tar

### DIFF
--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -272,6 +272,10 @@ func copy(src, destPath, dest string, idMappingOpts storage.IDMappingOptions, ch
 		}
 		return nil
 	}
+
+	if destDirIsExist || strings.HasSuffix(dest, string(os.PathSeparator)) {
+		destPath = filepath.Join(destPath, filepath.Base(srcPath))
+	}
 	// Copy the file, preserving attributes.
 	logrus.Debugf("copying %q to %q", srcPath, destPath)
 	if err = copyFileWithTar(srcPath, destPath); err != nil {


### PR DESCRIPTION

when podman cp tar without --extract flag, if the destination already exists, or ends with a path separator, cp the tar under the directory, otherwise copy the tar named with the destination

close #3184  `podman cp tar destdir` will change the destination directory into the tar file
Signed-off-by: Qi Wang <qiwan@redhat.com>