### PR TITLE
rootless: enable linger if /run/user/UID not exists

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -100,7 +100,7 @@ func initConfig() {
 }
 
 func before(cmd *cobra.Command, args []string) error {
-	if err := libpod.SetXdgRuntimeDir(""); err != nil {
+	if err := libpod.SetXdgRuntimeDir(); err != nil {
 		logrus.Errorf(err.Error())
 		os.Exit(1)
 	}

--- a/pkg/rootless/rootless_unsupported.go
+++ b/pkg/rootless/rootless_unsupported.go
@@ -29,6 +29,12 @@ func GetRootlessGID() int {
 	return -1
 }
 
+// EnableLinger configures the system to not kill the user processes once the session
+// terminates
+func EnableLinger() (string, error) {
+	return "", nil
+}
+
 // TryJoinFromFilePaths attempts to join the namespaces of the pid files in paths.
 // This is useful when there are already running containers and we
 // don't have a pause process yet.  We can use the paths to the conmon


### PR DESCRIPTION
at least on Fedora 30 it creates the /run/user/UID directory for the
user logged in via ssh.

This needs to be done very early so that every other check when we
create the default configuration file will point to the correct
location.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>