### PR TITLE
Add missing 'container cp' alias and document missing 'container update' command

### DIFF
--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -54,6 +54,7 @@ var (
 		_checkpointCommand,
 		_containerExistsCommand,
 		_contInspectSubCommand,
+		_cpCommand,
 		_diffCommand,
 		_exportCommand,
 		_createCommand,

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -764,6 +764,10 @@ _podman_container_commit() {
      _podman_commit
 }
 
+_podman_container_cp() {
+     _podman_cp
+}
+
 _podman_container_create() {
      _podman_create
 }
@@ -961,6 +965,7 @@ _podman_container() {
 	 attach
 	 checkpoint
 	 commit
+	 cp
 	 create
 	 diff
 	 exec

--- a/docs/podman-container.1.md
+++ b/docs/podman-container.1.md
@@ -17,6 +17,7 @@ The container command allows you to manage containers
 | checkpoint | [podman-container-checkpoint(1)](podman-container-checkpoint.1.md)  | Checkpoints one or more containers.                          |
 | cleanup    | [podman-container-cleanup(1)](podman-container-cleanup.1.md)    | Cleanup containers network and mountpoints.                      |
 | commit     | [podman-commit(1)](podman-commit.1.md)              | Create new image based on the changed container.                             |
+| cp         | [podman-cp(1)](podman-cp.1.md)                      | Copy files/folders between a container and the local filesystem.             |
 | create     | [podman-create(1)](podman-create.1.md)              | Create a new container.                                                      |
 | diff       | [podman-diff(1)](podman-diff.1.md)                  | Inspect changes on a container or image's filesystem.                        |
 | exec       | [podman-exec(1)](podman-exec.1.md)                  | Execute a command in a running container.                                    |

--- a/transfer.md
+++ b/transfer.md
@@ -91,10 +91,11 @@ Those Docker commands currently do not have equivalents in `podman`:
 
 | Missing command | Description|
 | :--- | :--- |
+| `docker container update`  | podman does not support altering running containers. We recommend recreating containers with the correct arguments.|
+| `docker container rename`   | podman does not support `container rename` - or the `rename` shorthand. We recommend using `podman rm` and  `podman create` to create a container with a specific name.|
 | `docker network`  ||
 | `docker node`     ||
 | `docker plugin`   | podman does not support plugins.  We recommend you use alternative OCI Runtimes or OCI Runtime Hooks to alter behavior of podman.|
-| `docker rename`   | podman does not support rename, you need to use `podman rm` and  `podman create` to rename a container.|
 | `docker secret`   ||
 | `docker service`  ||
 | `docker stack`    ||


### PR DESCRIPTION
Some notes

- Also reorder the missing update command to better match the container update command (it is in the same management namespace)
- 'docker cp' is an alias for 'docker container cp', and podman should have the equivalent alias.
