### PR TITLE
Set a default log driver if none is specified

### DIFF
--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -320,7 +320,9 @@ func (c *CreateConfig) getContainerCreateOptions(runtime *libpod.Runtime, pod *l
 		options = append(options, libpod.WithLogPath(logPath))
 	}
 
-	options = append(options, libpod.WithLogDriver(c.LogDriver))
+	if c.LogDriver != "" {
+		options = append(options, libpod.WithLogDriver(c.LogDriver))
+	}
 
 	if c.IPAddress != "" {
 		ip := net.ParseIP(c.IPAddress)


### PR DESCRIPTION
Not having a default broke play kube. Rather than requiring a caller to add a log driver, let's set a logical default in the library

note: I considered fixing it on the play kube side, but instead opted for this. If that option is preferred though, it's a single line of code. Hard to tell who should be responsible for the default here.

Fixes: https://github.com/containers/libpod/issues/3157#issuecomment-500104440