### PR TITLE
account for varlink calls that dont use more

### DIFF
--- a/pkg/channelwriter/channelwriter.go
+++ b/pkg/channelwriter/channelwriter.go
@@ -1,0 +1,34 @@
+package channelwriter
+
+import "github.com/pkg/errors"
+
+// Writer is an io.writer-like object that "writes" to a channel
+// instead of a buffer or file, etc. It is handy for varlink endpoints when
+// needing to handle endpoints that do logging "real-time"
+type Writer struct {
+	ByteChannel chan []byte
+}
+
+// NewChannelWriter creates a new channel writer and adds a
+// byte slice channel into it.
+func NewChannelWriter() *Writer {
+	byteChannel := make(chan []byte)
+	return &Writer{
+		ByteChannel: byteChannel,
+	}
+}
+
+// Write method for Writer
+func (c *Writer) Write(w []byte) (int, error) {
+	if c.ByteChannel == nil {
+		return 0, errors.New("channel writer channel cannot be nil")
+	}
+	c.ByteChannel <- w
+	return len(w), nil
+}
+
+// Close method for Writer
+func (c *Writer) Close() error {
+	close(c.ByteChannel)
+	return nil
+}

--- a/pkg/varlinkapi/util.go
+++ b/pkg/varlinkapi/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/define"
+	"github.com/containers/libpod/pkg/channelwriter"
 	"github.com/containers/storage/pkg/archive"
 )
 
@@ -195,4 +196,43 @@ func makePsOpts(inOpts iopodman.PsOpts) shared.PsOptions {
 		Namespace: true,
 		Sync:      derefBool(inOpts.Sync),
 	}
+}
+
+// forwardOutput is a helper method for varlink endpoints that employ both more and without
+// more.  it is capable of sending updates as the output writer gets them or append them
+// all to a log.  the chan error is the error from the libpod call so we can honor
+// and error event in that case.
+func forwardOutput(log []string, c chan error, wantsMore bool, output *channelwriter.Writer, reply func(br iopodman.MoreResponse) error) ([]string, error) {
+	done := false
+	for {
+		select {
+		// We need to check if the libpod func being called has returned an
+		// error yet
+		case err := <-c:
+			if err != nil {
+				return nil, err
+			}
+			done = true
+		// if no error is found, we pull what we can from the log writer and
+		// append it to log string slice
+		case line := <-output.ByteChannel:
+			log = append(log, string(line))
+			// If the end point is being used in more mode, send what we have
+			if wantsMore {
+				br := iopodman.MoreResponse{
+					Logs: log,
+				}
+				if err := reply(br); err != nil {
+					return nil, err
+				}
+				// "reset" the log to empty because we are sending what we
+				// get as we get it
+				log = []string{}
+			}
+		}
+		if done {
+			break
+		}
+	}
+	return log, nil
 }


### PR DESCRIPTION
the commit and pull varlink endpoints were not working correctly when
'more' was not being specified.

Fixes: #3317
Fixes: #3318

Signed-off-by: baude <bbaude@redhat.com>