### PR TITLE
docs: add note to system migrate

### DIFF
--- a/docs/podman-system-migrate.1.md
+++ b/docs/podman-system-migrate.1.md
@@ -11,11 +11,24 @@ podman\-system\-migrate - Migrate container to the latest version of podman
 
 **podman system migrate** takes care of migrating existing containers to the latest version of podman if any change is necessary.
 
+"Rootless Podman uses a pause process to keep the unprivileged
+namespaces alive. This prevents any change to the `/etc/subuid` and
+`/etc/subgid` files from being propagated to the rootless containers
+while the pause process is running.
+
+For these changes to be propagated, it is necessary to first stop all
+running containers associated with the user and to also stop the pause
+process and delete its pid file.  Instead of doing it manually, `podman
+system migrate` can be used to stop both the running containers and the
+pause process. The `/etc/subuid` and `/etc/subgid` files can then be
+edited or changed with usermod to recreate the user namespace with the
+newly configured mappings.
+
 ## SYNOPSIS
 **podman system migrate**
 
 ## SEE ALSO
-`podman(1)`, `libpod.conf(5)`
+`podman(1)`, `libpod.conf(5)`, `usermod(8)`
 
 ## HISTORY
 April 2019, Originally compiled by Giuseppe Scrivano (gscrivan at redhat dot com)


### PR DESCRIPTION
add a note explaining how it can be used to recreate the rootless user
namespace.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>