### PR TITLE
When you change the storage driver we ignore the storage-options

### DIFF
--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -67,7 +67,10 @@ func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber bool, 
 	if c.Flags().Changed("storage-driver") {
 		storageSet = true
 		storageOpts.GraphDriverName = c.GlobalFlags.StorageDriver
+		// Overriding the default storage driver caused GraphDriverOptions from storage.conf to be ignored
+		storageOpts.GraphDriverOptions = []string{}
 	}
+	// This should always be checked after storage-driver is checked
 	if len(c.GlobalFlags.StorageOpts) > 0 {
 		storageSet = true
 		storageOpts.GraphDriverOptions = c.GlobalFlags.StorageOpts

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -360,7 +360,8 @@ func (c *Container) setupStorage(ctx context.Context) error {
 			}
 			return false
 		}
-		defOptions, err := storage.GetDefaultMountOptions()
+
+		defOptions, err := storage.GetMountOptions(c.runtime.store.GraphDriverName(), c.runtime.store.GraphOptions())
 		if err != nil {
 			return errors.Wrapf(err, "error getting default mount options")
 		}

--- a/vendor.conf
+++ b/vendor.conf
@@ -19,7 +19,7 @@ github.com/containers/image 2c0349c99af7d90694b3faa0e9bde404d407b145
 github.com/vbauerster/mpb v3.3.4
 github.com/mattn/go-isatty v0.0.4
 github.com/VividCortex/ewma v1.1.1
-github.com/containers/storage 9b10041d7b2ef767ce9c42b5862b6c51eeb82214
+github.com/containers/storage v1.12.10
 github.com/containers/psgo v1.3.0
 github.com/coreos/go-systemd v17
 github.com/coreos/pkg v4

--- a/vendor/github.com/containers/storage/store.go
+++ b/vendor/github.com/containers/storage/store.go
@@ -3398,12 +3398,18 @@ func init() {
 	ReloadConfigurationFile(defaultConfigFile, &defaultStoreOptions)
 }
 
+// GetDefaultMountOptions returns the default mountoptions defined in container/storage
 func GetDefaultMountOptions() ([]string, error) {
+	return GetMountOptions(defaultStoreOptions.GraphDriverName, defaultStoreOptions.GraphDriverOptions)
+}
+
+// GetMountOptions returns the mountoptions for the specified driver and graphDriverOptions
+func GetMountOptions(driver string, graphDriverOptions []string) ([]string, error) {
 	mountOpts := []string{
 		".mountopt",
-		fmt.Sprintf("%s.mountopt", defaultStoreOptions.GraphDriverName),
+		fmt.Sprintf("%s.mountopt", driver),
 	}
-	for _, option := range defaultStoreOptions.GraphDriverOptions {
+	for _, option := range graphDriverOptions {
 		key, val, err := parsers.ParseKeyValueOpt(option)
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/containers/storage/utils.go
+++ b/vendor/github.com/containers/storage/utils.go
@@ -71,14 +71,16 @@ func ParseIDMapping(UIDMapSlice, GIDMapSlice []string, subUIDMap, subGIDMap stri
 // GetRootlessRuntimeDir returns the runtime directory when running as non root
 func GetRootlessRuntimeDir(rootlessUid int) (string, error) {
 	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
-	if runtimeDir == "" {
-		tmpDir := fmt.Sprintf("/run/user/%d", rootlessUid)
-		st, err := system.Stat(tmpDir)
-		if err == nil && int(st.UID()) == os.Getuid() && st.Mode()&0700 == 0700 && st.Mode()&0066 == 0000 {
-			return tmpDir, nil
-		}
+
+	if runtimeDir != "" {
+		return runtimeDir, nil
 	}
-	tmpDir := fmt.Sprintf("%s/%d", os.TempDir(), rootlessUid)
+	tmpDir := fmt.Sprintf("/run/user/%d", rootlessUid)
+	st, err := system.Stat(tmpDir)
+	if err == nil && int(st.UID()) == os.Getuid() && st.Mode()&0700 == 0700 && st.Mode()&0066 == 0000 {
+		return tmpDir, nil
+	}
+	tmpDir = fmt.Sprintf("%s/%d", os.TempDir(), rootlessUid)
 	if err := os.MkdirAll(tmpDir, 0700); err != nil {
 		logrus.Errorf("failed to create %s: %v", tmpDir, err)
 	} else {


### PR DESCRIPTION
The storage driver and the storage options in storage.conf should
match, but if you change the storage driver via the command line
then we need to nil out the default storage options from storage.conf.

If the user wants to change the storage driver and use storage options,
they need to specify them on the command line.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>