### PR TITLE
Only include ports in one container in Kube YAML

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -138,6 +138,11 @@ func (p *Pod) podWithContainers(containers []*Container, ports []v1.ContainerPor
 			if err != nil {
 				return nil, err
 			}
+
+			// Since port bindings for the pod are handled by the
+			// infra container, wipe them here.
+			result.Ports = nil
+
 			// We add the original port declarations from the libpod infra container
 			// to the first kubernetes container description because otherwise we loose
 			// the original container/port bindings.

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -58,7 +58,8 @@ var _ = Describe("Podman generate kube", func() {
 		kube.WaitWithDefaultTimeout()
 		Expect(kube.ExitCode()).To(Equal(0))
 
-		_, err := yaml.Marshal(kube.OutputToString())
+		pod := new(v1.Pod)
+		err := yaml.Unmarshal(kube.OutputToString(), pod)
 		Expect(err).To(BeNil())
 	})
 
@@ -71,7 +72,8 @@ var _ = Describe("Podman generate kube", func() {
 		kube.WaitWithDefaultTimeout()
 		Expect(kube.ExitCode()).To(Equal(0))
 
-		_, err := yaml.Marshal(kube.OutputToString())
+		pod := new(v1.Pod)
+		err := yaml.Unmarshal(kube.OutputToString(), pod)
 		Expect(err).To(BeNil())
 	})
 
@@ -87,7 +89,8 @@ var _ = Describe("Podman generate kube", func() {
 		kube.WaitWithDefaultTimeout()
 		Expect(kube.ExitCode()).To(Equal(0))
 
-		_, err := yaml.Marshal(kube.OutputToString())
+		pod := new(v1.Pod)
+		err := yaml.Unmarshal(kube.OutputToString(), pod)
 		Expect(err).To(BeNil())
 	})
 
@@ -103,8 +106,10 @@ var _ = Describe("Podman generate kube", func() {
 		kube.WaitWithDefaultTimeout()
 		Expect(kube.ExitCode()).To(Equal(0))
 
-		_, err := yaml.Marshal(kube.OutputToString())
-		Expect(err).To(BeNil())
+		// TODO: How do we test unmarshal with a service? We have two
+		// structs that need to be unmarshalled...
+		// _, err := yaml.Marshal(kube.OutputToString())
+		// Expect(err).To(BeNil())
 	})
 
 	It("podman generate kube on pod with ports", func() {

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -59,8 +59,14 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(kube.ExitCode()).To(Equal(0))
 
 		pod := new(v1.Pod)
-		err := yaml.Unmarshal([]byte(kube.OutputToString()), pod)
+		err := yaml.Unmarshal(kube.Out.Contents(), pod)
 		Expect(err).To(BeNil())
+
+		numContainers := 0
+		for range pod.Spec.Containers {
+			numContainers = numContainers + 1
+		}
+		Expect(numContainers).To(Equal(1))
 	})
 
 	It("podman generate service kube on container", func() {
@@ -72,9 +78,11 @@ var _ = Describe("Podman generate kube", func() {
 		kube.WaitWithDefaultTimeout()
 		Expect(kube.ExitCode()).To(Equal(0))
 
-		pod := new(v1.Pod)
-		err := yaml.Unmarshal([]byte(kube.OutputToString()), pod)
-		Expect(err).To(BeNil())
+		// TODO - test generated YAML - service produces multiple
+		// structs.
+		// pod := new(v1.Pod)
+		// err := yaml.Unmarshal([]byte(kube.OutputToString()), pod)
+		// Expect(err).To(BeNil())
 	})
 
 	It("podman generate kube on pod", func() {
@@ -90,8 +98,14 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(kube.ExitCode()).To(Equal(0))
 
 		pod := new(v1.Pod)
-		err := yaml.Unmarshal([]byte(kube.OutputToString()), pod)
+		err := yaml.Unmarshal(kube.Out.Contents(), pod)
 		Expect(err).To(BeNil())
+
+		numContainers := 0
+		for range pod.Spec.Containers {
+			numContainers = numContainers + 1
+		}
+		Expect(numContainers).To(Equal(1))
 	})
 
 	It("podman generate service kube on pod", func() {

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/api/core/v1"
 )
 
 var _ = Describe("Podman generate kube", func() {
@@ -104,6 +105,49 @@ var _ = Describe("Podman generate kube", func() {
 
 		_, err := yaml.Marshal(kube.OutputToString())
 		Expect(err).To(BeNil())
+	})
+
+	It("podman generate kube on pod with ports", func() {
+		podName := "test"
+		podSession := podmanTest.Podman("pod", "create", "--name", podName, "-p", "4000:4000", "-p", "5000:5000")
+		podSession.WaitWithDefaultTimeout()
+		Expect(podSession.ExitCode()).To(Equal(0))
+
+		ctr1Name := "ctr1"
+		ctr1Session := podmanTest.Podman("create", "--name", ctr1Name, "--pod", podName, ALPINE, "top")
+		ctr1Session.WaitWithDefaultTimeout()
+		Expect(ctr1Session.ExitCode()).To(Equal(0))
+
+		ctr2Name := "ctr2"
+		ctr2Session := podmanTest.Podman("create", "--name", ctr2Name, "--pod", podName, ALPINE, "top")
+		ctr2Session.WaitWithDefaultTimeout()
+		Expect(ctr2Session.ExitCode()).To(Equal(0))
+
+		kube := podmanTest.Podman([]string{"generate", "kube", podName})
+		kube.WaitWithDefaultTimeout()
+		Expect(kube.ExitCode()).To(Equal(0))
+
+		pod := new(v1.Pod)
+		err := yaml.Unmarshal(kube.OutputToString(), pod)
+		Expect(err).To(BeNil())
+
+		foundPort4000 := 0
+		foundPort5000 := 0
+		foundOtherPort := 0
+		for _, ctr := range pod.Spec.Containers {
+			for _, port := range ctr.Ports {
+				if port.HostPort == 4000 {
+					foundPort4000 = foundPort4000 + 1
+				} else if port.HostPort == 5000 {
+					foundPort5000 = foundPort5000 + 1
+				} else {
+					foundOtherPort = foundOtherPort + 1
+				}
+			}
+		}
+		Expect(foundPort4000).To(Equal(1))
+		Expect(foundPort5000).To(Equal(1))
+		Expect(foundOtherPort).To(Equal(0))
 	})
 
 	It("podman generate and reimport kube on pod", func() {

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(kube.ExitCode()).To(Equal(0))
 
 		pod := new(v1.Pod)
-		err := yaml.Unmarshal(kube.OutputToString(), pod)
+		err := yaml.Unmarshal([]byte(kube.OutputToString()), pod)
 		Expect(err).To(BeNil())
 	})
 
@@ -73,7 +73,7 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(kube.ExitCode()).To(Equal(0))
 
 		pod := new(v1.Pod)
-		err := yaml.Unmarshal(kube.OutputToString(), pod)
+		err := yaml.Unmarshal([]byte(kube.OutputToString()), pod)
 		Expect(err).To(BeNil())
 	})
 
@@ -90,7 +90,7 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(kube.ExitCode()).To(Equal(0))
 
 		pod := new(v1.Pod)
-		err := yaml.Unmarshal(kube.OutputToString(), pod)
+		err := yaml.Unmarshal([]byte(kube.OutputToString()), pod)
 		Expect(err).To(BeNil())
 	})
 
@@ -114,17 +114,17 @@ var _ = Describe("Podman generate kube", func() {
 
 	It("podman generate kube on pod with ports", func() {
 		podName := "test"
-		podSession := podmanTest.Podman("pod", "create", "--name", podName, "-p", "4000:4000", "-p", "5000:5000")
+		podSession := podmanTest.Podman([]string{"pod", "create", "--name", podName, "-p", "4000:4000", "-p", "5000:5000"})
 		podSession.WaitWithDefaultTimeout()
 		Expect(podSession.ExitCode()).To(Equal(0))
 
 		ctr1Name := "ctr1"
-		ctr1Session := podmanTest.Podman("create", "--name", ctr1Name, "--pod", podName, ALPINE, "top")
+		ctr1Session := podmanTest.Podman([]string{"create", "--name", ctr1Name, "--pod", podName, ALPINE, "top"})
 		ctr1Session.WaitWithDefaultTimeout()
 		Expect(ctr1Session.ExitCode()).To(Equal(0))
 
 		ctr2Name := "ctr2"
-		ctr2Session := podmanTest.Podman("create", "--name", ctr2Name, "--pod", podName, ALPINE, "top")
+		ctr2Session := podmanTest.Podman([]string{"create", "--name", ctr2Name, "--pod", podName, ALPINE, "top"})
 		ctr2Session.WaitWithDefaultTimeout()
 		Expect(ctr2Session.ExitCode()).To(Equal(0))
 
@@ -133,7 +133,7 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(kube.ExitCode()).To(Equal(0))
 
 		pod := new(v1.Pod)
-		err := yaml.Unmarshal(kube.OutputToString(), pod)
+		err := yaml.Unmarshal([]byte(kube.OutputToString()), pod)
 		Expect(err).To(BeNil())
 
 		foundPort4000 := 0

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Podman generate kube", func() {
 		Expect(kube.ExitCode()).To(Equal(0))
 
 		pod := new(v1.Pod)
-		err := yaml.Unmarshal([]byte(kube.OutputToString()), pod)
+		err := yaml.Unmarshal(kube.Out.Contents(), pod)
 		Expect(err).To(BeNil())
 
 		foundPort4000 := 0


### PR DESCRIPTION
This likely broke when we made containers able to detect that they shared a network namespace and grab ports from the dependency container - prior to that, we could grab ports without concern for conflict, only the infra container had them. Now, all containers in a pod will return the same ports, so we have to work around this.

Fixes #3408

Still needs a test, writing one now.