### PR TITLE
Cirrus: Temp. workaround VFS incompatible option

### DIFF
--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -89,6 +89,10 @@ RUN mkdir -p /etc/containers
 COPY test/policy.json /etc/containers/policy.json
 COPY test/redhat_sigstore.yaml /etc/containers/registries.d/registry.access.redhat.com.yaml
 
+# WORKAROUND/HACK (05/30/19): metacopy=on breaks tests using VFS"
+RUN echo "WORKAROUND/HACK (05/30/19): metacopy=on breaks tests using VFS" && \
+    sed -i -r -e 's/^mountopt =.+/mountopt = "nodev"/' /etc/containers/storage.conf
+
 # Install varlink stuff
 RUN pip3 install varlink
 

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -58,6 +58,12 @@ cd "${GOSRC}/"
 # Reload to incorporate any changes from above
 source "$SCRIPT_BASE/lib.sh"
 
+if [[ -r "/etc/containers/storage.conf" ]]
+then
+    echo ">>>>> WORKAROUND/HACK (05/30/19): metacopy=on breaks tests using VFS"
+    sed -i -r -e 's/^mountopt =.+/mountopt = "nodev"/' /etc/containers/storage.conf
+fi
+
 echo "Installing cni config, policy and registry config"
 req_env_var GOSRC
 sudo install -D -m 755 $GOSRC/cni/87-podman-bridge.conflist \


### PR DESCRIPTION
There are many integration tests using the VFS storage driver.  A
recent update to the containers-common package in Fedora added a new
mount option `metacopy=on` as it enhances security.  However, this option
is not compatible with the VFS storage driver, causing those tests to
fail.

Until a better solution is realized, workaround this problem by forcing
"nodev" as the only mount option on all platforms.  Also add a visible
note to the output flagging the change.

Signed-off-by: Chris Evich <cevich@redhat.com>