### PR TITLE
rootless: use the slirp4netns builtin DNS first

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1000,7 +1000,7 @@ func (c *Container) generateResolvConf() (string, error) {
 	nameservers := resolvconf.GetNameservers(resolv.Content)
 	// slirp4netns has a built in DNS server.
 	if c.config.NetMode.IsSlirp4netns() {
-		nameservers = append(nameservers, "10.0.2.3")
+		nameservers = append([]string{"10.0.2.3"}, nameservers...)
 	}
 	if len(c.config.DNSServer) > 0 {
 		// We store DNS servers as net.IP, so need to convert to string


### PR DESCRIPTION
When using slirp4netns, be sure the built-in DNS server is the first
one to be used.

Closes: https://github.com/containers/libpod/issues/3277

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>