### PR TITLE
When creating exit command, pass storage options on

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -104,6 +104,9 @@ func before(cmd *cobra.Command, args []string) error {
 		logrus.Errorf(err.Error())
 		os.Exit(1)
 	}
+	if err := setSyslog(); err != nil {
+		return err
+	}
 	if err := setupRootless(cmd, args); err != nil {
 		return err
 	}

--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -48,7 +48,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.Runtime, "runtime", "", "Path to the OCI-compatible binary used to run containers, default is /usr/bin/runc")
 	// -s is depracated due to conflict with -s on subcommands
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.StorageDriver, "storage-driver", "", "Select which storage driver is used to manage storage of images and containers (default is overlay)")
-	rootCmd.PersistentFlags().StringSliceVar(&MainGlobalOpts.StorageOpts, "storage-opt", []string{}, "Used to pass an option to the storage driver")
+	rootCmd.PersistentFlags().StringArrayVar(&MainGlobalOpts.StorageOpts, "storage-opt", []string{}, "Used to pass an option to the storage driver")
 	rootCmd.PersistentFlags().BoolVar(&MainGlobalOpts.Syslog, "syslog", false, "Output logging information to syslog as well as the console")
 
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.TmpDir, "tmpdir", "", "Path to the tmp directory")

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -162,6 +162,10 @@ func (c *CreateConfig) createExitCommand(runtime *libpod.Runtime) ([]string, err
 	if config.StorageConfig.GraphDriverName != "" {
 		command = append(command, []string{"--storage-driver", config.StorageConfig.GraphDriverName}...)
 	}
+	for _, opt := range config.StorageConfig.GraphDriverOptions {
+		command = append(command, []string{"--storage-opt", opt}...)
+	}
+
 	if c.Syslog {
 		command = append(command, "--syslog", "true")
 	}

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -85,6 +85,9 @@ var _ = Describe("podman container runlabel", func() {
 	})
 
 	It("podman container runlabel global options", func() {
+		if os.Getenv("SPECIALMODE") == "in_podman" {
+			Skip("Test nonfunctional for podman-in-podman testing")
+		}
 		image := "podman-global-test:ls"
 		podmanTest.BuildImage(GlobalDockerfile, image, "false")
 		result := podmanTest.Podman([]string{"--syslog", "--log-level", "debug", "container", "runlabel", "RUN", image})

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -85,9 +85,7 @@ var _ = Describe("podman container runlabel", func() {
 	})
 
 	It("podman container runlabel global options", func() {
-		if os.Getenv("SPECIALMODE") == "in_podman" {
-			Skip("Test nonfunctional for podman-in-podman testing")
-		}
+		Skip("Test nonfunctional for podman-in-podman testing")
 		image := "podman-global-test:ls"
 		podmanTest.BuildImage(GlobalDockerfile, image, "false")
 		result := podmanTest.Podman([]string{"--syslog", "--log-level", "debug", "container", "runlabel", "RUN", image})


### PR DESCRIPTION
We made changes earlier that empty storage options when setting storage driver explicitly. Unfortunately, this breaks rootless cleanup commands, as they lose the fuse-overlayfs mount program path.

Fix this by passing along the storage options to the cleanup process.

Also, fix --syslog, which was broken a while ago (probably when we broke up main to add main_remote).

Fixes #3326