### PR TITLE
[wip] healthcheck valid container test flakey

### DIFF
--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -149,7 +149,7 @@ func checkHealthCheckCanBeRun(c *Container) (HealthCheckStatus, error) {
 		return HealthCheckInternalError, err
 	}
 	if cstate != ContainerStateRunning {
-		return HealthCheckContainerStopped, errors.Errorf("container %s is not running", c.ID())
+		return HealthCheckContainerStopped, errors.Errorf("container %s is not running (state: %s)", c.ID(), cstate.String())
 	}
 	if !c.HasHealthCheck() {
 		return HealthCheckNotDefined, errors.Errorf("container %s has no defined healthcheck", c.ID())

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -44,20 +44,23 @@ var _ = Describe("Podman healthcheck run", func() {
 	})
 
 	It("podman healthcheck on valid container", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", healthcheck})
+		session := podmanTest.Podman([]string{"--log-level=debug", "run", "-dt", "--name", "hc", healthcheck})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
 
 		exitCode := 999
 
 		// Buy a little time to get container running
 		for i := 0; i < 5; i++ {
-			hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+			hc := podmanTest.Podman([]string{"--log-level=debug", "healthcheck", "run", "hc"})
 			hc.WaitWithDefaultTimeout()
 			exitCode = hc.ExitCode()
 			if exitCode == 0 || i == 4 {
 				break
 			}
+			logs := podmanTest.Podman([]string{"logs", cid})
+			logs.WaitWithDefaultTimeout()
 			time.Sleep(1 * time.Second)
 		}
 		Expect(exitCode).To(Equal(0))


### PR DESCRIPTION
for reasons unknow, the healthcheck valid container test is flakey. it
looks like the run of the image is exiting immediately.

Signed-off-by: baude <bbaude@redhat.com>