### PR TITLE
rootless: skip check fo /etc/containers/registries.conf

### DIFF
--- a/cmd/podman/platform_linux.go
+++ b/cmd/podman/platform_linux.go
@@ -4,13 +4,25 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/sirupsen/logrus"
 )
+
+// userRegistriesFile is the path to the per user registry configuration file.
+var userRegistriesFile = filepath.Join(os.Getenv("HOME"), ".config/containers/registries.conf")
 
 func CheckForRegistries() {
 	if _, err := os.Stat("/etc/containers/registries.conf"); err != nil {
 		if os.IsNotExist(err) {
+			// If it is running in rootless mode, also check the user configuration file
+			if rootless.IsRootless() {
+				if _, err := os.Stat(userRegistriesFile); err != nil {
+					logrus.Warnf("unable to find %s. some podman (image shortnames) commands may be limited", userRegistriesFile)
+				}
+				return
+			}
 			logrus.Warn("unable to find /etc/containers/registries.conf. some podman (image shortnames) commands may be limited")
 		}
 	}


### PR DESCRIPTION
the warning can be confusing when used in rootless mode as the
unprivileged user has no way for setting it up.

Closes: https://github.com/containers/libpod/issues/2955

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>