### PR TITLE
libpod/container_internal: Make all errors loading explicitly configured hook dirs fatal

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1407,10 +1407,6 @@ func (c *Container) setupOCIHooks(ctx context.Context, config *spec.Spec) (exten
 	} else {
 		manager, err := hooks.New(ctx, c.runtime.config.HooksDir, []string{"precreate", "poststop"})
 		if err != nil {
-			if os.IsNotExist(err) {
-				logrus.Warnf("Requested OCI hooks directory %q does not exist", c.runtime.config.HooksDir)
-				return nil, nil
-			}
 			return nil, err
 		}
 


### PR DESCRIPTION
Remove this `IsNotExist` out which was added along with the rest of this block in f6a2b6bf2b (#1830).  Besides the obvious "hook directory does not exist", it was swallowing the less-obvious "hook command does not exist".  And either way, folks are likely going to want non-zero `podman` exits when we fail to load a hook directory they explicitly pointed us towards.