### PR TITLE
rootless: skip NS_GET_PARENT on old kernels

### DIFF
--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -169,6 +169,9 @@ func getUserNSFirstChild(fd uintptr) (*os.File, error) {
 	for {
 		nextFd, err := getParentUserNs(fd)
 		if err != nil {
+			if err == syscall.ENOTTY {
+				return os.NewFile(fd, "userns child"), nil
+			}
 			return nil, errors.Wrapf(err, "cannot get parent user namespace")
 		}
 


### PR DESCRIPTION
on old kernels the ioctl NS_GET_PARENT is not available.

Handle the error code and immediately return the same fd.  It should
be fine now that we use the namespace resolution using the conmon pid,
so the namespace parent resolution is just a safety measure.

Closes: https://github.com/containers/libpod/issues/2968

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>