### PR TITLE
do not run remote tests inside container

### DIFF
--- a/contrib/cirrus/container_test.sh
+++ b/contrib/cirrus/container_test.sh
@@ -35,7 +35,7 @@ options=0
 noremote=0
 install_tools_made=0
 
-while getopts "biptuv" opt; do
+while getopts "bitnuv" opt; do
     case "$opt" in
     b) build=1
        options=1


### PR DESCRIPTION
when running the podman integration tests inside a container, we should
not be running the remote tests.

Signed-off-by: baude <bbaude@redhat.com>