### PR TITLE
rootless: add an entry to /etc/hosts when using slirp4netns

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1069,6 +1069,10 @@ func (c *Container) getHosts() string {
 			hosts += fmt.Sprintf("%s %s\n", fields[1], fields[0])
 		}
 	}
+	if c.config.NetMode.IsSlirp4netns() {
+		// When using slirp4netns, the interface gets a static IP
+		hosts += fmt.Sprintf("# used by slirp4netns\n%s\t%s\n", "10.0.2.100", c.Hostname())
+	}
 	if len(c.state.NetworkStatus) > 0 && len(c.state.NetworkStatus[0].IPs) > 0 {
 		ipAddress := strings.Split(c.state.NetworkStatus[0].IPs[0].Address.String(), "/")[0]
 		hosts += fmt.Sprintf("%s\t%s\n", ipAddress, c.Hostname())

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -178,6 +178,12 @@ var _ = Describe("Podman run networking", func() {
 		Expect(exec4.OutputToString()).To(ContainSubstring("192.0.2.2 test1"))
 	})
 
+	It("podman run /etc/hosts contains --hostname", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "--hostname", "foohostname", ALPINE, "grep", "foohostname", "/etc/hosts"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
 	It("podman run network in user created network namespace", func() {
 		SkipIfRootless()
 		if Containerized() {


### PR DESCRIPTION
Closes: https://github.com/containers/libpod/issues/3405

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>