### PR TITLE
oci: use json formatted errors from the runtime

### DIFF
--- a/libpod.conf
+++ b/libpod.conf
@@ -106,6 +106,10 @@ num_locks = 2048
 # Default OCI runtime
 runtime = "runc"
 
+# List of the OCI runtimes that support --format=json.  When json is supported
+# libpod will use it for reporting nicer errors.
+runtime_supports_json = ["runc"]
+
 # Paths to look for a valid OCI runtime (runc, runv, etc)
 [runtimes]
 runc = [

--- a/libpod/errors.go
+++ b/libpod/errors.go
@@ -96,4 +96,7 @@ var (
 	// ErrOSNotSupported indicates the function is not available on the particular
 	// OS.
 	ErrOSNotSupported = errors.New("No support for this OS yet")
+
+	// ErrOCIRuntime indicates an error from the OCI runtime
+	ErrOCIRuntime = errors.New("OCI runtime error")
 )

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -58,6 +58,7 @@ type OCIRuntime struct {
 	logSizeMax    int64
 	noPivot       bool
 	reservePorts  bool
+	supportsJSON  bool
 }
 
 // syncInfo is used to return data from monitor process to daemon
@@ -75,7 +76,7 @@ type ociError struct {
 }
 
 // Make a new OCI runtime with provided options
-func newOCIRuntime(oruntime OCIRuntimePath, conmonPath string, conmonEnv []string, cgroupManager string, tmpDir string, logSizeMax int64, noPivotRoot bool, reservePorts bool) (*OCIRuntime, error) {
+func newOCIRuntime(oruntime OCIRuntimePath, conmonPath string, conmonEnv []string, cgroupManager string, tmpDir string, logSizeMax int64, noPivotRoot bool, reservePorts bool, supportsJSON bool) (*OCIRuntime, error) {
 	runtime := new(OCIRuntime)
 	runtime.name = oruntime.Name
 	runtime.path = oruntime.Paths[0]
@@ -86,6 +87,7 @@ func newOCIRuntime(oruntime OCIRuntimePath, conmonPath string, conmonEnv []strin
 	runtime.logSizeMax = logSizeMax
 	runtime.noPivot = noPivotRoot
 	runtime.reservePorts = reservePorts
+	runtime.supportsJSON = supportsJSON
 
 	runtime.exitsDir = filepath.Join(runtime.tmpDir, "exits")
 	runtime.socketsDir = filepath.Join(runtime.tmpDir, "socket")

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -66,6 +66,14 @@ type syncInfo struct {
 	Message string `json:"message,omitempty"`
 }
 
+// ociError is used to parse the OCI runtime JSON log.  It is not part of the
+// OCI runtime specifications, it follows what runc does
+type ociError struct {
+	Level string `json:"level,omitempty"`
+	Time  string `json:"time,omitempty"`
+	Msg   string `json:"msg,omitempty"`
+}
+
 // Make a new OCI runtime with provided options
 func newOCIRuntime(oruntime OCIRuntimePath, conmonPath string, conmonEnv []string, cgroupManager string, tmpDir string, logSizeMax int64, noPivotRoot bool, reservePorts bool) (*OCIRuntime, error) {
 	runtime := new(OCIRuntime)

--- a/libpod/oci_linux.go
+++ b/libpod/oci_linux.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -208,6 +209,9 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 	defer parentPipe.Close()
 	defer parentStartPipe.Close()
 
+	ociLog := filepath.Join(ctr.state.RunDir, "oci-log")
+	logLevel := logrus.GetLevel()
+
 	args := []string{}
 	if r.cgroupManager == SystemdCgroupsManager {
 		args = append(args, "-s")
@@ -219,6 +223,9 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 	args = append(args, "-b", ctr.bundlePath())
 	args = append(args, "-p", filepath.Join(ctr.state.RunDir, "pidfile"))
 	args = append(args, "--exit-dir", r.exitsDir)
+	if logLevel != logrus.DebugLevel {
+		args = append(args, "--runtime-arg", "--log-format=json", "--runtime-arg", "--log", fmt.Sprintf("--runtime-arg=%s", ociLog))
+	}
 	if ctr.config.ConmonPidFile != "" {
 		args = append(args, "--conmon-pidfile", ctr.config.ConmonPidFile)
 	}
@@ -248,7 +255,6 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 		args = append(args, "--no-pivot")
 	}
 
-	logLevel := logrus.GetLevel()
 	args = append(args, "--log-level", logLevel.String())
 
 	if logLevel == logrus.DebugLevel {
@@ -417,8 +423,16 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 		}
 		logrus.Debugf("Received container pid: %d", ss.si.Pid)
 		if ss.si.Pid == -1 {
+			data, err := ioutil.ReadFile(ociLog)
+			if err == nil {
+				var ociErr ociError
+				if err := json.Unmarshal(data, &ociErr); err == nil {
+					return errors.Wrapf(ErrOCIRuntime, "%s", strings.Trim(ociErr.Msg, "\n"))
+				}
+			}
+			// If we failed to parse the JSON errors, then print the output as it is
 			if ss.si.Message != "" {
-				return errors.Wrapf(ErrInternal, "container create failed: %s", ss.si.Message)
+				return errors.Wrapf(ErrOCIRuntime, "%s", ss.si.Message)
 			}
 			return errors.Wrapf(ErrInternal, "container create failed")
 		}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -151,6 +151,8 @@ type RuntimeConfig struct {
 	OCIRuntime string `toml:"runtime"`
 	// OCIRuntimes are the set of configured OCI runtimes (default is runc)
 	OCIRuntimes map[string][]string `toml:"runtimes"`
+	// RuntimeSupportsJSON is the list of the OCI runtimes that support --format=json
+	RuntimeSupportsJSON []string `toml:"runtime_supports_json"`
 	// RuntimePath is the path to OCI runtime binary for launching
 	// containers.
 	// The first path pointing to a valid file will be used
@@ -830,12 +832,21 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (err error) {
 		}
 	}
 
+	supportsJSON := false
+	for _, r := range runtime.config.RuntimeSupportsJSON {
+		if r == runtime.config.OCIRuntime {
+			supportsJSON = true
+			break
+		}
+	}
+
 	// Make an OCI runtime to perform container operations
 	ociRuntime, err := newOCIRuntime(runtime.ociRuntimePath,
 		runtime.conmonPath, runtime.config.ConmonEnvVars,
 		runtime.config.CgroupManager, runtime.config.TmpDir,
 		runtime.config.MaxLogSize, runtime.config.NoPivotRoot,
-		runtime.config.EnablePortReservation)
+		runtime.config.EnablePortReservation,
+		supportsJSON)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
request json formatted error messages from the OCI runtime so that we
can nicely print them.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>