### PR TITLE
libpod.conf: add runtime crun

### DIFF
--- a/libpod.conf
+++ b/libpod.conf
@@ -124,6 +124,11 @@ runc = [
 	    "/usr/lib/cri-o-runc/sbin/runc"
 ]
 
+crun = [
+	    "/usr/bin/crun",
+	    "/usr/local/bin/crun",
+]
+
 # The [runtimes] table MUST be the last thing in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being


### PR DESCRIPTION
now that crun is available as a Fedora package, we can add an entry to
the default libpod.conf so that it is easier to use it just by using
--runtime crun to Podman.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>