### PR TITLE
Add RUN priv'd test for build

### DIFF
--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -20,15 +20,16 @@ load helpers
     dockerfile=$tmpdir/Dockerfile
     cat >$dockerfile <<EOF
 FROM $IMAGE
+RUN apk add nginx
 RUN echo $rand_content > /$rand_filename
 EOF
 
     run_podman build -t build_test --format=docker $tmpdir
+    is "$output" ".*STEP 4: COMMIT" "COMMIT seen in log"
 
     run_podman run --rm build_test cat /$rand_filename
     is "$output"   "$rand_content"   "reading generated file in image"
 
     run_podman rmi build_test
 }
-
 # vim: filetype=sh

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -42,6 +42,15 @@ should be reserved for a first-pass fail-fast subset of tests:
 without having to wait for the entire test suite.
 
 
+Running tests
+=============
+To run the tests locally in your sandbox, you can use one of these methods:
+* make;PODMAN=./bin/podman bats ./test/system/070-build.bats # runs just the specified test
+* make;PODMAN=./bin/podman bats ./test/system                # runs all
+
+To test as root:
+*  $ PODMAN=./bin/podman sudo --preserve-env=PODMAN bats test/system
+
 Analyzing test failures
 =======================
 

--- a/test/test_podman_baseline.sh
+++ b/test/test_podman_baseline.sh
@@ -536,6 +536,28 @@ EOF
 fi
 
 ########
+# Build Dockerfile for RUN with priv'd command test
+########
+FILE=./Dockerfile
+/bin/cat <<EOM >$FILE
+FROM alpine
+RUN apk add nginx
+EOM
+chmod +x $FILE
+
+########
+# Build with the Dockerfile
+########
+podman build -f Dockerfile -t build-priv
+
+########
+# Cleanup
+########
+podman rm -a -f
+podman rmi -a -f
+rm ./Dockerfile
+
+########
 # Build Dockerfile for WhaleSays test
 ########
 FILE=./Dockerfile


### PR DESCRIPTION
Podman 1.4.1 had problems with builds with a
RUN command that tried to to a privliged command.

This adds a gating test for that situation.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>