### PR TITLE
Improve DESTDIR/PREFIX/ETCDIR handling

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -42,11 +42,13 @@ const (
 	SQLiteStateStore RuntimeStateStore = iota
 	// BoltDBStateStore is a state backed by a BoltDB database
 	BoltDBStateStore RuntimeStateStore = iota
+)
 
+var (
 	// SeccompDefaultPath defines the default seccomp path
-	SeccompDefaultPath = "/usr/share/containers/seccomp.json"
+	SeccompDefaultPath = installPrefix + "/share/containers/seccomp.json"
 	// SeccompOverridePath if this exists it overrides the default seccomp path
-	SeccompOverridePath = "/etc/crio/seccomp.json"
+	SeccompOverridePath = etcDir + "/crio/seccomp.json"
 
 	// ConfigPath is the path to the libpod configuration file
 	// This file is loaded to replace the builtin default config before
@@ -54,11 +56,11 @@ const (
 	// If it is not present, the builtin default config is used instead
 	// This path can be overridden when the runtime is created by using
 	// NewRuntimeFromConfig() instead of NewRuntime()
-	ConfigPath = "/usr/share/containers/libpod.conf"
+	ConfigPath = installPrefix + "/share/containers/libpod.conf"
 	// OverrideConfigPath is the path to an override for the default libpod
 	// configuration file. If OverrideConfigPath exists, it will be used in
 	// place of the configuration file pointed to by ConfigPath.
-	OverrideConfigPath = "/etc/containers/libpod.conf"
+	OverrideConfigPath = etcDir + "/containers/libpod.conf"
 
 	// DefaultInfraImage to use for infra container
 	DefaultInfraImage = "k8s.gcr.io/pause:3.1"
@@ -300,7 +302,7 @@ func defaultRuntimeConfig() (RuntimeConfig, error) {
 		TmpDir:                "",
 		MaxLogSize:            -1,
 		NoPivotRoot:           false,
-		CNIConfigDir:          "/etc/cni/net.d/",
+		CNIConfigDir:          etcDir + "/cni/net.d/",
 		CNIPluginDir:          []string{"/usr/libexec/cni", "/usr/lib/cni", "/usr/local/lib/cni", "/opt/cni/bin"},
 		InfraCommand:          DefaultInfraCommand,
 		InfraImage:            DefaultInfraImage,

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -47,10 +47,10 @@ const (
 var (
 	// InstallPrefix is the prefix where podman will be installed.
 	// It can be overridden at build time.
-	installPrefix string = "/usr/local"
+	installPrefix = "/usr/local"
 	// EtcDir is the sysconfdir where podman should look for system config files.
 	// It can be overridden at build time.
-	etcDir string = "/etc"
+	etcDir = "/etc"
 
 	// SeccompDefaultPath defines the default seccomp path
 	SeccompDefaultPath = installPrefix + "/share/containers/seccomp.json"

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -45,6 +45,13 @@ const (
 )
 
 var (
+	// InstallPrefix is the prefix where podman will be installed.
+	// It can be overridden at build time.
+	installPrefix string = "/usr/local"
+	// EtcDir is the sysconfdir where podman should look for system config files.
+	// It can be overridden at build time.
+	etcDir string = "/etc"
+
 	// SeccompDefaultPath defines the default seccomp path
 	SeccompDefaultPath = installPrefix + "/share/containers/seccomp.json"
 	// SeccompOverridePath if this exists it overrides the default seccomp path

--- a/libpod/version.go
+++ b/libpod/version.go
@@ -15,6 +15,12 @@ var (
 	// BuildInfo is the time at which the binary was built
 	// It will be populated by the Makefile.
 	buildInfo string
+	// InstallPrefix is the prefix where podman will be installed.
+	// It will be populated by the Makefile.
+	installPrefix string = "/usr/local"
+	// EtcDir is the sysconfdir where podman should look for system config files.
+	// It will be populated by the Makefile.
+	etcDir string = "/etc"
 )
 
 //Version is an output struct for varlink

--- a/libpod/version.go
+++ b/libpod/version.go
@@ -15,12 +15,6 @@ var (
 	// BuildInfo is the time at which the binary was built
 	// It will be populated by the Makefile.
 	buildInfo string
-	// InstallPrefix is the prefix where podman will be installed.
-	// It will be populated by the Makefile.
-	installPrefix string = "/usr/local"
-	// EtcDir is the sysconfdir where podman should look for system config files.
-	// It will be populated by the Makefile.
-	etcDir string = "/etc"
 )
 
 //Version is an output struct for varlink


### PR DESCRIPTION
We install our podman in a non-standard prefix, e.g. `PREFIX=/path/to/podman-1.3.1`, and during the installation process we stage the files in a `DESTDIR=/path/to/sandbox`.  This changeset makes the DESTDIR apply even if PREFIX is specified.  It also makes the constants in the binary prefix-aware, so it's able to find its own conf files rather than the hardcoded `/usr/local` path.  We could also make it search by relative path to the binary, but that's a little more involved.

One thing to note is that some of the constants were converted to vars so that they can be overridden at build time.  I don't think this should be an issue, but worth mentioning.

Work in progress, just wanted to push this up for comments/discussion. 