### PR TITLE
fix port -l timing with healthchecks

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/libpod"
@@ -22,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -507,4 +509,17 @@ func (p *PodmanTestIntegration) ImageExistsInMainStore(idOrName string) bool {
 	results := p.PodmanNoCache([]string{"image", "exists", idOrName})
 	results.WaitWithDefaultTimeout()
 	return Expect(results.ExitCode()).To(Equal(0))
+}
+
+func (p *PodmanTestIntegration) RunHealthCheck(cid string) error {
+	for i := 0; i < 10; i++ {
+		hc := p.Podman([]string{"healthcheck", "run", cid})
+		hc.WaitWithDefaultTimeout()
+		if hc.ExitCode() == 0 {
+			return nil
+		}
+		fmt.Printf("Waiting for %s to pass healthcheck\n", cid)
+		time.Sleep(1 * time.Second)
+	}
+	return errors.Errorf("unable to detect %s as running", cid)
 }

--- a/test/e2e/port_test.go
+++ b/test/e2e/port_test.go
@@ -48,10 +48,14 @@ var _ = Describe("Podman port", func() {
 		Expect(result.ExitCode()).ToNot(Equal(0))
 	})
 
-	It("podman port  -l nginx", func() {
+	It("podman port -l nginx", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "-P", nginx})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+
+		if err := podmanTest.RunHealthCheck(session.OutputToString()); err != nil {
+			Fail(err.Error())
+		}
 
 		result := podmanTest.Podman([]string{"port", "-l"})
 		result.WaitWithDefaultTimeout()
@@ -65,6 +69,10 @@ var _ = Describe("Podman port", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
+		if err := podmanTest.RunHealthCheck(session.OutputToString()); err != nil {
+			Fail(err.Error())
+		}
+
 		result := podmanTest.Podman([]string{"container", "port", "-l"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
@@ -77,6 +85,10 @@ var _ = Describe("Podman port", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
+		if err := podmanTest.RunHealthCheck(session.OutputToString()); err != nil {
+			Fail(err.Error())
+		}
+
 		result := podmanTest.Podman([]string{"port", "-l", "80"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
@@ -88,6 +100,10 @@ var _ = Describe("Podman port", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "-P", nginx})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+
+		if err := podmanTest.RunHealthCheck(session.OutputToString()); err != nil {
+			Fail(err.Error())
+		}
 
 		result := podmanTest.Podman([]string{"port", "-a"})
 		result.WaitWithDefaultTimeout()


### PR DESCRIPTION
many of the port tests use our nginx container image.  in some cases, we have timing
issues between when the nginx and the container are running and when the port -l
command is run causing test flakes.  we now use the container image's built in
healthcheck to ensure that nginx is running (and subsequently the container
itself) before running the port command.

Fixes: #3309

Signed-off-by: Brent Baude <bbaude@redhat.com>