### PR TITLE
Fix configs location in rootless tutorial.

### DIFF
--- a/docs/tutorials/rootless_tutorial.md
+++ b/docs/tutorials/rootless_tutorial.md
@@ -76,7 +76,7 @@ Once the Administrator has completed the setup on the machine and then the confi
 
 ### User Configuration Files.
 
-The Podman configuration files for root reside in /etc/containers.  In the rootless environment they reside in ${XDG_RUNTIME_DIR}/containers and are owned by each individual user.  The user can modify these files as they wish.
+The Podman configuration files for root reside in /etc/containers.  In the rootless environment they reside in ${HOME}/.config/containers and are owned by each individual user.  The user can modify these files as they wish.
 
 ## More information
 


### PR DESCRIPTION
Rootless tutorial specifies `${XGD_RUNTIME_DIR}/containers` directory as a location for user-specific libpod configs, but it seems that the real location is `${HOME}/.config/containers`, e.g.:

https://github.com/containers/libpod/blob/master/libpod/runtime.go#L415

`podman info` for non-root user also says that it uses the `storage.conf` from the home dir:

```
store:
  ConfigFile: /home/qazer/.config/containers/storage.conf
```

Also, considering that `${XDG_RUNTIME_DIR}` usually points to non-persistent location (`tmpfs`), that's probably an error in the doc.