### PR TITLE
userns: add new option --userns=keep-id

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -517,7 +517,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"Username or UID (format: <name|uid>[:<group|gid>])",
 	)
 	createFlags.String(
-		"userns", "",
+		"userns", os.Getenv("PODMAN_USERNS"),
 		"User namespace to use",
 	)
 	createFlags.String(

--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/pkg/namespaces"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/storage"
@@ -37,11 +38,12 @@ func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber bool, 
 	subgidname := c.Flags().Lookup("subgidname")
 	if (uidmapFlag != nil && gidmapFlag != nil && subuidname != nil && subgidname != nil) &&
 		(uidmapFlag.Changed || gidmapFlag.Changed || subuidname.Changed || subgidname.Changed) {
+		userns, _ := c.Flags().GetString("userns")
 		uidmapVal, _ := c.Flags().GetStringSlice("uidmap")
 		gidmapVal, _ := c.Flags().GetStringSlice("gidmap")
 		subuidVal, _ := c.Flags().GetString("subuidname")
 		subgidVal, _ := c.Flags().GetString("subgidname")
-		mappings, err := util.ParseIDMapping(uidmapVal, gidmapVal, subuidVal, subgidVal)
+		mappings, err := util.ParseIDMapping(namespaces.UsernsMode(userns), uidmapVal, gidmapVal, subuidVal, subgidVal)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -19,6 +19,7 @@ import (
 	ann "github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/inspect"
 	ns "github.com/containers/libpod/pkg/namespaces"
+	"github.com/containers/libpod/pkg/rootless"
 	cc "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/docker/docker/pkg/signal"
@@ -283,7 +284,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		namespaces                                               map[string]string
 	)
 
-	idmappings, err := util.ParseIDMapping(c.StringSlice("uidmap"), c.StringSlice("gidmap"), c.String("subuidname"), c.String("subgidname"))
+	idmappings, err := util.ParseIDMapping(ns.UsernsMode(c.String("userns")), c.StringSlice("uidmap"), c.StringSlice("gidmap"), c.String("subuidname"), c.String("subgidname"))
 	if err != nil {
 		return nil, err
 	}
@@ -451,7 +452,9 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 	// USER
 	user := c.String("user")
 	if user == "" {
-		if data == nil {
+		if usernsMode.IsKeepID() {
+			user = fmt.Sprintf("%d:%d", rootless.GetRootlessUID(), rootless.GetRootlessGID())
+		} else if data == nil {
 			user = "0"
 		} else {
 			user = data.Config.User

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -727,11 +727,13 @@ The followings examples are all valid:
 Without this argument the command will be run as root in the container.
 
 **--userns**=host
+**--userns**=keep-id
 **--userns**=ns:my_namespace
 
 Set the user namespace mode for the container. The use of userns is disabled by default.
 
 - `host`: run in the user namespace of the caller. This is the default if no user namespace options are set. The processes running in the container will have the same privileges on the host as any other process launched by the calling user.
+- `keep-id`: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is ignored for containers created by the root user.
 - `ns`: run the container in the given existing user namespace.
 
 This option is incompatible with --gidmap, --uidmap, --subuid and --subgid

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -730,7 +730,7 @@ Without this argument the command will be run as root in the container.
 **--userns**=keep-id
 **--userns**=ns:my_namespace
 
-Set the user namespace mode for the container. The use of userns is disabled by default.
+Set the user namespace mode for the container.  It defaults to the **PODMAN_USERNS** environment variable.  An empty value means user namespaces are disabled.
 
 - `host`: run in the user namespace of the caller. This is the default if no user namespace options are set. The processes running in the container will have the same privileges on the host as any other process launched by the calling user.
 - `keep-id`: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is ignored for containers created by the root user.

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -763,11 +763,13 @@ The followings examples are all valid:
 Without this argument the command will be run as root in the container.
 
 **--userns**=host
+**--userns**=keep-id
 **--userns**=ns:my_namespace
 
 Set the user namespace mode for the container. The use of userns is disabled by default.
 
 - `host`: run in the user namespace of the caller. This is the default if no user namespace options are set. The processes running in the container will have the same privileges on the host as any other process launched by the calling user.
+- `keep-id`: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is ignored for containers created by the root user.
 - `ns`: run the container in the given existing user namespace.
 
 This option is incompatible with --gidmap, --uidmap, --subuid and --subgid

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -766,7 +766,7 @@ Without this argument the command will be run as root in the container.
 **--userns**=keep-id
 **--userns**=ns:my_namespace
 
-Set the user namespace mode for the container. The use of userns is disabled by default.
+Set the user namespace mode for the container.  It defaults to the **PODMAN_USERNS** environment variable.  An empty value means user namespaces are disabled.
 
 - `host`: run in the user namespace of the caller. This is the default if no user namespace options are set. The processes running in the container will have the same privileges on the host as any other process launched by the calling user.
 - `keep-id`: creates a user namespace where the current rootless user's UID:GID are mapped to the same values in the container. This option is ignored for containers created by the root user.

--- a/pkg/namespaces/namespaces.go
+++ b/pkg/namespaces/namespaces.go
@@ -12,6 +12,11 @@ func (n UsernsMode) IsHost() bool {
 	return n == "host"
 }
 
+// IsKeepID indicates whether container uses a mapping where the (uid, gid) on the host is lept inside of the namespace.
+func (n UsernsMode) IsKeepID() bool {
+	return n == "keep-id"
+}
+
 // IsPrivate indicates whether the container uses the a private userns.
 func (n UsernsMode) IsPrivate() bool {
 	return !(n.IsHost())
@@ -21,7 +26,7 @@ func (n UsernsMode) IsPrivate() bool {
 func (n UsernsMode) Valid() bool {
 	parts := strings.Split(string(n), ":")
 	switch mode := parts[0]; mode {
-	case "", "host":
+	case "", "host", "keep-id":
 	default:
 		return false
 	}

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -24,6 +24,11 @@ func GetRootlessUID() int {
 	return -1
 }
 
+// GetRootlessGID returns the GID of the user in the parent userNS
+func GetRootlessGID() int {
+	return -1
+}
+
 // JoinUserAndMountNS re-exec podman in a new userNS and join the user and mount
 // namespace of the specified PID without looking up its parent.  Useful to join directly
 // the conmon process.  It is a convenience function for JoinUserAndMountNSWithOpts

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/containers/libpod/test/utils"
@@ -76,4 +77,12 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("podman --userns=keep-id", func() {
+		session := podmanTest.Podman([]string{"run", "--userns=keep-id", "alpine", "id", "-u"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		uid := fmt.Sprintf("%d", os.Geteuid())
+		ok, _ := session.GrepString(uid)
+		Expect(ok).To(BeTrue())
+	})
 })


### PR DESCRIPTION
it creates a namespace where the current UID:GID on the host is mapped to the same UID:GID in the container.

```
$ id -u; id -g
1000
1000
$ podman run --userns=keep-id --rm fedora cat /proc/self/uid_map
         0          1       1000
      1000          0          1
      1001       1001      64536
```

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

