### PR TITLE
include make podman target in install instructions

### DIFF
--- a/install.md
+++ b/install.md
@@ -193,7 +193,7 @@ To build from source, use the following:
 git clone https://github.com/containers/conmon
 cd conmon
 make
-sudo install -D -m 755 bin/conmon /usr/libexec/podman/conmon
+sudo make podman
 ```
 
 #### runc


### PR DESCRIPTION
now that podman ships conmon >=0.3.0

Signed-off-by: Peter Hunt <pehunt@redhat.com>