### PR TITLE
Add --latest, -l to 'podman diff'

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -113,6 +113,7 @@ type DiffValues struct {
 	PodmanCommand
 	Archive bool
 	Format  string
+	Latest  bool
 }
 
 type ExecValues struct {

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -80,4 +80,18 @@ var _ = Describe("Podman diff", func() {
 		sort.Strings(imageDiff)
 		Expect(imageDiff).To(Equal(containerDiff))
 	})
+
+	It("podman diff latest container", func() {
+		SkipIfRemote()
+		session := podmanTest.Podman([]string{"run", "--name=diff-test", ALPINE, "touch", "/tmp/diff-test"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"diff", "-l"})
+		session.WaitWithDefaultTimeout()
+		containerDiff := session.OutputToStringArray()
+		sort.Strings(containerDiff)
+		Expect(session.LineInOutputContains("C /tmp")).To(BeTrue())
+		Expect(session.LineInOutputContains("A /tmp/diff-test")).To(BeTrue())
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
The man page of 'podman diff' claims that the diff sub-command knows about --latest, -l. This adds support, as described in the man-page, to the diff sub-command for --latest, -l.