### PR TITLE
Fix inspect --format '{{.Mounts}}.

### DIFF
--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -98,6 +98,14 @@ func inspectCmd(c *cliconfig.InspectValues) error {
 	if strings.Contains(outputFormat, "{{.Id}}") {
 		outputFormat = strings.Replace(outputFormat, "{{.Id}}", formats.IDString, -1)
 	}
+	// These fields were renamed, so we need to provide backward compat for
+	// the old names.
+	if strings.Contains(outputFormat, ".Src") {
+		outputFormat = strings.Replace(outputFormat, ".Src", ".Source", -1)
+	}
+	if strings.Contains(outputFormat, ".Dst") {
+		outputFormat = strings.Replace(outputFormat, ".Dst", ".Destination", -1)
+	}
 	if latestContainer {
 		lc, err := runtime.GetLatestContainer()
 		if err != nil {

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -111,10 +111,10 @@ type InspectMount struct {
 	// The name of the volume. Empty for bind mounts.
 	Name string `json:"Name,omptempty"`
 	// The source directory for the volume.
-	Src string `json:"Source"`
+	Source string `json:"Source"`
 	// The destination directory for the volume. Specified as a path within
 	// the container, as it would be passed into the OCI runtime.
-	Dst string `json:"Destination"`
+	Destination string `json:"Destination"`
 	// The driver used for the named volume. Empty for bind mounts.
 	Driver string `json:"Driver"`
 	// Contains SELinux :z/:Z mount options. Unclear what, if anything, else
@@ -386,7 +386,7 @@ func (c *Container) getInspectMounts(ctrSpec *spec.Spec) ([]InspectMount, error)
 		if volume, ok := namedVolumes[vol]; ok {
 			mountStruct := InspectMount{}
 			mountStruct.Type = "volume"
-			mountStruct.Dst = volume.Dest
+			mountStruct.Destination = volume.Dest
 			mountStruct.Name = volume.Name
 
 			// For src and driver, we need to look up the named
@@ -396,7 +396,7 @@ func (c *Container) getInspectMounts(ctrSpec *spec.Spec) ([]InspectMount, error)
 				return nil, errors.Wrapf(err, "error looking up volume %s in container %s config", volume.Name, c.ID())
 			}
 			mountStruct.Driver = volFromDB.Driver()
-			mountStruct.Src = volFromDB.MountPoint()
+			mountStruct.Source = volFromDB.MountPoint()
 
 			parseMountOptionsForInspect(volume.Options, &mountStruct)
 
@@ -410,8 +410,8 @@ func (c *Container) getInspectMounts(ctrSpec *spec.Spec) ([]InspectMount, error)
 
 			mountStruct := InspectMount{}
 			mountStruct.Type = "bind"
-			mountStruct.Src = mount.Source
-			mountStruct.Dst = mount.Destination
+			mountStruct.Source = mount.Source
+			mountStruct.Destination = mount.Destination
 
 			parseMountOptionsForInspect(mount.Options, &mountStruct)
 

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -46,7 +46,7 @@ type InspectContainerData struct {
 	GraphDriver     *driver.Data            `json:"GraphDriver"`
 	SizeRw          int64                   `json:"SizeRw,omitempty"`
 	SizeRootFs      int64                   `json:"SizeRootFs,omitempty"`
-	Mounts          []*InspectMount         `json:"Mounts"`
+	Mounts          []InspectMount         `json:"Mounts"`
 	Dependencies    []string                `json:"Dependencies"`
 	NetworkSettings *InspectNetworkSettings `json:"NetworkSettings"` //TODO
 	ExitCommand     []string                `json:"ExitCommand"`
@@ -359,8 +359,8 @@ func (c *Container) getContainerInspectData(size bool, driverData *driver.Data) 
 // Get inspect-formatted mounts list.
 // Only includes user-specified mounts. Only includes bind mounts and named
 // volumes, not tmpfs volumes.
-func (c *Container) getInspectMounts(ctrSpec *spec.Spec) ([]*InspectMount, error) {
-	inspectMounts := []*InspectMount{}
+func (c *Container) getInspectMounts(ctrSpec *spec.Spec) ([]InspectMount, error) {
+	inspectMounts := []InspectMount{}
 
 	// No mounts, return early
 	if len(c.config.UserVolumes) == 0 {
@@ -384,7 +384,7 @@ func (c *Container) getInspectMounts(ctrSpec *spec.Spec) ([]*InspectMount, error
 		// We need to look up the volumes.
 		// First: is it a named volume?
 		if volume, ok := namedVolumes[vol]; ok {
-			mountStruct := new(InspectMount)
+			mountStruct := InspectMount{}
 			mountStruct.Type = "volume"
 			mountStruct.Dst = volume.Dest
 			mountStruct.Name = volume.Name
@@ -398,7 +398,7 @@ func (c *Container) getInspectMounts(ctrSpec *spec.Spec) ([]*InspectMount, error
 			mountStruct.Driver = volFromDB.Driver()
 			mountStruct.Src = volFromDB.MountPoint()
 
-			parseMountOptionsForInspect(volume.Options, mountStruct)
+			parseMountOptionsForInspect(volume.Options, &mountStruct)
 
 			inspectMounts = append(inspectMounts, mountStruct)
 		} else if mount, ok := mounts[vol]; ok {
@@ -408,12 +408,12 @@ func (c *Container) getInspectMounts(ctrSpec *spec.Spec) ([]*InspectMount, error
 				continue
 			}
 
-			mountStruct := new(InspectMount)
+			mountStruct := InspectMount{}
 			mountStruct.Type = "bind"
 			mountStruct.Src = mount.Source
 			mountStruct.Dst = mount.Destination
 
-			parseMountOptionsForInspect(mount.Options, mountStruct)
+			parseMountOptionsForInspect(mount.Options, &mountStruct)
 
 			inspectMounts = append(inspectMounts, mountStruct)
 		}

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -46,7 +46,7 @@ type InspectContainerData struct {
 	GraphDriver     *driver.Data            `json:"GraphDriver"`
 	SizeRw          int64                   `json:"SizeRw,omitempty"`
 	SizeRootFs      int64                   `json:"SizeRootFs,omitempty"`
-	Mounts          []InspectMount         `json:"Mounts"`
+	Mounts          []InspectMount          `json:"Mounts"`
 	Dependencies    []string                `json:"Dependencies"`
 	NetworkSettings *InspectNetworkSettings `json:"NetworkSettings"` //TODO
 	ExitCommand     []string                `json:"ExitCommand"`

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -107,4 +107,31 @@ var _ = Describe("Podman inspect", func() {
 		Expect(result.ExitCode()).To(Equal(125))
 	})
 
+	It("podman inspect with mount filters", func() {
+		SkipIfRemote()
+
+		ctrSession := podmanTest.Podman([]string{"create", "-v", "/tmp:/test1", ALPINE, "top"})
+		ctrSession.WaitWithDefaultTimeout()
+		Expect(ctrSession.ExitCode()).To(Equal(0))
+
+		inspectSource := podmanTest.Podman([]string{"inspect", "-l", "--format", "{{(index .Mounts 0).Source}}"})
+		inspectSource.WaitWithDefaultTimeout()
+		Expect(inspectSource.ExitCode()).To(Equal(0))
+		Expect(inspectSource.OutputToString()).To(Equal("/tmp"))
+
+		inspectSrc := podmanTest.Podman([]string{"inspect", "-l", "--format", "{{(index .Mounts 0).Src}}"})
+		inspectSrc.WaitWithDefaultTimeout()
+		Expect(inspectSrc.ExitCode()).To(Equal(0))
+		Expect(inspectSrc.OutputToString()).To(Equal("/tmp"))
+
+		inspectDestination := podmanTest.Podman([]string{"inspect", "-l", "--format", "{{(index .Mounts 0).Destination}}"})
+		inspectDestination.WaitWithDefaultTimeout()
+		Expect(inspectDestination.ExitCode()).To(Equal(0))
+		Expect(inspectDestination.OutputToString()).To(Equal("/test1"))
+
+		inspectDst := podmanTest.Podman([]string{"inspect", "-l", "--format", "{{(index .Mounts 0).Dst}}"})
+		inspectDst.WaitWithDefaultTimeout()
+		Expect(inspectDst.ExitCode()).To(Equal(0))
+		Expect(inspectDst.OutputToString()).To(Equal("/test1"))
+	})
 })


### PR DESCRIPTION
Go templating is incapable of dealing with pointers, so when we moved to Docker compatible mounts JSON, we broke it. The solution is to not use pointers in this part of inspect.