### PR TITLE
add windows bridge format

### DIFF
--- a/pkg/adapter/client.go
+++ b/pkg/adapter/client.go
@@ -91,3 +91,20 @@ func newSocketConnection(address string) (*Endpoint, error) {
 	}
 	return &endpoint, nil
 }
+
+// newBridgeConnection creates a bridge type endpoint with username, destination, and log-level
+func newBridgeConnection(formattedBridge string, remoteConn *remoteclientconfig.RemoteConnection, logLevel string) (*Endpoint, error) {
+	endpoint := Endpoint{
+		Type: BridgeConnection,
+	}
+
+	if len(formattedBridge) < 1 && remoteConn == nil {
+		return nil, errors.New("bridge connections must either be created by string or remoteconnection")
+	}
+	if len(formattedBridge) > 0 {
+		endpoint.Connection = formattedBridge
+		return &endpoint, nil
+	}
+	endpoint.Connection = formatDefaultBridge(remoteConn, logLevel)
+	return &endpoint, nil
+}

--- a/pkg/adapter/client_unix.go
+++ b/pkg/adapter/client_unix.go
@@ -7,24 +7,10 @@ import (
 	"fmt"
 
 	"github.com/containers/libpod/cmd/podman/remoteclientconfig"
-	"github.com/pkg/errors"
 )
 
-// newBridgeConnection creates a bridge type endpoint with username, destination, and log-level
-func newBridgeConnection(formattedBridge string, remoteConn *remoteclientconfig.RemoteConnection, logLevel string) (*Endpoint, error) {
-	endpoint := Endpoint{
-		Type: BridgeConnection,
-	}
-
-	if len(formattedBridge) < 1 && remoteConn == nil {
-		return nil, errors.New("bridge connections must either be created by string or remoteconnection")
-	}
-	if len(formattedBridge) > 0 {
-		endpoint.Connection = formattedBridge
-		return &endpoint, nil
-	}
-	endpoint.Connection = fmt.Sprintf(
+func formatDefaultBridge(remoteConn *remoteclientconfig.RemoteConnection, logLevel string) string {
+	return fmt.Sprintf(
 		`ssh -T %s@%s -- /usr/bin/varlink -A \'/usr/bin/podman --log-level=%s varlink \\\$VARLINK_ADDRESS\' bridge`,
 		remoteConn.Username, remoteConn.Destination, logLevel)
-	return &endpoint, nil
 }

--- a/pkg/adapter/client_windows.go
+++ b/pkg/adapter/client_windows.go
@@ -3,13 +3,13 @@
 package adapter
 
 import (
+	"fmt"
+
 	"github.com/containers/libpod/cmd/podman/remoteclientconfig"
-	"github.com/containers/libpod/libpod"
 )
 
-func newBridgeConnection(formattedBridge string, remoteConn *remoteclientconfig.RemoteConnection, logLevel string) (*Endpoint, error) {
-	// TODO
-	// Unix and Windows appear to quote their ssh implementations differently therefore once we figure out what
-	// windows ssh is doing here, we can then get the format correct.
-	return nil, libpod.ErrNotImplemented
+func formatDefaultBridge(remoteConn *remoteclientconfig.RemoteConnection, logLevel string) string {
+	return fmt.Sprintf(
+		`ssh -T %s@%s -- /usr/bin/varlink -A '/usr/bin/podman --log-level=%s varlink $VARLINK_ADDRESS' bridge`,
+		remoteConn.Username, remoteConn.Destination, logLevel)
 }


### PR DESCRIPTION
when using podman-remote on windows, the bridge format must account for
how windows deals with escape quoting.  in this case, it does not need
any.

also,  reduced duplicated code around generating the bridge endpoint for
the unix and windows platforms.

Signed-off-by: baude <bbaude@redhat.com>