### PR TITLE
Begin adding support for multiple OCI runtimes

### DIFF
--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -304,6 +304,16 @@ func (s *BoltState) getContainerFromDB(id []byte, ctr *Container, ctrsBkt *bolt.
 	}
 	ctr.lock = lock
 
+	if ctr.config.OCIRuntime == "" {
+		ctr.ociRuntime = s.runtime.defaultOCIRuntime
+	} else {
+		ociRuntime, ok := s.runtime.ociRuntimes[ctr.config.OCIRuntime]
+		if !ok {
+			return errors.Wrapf(ErrInternal, "container %s was created with OCI runtime %s, but that runtime is not available in the current configuration", ctr.ID(), ctr.config.OCIRuntime)
+		}
+		ctr.ociRuntime = ociRuntime
+	}
+
 	ctr.runtime = s.runtime
 	ctr.valid = valid
 

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"bytes"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -307,7 +308,14 @@ func (s *BoltState) getContainerFromDB(id []byte, ctr *Container, ctrsBkt *bolt.
 	if ctr.config.OCIRuntime == "" {
 		ctr.ociRuntime = s.runtime.defaultOCIRuntime
 	} else {
-		ociRuntime, ok := s.runtime.ociRuntimes[ctr.config.OCIRuntime]
+		// Handle legacy containers which might use a literal path for
+		// their OCI runtime name.
+		runtimeName := ctr.config.OCIRuntime
+		if strings.HasPrefix(runtimeName, "/") {
+			runtimeName = filepath.Base(runtimeName)
+		}
+
+		ociRuntime, ok := s.runtime.ociRuntimes[runtimeName]
 		if !ok {
 			return errors.Wrapf(ErrInternal, "container %s was created with OCI runtime %s, but that runtime is not available in the current configuration", ctr.ID(), ctr.config.OCIRuntime)
 		}

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -145,9 +145,10 @@ type Container struct {
 	// Functions called on a batched container will not lock or sync
 	batched bool
 
-	valid   bool
-	lock    lock.Locker
-	runtime *Runtime
+	valid      bool
+	lock       lock.Locker
+	runtime    *Runtime
+	ociRuntime *OCIRuntime
 
 	rootlessSlirpSyncR *os.File
 	rootlessSlirpSyncW *os.File
@@ -789,7 +790,7 @@ func (c *Container) LogDriver() string {
 
 // RuntimeName returns the name of the runtime
 func (c *Container) RuntimeName() string {
-	return c.runtime.ociRuntime.name
+	return c.config.OCIRuntime
 }
 
 // Runtime spec accessors

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -207,7 +207,7 @@ func (c *Container) Kill(signal uint) error {
 	}
 
 	defer c.newContainerEvent(events.Kill)
-	if err := c.runtime.ociRuntime.killContainer(c, signal); err != nil {
+	if err := c.ociRuntime.killContainer(c, signal); err != nil {
 		return err
 	}
 
@@ -280,7 +280,7 @@ func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir 
 
 	logrus.Debugf("Creating new exec session in container %s with session id %s", c.ID(), sessionID)
 
-	execCmd, err := c.runtime.ociRuntime.execContainer(c, cmd, capList, env, tty, workDir, hostUser, sessionID, streams, preserveFDs)
+	execCmd, err := c.ociRuntime.execContainer(c, cmd, capList, env, tty, workDir, hostUser, sessionID, streams, preserveFDs)
 	if err != nil {
 		return errors.Wrapf(err, "error exec %s", c.ID())
 	}
@@ -658,7 +658,7 @@ func (c *Container) Sync() error {
 		(c.state.State != ContainerStateConfigured) &&
 		(c.state.State != ContainerStateExited) {
 		oldState := c.state.State
-		if err := c.runtime.ociRuntime.updateContainerStatus(c, true); err != nil {
+		if err := c.ociRuntime.updateContainerStatus(c, true); err != nil {
 			return err
 		}
 		// Only save back to DB if state changed
@@ -715,7 +715,7 @@ func (c *Container) Refresh(ctx context.Context) error {
 	if len(c.state.ExecSessions) > 0 {
 		logrus.Infof("Killing %d exec sessions in container %s. They will not be restored after refresh.",
 			len(c.state.ExecSessions), c.ID())
-		if err := c.runtime.ociRuntime.execStopContainer(c, c.config.StopTimeout); err != nil {
+		if err := c.ociRuntime.execStopContainer(c, c.config.StopTimeout); err != nil {
 			return err
 		}
 	}

--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -52,11 +52,11 @@ func (c *Container) Commit(ctx context.Context, destImage string, options Contai
 	}
 
 	if c.state.State == ContainerStateRunning && options.Pause {
-		if err := c.runtime.ociRuntime.pauseContainer(c); err != nil {
+		if err := c.ociRuntime.pauseContainer(c); err != nil {
 			return nil, errors.Wrapf(err, "error pausing container %q", c.ID())
 		}
 		defer func() {
-			if err := c.runtime.ociRuntime.unpauseContainer(c); err != nil {
+			if err := c.ociRuntime.unpauseContainer(c); err != nil {
 				logrus.Errorf("error unpausing container %q: %v", c.ID(), err)
 			}
 		}()

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -31,6 +31,7 @@ type InspectContainerData struct {
 	HostsPath       string                  `json:"HostsPath"`
 	StaticDir       string                  `json:"StaticDir"`
 	OCIConfigPath   string                  `json:"OCIConfigPath,omitempty"`
+	OCIRuntime      string                  `json:"OCIRuntime,omitempty"`
 	LogPath         string                  `json:"LogPath"`
 	ConmonPidFile   string                  `json:"ConmonPidFile"`
 	Name            string                  `json:"Name"`
@@ -274,6 +275,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *driver.Data) 
 		HostsPath:       hostsPath,
 		StaticDir:       config.StaticDir,
 		LogPath:         config.LogPath,
+		OCIRuntime:      config.OCIRuntime,
 		ConmonPidFile:   config.ConmonPidFile,
 		Name:            config.Name,
 		RestartCount:    int32(runtimeInfo.RestartCount),

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -541,7 +541,7 @@ func (c *Container) checkpointRestoreSupported() (err error) {
 	if !criu.CheckForCriu() {
 		return errors.Errorf("Checkpoint/Restore requires at least CRIU %d", criu.MinCriuVersion)
 	}
-	if !c.runtime.ociRuntime.featureCheckCheckpointing() {
+	if !c.ociRuntime.featureCheckCheckpointing() {
 		return errors.Errorf("Configured runtime does not support checkpoint/restore")
 	}
 	return nil
@@ -575,7 +575,7 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 		return err
 	}
 
-	if err := c.runtime.ociRuntime.checkpointContainer(c, options); err != nil {
+	if err := c.ociRuntime.checkpointContainer(c, options); err != nil {
 		return err
 	}
 
@@ -769,7 +769,7 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 	if err := c.saveSpec(g.Spec()); err != nil {
 		return err
 	}
-	if err := c.runtime.ociRuntime.createContainer(c, c.config.CgroupParent, &options); err != nil {
+	if err := c.ociRuntime.createContainer(c, c.config.CgroupParent, &options); err != nil {
 		return err
 	}
 

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -47,12 +47,12 @@ func (r *Runtime) hostInfo() (map[string]interface{}, error) {
 	hostDistributionInfo := r.GetHostDistributionInfo()
 	info["Conmon"] = map[string]interface{}{
 		"path":    r.conmonPath,
-		"package": r.ociRuntime.conmonPackage(),
+		"package": r.defaultOCIRuntime.conmonPackage(),
 		"version": conmonVersion,
 	}
 	info["OCIRuntime"] = map[string]interface{}{
-		"path":    r.ociRuntime.path,
-		"package": r.ociRuntime.pathPackage(),
+		"path":    r.defaultOCIRuntime.path,
+		"package": r.defaultOCIRuntime.pathPackage(),
 		"version": ociruntimeVersion,
 	}
 	info["Distribution"] = map[string]interface{}{
@@ -190,12 +190,12 @@ func (r *Runtime) GetConmonVersion() (string, error) {
 
 // GetOCIRuntimePath returns the path to the OCI Runtime Path the runtime is using
 func (r *Runtime) GetOCIRuntimePath() string {
-	return r.ociRuntimePath.Paths[0]
+	return r.defaultOCIRuntime.path
 }
 
 // GetOCIRuntimeVersion returns a string representation of the oci runtimes version
 func (r *Runtime) GetOCIRuntimeVersion() (string, error) {
-	output, err := utils.ExecCmd(r.ociRuntimePath.Paths[0], "--version")
+	output, err := utils.ExecCmd(r.GetOCIRuntimePath(), "--version")
 	if err != nil {
 		return "", err
 	}

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -170,7 +170,7 @@ func (r *Runtime) setupRootlessNetNS(ctr *Container) (err error) {
 	defer syncW.Close()
 
 	havePortMapping := len(ctr.Config().PortMappings) > 0
-	apiSocket := filepath.Join(r.ociRuntime.tmpDir, fmt.Sprintf("%s.net", ctr.config.ID))
+	apiSocket := filepath.Join(ctr.ociRuntime.tmpDir, fmt.Sprintf("%s.net", ctr.config.ID))
 
 	cmdArgs := []string{}
 	if havePortMapping {

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -357,7 +357,7 @@ func (p *Pod) Kill(signal uint) (map[string]error, error) {
 			continue
 		}
 
-		if err := ctr.runtime.ociRuntime.killContainer(ctr, signal); err != nil {
+		if err := ctr.ociRuntime.killContainer(ctr, signal); err != nil {
 			ctr.lock.Unlock()
 			ctrErrors[ctr.ID()] = err
 			continue

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -837,13 +838,35 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (err error) {
 		runtime.ociRuntimes[name] = ociRuntime
 	}
 
-	// Set default runtime
+	// Do we have a default OCI runtime?
 	if runtime.config.OCIRuntime != "" {
-		ociRuntime, ok := runtime.ociRuntimes[runtime.config.OCIRuntime]
-		if !ok {
-			return errors.Wrapf(ErrInvalidArg, "default OCI runtime %q not found", runtime.config.OCIRuntime)
+		// If the string starts with / it's a path to a runtime
+		// executable.
+		if strings.HasPrefix(runtime.config.OCIRuntime, "/") {
+			name := filepath.Base(runtime.config.OCIRuntime)
+
+			supportsJSON := false
+			for _, r := range runtime.config.RuntimeSupportsJSON {
+				if r == name {
+					supportsJSON = true
+					break
+				}
+			}
+
+			ociRuntime, err := newOCIRuntime(name, []string{runtime.config.OCIRuntime}, runtime.conmonPath, runtime.config, supportsJSON)
+			if err != nil {
+				return err
+			}
+
+			runtime.ociRuntimes[name] = ociRuntime
+			runtime.defaultOCIRuntime = ociRuntime
+		} else {
+			ociRuntime, ok := runtime.ociRuntimes[runtime.config.OCIRuntime]
+			if !ok {
+				return errors.Wrapf(ErrInvalidArg, "default OCI runtime %q not found", runtime.config.OCIRuntime)
+			}
+			runtime.defaultOCIRuntime = ociRuntime
 		}
-		runtime.defaultOCIRuntime = ociRuntime
 	}
 
 	// Do we have at least one valid OCI runtime?

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -826,7 +826,12 @@ func makeRuntime(ctx context.Context, runtime *Runtime) (err error) {
 
 		ociRuntime, err := newOCIRuntime(name, paths, runtime.conmonPath, runtime.config, supportsJSON)
 		if err != nil {
-			return err
+			// Don't fatally error.
+			// This will allow us to ship configs including optional
+			// runtimes that might not be installed (crun, kata).
+			// Only a warnf so default configs don't spec errors.
+			logrus.Warnf("Error initializing configured OCI runtime %s: %v", name, err)
+			continue
 		}
 
 		runtime.ociRuntimes[name] = ociRuntime

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -94,7 +94,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 
 	ctr.config.StopTimeout = CtrRemoveTimeout
 
-	ctr.config.OCIRuntime = r.config.OCIRuntime
+	ctr.config.OCIRuntime = r.defaultOCIRuntime.name
 
 	// Set namespace based on current runtime namespace
 	// Do so before options run so they can override it


### PR DESCRIPTION
Containers already remember the runtime they were created with in their configs. Now, let's allow them to request that runtime on subsequent runs of Podman. This greatly improves support for running multiple OCI runtimes at once - containers started on `crun` or `kata` will continue to use those runtimes even if the default runtime swaps to `runc`, for example.