### PR TITLE
Cirrus: Track VM Image calling GCE project

### DIFF
--- a/contrib/imgts/entrypoint.sh
+++ b/contrib/imgts/entrypoint.sh
@@ -32,6 +32,7 @@ ARGS="--update-labels=last-used=$(date +%s)"
 # optional
 [[ -z "$BUILDID" ]] || ARGS="$ARGS --update-labels=build-id=$BUILDID"
 [[ -z "$REPOREF" ]] || ARGS="$ARGS --update-labels=repo-ref=$REPOREF"
+[[ -z "$GCPPROJECT" ]] || ARGS="$ARGS --update-labels=project=$GCPPROJECT"
 
 gcloud config set account "$GCPNAME"
 gcloud config set project "$GCPPROJECT"


### PR DESCRIPTION
With multiple `containers` projects updating VM Image metadata,
it would be very difficult to discover which Cirrus-CI setup
was responsible.  Add the GCE project name to the list
of metadata labels to update when this container runs.  This
will give more context as to which images are currently in use.

Signed-off-by: Chris Evich <cevich@redhat.com>