### PR TITLE
Build cgo files with -Wall and -Werror

### DIFF
--- a/libpod/lock/shm/shm_lock.c
+++ b/libpod/lock/shm/shm_lock.c
@@ -413,7 +413,7 @@ int32_t allocate_given_semaphore(shm_struct_t *shm, uint32_t sem_index) {
 // Returns 0 on success, negative ERRNO values on failure
 int32_t deallocate_semaphore(shm_struct_t *shm, uint32_t sem_index) {
   bitmap_t test_map;
-  int bitmap_index, index_in_bitmap, ret_code, i;
+  int bitmap_index, index_in_bitmap, ret_code;
 
   if (shm == NULL) {
     return -1 * EINVAL;
@@ -500,7 +500,7 @@ int32_t deallocate_all_semaphores(shm_struct_t *shm) {
 // subsequently realize they have been removed).
 // Returns 0 on success, -1 on failure
 int32_t lock_semaphore(shm_struct_t *shm, uint32_t sem_index) {
-  int bitmap_index, index_in_bitmap, ret_code;
+  int bitmap_index, index_in_bitmap;
 
   if (shm == NULL) {
     return -1 * EINVAL;
@@ -522,7 +522,7 @@ int32_t lock_semaphore(shm_struct_t *shm, uint32_t sem_index) {
 // subsequently realize they have been removed).
 // Returns 0 on success, -1 on failure
 int32_t unlock_semaphore(shm_struct_t *shm, uint32_t sem_index) {
-  int bitmap_index, index_in_bitmap, ret_code;
+  int bitmap_index, index_in_bitmap;
 
   if (shm == NULL) {
     return -1 * EINVAL;

--- a/libpod/lock/shm/shm_lock.go
+++ b/libpod/lock/shm/shm_lock.go
@@ -1,6 +1,7 @@
 package shm
 
 // #cgo LDFLAGS: -lrt -lpthread
+// #cgo CFLAGS: -Wall -Werror
 // #include <stdlib.h>
 // #include "shm_lock.h"
 // const uint32_t bitmap_size_c = BITMAP_SIZE;

--- a/libpod/lock/shm/shm_lock.h
+++ b/libpod/lock/shm/shm_lock.h
@@ -32,9 +32,6 @@ typedef struct shm_struct {
   lock_group_t    locks[];
 } shm_struct_t;
 
-static size_t compute_shm_size(uint32_t num_bitmaps);
-static int take_mutex(pthread_mutex_t *mutex);
-static int release_mutex(pthread_mutex_t *mutex);
 shm_struct_t *setup_lock_shm(char *path, uint32_t num_locks, int *error_code);
 shm_struct_t *open_lock_shm(char *path, uint32_t num_locks, int *error_code);
 int32_t close_lock_shm(shm_struct_t *shm);

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -22,7 +22,7 @@ import (
 )
 
 /*
-#cgo remoteclient CFLAGS: -DDISABLE_JOIN_SHORTCUT
+#cgo remoteclient CFLAGS: -Wall -Werror -DDISABLE_JOIN_SHORTCUT
 #include <stdlib.h>
 #include <sys/types.h>
 extern uid_t rootless_uid();

--- a/pkg/sysinfo/sysinfo_solaris.go
+++ b/pkg/sysinfo/sysinfo_solaris.go
@@ -11,6 +11,7 @@ import (
 
 /*
 #cgo LDFLAGS: -llgrp
+#cgo CFLAGS: -Wall -Werror
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/lgrp_user.h>


### PR DESCRIPTION
To avoid unnecessary warnings and errors in the future I'd like to
propose building all cgo related sources with `-Wall -Werror`. This
commit fixes some warnings which came up in `shm_lock.c`, too.
