### PR TITLE
Correctly identify the defaults for cgroup-manager

### DIFF
--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -27,7 +27,10 @@ Print usage statement
 
 **--cgroup-manager**=*manager*
 
-CGroup manager to use for container cgroups. Supported values are cgroupfs or systemd (default). Setting this flag can cause certain commands to break when called on containers created by the other CGroup manager type.
+CGroup manager to use for container cgroups. Supported values are cgroupfs or systemd. Default is systemd unless overridden in the libpod.conf file.
+
+Note: Setting this flag can cause certain commands to break when called on containers previously created by the other CGroup manager type.
+Note: CGroup manager is not supported in rootless mode when using CGroups Version V1.
 
 **--cpu-profile**=*path*
 

--- a/libpod/oci_linux.go
+++ b/libpod/oci_linux.go
@@ -294,7 +294,11 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 	cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", runtimeDir))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("_CONTAINERS_USERNS_CONFIGURED=%s", os.Getenv("_CONTAINERS_USERNS_CONFIGURED")))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("_CONTAINERS_ROOTLESS_UID=%s", os.Getenv("_CONTAINERS_ROOTLESS_UID")))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", os.Getenv("HOME")))
+	home, err := homeDir()
+	if err != nil {
+		return err
+	}
+	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", home))
 
 	if r.reservePorts && !ctr.config.NetMode.IsSlirp4netns() {
 		ports, err := bindPorts(ctr.config.PortMappings)


### PR DESCRIPTION
Currently we report cgroupmanager default as systemd, even if the user modified
the libpod.conf.  Also cgroupmanager does not work in rootless mode.  This
PR correctly identifies the default cgroup manager or reports it is not supported.

Also add homeDir to correctly get the homedir if the $HOME is not set.  Will
attempt to get Homedir out of /etc/passwd.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>