### PR TITLE
Do not add mount options for VFS when privileged

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -350,7 +350,7 @@ func (c *Container) setupStorage(ctx context.Context) error {
 		},
 		LabelOpts: c.config.LabelOpts,
 	}
-	if c.config.Privileged {
+	if c.config.Privileged && c.runtime.config.StorageConfig.GraphDriverName != "vfs" {
 		privOpt := func(opt string) bool {
 			for _, privopt := range []string{"nodev", "nosuid", "noexec"} {
 				if opt == privopt {


### PR DESCRIPTION
when running a container in privileged mode, no mount options should be
included for the vfs filesystem.

Signed-off-by: baude <bbaude@redhat.com>