### PR TITLE
fix port -l timing with healthchecks

### DIFF
--- a/test/e2e/port_test.go
+++ b/test/e2e/port_test.go
@@ -48,10 +48,13 @@ var _ = Describe("Podman port", func() {
 		Expect(result.ExitCode()).ToNot(Equal(0))
 	})
 
-	It("podman port  -l nginx", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "-P", nginx})
-		session.WaitWithDefaultTimeout()
+	It("podman port -l nginx", func() {
+		session, cid := podmanTest.RunNginxWithHealthCheck("")
 		Expect(session.ExitCode()).To(Equal(0))
+
+		if err := podmanTest.RunHealthCheck(cid); err != nil {
+			Fail(err.Error())
+		}
 
 		result := podmanTest.Podman([]string{"port", "-l"})
 		result.WaitWithDefaultTimeout()
@@ -61,9 +64,12 @@ var _ = Describe("Podman port", func() {
 	})
 
 	It("podman container port  -l nginx", func() {
-		session := podmanTest.Podman([]string{"container", "run", "-dt", "-P", nginx})
-		session.WaitWithDefaultTimeout()
+		session, cid := podmanTest.RunNginxWithHealthCheck("")
 		Expect(session.ExitCode()).To(Equal(0))
+
+		if err := podmanTest.RunHealthCheck(cid); err != nil {
+			Fail(err.Error())
+		}
 
 		result := podmanTest.Podman([]string{"container", "port", "-l"})
 		result.WaitWithDefaultTimeout()
@@ -73,9 +79,12 @@ var _ = Describe("Podman port", func() {
 	})
 
 	It("podman port -l port nginx", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "-P", nginx})
-		session.WaitWithDefaultTimeout()
+		session, cid := podmanTest.RunNginxWithHealthCheck("")
 		Expect(session.ExitCode()).To(Equal(0))
+
+		if err := podmanTest.RunHealthCheck(cid); err != nil {
+			Fail(err.Error())
+		}
 
 		result := podmanTest.Podman([]string{"port", "-l", "80"})
 		result.WaitWithDefaultTimeout()
@@ -85,9 +94,12 @@ var _ = Describe("Podman port", func() {
 	})
 
 	It("podman port -a nginx", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "-P", nginx})
-		session.WaitWithDefaultTimeout()
+		session, cid := podmanTest.RunNginxWithHealthCheck("")
 		Expect(session.ExitCode()).To(Equal(0))
+
+		if err := podmanTest.RunHealthCheck(cid); err != nil {
+			Fail(err.Error())
+		}
 
 		result := podmanTest.Podman([]string{"port", "-a"})
 		result.WaitWithDefaultTimeout()


### PR DESCRIPTION
many of the port tests use our nginx container image.  in some cases, we have timing
issues between when the nginx and the container are running and when the port -l
command is run causing test flakes.  we now use the container image's built in
healthcheck to ensure that nginx is running (and subsequently the container
itself) before running the port command.

Fixes: #3309

Signed-off-by: Brent Baude <bbaude@redhat.com>
Signed-off-by: baude <bbaude@redhat.com>