### PR TITLE
If container is not in correct state podman exec should exit with 126

### DIFF
--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -125,5 +125,10 @@ func execCmd(c *cliconfig.ExecValues) error {
 	streams.AttachError = true
 	streams.AttachInput = true
 
-	return ctr.Exec(c.Tty, c.Privileged, envs, cmd, c.User, c.Workdir, streams, c.PreserveFDs)
+	err = ctr.Exec(c.Tty, c.Privileged, envs, cmd, c.User, c.Workdir, streams, c.PreserveFDs)
+	if errors.Cause(err) == libpod.ErrCtrStateInvalid {
+		exitCode = 126
+	}
+
+	return err
 }

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -241,7 +241,7 @@ func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir 
 
 	// TODO can probably relax this once we track exec sessions
 	if conState != ContainerStateRunning {
-		return errors.Errorf("cannot exec into container that is not running")
+		return errors.Wrapf(ErrCtrStateInvalid, "cannot exec into container that is not running")
 	}
 	if privileged || c.config.Privileged {
 		capList = caps.GetAllCapabilities()


### PR DESCRIPTION
This way a tool can determine if the container exists or not, but is in the
wrong state.

Since 126 is documeted as:
**_126_** if the **_contained command_** cannot be invoked

It makes sense that the container would exit with this state.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>