### PR TITLE
Add additional debugging when refreshing locks

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -509,7 +509,7 @@ func (c *Container) refresh() error {
 	// We need to pick up a new lock
 	lock, err := c.runtime.lockManager.AllocateAndRetrieveLock(c.config.LockID)
 	if err != nil {
-		return errors.Wrapf(err, "error acquiring lock for container %s", c.ID())
+		return errors.Wrapf(err, "error acquiring lock %d for container %s", c.config.LockID, c.ID())
 	}
 	c.lock = lock
 

--- a/libpod/pod_internal.go
+++ b/libpod/pod_internal.go
@@ -58,7 +58,7 @@ func (p *Pod) refresh() error {
 	// Retrieve the pod's lock
 	lock, err := p.runtime.lockManager.AllocateAndRetrieveLock(p.config.LockID)
 	if err != nil {
-		return errors.Wrapf(err, "error retrieving lock for pod %s", p.ID())
+		return errors.Wrapf(err, "error retrieving lock %d for pod %s", p.config.LockID, p.ID())
 	}
 	p.lock = lock
 


### PR DESCRIPTION
When attempting to reacquire locks, print an error if the lock we request cannot be allocated.