### PR TITLE
libpod: specify a detach keys sequence in libpod.conf

### DIFF
--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -31,7 +31,7 @@ func init() {
 	attachCommand.SetHelpTemplate(HelpTemplate())
 	attachCommand.SetUsageTemplate(UsageTemplate())
 	flags := attachCommand.Flags()
-	flags.StringVar(&attachCommand.DetachKeys, "detach-keys", "", "Override the key sequence for detaching a container. Format is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _")
+	flags.StringVar(&attachCommand.DetachKeys, "detach-keys", "", "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 	flags.BoolVar(&attachCommand.NoStdin, "no-stdin", false, "Do not attach STDIN. The default is false")
 	flags.BoolVar(&attachCommand.SigProxy, "sig-proxy", true, "Proxy received signals to the process")
 	flags.BoolVarP(&attachCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -181,7 +181,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.String(
 		"detach-keys", "",
-		"Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`",
+		"Override the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`",
 	)
 	createFlags.StringSlice(
 		"device", []string{},

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -35,7 +35,7 @@ func init() {
 	startCommand.SetUsageTemplate(UsageTemplate())
 	flags := startCommand.Flags()
 	flags.BoolVarP(&startCommand.Attach, "attach", "a", false, "Attach container's STDOUT and STDERR")
-	flags.StringVar(&startCommand.DetachKeys, "detach-keys", "", "Override the key sequence for detaching a container. Format is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _")
+	flags.StringVar(&startCommand.DetachKeys, "detach-keys", "", "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or a comma separated sequence of `ctrl-<value>`, where `<value>` is one of: `a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`")
 	flags.BoolVarP(&startCommand.Interactive, "interactive", "i", false, "Keep STDIN open even if not attached")
 	flags.BoolVarP(&startCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&startCommand.SigProxy, "sig-proxy", false, "Proxy received signals to the process (default true if attaching, false otherwise)")

--- a/docs/libpod.conf.5.md
+++ b/docs/libpod.conf.5.md
@@ -98,6 +98,9 @@ libpod to manage containers.
 **events_logger**=""
   Default method to use when logging events. Valid values are "journald" and "file".
 
+**detach_keys**=""
+  Keys sequence used for detaching a container
+
 ## FILES
   `/usr/share/containers/libpod.conf`, default libpod configuration path
 

--- a/docs/podman-attach.1.md
+++ b/docs/podman-attach.1.md
@@ -11,12 +11,16 @@ The attach command allows you to attach to a running container using the contain
 or name, either to view its ongoing output or to control it interactively.
 
 You can detach from the container (and leave it running) using a configurable key sequence. The default
-sequence is `ctrl-p,ctrl-q`. You configure the key sequence using the --detach-keys option
+sequence is `ctrl-p,ctrl-q`.
+Configure the keys sequence using the **--detach-keys** option, or specifying
+it in the **libpod.conf** file: see **libpod.conf(5)** for more information.
 
 ## OPTIONS
-**--detach-keys**=*char*
+**--detach-keys**=*sequence*
 
-Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`.
+Override the key sequence for detaching a container. Format is a single character `[a-Z]` or
+a comma separated sequence of `ctrl-<value>`, where `<value>` is one of:
+`a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`.
 
 **--latest**, **-l**
 

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -175,12 +175,14 @@ detached container with **podman attach**.
 
 When attached in the tty mode, you can detach from the container (and leave it
 running) using a configurable key sequence. The default sequence is `ctrl-p,ctrl-q`.
-You configure the key sequence using the **--detach-keys** option or a configuration file.
-See **config-json(5)** for documentation on using a configuration file.
+Configure the keys sequence using the **--detach-keys** option, or specifying
+it in the **libpod.conf** file: see **libpod.conf(5)** for more information.
 
-**--detach-keys**=*char*
+**--detach-keys**=*sequence*
 
-Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`.
+Override the key sequence for detaching a container. Format is a single character `[a-Z]` or
+a comma separated sequence of `ctrl-<value>`, where `<value>` is one of:
+`a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`.
 
 **--device**=*device*
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -181,12 +181,14 @@ detached container with **podman attach**.
 
 When attached in the tty mode, you can detach from the container (and leave it
 running) using a configurable key sequence. The default sequence is `ctrl-p,ctrl-q`.
-You configure the key sequence using the **--detach-keys** option or a configuration file.
-See **config-json(5)** for documentation on using a configuration file.
+Configure the keys sequence using the **--detach-keys** option, or specifying
+it in the **libpod.conf** file: see **libpod.conf(5)** for more information.
 
-**--detach-keys**=*char*
+**--detach-keys**=*sequence*
 
-Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
+Override the key sequence for detaching a container. Format is a single character `[a-Z]` or
+a comma separated sequence of `ctrl-<value>`, where `<value>` is one of:
+`a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`.
 
 **--device**=*device*
 

--- a/docs/podman-start.1.md
+++ b/docs/podman-start.1.md
@@ -19,9 +19,11 @@ attach to the container.
 Attach container's STDOUT and STDERR.  The default is false. This option cannot be used when
 starting multiple containers.
 
-**--detach-keys**=*char*
+**--detach-keys**=*sequence*
 
-Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`.
+Override the key sequence for detaching a container. Format is a single character `[a-Z]` or
+a comma separated sequence of `ctrl-<value>`, where `<value>` is one of:
+`a-z`, `@`, `^`, `[`, `\\`, `]`, `^` or `_`.
 
 **--interactive**, **-i**
 

--- a/libpod.conf
+++ b/libpod.conf
@@ -105,6 +105,13 @@ num_locks = 2048
 # are `journald` or `file`.
 # events_logger = "journald"
 
+# Specify the keys sequence used to detach a container.
+# Format is a single character [a-Z] or a comma separated sequence of
+# `ctrl-<value>`, where `<value>` is one of:
+# `a-z`, `@`, `^`, `[`, `\`, `]`, `^` or `_`
+#
+# detach_keys = "ctrl-p,ctrl-q"
+
 # Default OCI runtime
 runtime = "runc"
 

--- a/libpod/container_attach_linux.go
+++ b/libpod/container_attach_linux.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"sync"
 
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/kubeutils"
@@ -33,22 +32,22 @@ const (
 
 // Attach to the given container
 // Does not check if state is appropriate
-func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, wg *sync.WaitGroup) error {
+func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, started chan bool) error {
 	if !streams.AttachOutput && !streams.AttachError && !streams.AttachInput {
 		return errors.Wrapf(define.ErrInvalidArg, "must provide at least one stream to attach to")
 	}
 
 	logrus.Debugf("Attaching to container %s", c.ID())
 
-	return c.attachContainerSocket(resize, keys, streams, startContainer, wg)
+	return c.attachContainerSocket(resize, keys, streams, startContainer, started)
 }
 
 // attachContainerSocket connects to the container's attach socket and deals with the IO.
-// wg is only required if startContainer is true
+// started is only required if startContainer is true
 // TODO add a channel to allow interrupting
-func (c *Container) attachContainerSocket(resize <-chan remotecommand.TerminalSize, keys string, streams *AttachStreams, startContainer bool, wg *sync.WaitGroup) error {
-	if startContainer && wg == nil {
-		return errors.Wrapf(define.ErrInternal, "wait group not passed when startContainer set")
+func (c *Container) attachContainerSocket(resize <-chan remotecommand.TerminalSize, keys string, streams *AttachStreams, startContainer bool, started chan bool) error {
+	if startContainer && started == nil {
+		return errors.Wrapf(define.ErrInternal, "started chan not passed when startContainer set")
 	}
 
 	// Use default detach keys when keys aren't passed or specified in libpod.conf
@@ -100,7 +99,7 @@ func (c *Container) attachContainerSocket(resize <-chan remotecommand.TerminalSi
 		if err := c.start(); err != nil {
 			return err
 		}
-		wg.Done()
+		started <- true
 	}
 
 	receiveStdoutError := make(chan error)

--- a/libpod/container_attach_unsupported.go
+++ b/libpod/container_attach_unsupported.go
@@ -3,12 +3,10 @@
 package libpod
 
 import (
-	"sync"
-
 	"github.com/containers/libpod/libpod/define"
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, wg *sync.WaitGroup) error {
+func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, started chan bool) error {
 	return define.ErrNotImplemented
 }

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -81,6 +81,10 @@ var (
 	DefaultSHMLockPath = "/libpod_lock"
 	// DefaultRootlessSHMLockPath is the default path for rootless SHM locks
 	DefaultRootlessSHMLockPath = "/libpod_rootless_lock"
+
+	// DefaultDetachKeys is the default keys sequence for detaching a
+	// container
+	DefaultDetachKeys = "ctrl-p,ctrl-q"
 )
 
 // A RuntimeOption is a functional option which alters the Runtime created by
@@ -236,6 +240,8 @@ type RuntimeConfig struct {
 	EventsLogger string `toml:"events_logger"`
 	// EventsLogFilePath is where the events log is stored.
 	EventsLogFilePath string `toml:-"events_logfile_path"`
+	//DetachKeys is the sequence of keys used to detach a container
+	DetachKeys string `toml:"detach_keys"`
 }
 
 // runtimeConfiguredFrom is a struct used during early runtime init to help
@@ -311,6 +317,7 @@ func defaultRuntimeConfig() (RuntimeConfig, error) {
 		EnableLabeling:        true,
 		NumLocks:              2048,
 		EventsLogger:          events.DefaultEventerType.String(),
+		DetachKeys:            DefaultDetachKeys,
 	}, nil
 }
 

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -381,8 +381,18 @@ func (r *LocalRuntime) Run(ctx context.Context, c *cliconfig.RunValues, exitCode
 			}
 		}
 	}
+
+	config, err := r.Runtime.GetConfig()
+	if err != nil {
+		return exitCode, err
+	}
+	detachKeys := c.String("detach-keys")
+	if detachKeys == "" {
+		detachKeys = config.DetachKeys
+	}
+
 	// if the container was created as part of a pod, also start its dependencies, if any.
-	if err := StartAttachCtr(ctx, ctr, outputStream, errorStream, inputStream, c.String("detach-keys"), c.Bool("sig-proxy"), true, c.IsSet("pod")); err != nil {
+	if err := StartAttachCtr(ctx, ctr, outputStream, errorStream, inputStream, detachKeys, c.Bool("sig-proxy"), true, c.IsSet("pod")); err != nil {
 		// We've manually detached from the container
 		// Do not perform cleanup, or wait for container exit code
 		// Just exit immediately
@@ -407,10 +417,6 @@ func (r *LocalRuntime) Run(ctx context.Context, c *cliconfig.RunValues, exitCode
 		if errors.Cause(err) == define.ErrNoSuchCtr {
 			// The container may have been removed
 			// Go looking for an exit file
-			config, err := r.Runtime.GetConfig()
-			if err != nil {
-				return exitCode, err
-			}
 			ctrExitCode, err := ReadExitFile(config.TmpDir, ctr.ID())
 			if err != nil {
 				logrus.Errorf("Cannot get exit code: %v", err)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -59,11 +59,6 @@ var ErrDetach = errors.New("detached from container")
 
 // CopyDetachable is similar to io.Copy but support a detach key sequence to break out.
 func CopyDetachable(dst io.Writer, src io.Reader, keys []byte) (written int64, err error) {
-	if len(keys) == 0 {
-		// Default keys : ctrl-p,ctrl-q
-		keys = []byte{16, 17}
-	}
-
 	buf := make([]byte, 32*1024)
 	for {
 		nr, er := src.Read(buf)


### PR DESCRIPTION
Add the ability of specifying a detach keys sequence in libpod.conf

Signed-off-by: Marco Vedovati <mvedovati@suse.com>