### PR TITLE
Update containers/image to v2.0.0, and buildah to v1.8.4

### DIFF
--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -44,17 +44,7 @@ func getRegistries() ([]sysregistriesv2.Registry, error) {
 
 // GetRegistries obtains the list of search registries defined in the global registries file.
 func GetRegistries() ([]string, error) {
-	var searchRegistries []string
-	registries, err := getRegistries()
-	if err != nil {
-		return nil, err
-	}
-	for _, reg := range registries {
-		if reg.Search {
-			searchRegistries = append(searchRegistries, reg.Location)
-		}
-	}
-	return searchRegistries, nil
+	return sysregistriesv2.UnqualifiedSearchRegistries(&types.SystemContext{SystemRegistriesConfPath: SystemRegistriesConfPath()})
 }
 
 // GetBlockedRegistries obtains the list of blocked registries defined in the global registries file.

--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -56,7 +56,7 @@ func GetBlockedRegistries() ([]string, error) {
 	}
 	for _, reg := range registries {
 		if reg.Blocked {
-			blockedRegistries = append(blockedRegistries, reg.Location)
+			blockedRegistries = append(blockedRegistries, reg.Prefix)
 		}
 	}
 	return blockedRegistries, nil
@@ -71,7 +71,7 @@ func GetInsecureRegistries() ([]string, error) {
 	}
 	for _, reg := range registries {
 		if reg.Insecure {
-			insecureRegistries = append(insecureRegistries, reg.Location)
+			insecureRegistries = append(insecureRegistries, reg.Prefix)
 		}
 	}
 	return insecureRegistries, nil

--- a/vendor.conf
+++ b/vendor.conf
@@ -15,7 +15,7 @@ github.com/containerd/cgroups 4994991857f9b0ae8dc439551e8bebdbb4bf66c1
 github.com/containerd/continuity 004b46473808b3e7a4a3049c20e4376c91eb966d
 github.com/containernetworking/cni v0.7.0-rc2
 github.com/containernetworking/plugins v0.7.4
-github.com/containers/image 2c0349c99af7d90694b3faa0e9bde404d407b145
+github.com/containers/image v2.0.0
 github.com/vbauerster/mpb v3.3.4
 github.com/mattn/go-isatty v0.0.4
 github.com/VividCortex/ewma v1.1.1
@@ -93,7 +93,7 @@ k8s.io/api kubernetes-1.10.13-beta.0 https://github.com/kubernetes/api
 k8s.io/apimachinery kubernetes-1.10.13-beta.0 https://github.com/kubernetes/apimachinery
 k8s.io/client-go kubernetes-1.10.13-beta.0 https://github.com/kubernetes/client-go
 github.com/mrunalp/fileutils 7d4729fb36185a7c1719923406c9d40e54fb93c7
-github.com/containers/buildah v1.8.3
+github.com/containers/buildah v1.8.4
 github.com/varlink/go 0f1d566d194b9d6d48e0d47c5e4d822628919066
 # TODO: Gotty has not been updated since 2012. Can we find replacement?
 github.com/Nvveen/Gotty cd527374f1e5bff4938207604a14f2e38a9cf512

--- a/vendor/github.com/containers/buildah/buildah.go
+++ b/vendor/github.com/containers/buildah/buildah.go
@@ -26,7 +26,7 @@ const (
 	Package = "buildah"
 	// Version for the Package.  Bump version in contrib/rpm/buildah.spec
 	// too.
-	Version = "1.8.3"
+	Version = "1.8.4"
 	// The value we use to identify what type of information, currently a
 	// serialized Builder structure, we are using as per-container state.
 	// This should only be changed when we make incompatible changes to

--- a/vendor/github.com/containers/buildah/image.go
+++ b/vendor/github.com/containers/buildah/image.go
@@ -707,7 +707,7 @@ func (b *Builder) makeImageRef(options CommitOptions, exporting bool) (types.Ima
 		exporting:             exporting,
 		squash:                options.Squash,
 		emptyLayer:            options.EmptyLayer,
-		tarPath:               b.tarPath(),
+		tarPath:               b.tarPath(&b.IDMappingOptions),
 		parent:                parent,
 		blobDirectory:         options.BlobDirectory,
 		preEmptyLayers:        b.PrependedEmptyLayers,

--- a/vendor/github.com/containers/buildah/pkg/unshare/unshare.c
+++ b/vendor/github.com/containers/buildah/pkg/unshare/unshare.c
@@ -3,7 +3,7 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
-#include <linux/memfd.h>
+#include <sys/mman.h>
 #include <fcntl.h>
 #include <grp.h>
 #include <sched.h>
@@ -13,6 +13,17 @@
 #include <termios.h>
 #include <errno.h>
 #include <unistd.h>
+
+/* Open Source projects like conda-forge, want to package podman and are based
+   off of centos:6, Conda-force has minimal libc requirements and is lacking
+   the memfd.h file, so we use mmam.h
+*/
+#ifndef MFD_ALLOW_SEALING
+#define MFD_ALLOW_SEALING 2U
+#endif
+#ifndef MFD_CLOEXEC
+#define MFD_CLOEXEC 1U
+#endif
 
 #ifndef F_LINUX_SPECIFIC_BASE
 #define F_LINUX_SPECIFIC_BASE 1024

--- a/vendor/github.com/containers/buildah/vendor.conf
+++ b/vendor/github.com/containers/buildah/vendor.conf
@@ -3,12 +3,12 @@ github.com/blang/semver v3.5.0
 github.com/BurntSushi/toml v0.2.0
 github.com/containerd/continuity 004b46473808b3e7a4a3049c20e4376c91eb966d
 github.com/containernetworking/cni v0.7.0-rc2
-github.com/containers/image 9467ac9cfd92c545aa389f22f27e552de053c0f2
+github.com/containers/image v2.0.0
 github.com/cyphar/filepath-securejoin v0.2.1
 github.com/vbauerster/mpb v3.3.4
 github.com/mattn/go-isatty v0.0.4
 github.com/VividCortex/ewma v1.1.1
-github.com/containers/storage v1.12.7
+github.com/containers/storage v1.12.10
 github.com/docker/distribution 5f6282db7d65e6d72ad7c2cc66310724a57be716
 github.com/docker/docker 54dddadc7d5d89fe0be88f76979f6f6ab0dede83
 github.com/docker/docker-credential-helpers v0.6.1

--- a/vendor/github.com/containers/image/docker/reference/README.md
+++ b/vendor/github.com/containers/image/docker/reference/README.md
@@ -1,2 +1,2 @@
-This is a copy of github.com/docker/distribution/reference as of commit fb0bebc4b64e3881cc52a2478d749845ed76d2a8,
+This is a copy of github.com/docker/distribution/reference as of commit 3226863cbcba6dbc2f6c83a37b28126c934af3f8,
 except that ParseAnyReferenceWithSet has been removed to drop the dependency on github.com/docker/distribution/digestset.

--- a/vendor/github.com/containers/image/docker/reference/normalize.go
+++ b/vendor/github.com/containers/image/docker/reference/normalize.go
@@ -55,6 +55,35 @@ func ParseNormalizedNamed(s string) (Named, error) {
 	return named, nil
 }
 
+// ParseDockerRef normalizes the image reference following the docker convention. This is added
+// mainly for backward compatibility.
+// The reference returned can only be either tagged or digested. For reference contains both tag
+// and digest, the function returns digested reference, e.g. docker.io/library/busybox:latest@
+// sha256:7cc4b5aefd1d0cadf8d97d4350462ba51c694ebca145b08d7d41b41acc8db5aa will be returned as
+// docker.io/library/busybox@sha256:7cc4b5aefd1d0cadf8d97d4350462ba51c694ebca145b08d7d41b41acc8db5aa.
+func ParseDockerRef(ref string) (Named, error) {
+	named, err := ParseNormalizedNamed(ref)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := named.(NamedTagged); ok {
+		if canonical, ok := named.(Canonical); ok {
+			// The reference is both tagged and digested, only
+			// return digested.
+			newNamed, err := WithName(canonical.Name())
+			if err != nil {
+				return nil, err
+			}
+			newCanonical, err := WithDigest(newNamed, canonical.Digest())
+			if err != nil {
+				return nil, err
+			}
+			return newCanonical, nil
+		}
+	}
+	return TagNameOnly(named), nil
+}
+
 // splitDockerDomain splits a repository name to domain and remotename string.
 // If no valid domain is found, the default domain is used. Repository name
 // needs to be already validated before.

--- a/vendor/github.com/containers/image/docker/reference/reference.go
+++ b/vendor/github.com/containers/image/docker/reference/reference.go
@@ -15,7 +15,7 @@
 //	tag                             := /[\w][\w.-]{0,127}/
 //
 //	digest                          := digest-algorithm ":" digest-hex
-//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]
+//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]*
 //	digest-algorithm-separator      := /[+.-_]/
 //	digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/
 //	digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
@@ -205,7 +205,7 @@ func Parse(s string) (Reference, error) {
 	var repo repository
 
 	nameMatch := anchoredNameRegexp.FindStringSubmatch(matches[1])
-	if nameMatch != nil && len(nameMatch) == 3 {
+	if len(nameMatch) == 3 {
 		repo.domain = nameMatch[1]
 		repo.path = nameMatch[2]
 	} else {

--- a/vendor/github.com/containers/image/docker/reference/regexp.go
+++ b/vendor/github.com/containers/image/docker/reference/regexp.go
@@ -20,15 +20,15 @@ var (
 		optional(repeated(separatorRegexp, alphaNumericRegexp)))
 
 	// domainComponentRegexp restricts the registry domain component of a
-	// repository name to start with a component as defined by domainRegexp
+	// repository name to start with a component as defined by DomainRegexp
 	// and followed by an optional port.
 	domainComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
 
-	// domainRegexp defines the structure of potential domain components
+	// DomainRegexp defines the structure of potential domain components
 	// that may be part of image names. This is purposely a subset of what is
 	// allowed by DNS to ensure backwards compatibility with Docker image
 	// names.
-	domainRegexp = expression(
+	DomainRegexp = expression(
 		domainComponentRegexp,
 		optional(repeated(literal(`.`), domainComponentRegexp)),
 		optional(literal(`:`), match(`[0-9]+`)))
@@ -51,14 +51,14 @@ var (
 	// regexp has capturing groups for the domain and name part omitting
 	// the separating forward slash from either.
 	NameRegexp = expression(
-		optional(domainRegexp, literal(`/`)),
+		optional(DomainRegexp, literal(`/`)),
 		nameComponentRegexp,
 		optional(repeated(literal(`/`), nameComponentRegexp)))
 
 	// anchoredNameRegexp is used to parse a name value, capturing the
 	// domain and trailing components.
 	anchoredNameRegexp = anchored(
-		optional(capture(domainRegexp), literal(`/`)),
+		optional(capture(DomainRegexp), literal(`/`)),
 		capture(nameComponentRegexp,
 			optional(repeated(literal(`/`), nameComponentRegexp))))
 

--- a/vendor/github.com/containers/image/version/version.go
+++ b/vendor/github.com/containers/image/version/version.go
@@ -4,14 +4,14 @@ import "fmt"
 
 const (
 	// VersionMajor is for an API incompatible changes
-	VersionMajor = 1
+	VersionMajor = 2
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 7
+	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This adds the the mirror-by-digest-only option to mirrors, and moves the search order to an independent list.

Also includes a ~unrelated bug fix in dealing with the affected c/image API.

AFAICS needs https://github.com/containers/buildah/pull/1634 to be merged first.