### PR TITLE
Fix example in oci-hooks.5.md

### DIFF
--- a/pkg/hooks/docs/oci-hooks.5.md
+++ b/pkg/hooks/docs/oci-hooks.5.md
@@ -90,7 +90,7 @@ $ cat /etc/containers/oci/hooks.d/oci-systemd-hook.json
     "path": "/usr/libexec/oci/hooks.d/oci-systemd-hook"
   }
   "when": {
-    "args": [".*/init$" , ".*/systemd$"],
+    "commands": [".*/init$" , ".*/systemd$"],
   },
   "stages": ["prestart", "poststop"]
 }


### PR DESCRIPTION
Replace "args" with "commands" to fix the example in oci-hooks.5.md

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>