### PR TITLE
Add support for cached, delegated mounts

### DIFF
--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -582,22 +582,7 @@ func ValidateVolumeCtrDir(ctrDir string) error {
 func ValidateVolumeOpts(options []string) ([]string, error) {
 	var foundRootPropagation, foundRWRO, foundLabelChange, bindType int
 	finalOpts := make([]string, 0, len(options))
-	discardOpts := []string{"cached", "delegated"}
 	for _, opt := range options {
-		// The discarded ops are OS X specific volume options introduced
-		// in a recent Docker version.
-		// They have no meaning on Linux, so here we silently drop them.
-		// This matches Docker's behavior (the options are intended to
-		// be always safe to use, even not on OS X).
-		bad := false
-		for _, discard := range discardOpts {
-			if opt == discard {
-				bad = true
-			}
-		}
-		if bad {
-			continue
-		}
 		switch opt {
 		case "rw", "ro":
 			foundRWRO++
@@ -619,6 +604,14 @@ func ValidateVolumeOpts(options []string) ([]string, error) {
 			if bindType > 1 {
 				return nil, errors.Errorf("invalid options %q, can only specify 1 '[r]bind' option", strings.Join(options, ", "))
 			}
+		case "cached", "delegated":
+			// The discarded ops are OS X specific volume options
+			// introduced in a recent Docker version.
+			// They have no meaning on Linux, so here we silently
+			// drop them. This matches Docker's behavior (the options
+			// are intended to be always safe to use, even not on OS
+			// X).
+			continue
 		default:
 			return nil, errors.Errorf("invalid mount option %q", opt)
 		}

--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -251,9 +251,11 @@ func (config *CreateConfig) getVolumesFrom(runtime *libpod.Runtime) (map[string]
 				return nil, nil, errors.Errorf("invalid options %q, can only specify 'ro', 'rw', and 'z", splitVol[1])
 			}
 			options = strings.Split(splitVol[1], ",")
-			if err := ValidateVolumeOpts(options); err != nil {
+			opts, err := ValidateVolumeOpts(options)
+			if err != nil {
 				return nil, nil, err
 			}
+			options = opts
 		}
 		ctr, err := runtime.LookupContainer(splitVol[0])
 		if err != nil {
@@ -447,9 +449,11 @@ func getBindMount(args []string) (spec.Mount, error) {
 		newMount.Source = newMount.Destination
 	}
 
-	if err := ValidateVolumeOpts(newMount.Options); err != nil {
+	opts, err := ValidateVolumeOpts(newMount.Options)
+	if err != nil {
 		return newMount, err
 	}
+	newMount.Options = opts
 
 	return newMount, nil
 }
@@ -575,35 +579,52 @@ func ValidateVolumeCtrDir(ctrDir string) error {
 }
 
 // ValidateVolumeOpts validates a volume's options
-func ValidateVolumeOpts(options []string) error {
+func ValidateVolumeOpts(options []string) ([]string, error) {
 	var foundRootPropagation, foundRWRO, foundLabelChange, bindType int
+	finalOpts := make([]string, 0, len(options))
+	discardOpts := []string{"cached", "delegated"}
 	for _, opt := range options {
+		// The discarded ops are OS X specific volume options introduced
+		// in a recent Docker version.
+		// They have no meaning on Linux, so here we silently drop them.
+		// This matches Docker's behavior (the options are intended to
+		// be always safe to use, even not on OS X).
+		bad := false
+		for _, discard := range discardOpts {
+			if opt == discard {
+				bad = true
+			}
+		}
+		if bad {
+			continue
+		}
 		switch opt {
 		case "rw", "ro":
 			foundRWRO++
 			if foundRWRO > 1 {
-				return errors.Errorf("invalid options %q, can only specify 1 'rw' or 'ro' option", strings.Join(options, ", "))
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'rw' or 'ro' option", strings.Join(options, ", "))
 			}
 		case "z", "Z":
 			foundLabelChange++
 			if foundLabelChange > 1 {
-				return errors.Errorf("invalid options %q, can only specify 1 'z' or 'Z' option", strings.Join(options, ", "))
+				return nil, errors.Errorf("invalid options %q, can only specify 1 'z' or 'Z' option", strings.Join(options, ", "))
 			}
 		case "private", "rprivate", "shared", "rshared", "slave", "rslave":
 			foundRootPropagation++
 			if foundRootPropagation > 1 {
-				return errors.Errorf("invalid options %q, can only specify 1 '[r]shared', '[r]private' or '[r]slave' option", strings.Join(options, ", "))
+				return nil, errors.Errorf("invalid options %q, can only specify 1 '[r]shared', '[r]private' or '[r]slave' option", strings.Join(options, ", "))
 			}
 		case "bind", "rbind":
 			bindType++
 			if bindType > 1 {
-				return errors.Errorf("invalid options %q, can only specify 1 '[r]bind' option", strings.Join(options, ", "))
+				return nil, errors.Errorf("invalid options %q, can only specify 1 '[r]bind' option", strings.Join(options, ", "))
 			}
 		default:
-			return errors.Errorf("invalid option type %q", opt)
+			return nil, errors.Errorf("invalid mount option %q", opt)
 		}
+		finalOpts = append(finalOpts, opt)
 	}
-	return nil
+	return finalOpts, nil
 }
 
 // GetVolumeMounts takes user provided input for bind mounts and creates Mount structs
@@ -633,9 +654,11 @@ func (config *CreateConfig) getVolumeMounts() (map[string]spec.Mount, map[string
 		}
 		if len(splitVol) > 2 {
 			options = strings.Split(splitVol[2], ",")
-			if err := ValidateVolumeOpts(options); err != nil {
+			opts, err := ValidateVolumeOpts(options)
+			if err != nil {
 				return nil, nil, err
 			}
+			options = opts
 		}
 
 		if err := ValidateVolumeHostDir(src); err != nil {

--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -20,25 +20,21 @@ func ProcessOptions(options []string) []string {
 		foundbind, foundrw, foundro bool
 		rootProp                    string
 	)
+
 	for _, opt := range options {
 		switch opt {
 		case "bind", "rbind":
 			foundbind = true
-			break
+		case "ro":
+			foundro = true
+		case "rw":
+			foundrw = true
+		case "private", "rprivate", "slave", "rslave", "shared", "rshared":
+			rootProp = opt
 		}
 	}
 	if !foundbind {
 		options = append(options, "rbind")
-	}
-	for _, opt := range options {
-		switch opt {
-		case "rw":
-			foundrw = true
-		case "ro":
-			foundro = true
-		case "private", "rprivate", "slave", "rslave", "shared", "rshared":
-			rootProp = opt
-		}
 	}
 	if !foundrw && !foundro {
 		options = append(options, "rw")

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -63,6 +63,24 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(found).Should(BeTrue())
 		Expect(matches[0]).To(ContainSubstring("rw"))
 		Expect(matches[0]).To(ContainSubstring("shared"))
+
+		// Cached is ignored
+		session = podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:/run/test:cached", mountPath), ALPINE, "grep", "/run/test", "/proc/self/mountinfo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		found, matches = session.GrepString("/run/test")
+		Expect(found).Should(BeTrue())
+		Expect(matches[0]).To(ContainSubstring("rw"))
+		Expect(matches[0]).To(Not(ContainSubstring("cached")))
+
+		// Delegated is ignored
+		session = podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:/run/test:delegated", mountPath), ALPINE, "grep", "/run/test", "/proc/self/mountinfo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		found, matches = session.GrepString("/run/test")
+		Expect(found).Should(BeTrue())
+		Expect(matches[0]).To(ContainSubstring("rw"))
+		Expect(matches[0]).To(Not(ContainSubstring("delegated")))
 	})
 
 	It("podman run with --mount flag", func() {


### PR DESCRIPTION
And by "support" I mean that we ignore them.

These are OS X only options from a recent Docker that are ignored on other OSes. Because it's safe everywhere, people are starting to use them, so let's add support for ignoring them, as Docker does.

Also includes some small cleanups in how we handle mount options.