### PR TITLE
Add remote client log to file

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -104,9 +104,7 @@ func before(cmd *cobra.Command, args []string) error {
 		logrus.Errorf(err.Error())
 		os.Exit(1)
 	}
-	if err := setSyslog(); err != nil {
-		return err
-	}
+
 	if err := setupRootless(cmd, args); err != nil {
 		return err
 	}
@@ -121,6 +119,9 @@ func before(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	logrus.SetLevel(level)
+	if err := setSyslog(); err != nil {
+		return err
+	}
 
 	if err := setRLimits(); err != nil {
 		return err

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -90,6 +90,8 @@ Storage driver option, Default storage driver options are configured in /etc/con
 
 output logging information to syslog as well as the console
 
+On remote clients, logging is directed to the file ~/.config/containers/podman.log
+
 **--version**, **-v**
 
 Print the version


### PR DESCRIPTION
Logging messages from the dependency libraries should not log onto the
screen when using the remote client.  This patch writes logging to
~/.config/containers/podman-remote.log

Fixes #3299

Signed-off-by: Jhon Honce <jhonce@redhat.com>