### PR TITLE
cirrus: minor cleanup and refactoring

### DIFF
--- a/contrib/cirrus/container_test.sh
+++ b/contrib/cirrus/container_test.sh
@@ -133,8 +133,8 @@ fi
 if [ $integrationtest -eq 1 ]; then
     make TAGS="${TAGS}" test-binaries
     make varlink_generate
-    make ginkgo $INTEGRATION_TEST_ENVS
+    make localintegration $INTEGRATION_TEST_ENVS
     if [ $remote -eq 1 ]; then
-        make ginkgo-remote $INTEGRATION_TEST_ENVS
+        make remoteintegration $INTEGRATION_TEST_ENVS
     fi
 fi

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -5,6 +5,14 @@ source $(dirname $0)/lib.sh
 
 req_env_var GOSRC SCRIPT_BASE OS_RELEASE_ID OS_RELEASE_VER CONTAINER_RUNTIME
 
+# Our name must be of the form xxxx_test or xxxx_test.sh, where xxxx is
+# the test suite to run; currently (2019-05) the only option is 'integration'
+# but pr2947 intends to add 'system'.
+TESTSUITE=$(expr $(basename $0) : '\(.*\)_test')
+if [[ -z $TESTSUITE ]]; then
+    die 1 "Script name is not of the form xxxx_test.sh"
+fi
+
 cd "$GOSRC"
 
 if [[ "$SPECIALMODE" == "in_podman" ]]
@@ -28,11 +36,11 @@ then
 
     if [[ "$USER" == "$ROOTLESS_USER" ]]
     then
-        $GOSRC/$SCRIPT_BASE/rootless_test.sh
+        $GOSRC/$SCRIPT_BASE/rootless_test.sh ${TESTSUITE}
     else
         ssh $ROOTLESS_USER@localhost \
                 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o CheckHostIP=no \
-                $GOSRC/$SCRIPT_BASE/rootless_test.sh
+                $GOSRC/$SCRIPT_BASE/rootless_test.sh ${TESTSUITE}
     fi
 else
     make
@@ -40,9 +48,9 @@ else
     make test-binaries
     if [[ "$TEST_REMOTE_CLIENT" == "true" ]]
     then
-        make remoteintegration
+        make remote${TESTSUITE}
     else
-        make localintegration
+        make local${TESTSUITE}
     fi
     exit $?
 fi

--- a/contrib/cirrus/rootless_test.sh
+++ b/contrib/cirrus/rootless_test.sh
@@ -18,6 +18,12 @@ then
     exit 1
 fi
 
+# Which set of tests to run; possible alternative is "system"
+TESTSUITE=integration
+if [[ -n "$*" ]]; then
+    TESTSUITE="$1"
+fi
+
 # Ensure environment setup correctly
 req_env_var GOSRC ROOTLESS_USER
 
@@ -34,7 +40,7 @@ make
 make varlink_generate
 make test-binaries
 if [ $remote -eq 0 ]; then
-    make ginkgo
+    make local${TESTSUITE}
 else
-    make ginkgo-remote
+    make remote${TESTSUITE}
 fi


### PR DESCRIPTION
...with the goal of (very soon) reusing this code, in #2947,
to run system tests in CI. This is the cleanest way I can
think of to do so without duplication or a large maintenance
burden.

Changes are:
 - replace references to 'ginkgo' with 'integration'. That
   target is already in Makefile, and is not only more
   readable, it's also more abstract. There is no reason
   for this level of code to know about ginkgo.
 - replace a 'noxxx' option with the more usable 'xxx'
   - and fix a logic bug: the '-n' (no-remote) option
     should not be treated as an actual test-defining
     argument option.
 - allow rootless_test.sh to accept an argument,
   that being the name of the test suite to run
   (default: integration). #2947 will enable 'system'.
 - allow integration_test.sh to serve multiple purposes,
   by checking its filename. #2947 will add a symlink,
   system_test.sh, which will then cascade down to
   invoke system tests.

Signed-off-by: Ed Santiago <santiago@redhat.com>