### PR TITLE
fix broken healthcheck tests

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -811,7 +811,7 @@ func makeHealthCheckFromCli(c *GenericCLIResults) (*manifest.Schema2HealthConfig
 		return nil, errors.Wrapf(err, "invalid healthcheck-start-period %s", inStartPeriod)
 	}
 	if startPeriodDuration < time.Duration(0) {
-		return nil, errors.New("healthcheck-start-period must be a 0 seconds or greater")
+		return nil, errors.New("healthcheck-start-period must be 0 seconds or greater")
 	}
 	hc.StartPeriod = startPeriodDuration
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -712,28 +712,25 @@ USER mail`
 		Expect(session.OutputToString()).To(Not(ContainSubstring("/dev/shm type tmpfs (ro,")))
 	})
 
-	It("podman run with bad healthcheck interval", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--healthcheck-cmd", "foo", "--healthcheck-interval", "0.5s", ALPINE, "top"})
-		session.Wait()
-		Expect(session.ExitCode()).ToNot(Equal(0))
-	})
-
 	It("podman run with bad healthcheck retries", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--healthcheck-cmd", "foo", "--healthcheck-retries", "0", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"run", "-dt", "--healthcheck-command", "foo", "--healthcheck-retries", "0", ALPINE, "top"})
 		session.Wait()
 		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session.ErrorToString()).To(ContainSubstring("healthcheck-retries must be greater than 0"))
 	})
 
 	It("podman run with bad healthcheck timeout", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--healthcheck-cmd", "foo", "--healthcheck-timeout", "0s", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"run", "-dt", "--healthcheck-command", "foo", "--healthcheck-timeout", "0s", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session.ErrorToString()).To(ContainSubstring("healthcheck-timeout must be at least 1 second"))
 	})
 
 	It("podman run with bad healthcheck start-period", func() {
-		session := podmanTest.Podman([]string{"run", "-dt", "--healthcheck-cmd", "foo", "--healthcheck-start-period", "-1s", ALPINE, "top"})
+		session := podmanTest.Podman([]string{"run", "-dt", "--healthcheck-command", "foo", "--healthcheck-start-period", "-1s", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session.ErrorToString()).To(ContainSubstring("healthcheck-start-period must be 0 seconds or greater"))
 	})
 
 	It("podman run with --add-host and --no-hosts fails", func() {


### PR DESCRIPTION
Four of the healthcheck tests were completely broken. They
were written with the option '--healthcheck-cmd' which is
not an option (it should be  '--healthcheck-command', with
'command' as a full word). The tests were merely checking
exit code, not error message, so of course they failed.
I have fixed the command line and added checks for the
expected diagnostic.

(Side note: do not write tests that check exit code but
nothing else. This should not need to be said).

One of the four tests looks invalid to me: it runs
with --healthcheck-interval 0.5s and expects a nonzero
exit status, but that actually works fine for me. This
test will of course fail in CI, but I've added a huge
FIXME and hope that someone will look at it and tell me
what this test is expected to do; I will then fix it
and push a corrected test.

Also: grammar fix in an error message.

Caught by my ginkgo log greasemonkey script, which
highlights 'Error' messages and grabbed my attention.

Signed-off-by: Ed Santiago <santiago@redhat.com>