### PR TITLE
Spoof json-file logging support

### DIFF
--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -382,7 +382,7 @@ Not implemented
 
 **--log-driver**="*k8s-file*"
 
-Logging driver for the container.  Currently not supported.  This flag is a NOOP provided solely for scripting compatibility.
+Logging driver for the container.  Currently available options are *k8s-file* and *journald*, with *json-file* aliased to *k8s-file* for scripting compatibility.
 
 **--log-opt**=*path*
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -395,7 +395,7 @@ Not implemented
 
 **--log-driver**="*k8s-file*"
 
-Logging driver for the container.  Currently not supported.  This flag is a NOOP provided solely for scripting compatibility.
+Logging driver for the container.  Currently available options are *k8s-file* and *journald*, with *json-file* aliased to *k8s-file* for scripting compatibility.
 
 **--log-opt**=*path*
 

--- a/libpod/oci_linux.go
+++ b/libpod/oci_linux.go
@@ -246,7 +246,9 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 	}
 
 	logDriver := KubernetesLogging
-	if ctr.LogDriver() != "" {
+	if ctr.LogDriver() == JSONLogging {
+		logrus.Errorf("json-file logging specified but not supported. Choosing k8s-file logging instead")
+	} else if ctr.LogDriver() != "" {
 		logDriver = ctr.LogDriver()
 	}
 	args = append(args, "-l", fmt.Sprintf("%s:%s", logDriver, ctr.LogPath()))


### PR DESCRIPTION
For docker scripting compatibility, allow for json-file logging when creating args for conmon. That way, when json-file is supported, that case can be easily removed.
Fixes: https://github.com/containers/libpod/issues/3363