### PR TITLE
Podman logs man page shouldn't include timestamps

### DIFF
--- a/docs/podman-logs.1.md
+++ b/docs/podman-logs.1.md
@@ -50,7 +50,7 @@ Show timestamps in the log outputs.  The default is false
 
 To view a container's logs:
 ```
-podman logs b3f2436bdb978c1d33b1387afb5d7ba7e3243ed2ce908db431ac0069da86cb45
+podman logs -t b3f2436bdb978c1d33b1387afb5d7ba7e3243ed2ce908db431ac0069da86cb45
 
 2017/08/07 10:16:21 Seeked /var/log/crio/pods/eb296bd56fab164d4d3cc46e5776b54414af3bf543d138746b25832c816b933b/c49f49788da14f776b7aa93fb97a2a71f9912f4e5a3e30397fca7dfe0ee0367b.log - &{Offset:0 Whence:0}
 1:C 07 Aug 14:10:09.055 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
@@ -68,13 +68,13 @@ To view only the last two lines in container's log:
 ```
 podman logs --tail 2 b3f2436bdb97
 
-1:M 07 Aug 14:10:09.056 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
-1:M 07 Aug 14:10:09.056 # Server initialized
+# WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
+# Server initialized
 ```
 
 To view a containers logs since a certain time:
 ```
-podman logs --since 2017-08-07T10:10:09.055837383-04:00 myserver
+podman logs -t --since 2017-08-07T10:10:09.055837383-04:00 myserver
 
 1:M 07 Aug 14:10:09.055 # Server can't set maximum open files to 10032 because of OS error: Operation not permitted.
 1:M 07 Aug 14:10:09.055 # Current maximum open files is 4096. maxclients has been reduced to 4064 to compensate for low ulimit. If you need higher maxclients increase 'ulimit -n'.
@@ -87,8 +87,8 @@ To view a container's logs generated in the last 10 minutes:
 ```
 podman logs --since 10m myserver
 
-1:M 07 Aug 14:10:09.055 # Server can't set maximum open files to 10032 because of OS error: Operation not permitted.
-1:M 07 Aug 14:10:09.055 # Current maximum open files is 4096. maxclients has been reduced to 4064 to compensate for low ulimit. If you need higher maxclients increase 'ulimit -n'.
+# Server can't set maximum open files to 10032 because of OS error: Operation not permitted.
+# Current maximum open files is 4096. maxclients has been reduced to 4064 to compensate for low ulimit. If you need higher maxclients increase 'ulimit -n'.
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
Change man page to reflect default output. Commands
with timestamps should include `-t` option.

Closes: #2920
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>