### PR TITLE
Purge all use of easyjson and ffjson in libpod

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -39,7 +39,6 @@ ${LINTER} \
 	--exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$'\
 	--exclude='duplicate of.*_test.go.*\(dupl\)$'\
 	--exclude='cmd\/client\/.*\.go.*\(dupl\)$'\
-	--exclude='libpod\/.*_easyjson.go:.*'\
 	--exclude='vendor\/.*'\
 	--exclude='podman\/.*'\
 	--exclude='server\/seccomp\/.*\.go.*$'\

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,12 +90,6 @@ RUN set -x \
        && export GOPATH=/go \
        && go get github.com/onsi/gomega/...
 
-# Install easyjson
-RUN set -x \
-      && export GOPATH=/go \
-      && go get -u github.com/mailru/easyjson/... \
-      && install -D -m 755 "$GOPATH"/bin/easyjson /usr/bin/
-
 # Install latest stable criu version
 RUN set -x \
       && cd /tmp \

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -49,12 +49,6 @@ RUN set -x \
        && export GOPATH=/go \
        && go get github.com/onsi/gomega/...
 
-# Install easyjson
-RUN set -x \
-      && export GOPATH=/go \
-      && go get -u github.com/mailru/easyjson/... \
-      && install -D -m 755 "$GOPATH"/bin/easyjson /usr/bin/
-
 # Install conmon
 ENV CONMON_COMMIT 59952292a3b07ac125575024ae21956efe0ecdfb
 RUN set -x \

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -53,12 +53,6 @@ RUN set -x \
        && export GOPATH=/go \
        && go get github.com/onsi/gomega/...
 
-# Install easyjson
-RUN set -x \
-      && export GOPATH=/go \
-      && go get -u github.com/mailru/easyjson/... \
-      && install -D -m 755 "$GOPATH"/bin/easyjson /usr/bin/
-
 # Install conmon
 ENV CONMON_COMMIT 59952292a3b07ac125575024ae21956efe0ecdfb
 RUN set -x \

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -135,7 +135,6 @@ const (
 // assume that their callers handled this requirement. Generally speaking, if a
 // function takes the container lock and accesses any part of state, it should
 // syncContainer() immediately after locking.
-// ffjson: skip
 type Container struct {
 	config *ContainerConfig
 
@@ -161,7 +160,6 @@ type Container struct {
 
 // ContainerState contains the current state of the container
 // It is stored on disk in a tmpfs and recreated on reboot
-// easyjson:json
 type ContainerState struct {
 	// The current state of the running container
 	State ContainerStatus `json:"state"`
@@ -222,7 +220,6 @@ type ContainerState struct {
 }
 
 // ExecSession contains information on an active exec session
-// easyjson:json
 type ExecSession struct {
 	ID      string   `json:"id"`
 	Command []string `json:"command"`
@@ -232,7 +229,6 @@ type ExecSession struct {
 // ContainerConfig contains all information that was used to create the
 // container. It may not be changed once created.
 // It is stored, read-only, on disk
-// easyjson:json
 type ContainerConfig struct {
 	Spec *spec.Spec `json:"spec"`
 	ID   string     `json:"id"`

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -18,7 +18,6 @@ import (
 // assume their callers handled this requirement. Generally speaking, if a
 // function takes the pod lock and accesses any part of state, it should
 // updatePod() immediately after locking.
-// ffjson: skip
 // Pod represents a group of containers that may share namespaces
 type Pod struct {
 	config *PodConfig
@@ -30,7 +29,6 @@ type Pod struct {
 }
 
 // PodConfig represents a pod's static configuration
-// easyjson:json
 type PodConfig struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -66,7 +64,6 @@ type PodConfig struct {
 }
 
 // podState represents a pod's state
-// easyjson:json
 type podState struct {
 	// CgroupPath is the path to the pod's CGroup
 	CgroupPath string `json:"cgroupPath"`
@@ -77,7 +74,6 @@ type podState struct {
 
 // PodInspect represents the data we want to display for
 // podman pod inspect
-// easyjson:json
 type PodInspect struct {
 	Config     *PodConfig
 	State      *PodInspectState
@@ -85,14 +81,12 @@ type PodInspect struct {
 }
 
 // PodInspectState contains inspect data on the pod's state
-// easyjson:json
 type PodInspectState struct {
 	CgroupPath       string `json:"cgroupPath"`
 	InfraContainerID string `json:"infraContainerID"`
 }
 
 // PodContainerInfo keeps information on a container in a pod
-// easyjson:json
 type PodContainerInfo struct {
 	ID    string `json:"id"`
 	State string `json:"state"`

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -10,7 +10,6 @@ type Volume struct {
 }
 
 // VolumeConfig holds the volume's config information
-//easyjson:json
 type VolumeConfig struct {
 	// Name of the volume
 	Name string `json:"name"`


### PR DESCRIPTION
We're no longer using either of these JSON libraries, dropped them in favor of jsoniter. We can't completely remove ffjson as c/storage uses it and can't easily migrate, but we can make sure that libpod itself isn't doing anything with them anymore.