### PR TITLE
Fix a segfault in 'podman ps --sync'

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -627,6 +627,7 @@ func (c *Container) Batch(batchFunc func(*Container) error) error {
 	newCtr.config = c.config
 	newCtr.state = c.state
 	newCtr.runtime = c.runtime
+	newCtr.ociRuntime = c.ociRuntime
 	newCtr.lock = c.lock
 	newCtr.valid = true
 

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -320,4 +320,16 @@ var _ = Describe("Podman ps", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.OutputToString()).To(ContainSubstring("0.0.0.0:1000-1006"))
 	})
+
+	It("podman ps sync flag", func() {
+		session := podmanTest.RunTopContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		fullCid := session.OutputToString()
+
+		result := podmanTest.Podman([]string{"ps", "-q", "--no-trunc", "--sync"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(result.OutputToStringArray()[0]).To(Equal(fullCid))
+	})
 })


### PR DESCRIPTION
We weren't properly populating the container's OCI Runtime in Batch(), causing segfaults on attempting to access it. Add a test to make sure we actually catch cases like this in the future.

Fixes #3411