### PR TITLE
Fix ENV parsing on `podman import`

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -99,7 +99,10 @@ func GetImageConfig(changes []string) (v1.ImageConfig, error) {
 			var st struct{}
 			exposedPorts[pair[1]] = st
 		case "ENV":
-			env = append(env, pair[1])
+			if len(pair) < 3 {
+				return v1.ImageConfig{}, errors.Errorf("no value given for environment variable %q", pair[1])
+			}
+			env = append(env, strings.Join(pair[1:], "="))
 		case "ENTRYPOINT":
 			entrypoint = append(entrypoint, pair[1])
 		case "CMD":


### PR DESCRIPTION
The code that parses `--change` options to `podman import` was not processing the `ENV` command in a useful way. `pair` is created by splitting the option value on `=`, but only `pair[1]` was being appended to `env`; this meant that there was no way to actually specify a value for an environment variable, since `env` is expected to be a list of strings of the form `KEY=VALUE`.

This PR fixes the issue by re-joining the elements of the `pair` array with `=` from index 1 onward, and appending that to `env` instead of just appending `pair[1]`. This allows a command like the one below to function as expected:

```
podman import -c ENV=LANG=en_US.UTF-8 -
```

The resulting container will have `LANG` set to `en_US.UTF-8` in its environment.

No special consideration or treatment is made to the string other than re-joining the remainder on `=`. This allows environment variables with embedded `=` characters to be specified without any additional gymnastics:

```
podman import -c ENV=EQUATION=FOO=BAR -
```

The resulting container will have `EQUATION` set to `FOO=BAR` in its environment.
