### PR TITLE
remove libpod from main

### DIFF
--- a/cmd/podman/checkpoint.go
+++ b/cmd/podman/checkpoint.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
@@ -59,13 +58,7 @@ func checkpointCmd(c *cliconfig.CheckpointValues) error {
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}
-	defer runtime.Shutdown(false)
 
-	options := libpod.ContainerCheckpointOptions{
-		Keep:           c.Keep,
-		KeepRunning:    c.LeaveRunning,
-		TCPEstablished: c.TcpEstablished,
-		TargetFile:     c.Export,
-	}
-	return runtime.Checkpoint(c, options)
+	defer runtime.Shutdown(false)
+	return runtime.Checkpoint(c)
 }

--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
@@ -30,6 +29,9 @@ var (
   podman commit -q --author "firstName lastName" reverent_golick image-committed
   podman commit -q --pause=false containerID image-committed`,
 	}
+
+	// ChangeCmds is the list of valid Changes commands to passed to the Commit call
+	ChangeCmds = []string{"CMD", "ENTRYPOINT", "ENV", "EXPOSE", "LABEL", "ONBUILD", "STOPSIGNAL", "USER", "VOLUME", "WORKDIR"}
 )
 
 func init() {
@@ -37,7 +39,7 @@ func init() {
 	commitCommand.SetHelpTemplate(HelpTemplate())
 	commitCommand.SetUsageTemplate(UsageTemplate())
 	flags := commitCommand.Flags()
-	flags.StringArrayVarP(&commitCommand.Change, "change", "c", []string{}, fmt.Sprintf("Apply the following possible instructions to the created image (default []): %s", strings.Join(libpod.ChangeCmds, " | ")))
+	flags.StringArrayVarP(&commitCommand.Change, "change", "c", []string{}, fmt.Sprintf("Apply the following possible instructions to the created image (default []): %s", strings.Join(ChangeCmds, " | ")))
 	flags.StringVarP(&commitCommand.Format, "format", "f", "oci", "`Format` of the image manifest and metadata")
 	flags.StringVarP(&commitCommand.Message, "message", "m", "", "Set commit message for imported image")
 	flags.StringVarP(&commitCommand.Author, "author", "a", "", "Set the author for the image committed")
@@ -66,7 +68,7 @@ func commitCmd(c *cliconfig.CommitValues) error {
 			if len(splitChange) == 1 {
 				splitChange = strings.Split(strings.ToUpper(change), " ")
 			}
-			if !util.StringInSlice(splitChange[0], libpod.ChangeCmds) {
+			if !util.StringInSlice(splitChange[0], ChangeCmds) {
 				return errors.Errorf("invalid syntax for --change: %s", change)
 			}
 		}

--- a/cmd/podman/common_libpod.go
+++ b/cmd/podman/common_libpod.go
@@ -1,0 +1,64 @@
+//build !remoteclient
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/containers/libpod/libpod"
+	"github.com/pkg/errors"
+)
+
+// getAllOrLatestContainers tries to return the correct list of containers
+// depending if --all, --latest or <container-id> is used.
+// It requires the Context (c) and the Runtime (runtime). As different
+// commands are using different container state for the --all option
+// the desired state has to be specified in filterState. If no filter
+// is desired a -1 can be used to get all containers. For a better
+// error message, if the filter fails, a corresponding verb can be
+// specified which will then appear in the error message.
+func getAllOrLatestContainers(c *cliconfig.PodmanCommand, runtime *libpod.Runtime, filterState libpod.ContainerStatus, verb string) ([]*libpod.Container, error) {
+	var containers []*libpod.Container
+	var lastError error
+	var err error
+	if c.Bool("all") {
+		if filterState != -1 {
+			var filterFuncs []libpod.ContainerFilter
+			filterFuncs = append(filterFuncs, func(c *libpod.Container) bool {
+				state, _ := c.State()
+				return state == filterState
+			})
+			containers, err = runtime.GetContainers(filterFuncs...)
+		} else {
+			containers, err = runtime.GetContainers()
+		}
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to get %s containers", verb)
+		}
+	} else if c.Bool("latest") {
+		lastCtr, err := runtime.GetLatestContainer()
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to get latest container")
+		}
+		containers = append(containers, lastCtr)
+	} else {
+		args := c.InputArgs
+		for _, i := range args {
+			container, err := runtime.LookupContainer(i)
+			if err != nil {
+				if lastError != nil {
+					fmt.Fprintln(os.Stderr, lastError)
+				}
+				lastError = errors.Wrapf(err, "unable to find container %s", i)
+			}
+			if container != nil {
+				// This is here to make sure this does not return [<nil>] but only nil
+				containers = append(containers, container)
+			}
+		}
+	}
+
+	return containers, lastError
+}

--- a/cmd/podman/containers_prune.go
+++ b/cmd/podman/containers_prune.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/shared"
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -51,7 +51,7 @@ func pruneContainersCmd(c *cliconfig.PruneContainersValues) error {
 	}
 	ok, failures, err := runtime.Prune(getContext(), maxWorkers, c.Force)
 	if err != nil {
-		if errors.Cause(err) == libpod.ErrNoSuchCtr {
+		if errors.Cause(err) == define.ErrNoSuchCtr {
 			if len(c.InputArgs) > 1 {
 				exitCode = 125
 			} else {

--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -13,14 +13,15 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/chrootarchive"
 	"github.com/containers/storage/pkg/idtools"
 	securejoin "github.com/cyphar/filepath-securejoin"
-	digest "github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -114,7 +115,7 @@ func copyBetweenHostAndContainer(runtime *libpod.Runtime, src string, dest strin
 			// TODO: We can potentially start the container while
 			// the copy is running, which still allows a race where
 			// malicious code could mess with the symlink.
-			if errors.Cause(err) != libpod.ErrCtrStateInvalid {
+			if errors.Cause(err) != define.ErrCtrStateInvalid {
 				return err
 			}
 		} else if err == nil {

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/cmd/podman/shared/parse"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -126,7 +127,7 @@ func execCmd(c *cliconfig.ExecValues) error {
 	streams.AttachInput = true
 
 	err = ctr.Exec(c.Tty, c.Privileged, envs, cmd, c.User, c.Workdir, streams, c.PreserveFDs)
-	if errors.Cause(err) == libpod.ErrCtrStateInvalid {
+	if errors.Cause(err) == define.ErrCtrStateInvalid {
 		exitCode = 126
 	}
 

--- a/cmd/podman/exists.go
+++ b/cmd/podman/exists.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/spf13/cobra"
 	"os"
 
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -113,7 +113,7 @@ func containerExistsCmd(c *cliconfig.ContainerExistsValues) error {
 	}
 	defer runtime.Shutdown(false)
 	if _, err := runtime.LookupContainer(args[0]); err != nil {
-		if errors.Cause(err) == libpod.ErrNoSuchCtr || err.Error() == "io.podman.ContainerNotFound" {
+		if errors.Cause(err) == define.ErrNoSuchCtr || err.Error() == "io.podman.ContainerNotFound" {
 			os.Exit(1)
 		}
 		return err
@@ -133,7 +133,7 @@ func podExistsCmd(c *cliconfig.PodExistsValues) error {
 	defer runtime.Shutdown(false)
 
 	if _, err := runtime.LookupPod(args[0]); err != nil {
-		if errors.Cause(err) == libpod.ErrNoSuchPod || err.Error() == "io.podman.PodNotFound" {
+		if errors.Cause(err) == define.ErrNoSuchPod || err.Error() == "io.podman.PodNotFound" {
 			os.Exit(1)
 		}
 		return err

--- a/cmd/podman/pause.go
+++ b/cmd/podman/pause.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -55,7 +55,7 @@ func pauseCmd(c *cliconfig.PauseValues) error {
 	}
 	ok, failures, err := runtime.PauseContainers(getContext(), c)
 	if err != nil {
-		if errors.Cause(err) == libpod.ErrNoSuchCtr {
+		if errors.Cause(err) == define.ErrNoSuchCtr {
 			if len(c.InputArgs) > 1 {
 				exitCode = 125
 			} else {

--- a/cmd/podman/pod_stats.go
+++ b/cmd/podman/pod_stats.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/buildah/pkg/formats"
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -153,7 +154,7 @@ func podStatsCmd(c *cliconfig.PodStatsValues) error {
 		for _, p := range pods {
 			prevStat := getPreviousPodContainerStats(p.ID(), previousPodStats)
 			newPodStats, err := p.GetPodStats(prevStat)
-			if errors.Cause(err) == libpod.ErrNoSuchPod {
+			if errors.Cause(err) == define.ErrNoSuchPod {
 				continue
 			}
 			if err != nil {

--- a/cmd/podman/restart.go
+++ b/cmd/podman/restart.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -39,8 +39,8 @@ func init() {
 	flags.BoolVarP(&restartCommand.All, "all", "a", false, "Restart all non-running containers")
 	flags.BoolVarP(&restartCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&restartCommand.Running, "running", false, "Restart only running containers when --all is used")
-	flags.UintVarP(&restartCommand.Timeout, "timeout", "t", libpod.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
-	flags.UintVar(&restartCommand.Timeout, "time", libpod.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
+	flags.UintVarP(&restartCommand.Timeout, "timeout", "t", define.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
+	flags.UintVar(&restartCommand.Timeout, "time", define.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
 
 	markFlagHiddenForRemoteClient("latest", flags)
 }
@@ -48,7 +48,7 @@ func init() {
 func restartCmd(c *cliconfig.RestartValues) error {
 	all := c.All
 	if len(c.InputArgs) < 1 && !c.Latest && !all {
-		return errors.Wrapf(libpod.ErrInvalidArg, "you must provide at least one container name or ID")
+		return errors.Wrapf(define.ErrInvalidArg, "you must provide at least one container name or ID")
 	}
 
 	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
@@ -59,7 +59,7 @@ func restartCmd(c *cliconfig.RestartValues) error {
 
 	ok, failures, err := runtime.Restart(getContext(), c)
 	if err != nil {
-		if errors.Cause(err) == libpod.ErrNoSuchCtr {
+		if errors.Cause(err) == define.ErrNoSuchCtr {
 			if len(c.InputArgs) > 1 {
 				exitCode = 125
 			} else {

--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -65,7 +65,7 @@ func rmCmd(c *cliconfig.RmValues) error {
 
 	ok, failures, err := runtime.RemoveContainers(getContext(), c)
 	if err != nil {
-		if errors.Cause(err) == libpod.ErrNoSuchCtr {
+		if errors.Cause(err) == define.ErrNoSuchCtr {
 			if len(c.InputArgs) > 1 {
 				exitCode = 125
 			} else {

--- a/cmd/podman/runlabel.go
+++ b/cmd/podman/runlabel.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/cmd/podman/shared"
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/libpod/utils"
@@ -169,7 +169,7 @@ func runlabelCmd(c *cliconfig.RunlabelValues) error {
 				name := cmd[i+1]
 				ctr, err := runtime.LookupContainer(name)
 				if err != nil {
-					if errors.Cause(err) != libpod.ErrNoSuchCtr {
+					if errors.Cause(err) != define.ErrNoSuchCtr {
 						logrus.Debugf("Error occurred searching for container %s: %s", name, err.Error())
 						return err
 					}

--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/containers/image/types"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/cri-o/ocicni/pkg/ocicni"
@@ -824,7 +825,7 @@ func GenerateKube(name string, service bool, r *libpod.Runtime) (*v1.Pod, *v1.Se
 		podYAML, servicePorts, err = pod.GenerateForKube()
 	} else {
 		if len(container.Dependencies()) > 0 {
-			return nil, nil, errors.Wrapf(libpod.ErrNotImplemented, "containers with dependencies")
+			return nil, nil, errors.Wrapf(define.ErrNotImplemented, "containers with dependencies")
 		}
 		podYAML, err = container.GenerateForKube()
 	}

--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -62,7 +62,7 @@ func startCmd(c *cliconfig.StartValues) error {
 	sigProxy := c.SigProxy || attach
 
 	if sigProxy && !attach {
-		return errors.Wrapf(libpod.ErrInvalidArg, "you cannot use sig-proxy without --attach")
+		return errors.Wrapf(define.ErrInvalidArg, "you cannot use sig-proxy without --attach")
 	}
 
 	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)

--- a/cmd/podman/stats.go
+++ b/cmd/podman/stats.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -127,7 +128,7 @@ func statsCmd(c *cliconfig.StatsValues) error {
 		initialStats, err := ctr.GetContainerStats(&libpod.ContainerStats{})
 		if err != nil {
 			// when doing "all", dont worry about containers that are not running
-			if c.All && errors.Cause(err) == libpod.ErrCtrRemoved || errors.Cause(err) == libpod.ErrNoSuchCtr || errors.Cause(err) == libpod.ErrCtrStateInvalid {
+			if c.All && errors.Cause(err) == define.ErrCtrRemoved || errors.Cause(err) == define.ErrNoSuchCtr || errors.Cause(err) == define.ErrCtrStateInvalid {
 				continue
 			}
 			return err
@@ -148,7 +149,7 @@ func statsCmd(c *cliconfig.StatsValues) error {
 			id := ctr.ID()
 			if _, ok := containerStats[ctr.ID()]; !ok {
 				initialStats, err := ctr.GetContainerStats(&libpod.ContainerStats{})
-				if errors.Cause(err) == libpod.ErrCtrRemoved || errors.Cause(err) == libpod.ErrNoSuchCtr || errors.Cause(err) == libpod.ErrCtrStateInvalid {
+				if errors.Cause(err) == define.ErrCtrRemoved || errors.Cause(err) == define.ErrNoSuchCtr || errors.Cause(err) == define.ErrCtrStateInvalid {
 					// skip dealing with a container that is gone
 					continue
 				}
@@ -158,7 +159,7 @@ func statsCmd(c *cliconfig.StatsValues) error {
 				containerStats[id] = initialStats
 			}
 			stats, err := ctr.GetContainerStats(containerStats[id])
-			if err != nil && errors.Cause(err) != libpod.ErrNoSuchCtr {
+			if err != nil && errors.Cause(err) != define.ErrNoSuchCtr {
 				return err
 			}
 			// replace the previous measurement with the current one

--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -40,8 +40,8 @@ func init() {
 	flags := stopCommand.Flags()
 	flags.BoolVarP(&stopCommand.All, "all", "a", false, "Stop all running containers")
 	flags.BoolVarP(&stopCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
-	flags.UintVar(&stopCommand.Timeout, "time", libpod.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
-	flags.UintVarP(&stopCommand.Timeout, "timeout", "t", libpod.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
+	flags.UintVar(&stopCommand.Timeout, "time", define.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
+	flags.UintVarP(&stopCommand.Timeout, "timeout", "t", define.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
 	markFlagHiddenForRemoteClient("latest", flags)
 }
 

--- a/cmd/podman/unpause.go
+++ b/cmd/podman/unpause.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -54,7 +54,7 @@ func unpauseCmd(c *cliconfig.UnpauseValues) error {
 	}
 	ok, failures, err := runtime.UnpauseContainers(getContext(), c)
 	if err != nil {
-		if errors.Cause(err) == libpod.ErrNoSuchCtr {
+		if errors.Cause(err) == define.ErrNoSuchCtr {
 			if len(c.InputArgs) > 1 {
 				exitCode = 125
 			} else {

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containers/libpod/libpod/define"
 	bolt "github.com/etcd-io/bbolt"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -133,7 +134,7 @@ func (s *BoltState) Close() error {
 // Refresh clears container and pod states after a reboot
 func (s *BoltState) Refresh() error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	db, err := s.getDBCon()
@@ -171,13 +172,13 @@ func (s *BoltState) Refresh() error {
 				if podBkt == nil {
 					// This is neither a pod nor a container
 					// Error out on the dangling ID
-					return errors.Wrapf(ErrInternal, "id %s is not a pod or a container", string(id))
+					return errors.Wrapf(define.ErrInternal, "id %s is not a pod or a container", string(id))
 				}
 
 				// Get the state
 				stateBytes := podBkt.Get(stateKey)
 				if stateBytes == nil {
-					return errors.Wrapf(ErrInternal, "pod %s missing state key", string(id))
+					return errors.Wrapf(define.ErrInternal, "pod %s missing state key", string(id))
 				}
 
 				state := new(podState)
@@ -210,7 +211,7 @@ func (s *BoltState) Refresh() error {
 			stateBytes := ctrBkt.Get(stateKey)
 			if stateBytes == nil {
 				// Badly formatted container bucket
-				return errors.Wrapf(ErrInternal, "container %s missing state in DB", string(id))
+				return errors.Wrapf(define.ErrInternal, "container %s missing state in DB", string(id))
 			}
 
 			state := new(ContainerState)
@@ -243,7 +244,7 @@ func (s *BoltState) Refresh() error {
 // the database was first initialized
 func (s *BoltState) GetDBConfig() (*DBConfig, error) {
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	cfg := new(DBConfig)
@@ -290,7 +291,7 @@ func (s *BoltState) GetDBConfig() (*DBConfig, error) {
 // ValidateDBConfig validates paths in the given runtime against the database
 func (s *BoltState) ValidateDBConfig(runtime *Runtime) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	db, err := s.getDBCon()
@@ -324,11 +325,11 @@ func (s *BoltState) SetNamespace(ns string) error {
 // Container retrieves a single container from the state by its full ID
 func (s *BoltState) Container(id string) (*Container, error) {
 	if id == "" {
-		return nil, ErrEmptyID
+		return nil, define.ErrEmptyID
 	}
 
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	ctrID := []byte(id)
@@ -362,11 +363,11 @@ func (s *BoltState) Container(id string) (*Container, error) {
 // partial ID or name
 func (s *BoltState) LookupContainer(idOrName string) (*Container, error) {
 	if idOrName == "" {
-		return nil, ErrEmptyID
+		return nil, define.ErrEmptyID
 	}
 
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	ctr := new(Container)
@@ -446,7 +447,7 @@ func (s *BoltState) LookupContainer(idOrName string) (*Container, error) {
 			}
 			if strings.HasPrefix(string(checkID), idOrName) {
 				if exists {
-					return errors.Wrapf(ErrCtrExists, "more than one result for container ID %s", idOrName)
+					return errors.Wrapf(define.ErrCtrExists, "more than one result for container ID %s", idOrName)
 				}
 				id = checkID
 				exists = true
@@ -458,9 +459,9 @@ func (s *BoltState) LookupContainer(idOrName string) (*Container, error) {
 			return err
 		} else if !exists {
 			if isPod {
-				return errors.Wrapf(ErrNoSuchCtr, "%s is a pod, not a container", idOrName)
+				return errors.Wrapf(define.ErrNoSuchCtr, "%s is a pod, not a container", idOrName)
 			}
-			return errors.Wrapf(ErrNoSuchCtr, "no container with name or ID %s found", idOrName)
+			return errors.Wrapf(define.ErrNoSuchCtr, "no container with name or ID %s found", idOrName)
 		}
 
 		return s.getContainerFromDB(id, ctr, ctrBucket)
@@ -475,11 +476,11 @@ func (s *BoltState) LookupContainer(idOrName string) (*Container, error) {
 // HasContainer checks if a container is present in the state
 func (s *BoltState) HasContainer(id string) (bool, error) {
 	if id == "" {
-		return false, ErrEmptyID
+		return false, define.ErrEmptyID
 	}
 
 	if !s.valid {
-		return false, ErrDBClosed
+		return false, define.ErrDBClosed
 	}
 
 	ctrID := []byte(id)
@@ -523,15 +524,15 @@ func (s *BoltState) HasContainer(id string) (bool, error) {
 // The container being added cannot belong to a pod
 func (s *BoltState) AddContainer(ctr *Container) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !ctr.valid {
-		return ErrCtrRemoved
+		return define.ErrCtrRemoved
 	}
 
 	if ctr.config.Pod != "" {
-		return errors.Wrapf(ErrInvalidArg, "cannot add a container that belongs to a pod with AddContainer - use AddContainerToPod")
+		return errors.Wrapf(define.ErrInvalidArg, "cannot add a container that belongs to a pod with AddContainer - use AddContainerToPod")
 	}
 
 	return s.addContainer(ctr, nil)
@@ -542,11 +543,11 @@ func (s *BoltState) AddContainer(ctr *Container) error {
 // pod, use RemoveContainerFromPod
 func (s *BoltState) RemoveContainer(ctr *Container) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if ctr.config.Pod != "" {
-		return errors.Wrapf(ErrPodExists, "container %s is part of a pod, use RemoveContainerFromPod instead", ctr.ID())
+		return errors.Wrapf(define.ErrPodExists, "container %s is part of a pod, use RemoveContainerFromPod instead", ctr.ID())
 	}
 
 	db, err := s.getDBCon()
@@ -564,15 +565,15 @@ func (s *BoltState) RemoveContainer(ctr *Container) error {
 // UpdateContainer updates a container's state from the database
 func (s *BoltState) UpdateContainer(ctr *Container) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !ctr.valid {
-		return ErrCtrRemoved
+		return define.ErrCtrRemoved
 	}
 
 	if s.namespace != "" && s.namespace != ctr.config.Namespace {
-		return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
+		return errors.Wrapf(define.ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
 	}
 
 	newState := new(ContainerState)
@@ -595,12 +596,12 @@ func (s *BoltState) UpdateContainer(ctr *Container) error {
 		ctrToUpdate := ctrBucket.Bucket(ctrID)
 		if ctrToUpdate == nil {
 			ctr.valid = false
-			return errors.Wrapf(ErrNoSuchCtr, "container %s does not exist in database", ctr.ID())
+			return errors.Wrapf(define.ErrNoSuchCtr, "container %s does not exist in database", ctr.ID())
 		}
 
 		newStateBytes := ctrToUpdate.Get(stateKey)
 		if newStateBytes == nil {
-			return errors.Wrapf(ErrInternal, "container %s does not have a state key in DB", ctr.ID())
+			return errors.Wrapf(define.ErrInternal, "container %s does not have a state key in DB", ctr.ID())
 		}
 
 		if err := json.Unmarshal(newStateBytes, newState); err != nil {
@@ -632,15 +633,15 @@ func (s *BoltState) UpdateContainer(ctr *Container) error {
 // SaveContainer saves a container's current state in the database
 func (s *BoltState) SaveContainer(ctr *Container) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !ctr.valid {
-		return ErrCtrRemoved
+		return define.ErrCtrRemoved
 	}
 
 	if s.namespace != "" && s.namespace != ctr.config.Namespace {
-		return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
+		return errors.Wrapf(define.ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
 	}
 
 	stateJSON, err := json.Marshal(ctr.state)
@@ -666,7 +667,7 @@ func (s *BoltState) SaveContainer(ctr *Container) error {
 		ctrToSave := ctrBucket.Bucket(ctrID)
 		if ctrToSave == nil {
 			ctr.valid = false
-			return errors.Wrapf(ErrNoSuchCtr, "container %s does not exist in DB", ctr.ID())
+			return errors.Wrapf(define.ErrNoSuchCtr, "container %s does not exist in DB", ctr.ID())
 		}
 
 		// Update the state
@@ -695,15 +696,15 @@ func (s *BoltState) SaveContainer(ctr *Container) error {
 // container. If the slice is empty, no containers depend on the given container
 func (s *BoltState) ContainerInUse(ctr *Container) ([]string, error) {
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	if !ctr.valid {
-		return nil, ErrCtrRemoved
+		return nil, define.ErrCtrRemoved
 	}
 
 	if s.namespace != "" && s.namespace != ctr.config.Namespace {
-		return nil, errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
+		return nil, errors.Wrapf(define.ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
 	}
 
 	depCtrs := []string{}
@@ -723,12 +724,12 @@ func (s *BoltState) ContainerInUse(ctr *Container) ([]string, error) {
 		ctrDB := ctrBucket.Bucket([]byte(ctr.ID()))
 		if ctrDB == nil {
 			ctr.valid = false
-			return errors.Wrapf(ErrNoSuchCtr, "no container with ID %s found in DB", ctr.ID())
+			return errors.Wrapf(define.ErrNoSuchCtr, "no container with ID %s found in DB", ctr.ID())
 		}
 
 		dependsBkt := ctrDB.Bucket(dependenciesBkt)
 		if dependsBkt == nil {
-			return errors.Wrapf(ErrInternal, "container %s has no dependencies bucket", ctr.ID())
+			return errors.Wrapf(define.ErrInternal, "container %s has no dependencies bucket", ctr.ID())
 		}
 
 		// Iterate through and add dependencies
@@ -754,7 +755,7 @@ func (s *BoltState) ContainerInUse(ctr *Container) ([]string, error) {
 // AllContainers retrieves all the containers in the database
 func (s *BoltState) AllContainers() ([]*Container, error) {
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	ctrs := []*Container{}
@@ -782,7 +783,7 @@ func (s *BoltState) AllContainers() ([]*Container, error) {
 			// be much less helpful.
 			ctrExists := ctrBucket.Bucket(id)
 			if ctrExists == nil {
-				return errors.Wrapf(ErrInternal, "state is inconsistent - container ID %s in all containers, but container not found", string(id))
+				return errors.Wrapf(define.ErrInternal, "state is inconsistent - container ID %s in all containers, but container not found", string(id))
 			}
 
 			ctr := new(Container)
@@ -794,7 +795,7 @@ func (s *BoltState) AllContainers() ([]*Container, error) {
 				// ignore it safely.
 				// We just won't include the container in the
 				// results.
-				if errors.Cause(err) != ErrNSMismatch {
+				if errors.Cause(err) != define.ErrNSMismatch {
 					// Even if it's not an NS mismatch, it's
 					// not worth erroring over.
 					// If we do, a single bad container JSON
@@ -821,11 +822,11 @@ func (s *BoltState) AllContainers() ([]*Container, error) {
 // comment on this function in state.go.
 func (s *BoltState) RewriteContainerConfig(ctr *Container, newCfg *ContainerConfig) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !ctr.valid {
-		return ErrCtrRemoved
+		return define.ErrCtrRemoved
 	}
 
 	newCfgJSON, err := json.Marshal(newCfg)
@@ -848,7 +849,7 @@ func (s *BoltState) RewriteContainerConfig(ctr *Container, newCfg *ContainerConf
 		ctrDB := ctrBkt.Bucket([]byte(ctr.ID()))
 		if ctrDB == nil {
 			ctr.valid = false
-			return errors.Wrapf(ErrNoSuchCtr, "no container with ID %s found in DB", ctr.ID())
+			return errors.Wrapf(define.ErrNoSuchCtr, "no container with ID %s found in DB", ctr.ID())
 		}
 
 		if err := ctrDB.Put(configKey, newCfgJSON); err != nil {
@@ -865,11 +866,11 @@ func (s *BoltState) RewriteContainerConfig(ctr *Container, newCfg *ContainerConf
 // comment on this function in state.go.
 func (s *BoltState) RewritePodConfig(pod *Pod, newCfg *PodConfig) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !pod.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	newCfgJSON, err := json.Marshal(newCfg)
@@ -892,7 +893,7 @@ func (s *BoltState) RewritePodConfig(pod *Pod, newCfg *PodConfig) error {
 		podDB := podBkt.Bucket([]byte(pod.ID()))
 		if podDB == nil {
 			pod.valid = false
-			return errors.Wrapf(ErrNoSuchPod, "no pod with ID %s found in DB", pod.ID())
+			return errors.Wrapf(define.ErrNoSuchPod, "no pod with ID %s found in DB", pod.ID())
 		}
 
 		if err := podDB.Put(configKey, newCfgJSON); err != nil {
@@ -907,11 +908,11 @@ func (s *BoltState) RewritePodConfig(pod *Pod, newCfg *PodConfig) error {
 // Pod retrieves a pod given its full ID
 func (s *BoltState) Pod(id string) (*Pod, error) {
 	if id == "" {
-		return nil, ErrEmptyID
+		return nil, define.ErrEmptyID
 	}
 
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	podID := []byte(id)
@@ -944,11 +945,11 @@ func (s *BoltState) Pod(id string) (*Pod, error) {
 // LookupPod retrieves a pod from full or unique partial ID or name
 func (s *BoltState) LookupPod(idOrName string) (*Pod, error) {
 	if idOrName == "" {
-		return nil, ErrEmptyID
+		return nil, define.ErrEmptyID
 	}
 
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	pod := new(Pod)
@@ -1025,7 +1026,7 @@ func (s *BoltState) LookupPod(idOrName string) (*Pod, error) {
 			}
 			if strings.HasPrefix(string(checkID), idOrName) {
 				if exists {
-					return errors.Wrapf(ErrPodExists, "more than one result for ID or name %s", idOrName)
+					return errors.Wrapf(define.ErrPodExists, "more than one result for ID or name %s", idOrName)
 				}
 				id = checkID
 				exists = true
@@ -1037,9 +1038,9 @@ func (s *BoltState) LookupPod(idOrName string) (*Pod, error) {
 			return err
 		} else if !exists {
 			if isCtr {
-				return errors.Wrapf(ErrNoSuchPod, "%s is a container, not a pod", idOrName)
+				return errors.Wrapf(define.ErrNoSuchPod, "%s is a container, not a pod", idOrName)
 			}
-			return errors.Wrapf(ErrNoSuchPod, "no pod with name or ID %s found", idOrName)
+			return errors.Wrapf(define.ErrNoSuchPod, "no pod with name or ID %s found", idOrName)
 		}
 
 		// We might have found a container ID, but it's OK
@@ -1056,11 +1057,11 @@ func (s *BoltState) LookupPod(idOrName string) (*Pod, error) {
 // HasPod checks if a pod with the given ID exists in the state
 func (s *BoltState) HasPod(id string) (bool, error) {
 	if id == "" {
-		return false, ErrEmptyID
+		return false, define.ErrEmptyID
 	}
 
 	if !s.valid {
-		return false, ErrDBClosed
+		return false, define.ErrDBClosed
 	}
 
 	podID := []byte(id)
@@ -1103,19 +1104,19 @@ func (s *BoltState) HasPod(id string) (bool, error) {
 // PodHasContainer checks if the given pod has a container with the given ID
 func (s *BoltState) PodHasContainer(pod *Pod, id string) (bool, error) {
 	if id == "" {
-		return false, ErrEmptyID
+		return false, define.ErrEmptyID
 	}
 
 	if !s.valid {
-		return false, ErrDBClosed
+		return false, define.ErrDBClosed
 	}
 
 	if !pod.valid {
-		return false, ErrPodRemoved
+		return false, define.ErrPodRemoved
 	}
 
 	if s.namespace != "" && s.namespace != pod.config.Namespace {
-		return false, errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
+		return false, errors.Wrapf(define.ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	ctrID := []byte(id)
@@ -1139,13 +1140,13 @@ func (s *BoltState) PodHasContainer(pod *Pod, id string) (bool, error) {
 		podDB := podBkt.Bucket(podID)
 		if podDB == nil {
 			pod.valid = false
-			return errors.Wrapf(ErrNoSuchPod, "pod %s not found in database", pod.ID())
+			return errors.Wrapf(define.ErrNoSuchPod, "pod %s not found in database", pod.ID())
 		}
 
 		// Get pod containers bucket
 		podCtrs := podDB.Bucket(containersBkt)
 		if podCtrs == nil {
-			return errors.Wrapf(ErrInternal, "pod %s missing containers bucket in DB", pod.ID())
+			return errors.Wrapf(define.ErrInternal, "pod %s missing containers bucket in DB", pod.ID())
 		}
 
 		// Don't bother with a namespace check on the container -
@@ -1170,15 +1171,15 @@ func (s *BoltState) PodHasContainer(pod *Pod, id string) (bool, error) {
 // PodContainersByID returns the IDs of all containers present in the given pod
 func (s *BoltState) PodContainersByID(pod *Pod) ([]string, error) {
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	if !pod.valid {
-		return nil, ErrPodRemoved
+		return nil, define.ErrPodRemoved
 	}
 
 	if s.namespace != "" && s.namespace != pod.config.Namespace {
-		return nil, errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
+		return nil, errors.Wrapf(define.ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	podID := []byte(pod.ID())
@@ -1201,13 +1202,13 @@ func (s *BoltState) PodContainersByID(pod *Pod) ([]string, error) {
 		podDB := podBkt.Bucket(podID)
 		if podDB == nil {
 			pod.valid = false
-			return errors.Wrapf(ErrNoSuchPod, "pod %s not found in database", pod.ID())
+			return errors.Wrapf(define.ErrNoSuchPod, "pod %s not found in database", pod.ID())
 		}
 
 		// Get pod containers bucket
 		podCtrs := podDB.Bucket(containersBkt)
 		if podCtrs == nil {
-			return errors.Wrapf(ErrInternal, "pod %s missing containers bucket in DB", pod.ID())
+			return errors.Wrapf(define.ErrInternal, "pod %s missing containers bucket in DB", pod.ID())
 		}
 
 		// Iterate through all containers in the pod
@@ -1232,15 +1233,15 @@ func (s *BoltState) PodContainersByID(pod *Pod) ([]string, error) {
 // PodContainers returns all the containers present in the given pod
 func (s *BoltState) PodContainers(pod *Pod) ([]*Container, error) {
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	if !pod.valid {
-		return nil, ErrPodRemoved
+		return nil, define.ErrPodRemoved
 	}
 
 	if s.namespace != "" && s.namespace != pod.config.Namespace {
-		return nil, errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
+		return nil, errors.Wrapf(define.ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	podID := []byte(pod.ID())
@@ -1268,13 +1269,13 @@ func (s *BoltState) PodContainers(pod *Pod) ([]*Container, error) {
 		podDB := podBkt.Bucket(podID)
 		if podDB == nil {
 			pod.valid = false
-			return errors.Wrapf(ErrNoSuchPod, "pod %s not found in database", pod.ID())
+			return errors.Wrapf(define.ErrNoSuchPod, "pod %s not found in database", pod.ID())
 		}
 
 		// Get pod containers bucket
 		podCtrs := podDB.Bucket(containersBkt)
 		if podCtrs == nil {
-			return errors.Wrapf(ErrInternal, "pod %s missing containers bucket in DB", pod.ID())
+			return errors.Wrapf(define.ErrInternal, "pod %s missing containers bucket in DB", pod.ID())
 		}
 
 		// Iterate through all containers in the pod
@@ -1303,11 +1304,11 @@ func (s *BoltState) PodContainers(pod *Pod) ([]*Container, error) {
 // the sub bucket holding the container dependencies that this volume has
 func (s *BoltState) AddVolume(volume *Volume) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !volume.valid {
-		return ErrVolumeRemoved
+		return define.ErrVolumeRemoved
 	}
 
 	volName := []byte(volume.Name())
@@ -1337,7 +1338,7 @@ func (s *BoltState) AddVolume(volume *Volume) error {
 		// Check if we already have a volume with the given name
 		volExists := allVolsBkt.Get(volName)
 		if volExists != nil {
-			return errors.Wrapf(ErrVolumeExists, "name %s is in use", volume.Name())
+			return errors.Wrapf(define.ErrVolumeExists, "name %s is in use", volume.Name())
 		}
 
 		// We are good to add the volume
@@ -1369,7 +1370,7 @@ func (s *BoltState) AddVolume(volume *Volume) error {
 // RemoveVolume removes the given volume from the state
 func (s *BoltState) RemoveVolume(volume *Volume) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	volName := []byte(volume.Name())
@@ -1400,7 +1401,7 @@ func (s *BoltState) RemoveVolume(volume *Volume) error {
 		volDB := volBkt.Bucket(volName)
 		if volDB == nil {
 			volume.valid = false
-			return errors.Wrapf(ErrNoSuchVolume, "volume %s does not exist in DB", volume.Name())
+			return errors.Wrapf(define.ErrNoSuchVolume, "volume %s does not exist in DB", volume.Name())
 		}
 
 		// Check if volume is not being used by any container
@@ -1430,7 +1431,7 @@ func (s *BoltState) RemoveVolume(volume *Volume) error {
 				return errors.Wrapf(err, "error getting list of dependencies from dependencies bucket for volumes %q", volume.Name())
 			}
 			if len(deps) > 0 {
-				return errors.Wrapf(ErrVolumeBeingUsed, "volume %s is being used by container(s) %s", volume.Name(), strings.Join(deps, ","))
+				return errors.Wrapf(define.ErrVolumeBeingUsed, "volume %s is being used by container(s) %s", volume.Name(), strings.Join(deps, ","))
 			}
 		}
 
@@ -1451,7 +1452,7 @@ func (s *BoltState) RemoveVolume(volume *Volume) error {
 // AllVolumes returns all volumes present in the state
 func (s *BoltState) AllVolumes() ([]*Volume, error) {
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	volumes := []*Volume{}
@@ -1477,14 +1478,14 @@ func (s *BoltState) AllVolumes() ([]*Volume, error) {
 			// This check can be removed if performance becomes an
 			// issue, but much less helpful errors will be produced
 			if volExists == nil {
-				return errors.Wrapf(ErrInternal, "inconsistency in state - volume %s is in all volumes bucket but volume not found", string(id))
+				return errors.Wrapf(define.ErrInternal, "inconsistency in state - volume %s is in all volumes bucket but volume not found", string(id))
 			}
 
 			volume := new(Volume)
 			volume.config = new(VolumeConfig)
 
 			if err := s.getVolumeFromDB(id, volume, volBucket); err != nil {
-				if errors.Cause(err) != ErrNSMismatch {
+				if errors.Cause(err) != define.ErrNSMismatch {
 					logrus.Errorf("Error retrieving volume %s from the database: %v", string(id), err)
 				}
 			} else {
@@ -1505,11 +1506,11 @@ func (s *BoltState) AllVolumes() ([]*Volume, error) {
 // Volume retrieves a volume from full name
 func (s *BoltState) Volume(name string) (*Volume, error) {
 	if name == "" {
-		return nil, ErrEmptyID
+		return nil, define.ErrEmptyID
 	}
 
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	volName := []byte(name)
@@ -1541,11 +1542,11 @@ func (s *BoltState) Volume(name string) (*Volume, error) {
 // HasVolume returns true if the given volume exists in the state, otherwise it returns false
 func (s *BoltState) HasVolume(name string) (bool, error) {
 	if name == "" {
-		return false, ErrEmptyID
+		return false, define.ErrEmptyID
 	}
 
 	if !s.valid {
-		return false, ErrDBClosed
+		return false, define.ErrDBClosed
 	}
 
 	volName := []byte(name)
@@ -1583,11 +1584,11 @@ func (s *BoltState) HasVolume(name string) (bool, error) {
 // volume. If the slice is empty, no containers use the given volume
 func (s *BoltState) VolumeInUse(volume *Volume) ([]string, error) {
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	if !volume.valid {
-		return nil, ErrVolumeRemoved
+		return nil, define.ErrVolumeRemoved
 	}
 
 	depCtrs := []string{}
@@ -1612,12 +1613,12 @@ func (s *BoltState) VolumeInUse(volume *Volume) ([]string, error) {
 		volDB := volBucket.Bucket([]byte(volume.Name()))
 		if volDB == nil {
 			volume.valid = false
-			return errors.Wrapf(ErrNoSuchVolume, "no volume with name %s found in DB", volume.Name())
+			return errors.Wrapf(define.ErrNoSuchVolume, "no volume with name %s found in DB", volume.Name())
 		}
 
 		dependsBkt := volDB.Bucket(volDependenciesBkt)
 		if dependsBkt == nil {
-			return errors.Wrapf(ErrInternal, "volume %s has no dependencies bucket", volume.Name())
+			return errors.Wrapf(define.ErrInternal, "volume %s has no dependencies bucket", volume.Name())
 		}
 
 		// Iterate through and add dependencies
@@ -1649,15 +1650,15 @@ func (s *BoltState) VolumeInUse(volume *Volume) ([]string, error) {
 // AddPod adds the given pod to the state.
 func (s *BoltState) AddPod(pod *Pod) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !pod.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	if s.namespace != "" && s.namespace != pod.config.Namespace {
-		return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
+		return errors.Wrapf(define.ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	podID := []byte(pod.ID())
@@ -1713,11 +1714,11 @@ func (s *BoltState) AddPod(pod *Pod) error {
 		// Check if we already have something with the given ID and name
 		idExist := idsBkt.Get(podID)
 		if idExist != nil {
-			return errors.Wrapf(ErrPodExists, "ID %s is in use", pod.ID())
+			return errors.Wrapf(define.ErrPodExists, "ID %s is in use", pod.ID())
 		}
 		nameExist := namesBkt.Get(podName)
 		if nameExist != nil {
-			return errors.Wrapf(ErrPodExists, "name %s is in use", pod.Name())
+			return errors.Wrapf(define.ErrPodExists, "name %s is in use", pod.Name())
 		}
 
 		// We are good to add the pod
@@ -1773,15 +1774,15 @@ func (s *BoltState) AddPod(pod *Pod) error {
 // Only empty pods can be removed
 func (s *BoltState) RemovePod(pod *Pod) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !pod.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	if s.namespace != "" && s.namespace != pod.config.Namespace {
-		return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
+		return errors.Wrapf(define.ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	podID := []byte(pod.ID())
@@ -1823,7 +1824,7 @@ func (s *BoltState) RemovePod(pod *Pod) error {
 		podDB := podBkt.Bucket(podID)
 		if podDB == nil {
 			pod.valid = false
-			return errors.Wrapf(ErrNoSuchPod, "pod %s does not exist in DB", pod.ID())
+			return errors.Wrapf(define.ErrNoSuchPod, "pod %s does not exist in DB", pod.ID())
 		}
 
 		// Check if pod is empty
@@ -1835,7 +1836,7 @@ func (s *BoltState) RemovePod(pod *Pod) error {
 		if podCtrsBkt != nil {
 			cursor := podCtrsBkt.Cursor()
 			if id, _ := cursor.First(); id != nil {
-				return errors.Wrapf(ErrCtrExists, "pod %s is not empty", pod.ID())
+				return errors.Wrapf(define.ErrCtrExists, "pod %s is not empty", pod.ID())
 			}
 		}
 
@@ -1869,15 +1870,15 @@ func (s *BoltState) RemovePod(pod *Pod) error {
 // RemovePodContainers removes all containers in a pod
 func (s *BoltState) RemovePodContainers(pod *Pod) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !pod.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	if s.namespace != "" && s.namespace != pod.config.Namespace {
-		return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
+		return errors.Wrapf(define.ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	podID := []byte(pod.ID())
@@ -1918,12 +1919,12 @@ func (s *BoltState) RemovePodContainers(pod *Pod) error {
 		podDB := podBkt.Bucket(podID)
 		if podDB == nil {
 			pod.valid = false
-			return errors.Wrapf(ErrNoSuchPod, "pod %s does not exist in DB", pod.ID())
+			return errors.Wrapf(define.ErrNoSuchPod, "pod %s does not exist in DB", pod.ID())
 		}
 
 		podCtrsBkt := podDB.Bucket(containersBkt)
 		if podCtrsBkt == nil {
-			return errors.Wrapf(ErrInternal, "pod %s does not have a containers bucket", pod.ID())
+			return errors.Wrapf(define.ErrInternal, "pod %s does not have a containers bucket", pod.ID())
 		}
 
 		// Traverse all containers in the pod with a cursor
@@ -1934,7 +1935,7 @@ func (s *BoltState) RemovePodContainers(pod *Pod) error {
 			if ctr == nil {
 				// This should never happen
 				// State is inconsistent
-				return errors.Wrapf(ErrNoSuchCtr, "pod %s referenced nonexistant container %s", pod.ID(), string(id))
+				return errors.Wrapf(define.ErrNoSuchCtr, "pod %s referenced nonexistant container %s", pod.ID(), string(id))
 			}
 			ctrDeps := ctr.Bucket(dependenciesBkt)
 			// This should never be nil, but if it is, we're
@@ -1943,7 +1944,7 @@ func (s *BoltState) RemovePodContainers(pod *Pod) error {
 				err = ctrDeps.ForEach(func(depID, name []byte) error {
 					exists := podCtrsBkt.Get(depID)
 					if exists == nil {
-						return errors.Wrapf(ErrCtrExists, "container %s has dependency %s outside of pod %s", string(id), string(depID), pod.ID())
+						return errors.Wrapf(define.ErrCtrExists, "container %s has dependency %s outside of pod %s", string(id), string(depID), pod.ID())
 					}
 					return nil
 				})
@@ -1955,7 +1956,7 @@ func (s *BoltState) RemovePodContainers(pod *Pod) error {
 			// Dependencies are set, we're clear to remove
 
 			if err := ctrBkt.DeleteBucket(id); err != nil {
-				return errors.Wrapf(ErrInternal, "error deleting container %s from DB", string(id))
+				return errors.Wrapf(define.ErrInternal, "error deleting container %s from DB", string(id))
 			}
 
 			if err := idsBkt.Delete(id); err != nil {
@@ -1997,19 +1998,19 @@ func (s *BoltState) RemovePodContainers(pod *Pod) error {
 // The container will be added to the state and the pod
 func (s *BoltState) AddContainerToPod(pod *Pod, ctr *Container) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !pod.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	if !ctr.valid {
-		return ErrCtrRemoved
+		return define.ErrCtrRemoved
 	}
 
 	if ctr.config.Pod != pod.ID() {
-		return errors.Wrapf(ErrNoSuchCtr, "container %s is not part of pod %s", ctr.ID(), pod.ID())
+		return errors.Wrapf(define.ErrNoSuchCtr, "container %s is not part of pod %s", ctr.ID(), pod.ID())
 	}
 
 	return s.addContainer(ctr, pod)
@@ -2019,28 +2020,28 @@ func (s *BoltState) AddContainerToPod(pod *Pod, ctr *Container) error {
 // The container will also be removed from the state
 func (s *BoltState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !pod.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	if s.namespace != "" {
 		if s.namespace != pod.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
+			return errors.Wrapf(define.ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 		}
 		if s.namespace != ctr.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "container %s in in namespace %q but we are in namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
+			return errors.Wrapf(define.ErrNSMismatch, "container %s in in namespace %q but we are in namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
 		}
 	}
 
 	if ctr.config.Pod == "" {
-		return errors.Wrapf(ErrNoSuchPod, "container %s is not part of a pod, use RemoveContainer instead", ctr.ID())
+		return errors.Wrapf(define.ErrNoSuchPod, "container %s is not part of a pod, use RemoveContainer instead", ctr.ID())
 	}
 
 	if ctr.config.Pod != pod.ID() {
-		return errors.Wrapf(ErrInvalidArg, "container %s is not part of pod %s", ctr.ID(), pod.ID())
+		return errors.Wrapf(define.ErrInvalidArg, "container %s is not part of pod %s", ctr.ID(), pod.ID())
 	}
 
 	db, err := s.getDBCon()
@@ -2058,15 +2059,15 @@ func (s *BoltState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 // UpdatePod updates a pod's state from the database
 func (s *BoltState) UpdatePod(pod *Pod) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !pod.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	if s.namespace != "" && s.namespace != pod.config.Namespace {
-		return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
+		return errors.Wrapf(define.ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	newState := new(podState)
@@ -2088,13 +2089,13 @@ func (s *BoltState) UpdatePod(pod *Pod) error {
 		podDB := podBkt.Bucket(podID)
 		if podDB == nil {
 			pod.valid = false
-			return errors.Wrapf(ErrNoSuchPod, "no pod with ID %s found in database", pod.ID())
+			return errors.Wrapf(define.ErrNoSuchPod, "no pod with ID %s found in database", pod.ID())
 		}
 
 		// Get the pod state JSON
 		podStateBytes := podDB.Get(stateKey)
 		if podStateBytes == nil {
-			return errors.Wrapf(ErrInternal, "pod %s is missing state key in DB", pod.ID())
+			return errors.Wrapf(define.ErrInternal, "pod %s is missing state key in DB", pod.ID())
 		}
 
 		if err := json.Unmarshal(podStateBytes, newState); err != nil {
@@ -2115,15 +2116,15 @@ func (s *BoltState) UpdatePod(pod *Pod) error {
 // SavePod saves a pod's state to the database
 func (s *BoltState) SavePod(pod *Pod) error {
 	if !s.valid {
-		return ErrDBClosed
+		return define.ErrDBClosed
 	}
 
 	if !pod.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	if s.namespace != "" && s.namespace != pod.config.Namespace {
-		return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
+		return errors.Wrapf(define.ErrNSMismatch, "pod %s is in namespace %q but we are in namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 	}
 
 	stateJSON, err := json.Marshal(pod.state)
@@ -2148,7 +2149,7 @@ func (s *BoltState) SavePod(pod *Pod) error {
 		podDB := podBkt.Bucket(podID)
 		if podDB == nil {
 			pod.valid = false
-			return errors.Wrapf(ErrNoSuchPod, "no pod with ID %s found in database", pod.ID())
+			return errors.Wrapf(define.ErrNoSuchPod, "no pod with ID %s found in database", pod.ID())
 		}
 
 		// Set the pod state JSON
@@ -2168,7 +2169,7 @@ func (s *BoltState) SavePod(pod *Pod) error {
 // AllPods returns all pods present in the state
 func (s *BoltState) AllPods() ([]*Pod, error) {
 	if !s.valid {
-		return nil, ErrDBClosed
+		return nil, define.ErrDBClosed
 	}
 
 	pods := []*Pod{}
@@ -2195,7 +2196,7 @@ func (s *BoltState) AllPods() ([]*Pod, error) {
 			// This check can be removed if performance becomes an
 			// issue, but much less helpful errors will be produced
 			if podExists == nil {
-				return errors.Wrapf(ErrInternal, "inconsistency in state - pod %s is in all pods bucket but pod not found", string(id))
+				return errors.Wrapf(define.ErrInternal, "inconsistency in state - pod %s is in all pods bucket but pod not found", string(id))
 			}
 
 			pod := new(Pod)
@@ -2203,7 +2204,7 @@ func (s *BoltState) AllPods() ([]*Pod, error) {
 			pod.state = new(podState)
 
 			if err := s.getPodFromDB(id, pod, podBucket); err != nil {
-				if errors.Cause(err) != ErrNSMismatch {
+				if errors.Cause(err) != define.ErrNSMismatch {
 					logrus.Errorf("Error retrieving pod %s from the database: %v", string(id), err)
 				}
 			} else {

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/storage"
 	bolt "github.com/etcd-io/bbolt"
@@ -222,7 +223,7 @@ func readOnlyValidateConfig(bucket *bolt.Bucket, toCheck dbConfigValidation) (bo
 			return true, nil
 		}
 
-		return true, errors.Wrapf(ErrDBBadConfig, "database %s %q does not match our %s %q",
+		return true, errors.Wrapf(define.ErrDBBadConfig, "database %s %q does not match our %s %q",
 			toCheck.name, dbValue, toCheck.name, toCheck.runtimeValue)
 	}
 
@@ -260,7 +261,7 @@ func (s *BoltState) closeDBCon(db *bolt.DB) error {
 func getIDBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(idRegistryBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(ErrDBBadConfig, "id registry bucket not found in DB")
+		return nil, errors.Wrapf(define.ErrDBBadConfig, "id registry bucket not found in DB")
 	}
 	return bkt, nil
 }
@@ -268,7 +269,7 @@ func getIDBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getNamesBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(nameRegistryBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(ErrDBBadConfig, "name registry bucket not found in DB")
+		return nil, errors.Wrapf(define.ErrDBBadConfig, "name registry bucket not found in DB")
 	}
 	return bkt, nil
 }
@@ -276,7 +277,7 @@ func getNamesBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getNSBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(nsRegistryBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(ErrDBBadConfig, "namespace registry bucket not found in DB")
+		return nil, errors.Wrapf(define.ErrDBBadConfig, "namespace registry bucket not found in DB")
 	}
 	return bkt, nil
 }
@@ -284,7 +285,7 @@ func getNSBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getCtrBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(ctrBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(ErrDBBadConfig, "containers bucket not found in DB")
+		return nil, errors.Wrapf(define.ErrDBBadConfig, "containers bucket not found in DB")
 	}
 	return bkt, nil
 }
@@ -292,7 +293,7 @@ func getCtrBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getAllCtrsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(allCtrsBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(ErrDBBadConfig, "all containers bucket not found in DB")
+		return nil, errors.Wrapf(define.ErrDBBadConfig, "all containers bucket not found in DB")
 	}
 	return bkt, nil
 }
@@ -300,7 +301,7 @@ func getAllCtrsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getPodBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(podBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(ErrDBBadConfig, "pods bucket not found in DB")
+		return nil, errors.Wrapf(define.ErrDBBadConfig, "pods bucket not found in DB")
 	}
 	return bkt, nil
 }
@@ -308,7 +309,7 @@ func getPodBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getAllPodsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(allPodsBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(ErrDBBadConfig, "all pods bucket not found in DB")
+		return nil, errors.Wrapf(define.ErrDBBadConfig, "all pods bucket not found in DB")
 	}
 	return bkt, nil
 }
@@ -316,7 +317,7 @@ func getAllPodsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getVolBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(volBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(ErrDBBadConfig, "volumes bucket not found in DB")
+		return nil, errors.Wrapf(define.ErrDBBadConfig, "volumes bucket not found in DB")
 	}
 	return bkt, nil
 }
@@ -324,7 +325,7 @@ func getVolBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getAllVolsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(allVolsBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(ErrDBBadConfig, "all volumes bucket not found in DB")
+		return nil, errors.Wrapf(define.ErrDBBadConfig, "all volumes bucket not found in DB")
 	}
 	return bkt, nil
 }
@@ -332,7 +333,7 @@ func getAllVolsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 func getRuntimeConfigBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	bkt := tx.Bucket(runtimeConfigBkt)
 	if bkt == nil {
-		return nil, errors.Wrapf(ErrDBBadConfig, "runtime configuration bucket not found in DB")
+		return nil, errors.Wrapf(define.ErrDBBadConfig, "runtime configuration bucket not found in DB")
 	}
 	return bkt, nil
 }
@@ -341,19 +342,19 @@ func (s *BoltState) getContainerFromDB(id []byte, ctr *Container, ctrsBkt *bolt.
 	valid := true
 	ctrBkt := ctrsBkt.Bucket(id)
 	if ctrBkt == nil {
-		return errors.Wrapf(ErrNoSuchCtr, "container %s not found in DB", string(id))
+		return errors.Wrapf(define.ErrNoSuchCtr, "container %s not found in DB", string(id))
 	}
 
 	if s.namespaceBytes != nil {
 		ctrNamespaceBytes := ctrBkt.Get(namespaceKey)
 		if !bytes.Equal(s.namespaceBytes, ctrNamespaceBytes) {
-			return errors.Wrapf(ErrNSMismatch, "cannot retrieve container %s as it is part of namespace %q and we are in namespace %q", string(id), string(ctrNamespaceBytes), s.namespace)
+			return errors.Wrapf(define.ErrNSMismatch, "cannot retrieve container %s as it is part of namespace %q and we are in namespace %q", string(id), string(ctrNamespaceBytes), s.namespace)
 		}
 	}
 
 	configBytes := ctrBkt.Get(configKey)
 	if configBytes == nil {
-		return errors.Wrapf(ErrInternal, "container %s missing config key in DB", string(id))
+		return errors.Wrapf(define.ErrInternal, "container %s missing config key in DB", string(id))
 	}
 
 	if err := json.Unmarshal(configBytes, ctr.config); err != nil {
@@ -379,7 +380,7 @@ func (s *BoltState) getContainerFromDB(id []byte, ctr *Container, ctrsBkt *bolt.
 
 		ociRuntime, ok := s.runtime.ociRuntimes[runtimeName]
 		if !ok {
-			return errors.Wrapf(ErrInternal, "container %s was created with OCI runtime %s, but that runtime is not available in the current configuration", ctr.ID(), ctr.config.OCIRuntime)
+			return errors.Wrapf(define.ErrInternal, "container %s was created with OCI runtime %s, but that runtime is not available in the current configuration", ctr.ID(), ctr.config.OCIRuntime)
 		}
 		ctr.ociRuntime = ociRuntime
 	}
@@ -393,19 +394,19 @@ func (s *BoltState) getContainerFromDB(id []byte, ctr *Container, ctrsBkt *bolt.
 func (s *BoltState) getPodFromDB(id []byte, pod *Pod, podBkt *bolt.Bucket) error {
 	podDB := podBkt.Bucket(id)
 	if podDB == nil {
-		return errors.Wrapf(ErrNoSuchPod, "pod with ID %s not found", string(id))
+		return errors.Wrapf(define.ErrNoSuchPod, "pod with ID %s not found", string(id))
 	}
 
 	if s.namespaceBytes != nil {
 		podNamespaceBytes := podDB.Get(namespaceKey)
 		if !bytes.Equal(s.namespaceBytes, podNamespaceBytes) {
-			return errors.Wrapf(ErrNSMismatch, "cannot retrieve pod %s as it is part of namespace %q and we are in namespace %q", string(id), string(podNamespaceBytes), s.namespace)
+			return errors.Wrapf(define.ErrNSMismatch, "cannot retrieve pod %s as it is part of namespace %q and we are in namespace %q", string(id), string(podNamespaceBytes), s.namespace)
 		}
 	}
 
 	podConfigBytes := podDB.Get(configKey)
 	if podConfigBytes == nil {
-		return errors.Wrapf(ErrInternal, "pod %s is missing configuration key in DB", string(id))
+		return errors.Wrapf(define.ErrInternal, "pod %s is missing configuration key in DB", string(id))
 	}
 
 	if err := json.Unmarshal(podConfigBytes, pod.config); err != nil {
@@ -428,12 +429,12 @@ func (s *BoltState) getPodFromDB(id []byte, pod *Pod, podBkt *bolt.Bucket) error
 func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bucket) error {
 	volDB := volBkt.Bucket(name)
 	if volDB == nil {
-		return errors.Wrapf(ErrNoSuchVolume, "volume with name %s not found", string(name))
+		return errors.Wrapf(define.ErrNoSuchVolume, "volume with name %s not found", string(name))
 	}
 
 	volConfigBytes := volDB.Get(configKey)
 	if volConfigBytes == nil {
-		return errors.Wrapf(ErrInternal, "volume %s is missing configuration key in DB", string(name))
+		return errors.Wrapf(define.ErrInternal, "volume %s is missing configuration key in DB", string(name))
 	}
 
 	if err := json.Unmarshal(volConfigBytes, volume.config); err != nil {
@@ -450,7 +451,7 @@ func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bu
 // If pod is not nil, the container is added to the pod as well
 func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 	if s.namespace != "" && s.namespace != ctr.config.Namespace {
-		return errors.Wrapf(ErrNSMismatch, "cannot add container %s as it is in namespace %q and we are in namespace %q",
+		return errors.Wrapf(define.ErrNSMismatch, "cannot add container %s as it is in namespace %q and we are in namespace %q",
 			ctr.ID(), s.namespace, ctr.config.Namespace)
 	}
 
@@ -526,16 +527,16 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 			podDB = podBucket.Bucket(podID)
 			if podDB == nil {
 				pod.valid = false
-				return errors.Wrapf(ErrNoSuchPod, "pod %s does not exist in database", pod.ID())
+				return errors.Wrapf(define.ErrNoSuchPod, "pod %s does not exist in database", pod.ID())
 			}
 			podCtrs = podDB.Bucket(containersBkt)
 			if podCtrs == nil {
-				return errors.Wrapf(ErrInternal, "pod %s does not have a containers bucket", pod.ID())
+				return errors.Wrapf(define.ErrInternal, "pod %s does not have a containers bucket", pod.ID())
 			}
 
 			podNS := podDB.Get(namespaceKey)
 			if !bytes.Equal(podNS, ctrNamespace) {
-				return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %s and pod %s is in namespace %s",
+				return errors.Wrapf(define.ErrNSMismatch, "container %s is in namespace %s and pod %s is in namespace %s",
 					ctr.ID(), ctr.config.Namespace, pod.ID(), pod.config.Namespace)
 			}
 		}
@@ -543,11 +544,11 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 		// Check if we already have a container with the given ID and name
 		idExist := idsBucket.Get(ctrID)
 		if idExist != nil {
-			return errors.Wrapf(ErrCtrExists, "ID %s is in use", ctr.ID())
+			return errors.Wrapf(define.ErrCtrExists, "ID %s is in use", ctr.ID())
 		}
 		nameExist := namesBucket.Get(ctrName)
 		if nameExist != nil {
-			return errors.Wrapf(ErrCtrExists, "name %s is in use", ctr.Name())
+			return errors.Wrapf(define.ErrCtrExists, "name %s is in use", ctr.Name())
 		}
 
 		// No overlapping containers
@@ -603,34 +604,34 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 
 			depCtrBkt := ctrBucket.Bucket(depCtrID)
 			if depCtrBkt == nil {
-				return errors.Wrapf(ErrNoSuchCtr, "container %s depends on container %s, but it does not exist in the DB", ctr.ID(), dependsCtr)
+				return errors.Wrapf(define.ErrNoSuchCtr, "container %s depends on container %s, but it does not exist in the DB", ctr.ID(), dependsCtr)
 			}
 
 			depCtrPod := depCtrBkt.Get(podIDKey)
 			if pod != nil {
 				// If we're part of a pod, make sure the dependency is part of the same pod
 				if depCtrPod == nil {
-					return errors.Wrapf(ErrInvalidArg, "container %s depends on container %s which is not in pod %s", ctr.ID(), dependsCtr, pod.ID())
+					return errors.Wrapf(define.ErrInvalidArg, "container %s depends on container %s which is not in pod %s", ctr.ID(), dependsCtr, pod.ID())
 				}
 
 				if string(depCtrPod) != pod.ID() {
-					return errors.Wrapf(ErrInvalidArg, "container %s depends on container %s which is in a different pod (%s)", ctr.ID(), dependsCtr, string(depCtrPod))
+					return errors.Wrapf(define.ErrInvalidArg, "container %s depends on container %s which is in a different pod (%s)", ctr.ID(), dependsCtr, string(depCtrPod))
 				}
 			} else {
 				// If we're not part of a pod, we cannot depend on containers in a pod
 				if depCtrPod != nil {
-					return errors.Wrapf(ErrInvalidArg, "container %s depends on container %s which is in a pod - containers not in pods cannot depend on containers in pods", ctr.ID(), dependsCtr)
+					return errors.Wrapf(define.ErrInvalidArg, "container %s depends on container %s which is in a pod - containers not in pods cannot depend on containers in pods", ctr.ID(), dependsCtr)
 				}
 			}
 
 			depNamespace := depCtrBkt.Get(namespaceKey)
 			if !bytes.Equal(ctrNamespace, depNamespace) {
-				return errors.Wrapf(ErrNSMismatch, "container %s in namespace %q depends on container %s in namespace %q - namespaces must match", ctr.ID(), ctr.config.Namespace, dependsCtr, string(depNamespace))
+				return errors.Wrapf(define.ErrNSMismatch, "container %s in namespace %q depends on container %s in namespace %q - namespaces must match", ctr.ID(), ctr.config.Namespace, dependsCtr, string(depNamespace))
 			}
 
 			depCtrDependsBkt := depCtrBkt.Bucket(dependenciesBkt)
 			if depCtrDependsBkt == nil {
-				return errors.Wrapf(ErrInternal, "container %s does not have a dependencies bucket", dependsCtr)
+				return errors.Wrapf(define.ErrInternal, "container %s does not have a dependencies bucket", dependsCtr)
 			}
 			if err := depCtrDependsBkt.Put(ctrID, ctrName); err != nil {
 				return errors.Wrapf(err, "error adding ctr %s as dependency of container %s", ctr.ID(), dependsCtr)
@@ -648,7 +649,7 @@ func (s *BoltState) addContainer(ctr *Container, pod *Pod) error {
 		for _, vol := range ctr.config.NamedVolumes {
 			volDB := volBkt.Bucket([]byte(vol.Name))
 			if volDB == nil {
-				return errors.Wrapf(ErrNoSuchVolume, "no volume with name %s found in database when adding container %s", vol.Name, ctr.ID())
+				return errors.Wrapf(define.ErrNoSuchVolume, "no volume with name %s found in database when adding container %s", vol.Name, ctr.ID())
 			}
 
 			ctrDepsBkt := volDB.Bucket(volDependenciesBkt)
@@ -714,7 +715,7 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 		podDB = podBucket.Bucket(podID)
 		if podDB == nil {
 			pod.valid = false
-			return errors.Wrapf(ErrNoSuchPod, "no pod with ID %s found in DB", pod.ID())
+			return errors.Wrapf(define.ErrNoSuchPod, "no pod with ID %s found in DB", pod.ID())
 		}
 	}
 
@@ -722,17 +723,17 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 	ctrExists := ctrBucket.Bucket(ctrID)
 	if ctrExists == nil {
 		ctr.valid = false
-		return errors.Wrapf(ErrNoSuchCtr, "no container with ID %s found in DB", ctr.ID())
+		return errors.Wrapf(define.ErrNoSuchCtr, "no container with ID %s found in DB", ctr.ID())
 	}
 
 	// Compare namespace
 	// We can't remove containers not in our namespace
 	if s.namespace != "" {
 		if s.namespace != ctr.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
+			return errors.Wrapf(define.ErrNSMismatch, "container %s is in namespace %q, does not match our namespace %q", ctr.ID(), ctr.config.Namespace, s.namespace)
 		}
 		if pod != nil && s.namespace != pod.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "pod %s is in namespace %q, does not match out namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
+			return errors.Wrapf(define.ErrNSMismatch, "pod %s is in namespace %q, does not match out namespace %q", pod.ID(), pod.config.Namespace, s.namespace)
 		}
 	}
 
@@ -745,7 +746,7 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 		} else {
 			ctrInPod := podCtrs.Get(ctrID)
 			if ctrInPod == nil {
-				return errors.Wrapf(ErrNoSuchCtr, "container %s is not in pod %s", ctr.ID(), pod.ID())
+				return errors.Wrapf(define.ErrNoSuchCtr, "container %s is not in pod %s", ctr.ID(), pod.ID())
 			}
 			if err := podCtrs.Delete(ctrID); err != nil {
 				return errors.Wrapf(err, "error removing container %s from pod %s", ctr.ID(), pod.ID())
@@ -756,7 +757,7 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 	// Does the container have dependencies?
 	ctrDepsBkt := ctrExists.Bucket(dependenciesBkt)
 	if ctrDepsBkt == nil {
-		return errors.Wrapf(ErrInternal, "container %s does not have a dependencies bucket", ctr.ID())
+		return errors.Wrapf(define.ErrInternal, "container %s does not have a dependencies bucket", ctr.ID())
 	}
 	deps := []string{}
 	err = ctrDepsBkt.ForEach(func(id, value []byte) error {
@@ -768,11 +769,11 @@ func (s *BoltState) removeContainer(ctr *Container, pod *Pod, tx *bolt.Tx) error
 		return err
 	}
 	if len(deps) != 0 {
-		return errors.Wrapf(ErrCtrExists, "container %s is a dependency of the following containers: %s", ctr.ID(), strings.Join(deps, ", "))
+		return errors.Wrapf(define.ErrCtrExists, "container %s is a dependency of the following containers: %s", ctr.ID(), strings.Join(deps, ", "))
 	}
 
 	if err := ctrBucket.DeleteBucket(ctrID); err != nil {
-		return errors.Wrapf(ErrInternal, "error deleting container %s from DB", ctr.ID())
+		return errors.Wrapf(define.ErrInternal, "error deleting container %s from DB", ctr.ID())
 	}
 
 	if err := idsBucket.Delete(ctrID); err != nil {

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	cnitypes "github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containers/image/manifest"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/lock"
 	"github.com/containers/libpod/pkg/namespaces"
 	"github.com/containers/storage"
@@ -463,7 +464,7 @@ func StringToContainerStatus(status string) (ContainerStatus, error) {
 	case ContainerStateExited.String():
 		return ContainerStateExited, nil
 	default:
-		return ContainerStateUnknown, errors.Wrapf(ErrInvalidArg, "unknown container state: %s", status)
+		return ContainerStateUnknown, errors.Wrapf(define.ErrInvalidArg, "unknown container state: %s", status)
 	}
 }
 
@@ -962,7 +963,7 @@ func (c *Container) ExecSession(id string) (*ExecSession, error) {
 
 	session, ok := c.state.ExecSessions[id]
 	if !ok {
-		return nil, errors.Wrapf(ErrNoSuchCtr, "no exec session with ID %s found in container %s", id, c.ID())
+		return nil, errors.Wrapf(define.ErrNoSuchCtr, "no exec session with ID %s found in container %s", id, c.ID())
 	}
 
 	returnSession := new(ExecSession)
@@ -987,7 +988,7 @@ func (c *Container) IPs() ([]net.IPNet, error) {
 	}
 
 	if !c.config.CreateNetNS {
-		return nil, errors.Wrapf(ErrInvalidArg, "container %s network namespace is not managed by libpod", c.ID())
+		return nil, errors.Wrapf(define.ErrInvalidArg, "container %s network namespace is not managed by libpod", c.ID())
 	}
 
 	ips := make([]net.IPNet, 0)
@@ -1015,7 +1016,7 @@ func (c *Container) Routes() ([]types.Route, error) {
 	}
 
 	if !c.config.CreateNetNS {
-		return nil, errors.Wrapf(ErrInvalidArg, "container %s network namespace is not managed by libpod", c.ID())
+		return nil, errors.Wrapf(define.ErrInvalidArg, "container %s network namespace is not managed by libpod", c.ID())
 	}
 
 	routes := make([]types.Route, 0)
@@ -1092,11 +1093,11 @@ func (c *Container) NamespacePath(ns LinuxNS) (string, error) {
 	}
 
 	if c.state.State != ContainerStateRunning && c.state.State != ContainerStatePaused {
-		return "", errors.Wrapf(ErrCtrStopped, "cannot get namespace path unless container %s is running", c.ID())
+		return "", errors.Wrapf(define.ErrCtrStopped, "cannot get namespace path unless container %s is running", c.ID())
 	}
 
 	if ns == InvalidNS {
-		return "", errors.Wrapf(ErrInvalidArg, "invalid namespace requested from container %s", c.ID())
+		return "", errors.Wrapf(define.ErrInvalidArg, "invalid namespace requested from container %s", c.ID())
 	}
 
 	return fmt.Sprintf("/proc/%d/ns/%s", c.state.PID, ns.String()), nil
@@ -1110,7 +1111,7 @@ func (c *Container) CGroupPath() (string, error) {
 	case SystemdCgroupsManager:
 		return filepath.Join(c.config.CgroupParent, createUnitName("libpod", c.ID())), nil
 	default:
-		return "", errors.Wrapf(ErrInvalidArg, "unsupported CGroup manager %s in use", c.runtime.config.CgroupManager)
+		return "", errors.Wrapf(define.ErrInvalidArg, "unsupported CGroup manager %s in use", c.runtime.config.CgroupManager)
 	}
 }
 

--- a/libpod/container_attach_linux.go
+++ b/libpod/container_attach_linux.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/kubeutils"
 	"github.com/containers/libpod/utils"
 	"github.com/docker/docker/pkg/term"
@@ -34,7 +35,7 @@ const (
 // Does not check if state is appropriate
 func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, wg *sync.WaitGroup) error {
 	if !streams.AttachOutput && !streams.AttachError && !streams.AttachInput {
-		return errors.Wrapf(ErrInvalidArg, "must provide at least one stream to attach to")
+		return errors.Wrapf(define.ErrInvalidArg, "must provide at least one stream to attach to")
 	}
 
 	// Check the validity of the provided keys first
@@ -57,7 +58,7 @@ func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan re
 // TODO add a channel to allow interrupting
 func (c *Container) attachContainerSocket(resize <-chan remotecommand.TerminalSize, detachKeys []byte, streams *AttachStreams, startContainer bool, wg *sync.WaitGroup) error {
 	if startContainer && wg == nil {
-		return errors.Wrapf(ErrInternal, "wait group not passed when startContainer set")
+		return errors.Wrapf(define.ErrInternal, "wait group not passed when startContainer set")
 	}
 
 	kubeutils.HandleResizing(resize, func(size remotecommand.TerminalSize) {
@@ -118,7 +119,7 @@ func (c *Container) attachContainerSocket(resize <-chan remotecommand.TerminalSi
 	case err := <-receiveStdoutError:
 		return err
 	case err := <-stdinDone:
-		if err == ErrDetach {
+		if err == define.ErrDetach {
 			return err
 		}
 		if streams.AttachOutput || streams.AttachError {

--- a/libpod/container_attach_unsupported.go
+++ b/libpod/container_attach_unsupported.go
@@ -5,9 +5,10 @@ package libpod
 import (
 	"sync"
 
+	"github.com/containers/libpod/libpod/define"
 	"k8s.io/client-go/tools/remotecommand"
 )
 
 func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, wg *sync.WaitGroup) error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }

--- a/libpod/container_commit.go
+++ b/libpod/container_commit.go
@@ -28,9 +28,6 @@ type ContainerCommitOptions struct {
 	Changes        []string
 }
 
-// ChangeCmds is the list of valid Changes commands to passed to the Commit call
-var ChangeCmds = []string{"CMD", "ENTRYPOINT", "ENV", "EXPOSE", "LABEL", "ONBUILD", "STOPSIGNAL", "USER", "VOLUME", "WORKDIR"}
-
 // Commit commits the changes between a container and its image, creating a new
 // image
 func (c *Container) Commit(ctx context.Context, destImage string, options ContainerCommitOptions) (*image.Image, error) {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/events"
 	"github.com/containers/libpod/pkg/ctime"
 	"github.com/containers/libpod/pkg/hooks"
@@ -23,7 +24,7 @@ import (
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -243,7 +244,7 @@ func (c *Container) handleRestartPolicy(ctx context.Context) (restarted bool, er
 	if c.state.State == ContainerStateRunning || c.state.State == ContainerStatePaused {
 		return false, nil
 	} else if c.state.State == ContainerStateUnknown {
-		return false, errors.Wrapf(ErrInternal, "invalid container state encountered in restart attempt!")
+		return false, errors.Wrapf(define.ErrInternal, "invalid container state encountered in restart attempt!")
 	}
 
 	c.newContainerEvent(events.Restart)
@@ -319,7 +320,7 @@ func (c *Container) syncContainer() error {
 	}
 
 	if !c.valid {
-		return errors.Wrapf(ErrCtrRemoved, "container %s is not valid", c.ID())
+		return errors.Wrapf(define.ErrCtrRemoved, "container %s is not valid", c.ID())
 	}
 
 	return nil
@@ -332,16 +333,16 @@ func (c *Container) setupStorage(ctx context.Context) error {
 	defer span.Finish()
 
 	if !c.valid {
-		return errors.Wrapf(ErrCtrRemoved, "container %s is not valid", c.ID())
+		return errors.Wrapf(define.ErrCtrRemoved, "container %s is not valid", c.ID())
 	}
 
 	if c.state.State != ContainerStateConfigured {
-		return errors.Wrapf(ErrCtrStateInvalid, "container %s must be in Configured state to have storage set up", c.ID())
+		return errors.Wrapf(define.ErrCtrStateInvalid, "container %s must be in Configured state to have storage set up", c.ID())
 	}
 
 	// Need both an image ID and image name, plus a bool telling us whether to use the image configuration
 	if c.config.Rootfs == "" && (c.config.RootfsImageID == "" || c.config.RootfsImageName == "") {
-		return errors.Wrapf(ErrInvalidArg, "must provide image ID and image name to use an image")
+		return errors.Wrapf(define.ErrInvalidArg, "must provide image ID and image name to use an image")
 	}
 
 	options := storage.ContainerOptions{
@@ -418,7 +419,7 @@ func (c *Container) setupStorage(ctx context.Context) error {
 // Tear down a container's storage prior to removal
 func (c *Container) teardownStorage() error {
 	if c.state.State == ContainerStateRunning || c.state.State == ContainerStatePaused {
-		return errors.Wrapf(ErrCtrStateInvalid, "cannot remove storage for container %s as it is running or paused", c.ID())
+		return errors.Wrapf(define.ErrCtrStateInvalid, "cannot remove storage for container %s as it is running or paused", c.ID())
 	}
 
 	artifacts := filepath.Join(c.config.StaticDir, artifactsDir)
@@ -478,7 +479,7 @@ func (c *Container) refresh() error {
 	}
 
 	if !c.valid {
-		return errors.Wrapf(ErrCtrRemoved, "container %s is not valid - may have been removed", c.ID())
+		return errors.Wrapf(define.ErrCtrRemoved, "container %s is not valid - may have been removed", c.ID())
 	}
 
 	// We need to get the container's temporary directory from c/storage
@@ -628,7 +629,7 @@ func (c *Container) prepareToStart(ctx context.Context, recursive bool) (err err
 		c.state.State == ContainerStateCreated ||
 		c.state.State == ContainerStateStopped ||
 		c.state.State == ContainerStateExited) {
-		return errors.Wrapf(ErrCtrStateInvalid, "container %s must be in Created or Stopped state to be started", c.ID())
+		return errors.Wrapf(define.ErrCtrStateInvalid, "container %s must be in Created or Stopped state to be started", c.ID())
 	}
 
 	if !recursive {
@@ -676,7 +677,7 @@ func (c *Container) checkDependenciesAndHandleError(ctx context.Context) error {
 	}
 	if len(notRunning) > 0 {
 		depString := strings.Join(notRunning, ",")
-		return errors.Wrapf(ErrCtrStateInvalid, "some dependencies of container %s are not started: %s", c.ID(), depString)
+		return errors.Wrapf(define.ErrCtrStateInvalid, "some dependencies of container %s are not started: %s", c.ID(), depString)
 	}
 
 	return nil
@@ -714,7 +715,7 @@ func (c *Container) startDependencies(ctx context.Context) error {
 		if len(graph.nodes) == 0 {
 			return nil
 		}
-		return errors.Wrapf(ErrNoSuchCtr, "All dependencies have dependencies of %s", c.ID())
+		return errors.Wrapf(define.ErrNoSuchCtr, "All dependencies have dependencies of %s", c.ID())
 	}
 
 	ctrErrors := make(map[string]error)
@@ -730,7 +731,7 @@ func (c *Container) startDependencies(ctx context.Context) error {
 		for _, e := range ctrErrors {
 			logrus.Errorf("%q", e)
 		}
-		return errors.Wrapf(ErrInternal, "error starting some containers")
+		return errors.Wrapf(define.ErrInternal, "error starting some containers")
 	}
 	return nil
 }
@@ -816,7 +817,7 @@ func (c *Container) checkDependenciesRunningLocked(depCtrs map[string]*Container
 	for _, dep := range deps {
 		depCtr, ok := depCtrs[dep]
 		if !ok {
-			return nil, errors.Wrapf(ErrNoSuchCtr, "container %s depends on container %s but it is not on containers passed to checkDependenciesRunning", c.ID(), dep)
+			return nil, errors.Wrapf(define.ErrNoSuchCtr, "container %s depends on container %s but it is not on containers passed to checkDependenciesRunning", c.ID(), dep)
 		}
 
 		if err := c.syncContainer(); err != nil {
@@ -964,7 +965,7 @@ func (c *Container) reinit(ctx context.Context, retainRetries bool) error {
 func (c *Container) initAndStart(ctx context.Context) (err error) {
 	// If we are ContainerStateUnknown, throw an error
 	if c.state.State == ContainerStateUnknown {
-		return errors.Wrapf(ErrCtrStateInvalid, "container %s is in an unknown state", c.ID())
+		return errors.Wrapf(define.ErrCtrStateInvalid, "container %s is in an unknown state", c.ID())
 	}
 
 	// If we are running, do nothing
@@ -973,7 +974,7 @@ func (c *Container) initAndStart(ctx context.Context) (err error) {
 	}
 	// If we are paused, throw an error
 	if c.state.State == ContainerStatePaused {
-		return errors.Wrapf(ErrCtrStateInvalid, "cannot start paused container %s", c.ID())
+		return errors.Wrapf(define.ErrCtrStateInvalid, "cannot start paused container %s", c.ID())
 	}
 
 	defer func() {
@@ -1080,7 +1081,7 @@ func (c *Container) unpause() error {
 // Internal, non-locking function to restart a container
 func (c *Container) restartWithTimeout(ctx context.Context, timeout uint) (err error) {
 	if c.state.State == ContainerStateUnknown || c.state.State == ContainerStatePaused {
-		return errors.Wrapf(ErrCtrStateInvalid, "unable to restart a container in a paused or unknown state")
+		return errors.Wrapf(define.ErrCtrStateInvalid, "unable to restart a container in a paused or unknown state")
 	}
 
 	c.newContainerEvent(events.Restart)
@@ -1489,16 +1490,16 @@ func (c *Container) copyWithTarFromImage(src, dest string) error {
 // Returns nil if safe to remove, or an error describing why it's unsafe if not.
 func (c *Container) checkReadyForRemoval() error {
 	if c.state.State == ContainerStateUnknown {
-		return errors.Wrapf(ErrCtrStateInvalid, "container %s is in invalid state", c.ID())
+		return errors.Wrapf(define.ErrCtrStateInvalid, "container %s is in invalid state", c.ID())
 	}
 
 	if c.state.State == ContainerStateRunning ||
 		c.state.State == ContainerStatePaused {
-		return errors.Wrapf(ErrCtrStateInvalid, "cannot remove container %s as it is %s - running or paused containers cannot be removed", c.ID(), c.state.State.String())
+		return errors.Wrapf(define.ErrCtrStateInvalid, "cannot remove container %s as it is %s - running or paused containers cannot be removed", c.ID(), c.state.State.String())
 	}
 
 	if len(c.state.ExecSessions) != 0 {
-		return errors.Wrapf(ErrCtrStateInvalid, "cannot remove container %s as it has active exec sessions", c.ID())
+		return errors.Wrapf(define.ErrCtrStateInvalid, "cannot remove container %s as it has active exec sessions", c.ID())
 	}
 
 	return nil

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -20,6 +20,7 @@ import (
 	cnitypes "github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containers/buildah/pkg/secrets"
+	"github.com/containers/libpod/libpod/define"
 	crioAnnotations "github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/apparmor"
 	"github.com/containers/libpod/pkg/criu"
@@ -568,7 +569,7 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 	}
 
 	if c.state.State != ContainerStateRunning {
-		return errors.Wrapf(ErrCtrStateInvalid, "%q is not running, cannot checkpoint", c.state.State)
+		return errors.Wrapf(define.ErrCtrStateInvalid, "%q is not running, cannot checkpoint", c.state.State)
 	}
 
 	if err := c.checkpointRestoreLabelLog("dump.log"); err != nil {
@@ -659,7 +660,7 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 	}
 
 	if (c.state.State != ContainerStateConfigured) && (c.state.State != ContainerStateExited) {
-		return errors.Wrapf(ErrCtrStateInvalid, "container %s is running or paused, cannot restore", c.ID())
+		return errors.Wrapf(define.ErrCtrStateInvalid, "container %s is running or paused, cannot restore", c.ID())
 	}
 
 	if options.TargetFile != "" {

--- a/libpod/container_internal_unsupported.go
+++ b/libpod/container_internal_unsupported.go
@@ -5,35 +5,36 @@ package libpod
 import (
 	"context"
 
+	"github.com/containers/libpod/libpod/define"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func (c *Container) mountSHM(shmOptions string) error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (c *Container) unmountSHM(mount string) error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (c *Container) prepare() (err error) {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (c *Container) cleanupNetwork() error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
-	return nil, ErrNotImplemented
+	return nil, define.ErrNotImplemented
 }
 
 func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointOptions) error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (c *Container) restore(ctx context.Context, options ContainerCheckpointOptions) error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (c *Container) copyOwnerAndPerms(source, dest string) error {

--- a/libpod/container_log_unsupported.go
+++ b/libpod/container_log_unsupported.go
@@ -3,9 +3,10 @@
 package libpod
 
 import (
+	"github.com/containers/libpod/libpod/define"
 	"github.com/pkg/errors"
 )
 
 func (c *Container) readFromJournal(options *LogOptions, logChannel chan *LogLine) error {
-	return errors.Wrapf(ErrOSNotSupported, "Journald logging only enabled with systemd on linux")
+	return errors.Wrapf(define.ErrOSNotSupported, "Journald logging only enabled with systemd on linux")
 }

--- a/libpod/container_top_unsupported.go
+++ b/libpod/container_top_unsupported.go
@@ -2,6 +2,8 @@
 
 package libpod
 
+import "github.com/containers/libpod/libpod/define"
+
 // GetContainerPidInformation returns process-related data of all processes in
 // the container.  The output data can be controlled via the `descriptors`
 // argument which expects format descriptors and supports all AIXformat
@@ -11,11 +13,11 @@ package libpod
 //
 // For more details, please refer to github.com/containers/psgo.
 func (c *Container) GetContainerPidInformation(descriptors []string) ([]string, error) {
-	return nil, ErrNotImplemented
+	return nil, define.ErrNotImplemented
 }
 
 // GetContainerPidInformationDescriptors returns a string slice of all supported
 // format descriptors of GetContainerPidInformation.
 func GetContainerPidInformationDescriptors() ([]string, error) {
-	return nil, ErrNotImplemented
+	return nil, define.ErrNotImplemented
 }

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -1,0 +1,10 @@
+package define
+
+var (
+	// DefaultInitPath is the default path to the container-init binary
+	DefaultInitPath = "/usr/libexec/podman/catatonit"
+)
+
+// CtrRemoveTimeout is the default number of seconds to wait after stopping a container
+// before sending the kill signal
+const CtrRemoveTimeout = 10

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -1,4 +1,4 @@
-package libpod
+package define
 
 import (
 	"errors"

--- a/libpod/healthcheck_unsupported.go
+++ b/libpod/healthcheck_unsupported.go
@@ -2,18 +2,20 @@
 
 package libpod
 
+import "github.com/containers/libpod/libpod/define"
+
 // createTimer systemd timers for healthchecks of a container
 func (c *Container) createTimer() error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 // startTimer starts a systemd timer for the healthchecks
 func (c *Container) startTimer() error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 // removeTimer removes the systemd timer and unit files
 // for the container
 func (c *Container) removeTimer() error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"strings"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/registrar"
 	"github.com/containers/storage/pkg/truncindex"
 	"github.com/pkg/errors"
@@ -99,12 +100,12 @@ func (s *InMemoryState) SetNamespace(ns string) error {
 // Container retrieves a container from its full ID
 func (s *InMemoryState) Container(id string) (*Container, error) {
 	if id == "" {
-		return nil, ErrEmptyID
+		return nil, define.ErrEmptyID
 	}
 
 	ctr, ok := s.containers[id]
 	if !ok {
-		return nil, errors.Wrapf(ErrNoSuchCtr, "no container with ID %s found", id)
+		return nil, errors.Wrapf(define.ErrNoSuchCtr, "no container with ID %s found", id)
 	}
 
 	if err := s.checkNSMatch(ctr.ID(), ctr.Namespace()); err != nil {
@@ -122,7 +123,7 @@ func (s *InMemoryState) LookupContainer(idOrName string) (*Container, error) {
 	)
 
 	if idOrName == "" {
-		return nil, ErrEmptyID
+		return nil, define.ErrEmptyID
 	}
 
 	if s.namespace != "" {
@@ -130,7 +131,7 @@ func (s *InMemoryState) LookupContainer(idOrName string) (*Container, error) {
 		if !ok {
 			// We have no containers in the namespace
 			// Return false
-			return nil, errors.Wrapf(ErrNoSuchCtr, "no container found with name or ID %s", idOrName)
+			return nil, errors.Wrapf(define.ErrNoSuchCtr, "no container found with name or ID %s", idOrName)
 		}
 		nameIndex = nsIndex.nameIndex
 		idIndex = nsIndex.idIndex
@@ -146,7 +147,7 @@ func (s *InMemoryState) LookupContainer(idOrName string) (*Container, error) {
 			fullID, err = idIndex.Get(idOrName)
 			if err != nil {
 				if err == truncindex.ErrNotExist {
-					return nil, errors.Wrapf(ErrNoSuchCtr, "no container found with name or ID %s", idOrName)
+					return nil, errors.Wrapf(define.ErrNoSuchCtr, "no container found with name or ID %s", idOrName)
 				}
 				return nil, errors.Wrapf(err, "error performing truncindex lookup for ID %s", idOrName)
 			}
@@ -158,7 +159,7 @@ func (s *InMemoryState) LookupContainer(idOrName string) (*Container, error) {
 	ctr, ok := s.containers[fullID]
 	if !ok {
 		// It's a pod, not a container
-		return nil, errors.Wrapf(ErrNoSuchCtr, "name or ID %s is a pod, not a container", idOrName)
+		return nil, errors.Wrapf(define.ErrNoSuchCtr, "name or ID %s is a pod, not a container", idOrName)
 	}
 
 	return ctr, nil
@@ -167,7 +168,7 @@ func (s *InMemoryState) LookupContainer(idOrName string) (*Container, error) {
 // HasContainer checks if a container with the given ID is present in the state
 func (s *InMemoryState) HasContainer(id string) (bool, error) {
 	if id == "" {
-		return false, ErrEmptyID
+		return false, define.ErrEmptyID
 	}
 
 	ctr, ok := s.containers[id]
@@ -182,15 +183,15 @@ func (s *InMemoryState) HasContainer(id string) (bool, error) {
 // Containers in a pod cannot be added to the state
 func (s *InMemoryState) AddContainer(ctr *Container) error {
 	if !ctr.valid {
-		return errors.Wrapf(ErrCtrRemoved, "container with ID %s is not valid", ctr.ID())
+		return errors.Wrapf(define.ErrCtrRemoved, "container with ID %s is not valid", ctr.ID())
 	}
 
 	if _, ok := s.containers[ctr.ID()]; ok {
-		return errors.Wrapf(ErrCtrExists, "container with ID %s already exists in state", ctr.ID())
+		return errors.Wrapf(define.ErrCtrExists, "container with ID %s already exists in state", ctr.ID())
 	}
 
 	if ctr.config.Pod != "" {
-		return errors.Wrapf(ErrInvalidArg, "cannot add a container that is in a pod with AddContainer, use AddContainerToPod")
+		return errors.Wrapf(define.ErrInvalidArg, "cannot add a container that is in a pod with AddContainer, use AddContainerToPod")
 	}
 
 	if err := s.checkNSMatch(ctr.ID(), ctr.Namespace()); err != nil {
@@ -204,12 +205,12 @@ func (s *InMemoryState) AddContainer(ctr *Container) error {
 	for _, depID := range depCtrs {
 		depCtr, ok := s.containers[depID]
 		if !ok {
-			return errors.Wrapf(ErrNoSuchCtr, "cannot depend on nonexistent container %s", depID)
+			return errors.Wrapf(define.ErrNoSuchCtr, "cannot depend on nonexistent container %s", depID)
 		} else if depCtr.config.Pod != "" {
-			return errors.Wrapf(ErrInvalidArg, "cannot depend on container in a pod if not part of same pod")
+			return errors.Wrapf(define.ErrInvalidArg, "cannot depend on container in a pod if not part of same pod")
 		}
 		if depCtr.config.Namespace != ctr.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %s and cannot depend on container %s in namespace %s", ctr.ID(), ctr.config.Namespace, depID, depCtr.config.Namespace)
+			return errors.Wrapf(define.ErrNSMismatch, "container %s is in namespace %s and cannot depend on container %s in namespace %s", ctr.ID(), ctr.config.Namespace, depID, depCtr.config.Namespace)
 		}
 	}
 
@@ -270,12 +271,12 @@ func (s *InMemoryState) RemoveContainer(ctr *Container) error {
 	deps, ok := s.ctrDepends[ctr.ID()]
 	if ok && len(deps) != 0 {
 		depsStr := strings.Join(deps, ", ")
-		return errors.Wrapf(ErrCtrExists, "the following containers depend on container %s: %s", ctr.ID(), depsStr)
+		return errors.Wrapf(define.ErrCtrExists, "the following containers depend on container %s: %s", ctr.ID(), depsStr)
 	}
 
 	if _, ok := s.containers[ctr.ID()]; !ok {
 		ctr.valid = false
-		return errors.Wrapf(ErrNoSuchCtr, "no container exists in state with ID %s", ctr.ID())
+		return errors.Wrapf(define.ErrNoSuchCtr, "no container exists in state with ID %s", ctr.ID())
 	}
 
 	if err := s.idIndex.Delete(ctr.ID()); err != nil {
@@ -289,7 +290,7 @@ func (s *InMemoryState) RemoveContainer(ctr *Container) error {
 	if ctr.config.Namespace != "" {
 		nsIndex, ok := s.namespaceIndexes[ctr.config.Namespace]
 		if !ok {
-			return errors.Wrapf(ErrInternal, "error retrieving index for namespace %q", ctr.config.Namespace)
+			return errors.Wrapf(define.ErrInternal, "error retrieving index for namespace %q", ctr.config.Namespace)
 		}
 		if err := nsIndex.idIndex.Delete(ctr.ID()); err != nil {
 			return errors.Wrapf(err, "error removing container %s from namespace ID index", ctr.ID())
@@ -317,13 +318,13 @@ func (s *InMemoryState) RemoveContainer(ctr *Container) error {
 func (s *InMemoryState) UpdateContainer(ctr *Container) error {
 	// If the container is invalid, return error
 	if !ctr.valid {
-		return errors.Wrapf(ErrCtrRemoved, "container with ID %s is not valid", ctr.ID())
+		return errors.Wrapf(define.ErrCtrRemoved, "container with ID %s is not valid", ctr.ID())
 	}
 
 	// If the container does not exist, return error
 	if _, ok := s.containers[ctr.ID()]; !ok {
 		ctr.valid = false
-		return errors.Wrapf(ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
+		return errors.Wrapf(define.ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
 	}
 
 	return s.checkNSMatch(ctr.ID(), ctr.Namespace())
@@ -336,13 +337,13 @@ func (s *InMemoryState) UpdateContainer(ctr *Container) error {
 func (s *InMemoryState) SaveContainer(ctr *Container) error {
 	// If the container is invalid, return error
 	if !ctr.valid {
-		return errors.Wrapf(ErrCtrRemoved, "container with ID %s is not valid", ctr.ID())
+		return errors.Wrapf(define.ErrCtrRemoved, "container with ID %s is not valid", ctr.ID())
 	}
 
 	// If the container does not exist, return error
 	if _, ok := s.containers[ctr.ID()]; !ok {
 		ctr.valid = false
-		return errors.Wrapf(ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
+		return errors.Wrapf(define.ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
 	}
 
 	return s.checkNSMatch(ctr.ID(), ctr.Namespace())
@@ -351,13 +352,13 @@ func (s *InMemoryState) SaveContainer(ctr *Container) error {
 // ContainerInUse checks if the given container is being used by other containers
 func (s *InMemoryState) ContainerInUse(ctr *Container) ([]string, error) {
 	if !ctr.valid {
-		return nil, ErrCtrRemoved
+		return nil, define.ErrCtrRemoved
 	}
 
 	// If the container does not exist, return error
 	if _, ok := s.containers[ctr.ID()]; !ok {
 		ctr.valid = false
-		return nil, errors.Wrapf(ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
+		return nil, errors.Wrapf(define.ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
 	}
 
 	if err := s.checkNSMatch(ctr.ID(), ctr.Namespace()); err != nil {
@@ -389,14 +390,14 @@ func (s *InMemoryState) AllContainers() ([]*Container, error) {
 // Please read the full comment on it in state.go before using it.
 func (s *InMemoryState) RewriteContainerConfig(ctr *Container, newCfg *ContainerConfig) error {
 	if !ctr.valid {
-		return ErrCtrRemoved
+		return define.ErrCtrRemoved
 	}
 
 	// If the container does not exist, return error
 	stateCtr, ok := s.containers[ctr.ID()]
 	if !ok {
 		ctr.valid = false
-		return errors.Wrapf(ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
+		return errors.Wrapf(define.ErrNoSuchCtr, "container with ID %s not found in state", ctr.ID())
 	}
 
 	stateCtr.config = newCfg
@@ -409,14 +410,14 @@ func (s *InMemoryState) RewriteContainerConfig(ctr *Container, newCfg *Container
 // Please read the full comment on it in state.go before using it.
 func (s *InMemoryState) RewritePodConfig(pod *Pod, newCfg *PodConfig) error {
 	if !pod.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	// If the pod does not exist, return error
 	statePod, ok := s.pods[pod.ID()]
 	if !ok {
 		pod.valid = false
-		return errors.Wrapf(ErrNoSuchPod, "pod with ID %s not found in state", pod.ID())
+		return errors.Wrapf(define.ErrNoSuchPod, "pod with ID %s not found in state", pod.ID())
 	}
 
 	statePod.config = newCfg
@@ -427,12 +428,12 @@ func (s *InMemoryState) RewritePodConfig(pod *Pod, newCfg *PodConfig) error {
 // Volume retrieves a volume from its full name
 func (s *InMemoryState) Volume(name string) (*Volume, error) {
 	if name == "" {
-		return nil, ErrEmptyID
+		return nil, define.ErrEmptyID
 	}
 
 	vol, ok := s.volumes[name]
 	if !ok {
-		return nil, errors.Wrapf(ErrNoSuchCtr, "no volume with name %s found", name)
+		return nil, errors.Wrapf(define.ErrNoSuchCtr, "no volume with name %s found", name)
 	}
 
 	return vol, nil
@@ -441,7 +442,7 @@ func (s *InMemoryState) Volume(name string) (*Volume, error) {
 // HasVolume checks if a volume with the given name is present in the state
 func (s *InMemoryState) HasVolume(name string) (bool, error) {
 	if name == "" {
-		return false, ErrEmptyID
+		return false, define.ErrEmptyID
 	}
 
 	_, ok := s.volumes[name]
@@ -455,11 +456,11 @@ func (s *InMemoryState) HasVolume(name string) (bool, error) {
 // AddVolume adds a volume to the state
 func (s *InMemoryState) AddVolume(volume *Volume) error {
 	if !volume.valid {
-		return errors.Wrapf(ErrVolumeRemoved, "volume with name %s is not valid", volume.Name())
+		return errors.Wrapf(define.ErrVolumeRemoved, "volume with name %s is not valid", volume.Name())
 	}
 
 	if _, ok := s.volumes[volume.Name()]; ok {
-		return errors.Wrapf(ErrVolumeExists, "volume with name %s already exists in state", volume.Name())
+		return errors.Wrapf(define.ErrVolumeExists, "volume with name %s already exists in state", volume.Name())
 	}
 
 	s.volumes[volume.Name()] = volume
@@ -473,12 +474,12 @@ func (s *InMemoryState) RemoveVolume(volume *Volume) error {
 	deps, ok := s.volumeDepends[volume.Name()]
 	if ok && len(deps) != 0 {
 		depsStr := strings.Join(deps, ", ")
-		return errors.Wrapf(ErrVolumeExists, "the following containers depend on volume %s: %s", volume.Name(), depsStr)
+		return errors.Wrapf(define.ErrVolumeExists, "the following containers depend on volume %s: %s", volume.Name(), depsStr)
 	}
 
 	if _, ok := s.volumes[volume.Name()]; !ok {
 		volume.valid = false
-		return errors.Wrapf(ErrVolumeRemoved, "no volume exists in state with name %s", volume.Name())
+		return errors.Wrapf(define.ErrVolumeRemoved, "no volume exists in state with name %s", volume.Name())
 	}
 
 	delete(s.volumes, volume.Name())
@@ -489,13 +490,13 @@ func (s *InMemoryState) RemoveVolume(volume *Volume) error {
 // VolumeInUse checks if the given volume is being used by at least one container
 func (s *InMemoryState) VolumeInUse(volume *Volume) ([]string, error) {
 	if !volume.valid {
-		return nil, ErrVolumeRemoved
+		return nil, define.ErrVolumeRemoved
 	}
 
 	// If the volume does not exist, return error
 	if _, ok := s.volumes[volume.Name()]; !ok {
 		volume.valid = false
-		return nil, errors.Wrapf(ErrNoSuchVolume, "volume with name %s not found in state", volume.Name())
+		return nil, errors.Wrapf(define.ErrNoSuchVolume, "volume with name %s not found in state", volume.Name())
 	}
 
 	arr, ok := s.volumeDepends[volume.Name()]
@@ -519,12 +520,12 @@ func (s *InMemoryState) AllVolumes() ([]*Volume, error) {
 // Pod retrieves a pod from the state from its full ID
 func (s *InMemoryState) Pod(id string) (*Pod, error) {
 	if id == "" {
-		return nil, ErrEmptyID
+		return nil, define.ErrEmptyID
 	}
 
 	pod, ok := s.pods[id]
 	if !ok {
-		return nil, errors.Wrapf(ErrNoSuchPod, "no pod with id %s found", id)
+		return nil, errors.Wrapf(define.ErrNoSuchPod, "no pod with id %s found", id)
 	}
 
 	if err := s.checkNSMatch(pod.ID(), pod.Namespace()); err != nil {
@@ -543,7 +544,7 @@ func (s *InMemoryState) LookupPod(idOrName string) (*Pod, error) {
 	)
 
 	if idOrName == "" {
-		return nil, ErrEmptyID
+		return nil, define.ErrEmptyID
 	}
 
 	if s.namespace != "" {
@@ -551,7 +552,7 @@ func (s *InMemoryState) LookupPod(idOrName string) (*Pod, error) {
 		if !ok {
 			// We have no containers in the namespace
 			// Return false
-			return nil, errors.Wrapf(ErrNoSuchCtr, "no container found with name or ID %s", idOrName)
+			return nil, errors.Wrapf(define.ErrNoSuchCtr, "no container found with name or ID %s", idOrName)
 		}
 		nameIndex = nsIndex.nameIndex
 		idIndex = nsIndex.idIndex
@@ -567,7 +568,7 @@ func (s *InMemoryState) LookupPod(idOrName string) (*Pod, error) {
 			fullID, err = idIndex.Get(idOrName)
 			if err != nil {
 				if err == truncindex.ErrNotExist {
-					return nil, errors.Wrapf(ErrNoSuchPod, "no pod found with name or ID %s", idOrName)
+					return nil, errors.Wrapf(define.ErrNoSuchPod, "no pod found with name or ID %s", idOrName)
 				}
 				return nil, errors.Wrapf(err, "error performing truncindex lookup for ID %s", idOrName)
 			}
@@ -579,7 +580,7 @@ func (s *InMemoryState) LookupPod(idOrName string) (*Pod, error) {
 	pod, ok := s.pods[fullID]
 	if !ok {
 		// It's a container not a pod
-		return nil, errors.Wrapf(ErrNoSuchPod, "id or name %s is a container not a pod", idOrName)
+		return nil, errors.Wrapf(define.ErrNoSuchPod, "id or name %s is a container not a pod", idOrName)
 	}
 
 	return pod, nil
@@ -588,7 +589,7 @@ func (s *InMemoryState) LookupPod(idOrName string) (*Pod, error) {
 // HasPod checks if a pod with the given ID is present in the state
 func (s *InMemoryState) HasPod(id string) (bool, error) {
 	if id == "" {
-		return false, ErrEmptyID
+		return false, define.ErrEmptyID
 	}
 
 	pod, ok := s.pods[id]
@@ -602,11 +603,11 @@ func (s *InMemoryState) HasPod(id string) (bool, error) {
 // PodHasContainer checks if the given pod has a container with the given ID
 func (s *InMemoryState) PodHasContainer(pod *Pod, ctrID string) (bool, error) {
 	if !pod.valid {
-		return false, errors.Wrapf(ErrPodRemoved, "pod %s is not valid", pod.ID())
+		return false, errors.Wrapf(define.ErrPodRemoved, "pod %s is not valid", pod.ID())
 	}
 
 	if ctrID == "" {
-		return false, ErrEmptyID
+		return false, define.ErrEmptyID
 	}
 
 	if err := s.checkNSMatch(pod.ID(), pod.Namespace()); err != nil {
@@ -616,7 +617,7 @@ func (s *InMemoryState) PodHasContainer(pod *Pod, ctrID string) (bool, error) {
 	podCtrs, ok := s.podContainers[pod.ID()]
 	if !ok {
 		pod.valid = false
-		return false, errors.Wrapf(ErrNoSuchPod, "no pod with ID %s found in state", pod.ID())
+		return false, errors.Wrapf(define.ErrNoSuchPod, "no pod with ID %s found in state", pod.ID())
 	}
 
 	_, ok = podCtrs[ctrID]
@@ -626,7 +627,7 @@ func (s *InMemoryState) PodHasContainer(pod *Pod, ctrID string) (bool, error) {
 // PodContainersByID returns the IDs of all containers in the given pod
 func (s *InMemoryState) PodContainersByID(pod *Pod) ([]string, error) {
 	if !pod.valid {
-		return nil, errors.Wrapf(ErrPodRemoved, "pod %s is not valid", pod.ID())
+		return nil, errors.Wrapf(define.ErrPodRemoved, "pod %s is not valid", pod.ID())
 	}
 
 	if err := s.checkNSMatch(pod.ID(), pod.Namespace()); err != nil {
@@ -636,7 +637,7 @@ func (s *InMemoryState) PodContainersByID(pod *Pod) ([]string, error) {
 	podCtrs, ok := s.podContainers[pod.ID()]
 	if !ok {
 		pod.valid = false
-		return nil, errors.Wrapf(ErrNoSuchPod, "no pod with ID %s found in state", pod.ID())
+		return nil, errors.Wrapf(define.ErrNoSuchPod, "no pod with ID %s found in state", pod.ID())
 	}
 
 	length := len(podCtrs)
@@ -655,7 +656,7 @@ func (s *InMemoryState) PodContainersByID(pod *Pod) ([]string, error) {
 // PodContainers retrieves the containers from a pod
 func (s *InMemoryState) PodContainers(pod *Pod) ([]*Container, error) {
 	if !pod.valid {
-		return nil, errors.Wrapf(ErrPodRemoved, "pod %s is not valid", pod.ID())
+		return nil, errors.Wrapf(define.ErrPodRemoved, "pod %s is not valid", pod.ID())
 	}
 
 	if err := s.checkNSMatch(pod.ID(), pod.Namespace()); err != nil {
@@ -665,7 +666,7 @@ func (s *InMemoryState) PodContainers(pod *Pod) ([]*Container, error) {
 	podCtrs, ok := s.podContainers[pod.ID()]
 	if !ok {
 		pod.valid = false
-		return nil, errors.Wrapf(ErrNoSuchPod, "no pod with ID %s found in state", pod.ID())
+		return nil, errors.Wrapf(define.ErrNoSuchPod, "no pod with ID %s found in state", pod.ID())
 	}
 
 	length := len(podCtrs)
@@ -684,7 +685,7 @@ func (s *InMemoryState) PodContainers(pod *Pod) ([]*Container, error) {
 // AddPod adds a given pod to the state
 func (s *InMemoryState) AddPod(pod *Pod) error {
 	if !pod.valid {
-		return errors.Wrapf(ErrPodRemoved, "pod %s is not valid and cannot be added", pod.ID())
+		return errors.Wrapf(define.ErrPodRemoved, "pod %s is not valid and cannot be added", pod.ID())
 	}
 
 	if err := s.checkNSMatch(pod.ID(), pod.Namespace()); err != nil {
@@ -692,11 +693,11 @@ func (s *InMemoryState) AddPod(pod *Pod) error {
 	}
 
 	if _, ok := s.pods[pod.ID()]; ok {
-		return errors.Wrapf(ErrPodExists, "pod with ID %s already exists in state", pod.ID())
+		return errors.Wrapf(define.ErrPodExists, "pod with ID %s already exists in state", pod.ID())
 	}
 
 	if _, ok := s.podContainers[pod.ID()]; ok {
-		return errors.Wrapf(ErrPodExists, "pod with ID %s already exists in state", pod.ID())
+		return errors.Wrapf(define.ErrPodExists, "pod with ID %s already exists in state", pod.ID())
 	}
 
 	if err := s.nameIndex.Reserve(pod.Name(), pod.ID()); err != nil {
@@ -746,15 +747,15 @@ func (s *InMemoryState) RemovePod(pod *Pod) error {
 
 	if _, ok := s.pods[pod.ID()]; !ok {
 		pod.valid = false
-		return errors.Wrapf(ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
+		return errors.Wrapf(define.ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
 	}
 	podCtrs, ok := s.podContainers[pod.ID()]
 	if !ok {
 		pod.valid = false
-		return errors.Wrapf(ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
+		return errors.Wrapf(define.ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
 	}
 	if len(podCtrs) != 0 {
-		return errors.Wrapf(ErrCtrExists, "pod %s is not empty and cannot be removed", pod.ID())
+		return errors.Wrapf(define.ErrCtrExists, "pod %s is not empty and cannot be removed", pod.ID())
 	}
 
 	if err := s.idIndex.Delete(pod.ID()); err != nil {
@@ -767,7 +768,7 @@ func (s *InMemoryState) RemovePod(pod *Pod) error {
 	if pod.config.Namespace != "" {
 		nsIndex, ok := s.namespaceIndexes[pod.config.Namespace]
 		if !ok {
-			return errors.Wrapf(ErrInternal, "error retrieving index for namespace %q", pod.config.Namespace)
+			return errors.Wrapf(define.ErrInternal, "error retrieving index for namespace %q", pod.config.Namespace)
 		}
 		if err := nsIndex.idIndex.Delete(pod.ID()); err != nil {
 			return errors.Wrapf(err, "error removing container %s from namespace ID index", pod.ID())
@@ -784,7 +785,7 @@ func (s *InMemoryState) RemovePod(pod *Pod) error {
 // Will only remove containers if no dependencies outside of the pod are present
 func (s *InMemoryState) RemovePodContainers(pod *Pod) error {
 	if !pod.valid {
-		return errors.Wrapf(ErrPodRemoved, "pod %s is not valid", pod.ID())
+		return errors.Wrapf(define.ErrPodRemoved, "pod %s is not valid", pod.ID())
 	}
 
 	if err := s.checkNSMatch(pod.ID(), pod.Namespace()); err != nil {
@@ -795,7 +796,7 @@ func (s *InMemoryState) RemovePodContainers(pod *Pod) error {
 	podCtrs, ok := s.podContainers[pod.ID()]
 	if !ok {
 		pod.valid = false
-		return errors.Wrapf(ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
+		return errors.Wrapf(define.ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
 	}
 
 	// Go through container dependencies. Check to see if any are outside the pod.
@@ -804,7 +805,7 @@ func (s *InMemoryState) RemovePodContainers(pod *Pod) error {
 		if ok {
 			for _, dep := range ctrDeps {
 				if _, ok := podCtrs[dep]; !ok {
-					return errors.Wrapf(ErrCtrExists, "container %s has dependency %s outside of pod %s", ctr, dep, pod.ID())
+					return errors.Wrapf(define.ErrCtrExists, "container %s has dependency %s outside of pod %s", ctr, dep, pod.ID())
 				}
 			}
 		}
@@ -830,18 +831,18 @@ func (s *InMemoryState) RemovePodContainers(pod *Pod) error {
 // state
 func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 	if !pod.valid {
-		return errors.Wrapf(ErrPodRemoved, "pod %s is not valid", pod.ID())
+		return errors.Wrapf(define.ErrPodRemoved, "pod %s is not valid", pod.ID())
 	}
 	if !ctr.valid {
-		return errors.Wrapf(ErrCtrRemoved, "container %s is not valid", ctr.ID())
+		return errors.Wrapf(define.ErrCtrRemoved, "container %s is not valid", ctr.ID())
 	}
 
 	if ctr.config.Pod != pod.ID() {
-		return errors.Wrapf(ErrInvalidArg, "container %s is not in pod %s", ctr.ID(), pod.ID())
+		return errors.Wrapf(define.ErrInvalidArg, "container %s is not in pod %s", ctr.ID(), pod.ID())
 	}
 
 	if ctr.config.Namespace != pod.config.Namespace {
-		return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %s and pod %s is in namespace %s",
+		return errors.Wrapf(define.ErrNSMismatch, "container %s is in namespace %s and pod %s is in namespace %s",
 			ctr.ID(), ctr.config.Namespace, pod.ID(), pod.config.Namespace)
 	}
 
@@ -853,12 +854,12 @@ func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 	podCtrs, ok := s.podContainers[pod.ID()]
 	if !ok {
 		pod.valid = false
-		return errors.Wrapf(ErrPodRemoved, "pod %s not found in state", pod.ID())
+		return errors.Wrapf(define.ErrPodRemoved, "pod %s not found in state", pod.ID())
 	}
 
 	// Is the container already in the pod?
 	if _, ok = podCtrs[ctr.ID()]; ok {
-		return errors.Wrapf(ErrCtrExists, "container with ID %s already exists in pod %s", ctr.ID(), pod.ID())
+		return errors.Wrapf(define.ErrCtrExists, "container with ID %s already exists in pod %s", ctr.ID(), pod.ID())
 	}
 
 	// There are potential race conditions with this
@@ -867,20 +868,20 @@ func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 	depCtrs := ctr.Dependencies()
 	for _, depCtr := range depCtrs {
 		if _, ok = s.containers[depCtr]; !ok {
-			return errors.Wrapf(ErrNoSuchCtr, "cannot depend on nonexistent container %s", depCtr)
+			return errors.Wrapf(define.ErrNoSuchCtr, "cannot depend on nonexistent container %s", depCtr)
 		}
 		depCtrStruct, ok := podCtrs[depCtr]
 		if !ok {
-			return errors.Wrapf(ErrInvalidArg, "cannot depend on container %s as it is not in pod %s", depCtr, pod.ID())
+			return errors.Wrapf(define.ErrInvalidArg, "cannot depend on container %s as it is not in pod %s", depCtr, pod.ID())
 		}
 		if depCtrStruct.config.Namespace != ctr.config.Namespace {
-			return errors.Wrapf(ErrNSMismatch, "container %s is in namespace %s and cannot depend on container %s in namespace %s", ctr.ID(), ctr.config.Namespace, depCtr, depCtrStruct.config.Namespace)
+			return errors.Wrapf(define.ErrNSMismatch, "container %s is in namespace %s and cannot depend on container %s in namespace %s", ctr.ID(), ctr.config.Namespace, depCtr, depCtrStruct.config.Namespace)
 		}
 	}
 
 	// Add container to state
 	if _, ok = s.containers[ctr.ID()]; ok {
-		return errors.Wrapf(ErrCtrExists, "container with ID %s already exists in state", ctr.ID())
+		return errors.Wrapf(define.ErrCtrExists, "container with ID %s already exists in state", ctr.ID())
 	}
 
 	if err := s.nameIndex.Reserve(ctr.Name(), ctr.ID()); err != nil {
@@ -928,10 +929,10 @@ func (s *InMemoryState) AddContainerToPod(pod *Pod, ctr *Container) error {
 // The container is also removed from the state
 func (s *InMemoryState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 	if !pod.valid {
-		return errors.Wrapf(ErrPodRemoved, "pod %s is not valid and containers cannot be removed", pod.ID())
+		return errors.Wrapf(define.ErrPodRemoved, "pod %s is not valid and containers cannot be removed", pod.ID())
 	}
 	if !ctr.valid {
-		return errors.Wrapf(ErrCtrRemoved, "container %s is not valid and cannot be removed from the pod", ctr.ID())
+		return errors.Wrapf(define.ErrCtrRemoved, "container %s is not valid and cannot be removed from the pod", ctr.ID())
 	}
 
 	if err := s.checkNSMatch(ctr.ID(), ctr.Namespace()); err != nil {
@@ -942,30 +943,30 @@ func (s *InMemoryState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 	deps, ok := s.ctrDepends[ctr.ID()]
 	if ok && len(deps) != 0 {
 		depsStr := strings.Join(deps, ", ")
-		return errors.Wrapf(ErrCtrExists, "the following containers depend on container %s: %s", ctr.ID(), depsStr)
+		return errors.Wrapf(define.ErrCtrExists, "the following containers depend on container %s: %s", ctr.ID(), depsStr)
 	}
 
 	// Retrieve pod containers
 	podCtrs, ok := s.podContainers[pod.ID()]
 	if !ok {
 		pod.valid = false
-		return errors.Wrapf(ErrPodRemoved, "pod %s has been removed", pod.ID())
+		return errors.Wrapf(define.ErrPodRemoved, "pod %s has been removed", pod.ID())
 	}
 
 	// Does the container exist?
 	if _, ok := s.containers[ctr.ID()]; !ok {
 		ctr.valid = false
-		return errors.Wrapf(ErrNoSuchCtr, "container %s does not exist in state", ctr.ID())
+		return errors.Wrapf(define.ErrNoSuchCtr, "container %s does not exist in state", ctr.ID())
 	}
 
 	// Is the container in the pod?
 	if _, ok := podCtrs[ctr.ID()]; !ok {
-		return errors.Wrapf(ErrNoSuchCtr, "container with ID %s not found in pod %s", ctr.ID(), pod.ID())
+		return errors.Wrapf(define.ErrNoSuchCtr, "container with ID %s not found in pod %s", ctr.ID(), pod.ID())
 	}
 
 	// Remove container from state
 	if _, ok := s.containers[ctr.ID()]; !ok {
-		return errors.Wrapf(ErrNoSuchCtr, "no container exists in state with ID %s", ctr.ID())
+		return errors.Wrapf(define.ErrNoSuchCtr, "no container exists in state with ID %s", ctr.ID())
 	}
 
 	if err := s.idIndex.Delete(ctr.ID()); err != nil {
@@ -980,7 +981,7 @@ func (s *InMemoryState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 	if ctr.config.Namespace != "" {
 		nsIndex, ok := s.namespaceIndexes[ctr.config.Namespace]
 		if !ok {
-			return errors.Wrapf(ErrInternal, "error retrieving index for namespace %q", ctr.config.Namespace)
+			return errors.Wrapf(define.ErrInternal, "error retrieving index for namespace %q", ctr.config.Namespace)
 		}
 		if err := nsIndex.idIndex.Delete(ctr.ID()); err != nil {
 			return errors.Wrapf(err, "error removing container %s from namespace ID index", ctr.ID())
@@ -1001,7 +1002,7 @@ func (s *InMemoryState) RemoveContainerFromPod(pod *Pod, ctr *Container) error {
 // This is a no-op as there is no backing store
 func (s *InMemoryState) UpdatePod(pod *Pod) error {
 	if !pod.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	if err := s.checkNSMatch(pod.ID(), pod.Namespace()); err != nil {
@@ -1010,7 +1011,7 @@ func (s *InMemoryState) UpdatePod(pod *Pod) error {
 
 	if _, ok := s.pods[pod.ID()]; !ok {
 		pod.valid = false
-		return errors.Wrapf(ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
+		return errors.Wrapf(define.ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
 	}
 
 	return nil
@@ -1020,7 +1021,7 @@ func (s *InMemoryState) UpdatePod(pod *Pod) error {
 // This is a no-op at there is no backing store
 func (s *InMemoryState) SavePod(pod *Pod) error {
 	if !pod.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	if err := s.checkNSMatch(pod.ID(), pod.Namespace()); err != nil {
@@ -1029,7 +1030,7 @@ func (s *InMemoryState) SavePod(pod *Pod) error {
 
 	if _, ok := s.pods[pod.ID()]; !ok {
 		pod.valid = false
-		return errors.Wrapf(ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
+		return errors.Wrapf(define.ErrNoSuchPod, "no pod exists in state with ID %s", pod.ID())
 	}
 
 	return nil
@@ -1133,7 +1134,7 @@ func (s *InMemoryState) removeCtrFromVolDependsMap(depCtrID, volName string) {
 // namespaces.
 func (s *InMemoryState) checkNSMatch(id, ns string) error {
 	if s.namespace != "" && s.namespace != ns {
-		return errors.Wrapf(ErrNSMismatch, "cannot access %s as it is in namespace %q and we are in namespace %q",
+		return errors.Wrapf(define.ErrNSMismatch, "cannot access %s as it is in namespace %q and we are in namespace %q",
 			id, ns, s.namespace)
 	}
 	return nil

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/lookup"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/cri-o/ocicni/pkg/ocicni"
@@ -209,7 +210,7 @@ func containerToV1Container(c *Container) (v1.Container, error) {
 			return kubeContainer, err
 		}
 		kubeContainer.VolumeDevices = devices
-		return kubeContainer, errors.Wrapf(ErrNotImplemented, "linux devices")
+		return kubeContainer, errors.Wrapf(define.ErrNotImplemented, "linux devices")
 	}
 
 	if len(c.config.UserVolumes) > 0 {

--- a/libpod/networking_unsupported.go
+++ b/libpod/networking_unsupported.go
@@ -2,20 +2,22 @@
 
 package libpod
 
+import "github.com/containers/libpod/libpod/define"
+
 func (r *Runtime) setupRootlessNetNS(ctr *Container) (err error) {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (r *Runtime) setupNetNS(ctr *Container) (err error) {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (r *Runtime) teardownNetNS(ctr *Container) error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (r *Runtime) createNetNS(ctr *Container) (err error) {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (c *Container) getContainerNetworkInfo(data *InspectContainerData) *InspectContainerData {

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -79,7 +80,7 @@ type ociError struct {
 // The first path that points to a valid executable will be used.
 func newOCIRuntime(name string, paths []string, conmonPath string, runtimeCfg *RuntimeConfig, supportsJSON bool) (*OCIRuntime, error) {
 	if name == "" {
-		return nil, errors.Wrapf(ErrInvalidArg, "the OCI runtime must be provided a non-empty name")
+		return nil, errors.Wrapf(define.ErrInvalidArg, "the OCI runtime must be provided a non-empty name")
 	}
 
 	runtime := new(OCIRuntime)
@@ -114,14 +115,14 @@ func newOCIRuntime(name string, paths []string, conmonPath string, runtimeCfg *R
 		break
 	}
 	if !foundPath {
-		return nil, errors.Wrapf(ErrInvalidArg, "no valid executable found for OCI runtime %s", name)
+		return nil, errors.Wrapf(define.ErrInvalidArg, "no valid executable found for OCI runtime %s", name)
 	}
 
 	runtime.exitsDir = filepath.Join(runtime.tmpDir, "exits")
 	runtime.socketsDir = filepath.Join(runtime.tmpDir, "socket")
 
 	if runtime.cgroupManager != CgroupfsCgroupsManager && runtime.cgroupManager != SystemdCgroupsManager {
-		return nil, errors.Wrapf(ErrInvalidArg, "invalid cgroup manager specified: %s", runtime.cgroupManager)
+		return nil, errors.Wrapf(define.ErrInvalidArg, "invalid cgroup manager specified: %s", runtime.cgroupManager)
 	}
 
 	// Create the exit files and attach sockets directories
@@ -290,7 +291,7 @@ func (r *OCIRuntime) updateContainerStatus(ctr *Container, useRuntime bool) erro
 	case "stopped":
 		ctr.state.State = ContainerStateStopped
 	default:
-		return errors.Wrapf(ErrInternal, "unrecognized status returned by runtime for container %s: %s",
+		return errors.Wrapf(define.ErrInternal, "unrecognized status returned by runtime for container %s: %s",
 			ctr.ID(), state.Status)
 	}
 
@@ -390,11 +391,11 @@ func (r *OCIRuntime) unpauseContainer(ctr *Container) error {
 // TODO: add --pid-file and use that to generate exec session tracking
 func (r *OCIRuntime) execContainer(c *Container, cmd, capAdd, env []string, tty bool, cwd, user, sessionID string, streams *AttachStreams, preserveFDs int) (*exec.Cmd, error) {
 	if len(cmd) == 0 {
-		return nil, errors.Wrapf(ErrInvalidArg, "must provide a command to execute")
+		return nil, errors.Wrapf(define.ErrInvalidArg, "must provide a command to execute")
 	}
 
 	if sessionID == "" {
-		return nil, errors.Wrapf(ErrEmptyID, "must provide a session ID for exec")
+		return nil, errors.Wrapf(define.ErrEmptyID, "must provide a session ID for exec")
 	}
 
 	runtimeDir, err := util.GetRootlessRuntimeDir()

--- a/libpod/oci_linux.go
+++ b/libpod/oci_linux.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/containerd/cgroups"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/libpod/utils"
@@ -430,19 +431,19 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, res
 				if err == nil {
 					var ociErr ociError
 					if err := json.Unmarshal(data, &ociErr); err == nil {
-						return errors.Wrapf(ErrOCIRuntime, "%s", strings.Trim(ociErr.Msg, "\n"))
+						return errors.Wrapf(define.ErrOCIRuntime, "%s", strings.Trim(ociErr.Msg, "\n"))
 					}
 				}
 			}
 			// If we failed to parse the JSON errors, then print the output as it is
 			if ss.si.Message != "" {
-				return errors.Wrapf(ErrOCIRuntime, "%s", ss.si.Message)
+				return errors.Wrapf(define.ErrOCIRuntime, "%s", ss.si.Message)
 			}
-			return errors.Wrapf(ErrInternal, "container create failed")
+			return errors.Wrapf(define.ErrInternal, "container create failed")
 		}
 		ctr.state.PID = ss.si.Pid
 	case <-time.After(ContainerCreateTimeout):
-		return errors.Wrapf(ErrInternal, "container creation timeout")
+		return errors.Wrapf(define.ErrInternal, "container creation timeout")
 	}
 	return nil
 }

--- a/libpod/oci_unsupported.go
+++ b/libpod/oci_unsupported.go
@@ -5,18 +5,20 @@ package libpod
 import (
 	"os"
 	"os/exec"
+
+	"github.com/containers/libpod/libpod/define"
 )
 
 func (r *OCIRuntime) moveConmonToCgroup(ctr *Container, cgroupParent string, cmd *exec.Cmd) error {
-	return ErrOSNotSupported
+	return define.ErrOSNotSupported
 }
 
 func newPipe() (parent *os.File, child *os.File, err error) {
-	return nil, nil, ErrNotImplemented
+	return nil, nil, define.ErrNotImplemented
 }
 
 func (r *OCIRuntime) createContainer(ctr *Container, cgroupParent string, restoreOptions *ContainerCheckpointOptions) (err error) {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (r *OCIRuntime) pathPackage() string {
@@ -28,13 +30,13 @@ func (r *OCIRuntime) conmonPackage() string {
 }
 
 func (r *OCIRuntime) createOCIContainer(ctr *Container, cgroupParent string, restoreOptions *ContainerCheckpointOptions) (err error) {
-	return ErrOSNotSupported
+	return define.ErrOSNotSupported
 }
 
 func (r *OCIRuntime) execStopContainer(ctr *Container, timeout uint) error {
-	return ErrOSNotSupported
+	return define.ErrOSNotSupported
 }
 
 func (r *OCIRuntime) stopContainer(ctr *Container, timeout uint) error {
-	return ErrOSNotSupported
+	return define.ErrOSNotSupported
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/containers/image/manifest"
+	config2 "github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/namespaces"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/util"
@@ -19,7 +20,7 @@ import (
 
 var (
 	nameRegex  = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
-	regexError = errors.Wrapf(ErrInvalidArg, "names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*")
+	regexError = errors.Wrapf(config2.ErrInvalidArg, "names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*")
 )
 
 // Runtime Creation Options
@@ -30,7 +31,7 @@ var (
 func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		setField := false
@@ -104,7 +105,7 @@ func WithStorageConfig(config storage.StoreOptions) RuntimeOption {
 func WithDefaultTransport(defaultTransport string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.ImageDefaultTransport = defaultTransport
@@ -120,7 +121,7 @@ func WithDefaultTransport(defaultTransport string) RuntimeOption {
 func WithSignaturePolicy(path string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.SignaturePolicyPath = path
@@ -136,11 +137,11 @@ func WithSignaturePolicy(path string) RuntimeOption {
 func WithStateType(storeType RuntimeStateStore) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		if storeType == InvalidStateStore {
-			return errors.Wrapf(ErrInvalidArg, "must provide a valid state store type")
+			return errors.Wrapf(config2.ErrInvalidArg, "must provide a valid state store type")
 		}
 
 		rt.config.StateType = storeType
@@ -153,11 +154,11 @@ func WithStateType(storeType RuntimeStateStore) RuntimeOption {
 func WithOCIRuntime(runtime string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		if runtime == "" {
-			return errors.Wrapf(ErrInvalidArg, "must provide a valid path")
+			return errors.Wrapf(config2.ErrInvalidArg, "must provide a valid path")
 		}
 
 		rt.config.OCIRuntime = runtime
@@ -172,11 +173,11 @@ func WithOCIRuntime(runtime string) RuntimeOption {
 func WithConmonPath(path string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		if path == "" {
-			return errors.Wrapf(ErrInvalidArg, "must provide a valid path")
+			return errors.Wrapf(config2.ErrInvalidArg, "must provide a valid path")
 		}
 
 		rt.config.ConmonPath = []string{path}
@@ -189,7 +190,7 @@ func WithConmonPath(path string) RuntimeOption {
 func WithConmonEnv(environment []string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.ConmonEnvVars = make([]string, len(environment))
@@ -204,7 +205,7 @@ func WithConmonEnv(environment []string) RuntimeOption {
 func WithNetworkCmdPath(path string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.NetworkCmdPath = path
@@ -219,11 +220,11 @@ func WithNetworkCmdPath(path string) RuntimeOption {
 func WithCgroupManager(manager string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		if manager != CgroupfsCgroupsManager && manager != SystemdCgroupsManager {
-			return errors.Wrapf(ErrInvalidArg, "CGroup manager must be one of %s and %s",
+			return errors.Wrapf(config2.ErrInvalidArg, "CGroup manager must be one of %s and %s",
 				CgroupfsCgroupsManager, SystemdCgroupsManager)
 		}
 
@@ -238,7 +239,7 @@ func WithCgroupManager(manager string) RuntimeOption {
 func WithStaticDir(dir string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.StaticDir = dir
@@ -252,12 +253,12 @@ func WithStaticDir(dir string) RuntimeOption {
 func WithHooksDir(hooksDirs ...string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		for _, hooksDir := range hooksDirs {
 			if hooksDir == "" {
-				return errors.Wrap(ErrInvalidArg, "empty-string hook directories are not supported")
+				return errors.Wrap(config2.ErrInvalidArg, "empty-string hook directories are not supported")
 			}
 		}
 
@@ -273,11 +274,11 @@ func WithHooksDir(hooksDirs ...string) RuntimeOption {
 func WithDefaultMountsFile(mountsFile string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		if mountsFile == "" {
-			return ErrInvalidArg
+			return config2.ErrInvalidArg
 		}
 		rt.config.DefaultMountsFile = mountsFile
 		return nil
@@ -290,7 +291,7 @@ func WithDefaultMountsFile(mountsFile string) RuntimeOption {
 func WithTmpDir(dir string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 		rt.config.TmpDir = dir
 		rt.configuredFrom.libpodTmpDirSet = true
@@ -304,7 +305,7 @@ func WithTmpDir(dir string) RuntimeOption {
 func WithMaxLogSize(limit int64) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.MaxLogSize = limit
@@ -318,7 +319,7 @@ func WithMaxLogSize(limit int64) RuntimeOption {
 func WithNoPivotRoot(noPivot bool) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.NoPivotRoot = true
@@ -331,7 +332,7 @@ func WithNoPivotRoot(noPivot bool) RuntimeOption {
 func WithCNIConfigDir(dir string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.CNIConfigDir = dir
@@ -344,7 +345,7 @@ func WithCNIConfigDir(dir string) RuntimeOption {
 func WithCNIPluginDir(dir string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.CNIPluginDir = []string{dir}
@@ -364,7 +365,7 @@ func WithCNIPluginDir(dir string) RuntimeOption {
 func WithNamespace(ns string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.Namespace = ns
@@ -380,7 +381,7 @@ func WithNamespace(ns string) RuntimeOption {
 func WithVolumePath(volPath string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.VolumePath = volPath
@@ -398,7 +399,7 @@ func WithVolumePath(volPath string) RuntimeOption {
 func WithDefaultInfraImage(img string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.InfraImage = img
@@ -412,7 +413,7 @@ func WithDefaultInfraImage(img string) RuntimeOption {
 func WithDefaultInfraCommand(cmd string) RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.config.InfraCommand = cmd
@@ -428,7 +429,7 @@ func WithDefaultInfraCommand(cmd string) RuntimeOption {
 func WithRenumber() RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.doRenumber = true
@@ -443,7 +444,7 @@ func WithRenumber() RuntimeOption {
 func WithMigrate() RuntimeOption {
 	return func(rt *Runtime) error {
 		if rt.valid {
-			return ErrRuntimeFinalized
+			return config2.ErrRuntimeFinalized
 		}
 
 		rt.doMigrate = true
@@ -458,7 +459,7 @@ func WithMigrate() RuntimeOption {
 func WithShmDir(dir string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.ShmDir = dir
@@ -470,7 +471,7 @@ func WithShmDir(dir string) CtrCreateOption {
 func WithSystemd() CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.Systemd = true
@@ -482,7 +483,7 @@ func WithSystemd() CtrCreateOption {
 func WithShmSize(size int64) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.ShmSize = size
@@ -494,7 +495,7 @@ func WithShmSize(size int64) CtrCreateOption {
 func WithPrivileged(privileged bool) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.Privileged = privileged
@@ -506,7 +507,7 @@ func WithPrivileged(privileged bool) CtrCreateOption {
 func WithSecLabels(labelOpts []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 		ctr.config.LabelOpts = labelOpts
 		return nil
@@ -518,7 +519,7 @@ func WithSecLabels(labelOpts []string) CtrCreateOption {
 func WithUser(user string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.User = user
@@ -534,14 +535,14 @@ func WithUser(user string) CtrCreateOption {
 func WithRootFSFromImage(imageID string, imageName string, useImageVolumes bool) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if ctr.config.RootfsImageID != "" || ctr.config.RootfsImageName != "" {
-			return errors.Wrapf(ErrInvalidArg, "container already configured with root filesystem")
+			return errors.Wrapf(config2.ErrInvalidArg, "container already configured with root filesystem")
 		}
 		if ctr.config.Rootfs != "" {
-			return errors.Wrapf(ErrInvalidArg, "cannot set both an image ID and a rootfs for a container")
+			return errors.Wrapf(config2.ErrInvalidArg, "cannot set both an image ID and a rootfs for a container")
 		}
 
 		ctr.config.RootfsImageID = imageID
@@ -556,7 +557,7 @@ func WithRootFSFromImage(imageID string, imageName string, useImageVolumes bool)
 func WithStdin() CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.Stdin = true
@@ -572,11 +573,11 @@ func WithStdin() CtrCreateOption {
 func (r *Runtime) WithPod(pod *Pod) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if pod == nil {
-			return ErrInvalidArg
+			return config2.ErrInvalidArg
 		}
 
 		ctr.config.Pod = pod.ID()
@@ -589,7 +590,7 @@ func (r *Runtime) WithPod(pod *Pod) CtrCreateOption {
 func WithLabels(labels map[string]string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.Labels = make(map[string]string)
@@ -605,7 +606,7 @@ func WithLabels(labels map[string]string) CtrCreateOption {
 func WithName(name string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		// Check the name against a regex
@@ -623,13 +624,13 @@ func WithName(name string) CtrCreateOption {
 func WithStopSignal(signal syscall.Signal) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if signal == 0 {
-			return errors.Wrapf(ErrInvalidArg, "stop signal cannot be 0")
+			return errors.Wrapf(config2.ErrInvalidArg, "stop signal cannot be 0")
 		} else if signal > 64 {
-			return errors.Wrapf(ErrInvalidArg, "stop signal cannot be greater than 64 (SIGRTMAX)")
+			return errors.Wrapf(config2.ErrInvalidArg, "stop signal cannot be greater than 64 (SIGRTMAX)")
 		}
 
 		ctr.config.StopSignal = uint(signal)
@@ -643,7 +644,7 @@ func WithStopSignal(signal syscall.Signal) CtrCreateOption {
 func WithStopTimeout(timeout uint) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.StopTimeout = timeout
@@ -656,7 +657,7 @@ func WithStopTimeout(timeout uint) CtrCreateOption {
 func WithIDMappings(idmappings storage.IDMappingOptions) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.IDMappings = idmappings
@@ -668,7 +669,7 @@ func WithIDMappings(idmappings storage.IDMappingOptions) CtrCreateOption {
 func WithExitCommand(exitCommand []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.ExitCommand = append(exitCommand, ctr.ID())
@@ -681,7 +682,7 @@ func WithExitCommand(exitCommand []string) CtrCreateOption {
 func WithUTSNSFromPod(p *Pod) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if err := validPodNSOption(p, ctr.config.Pod); err != nil {
@@ -705,19 +706,19 @@ func WithUTSNSFromPod(p *Pod) CtrCreateOption {
 func WithIPCNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if !nsCtr.valid {
-			return ErrCtrRemoved
+			return config2.ErrCtrRemoved
 		}
 
 		if nsCtr.ID() == ctr.ID() {
-			return errors.Wrapf(ErrInvalidArg, "must specify another container")
+			return errors.Wrapf(config2.ErrInvalidArg, "must specify another container")
 		}
 
 		if ctr.config.Pod != "" && nsCtr.config.Pod != ctr.config.Pod {
-			return errors.Wrapf(ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
+			return errors.Wrapf(config2.ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
 		}
 
 		ctr.config.IPCNsCtr = nsCtr.ID()
@@ -733,19 +734,19 @@ func WithIPCNSFrom(nsCtr *Container) CtrCreateOption {
 func WithMountNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if !nsCtr.valid {
-			return ErrCtrRemoved
+			return config2.ErrCtrRemoved
 		}
 
 		if nsCtr.ID() == ctr.ID() {
-			return errors.Wrapf(ErrInvalidArg, "must specify another container")
+			return errors.Wrapf(config2.ErrInvalidArg, "must specify another container")
 		}
 
 		if ctr.config.Pod != "" && nsCtr.config.Pod != ctr.config.Pod {
-			return errors.Wrapf(ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
+			return errors.Wrapf(config2.ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
 		}
 
 		ctr.config.MountNsCtr = nsCtr.ID()
@@ -761,23 +762,23 @@ func WithMountNSFrom(nsCtr *Container) CtrCreateOption {
 func WithNetNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if !nsCtr.valid {
-			return ErrCtrRemoved
+			return config2.ErrCtrRemoved
 		}
 
 		if nsCtr.ID() == ctr.ID() {
-			return errors.Wrapf(ErrInvalidArg, "must specify another container")
+			return errors.Wrapf(config2.ErrInvalidArg, "must specify another container")
 		}
 
 		if ctr.config.CreateNetNS {
-			return errors.Wrapf(ErrInvalidArg, "cannot join another container's net ns as we are making a new net ns")
+			return errors.Wrapf(config2.ErrInvalidArg, "cannot join another container's net ns as we are making a new net ns")
 		}
 
 		if ctr.config.Pod != "" && nsCtr.config.Pod != ctr.config.Pod {
-			return errors.Wrapf(ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
+			return errors.Wrapf(config2.ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
 		}
 
 		ctr.config.NetNsCtr = nsCtr.ID()
@@ -793,19 +794,19 @@ func WithNetNSFrom(nsCtr *Container) CtrCreateOption {
 func WithPIDNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if !nsCtr.valid {
-			return ErrCtrRemoved
+			return config2.ErrCtrRemoved
 		}
 
 		if nsCtr.ID() == ctr.ID() {
-			return errors.Wrapf(ErrInvalidArg, "must specify another container")
+			return errors.Wrapf(config2.ErrInvalidArg, "must specify another container")
 		}
 
 		if ctr.config.Pod != "" && nsCtr.config.Pod != ctr.config.Pod {
-			return errors.Wrapf(ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
+			return errors.Wrapf(config2.ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
 		}
 
 		ctr.config.PIDNsCtr = nsCtr.ID()
@@ -821,19 +822,19 @@ func WithPIDNSFrom(nsCtr *Container) CtrCreateOption {
 func WithUserNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if !nsCtr.valid {
-			return ErrCtrRemoved
+			return config2.ErrCtrRemoved
 		}
 
 		if nsCtr.ID() == ctr.ID() {
-			return errors.Wrapf(ErrInvalidArg, "must specify another container")
+			return errors.Wrapf(config2.ErrInvalidArg, "must specify another container")
 		}
 
 		if ctr.config.Pod != "" && nsCtr.config.Pod != ctr.config.Pod {
-			return errors.Wrapf(ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
+			return errors.Wrapf(config2.ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
 		}
 
 		ctr.config.UserNsCtr = nsCtr.ID()
@@ -849,19 +850,19 @@ func WithUserNSFrom(nsCtr *Container) CtrCreateOption {
 func WithUTSNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if !nsCtr.valid {
-			return ErrCtrRemoved
+			return config2.ErrCtrRemoved
 		}
 
 		if nsCtr.ID() == ctr.ID() {
-			return errors.Wrapf(ErrInvalidArg, "must specify another container")
+			return errors.Wrapf(config2.ErrInvalidArg, "must specify another container")
 		}
 
 		if ctr.config.Pod != "" && nsCtr.config.Pod != ctr.config.Pod {
-			return errors.Wrapf(ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
+			return errors.Wrapf(config2.ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
 		}
 
 		ctr.config.UTSNsCtr = nsCtr.ID()
@@ -877,19 +878,19 @@ func WithUTSNSFrom(nsCtr *Container) CtrCreateOption {
 func WithCgroupNSFrom(nsCtr *Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if !nsCtr.valid {
-			return ErrCtrRemoved
+			return config2.ErrCtrRemoved
 		}
 
 		if nsCtr.ID() == ctr.ID() {
-			return errors.Wrapf(ErrInvalidArg, "must specify another container")
+			return errors.Wrapf(config2.ErrInvalidArg, "must specify another container")
 		}
 
 		if ctr.config.Pod != "" && nsCtr.config.Pod != ctr.config.Pod {
-			return errors.Wrapf(ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
+			return errors.Wrapf(config2.ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, nsCtr.ID())
 		}
 
 		ctr.config.CgroupNsCtr = nsCtr.ID()
@@ -903,22 +904,22 @@ func WithCgroupNSFrom(nsCtr *Container) CtrCreateOption {
 func WithDependencyCtrs(ctrs []*Container) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		deps := make([]string, 0, len(ctrs))
 
 		for _, dep := range ctrs {
 			if !dep.valid {
-				return errors.Wrapf(ErrCtrRemoved, "container %s is not valid", dep.ID())
+				return errors.Wrapf(config2.ErrCtrRemoved, "container %s is not valid", dep.ID())
 			}
 
 			if dep.ID() == ctr.ID() {
-				return errors.Wrapf(ErrInvalidArg, "must specify another container")
+				return errors.Wrapf(config2.ErrInvalidArg, "must specify another container")
 			}
 
 			if ctr.config.Pod != "" && dep.config.Pod != ctr.config.Pod {
-				return errors.Wrapf(ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, dep.ID())
+				return errors.Wrapf(config2.ErrInvalidArg, "container has joined pod %s and dependency container %s is not a member of the pod", ctr.config.Pod, dep.ID())
 			}
 
 			deps = append(deps, dep.ID())
@@ -937,11 +938,11 @@ func WithDependencyCtrs(ctrs []*Container) CtrCreateOption {
 func WithNetNS(portMappings []ocicni.PortMapping, postConfigureNetNS bool, netmode string, networks []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if ctr.config.NetNsCtr != "" {
-			return errors.Wrapf(ErrInvalidArg, "container is already set to join another container's net ns, cannot create a new net ns")
+			return errors.Wrapf(config2.ErrInvalidArg, "container is already set to join another container's net ns, cannot create a new net ns")
 		}
 
 		ctr.config.PostConfigureNetNS = postConfigureNetNS
@@ -962,15 +963,15 @@ func WithNetNS(portMappings []ocicni.PortMapping, postConfigureNetNS bool, netmo
 func WithStaticIP(ip net.IP) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if !ctr.config.CreateNetNS {
-			return errors.Wrapf(ErrInvalidArg, "cannot set a static IP if the container is not creating a network namespace")
+			return errors.Wrapf(config2.ErrInvalidArg, "cannot set a static IP if the container is not creating a network namespace")
 		}
 
 		if len(ctr.config.Networks) != 0 {
-			return errors.Wrapf(ErrInvalidArg, "cannot set a static IP if joining additional CNI networks")
+			return errors.Wrapf(config2.ErrInvalidArg, "cannot set a static IP if joining additional CNI networks")
 		}
 
 		ctr.config.StaticIP = ip
@@ -983,15 +984,15 @@ func WithStaticIP(ip net.IP) CtrCreateOption {
 func WithLogDriver(driver string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 		switch driver {
 		case "":
-			return errors.Wrapf(ErrInvalidArg, "log driver must be set")
+			return errors.Wrapf(config2.ErrInvalidArg, "log driver must be set")
 		case JournaldLogging, KubernetesLogging, JSONLogging:
 			break
 		default:
-			return errors.Wrapf(ErrInvalidArg, "invalid log driver")
+			return errors.Wrapf(config2.ErrInvalidArg, "invalid log driver")
 		}
 
 		ctr.config.LogDriver = driver
@@ -1004,10 +1005,10 @@ func WithLogDriver(driver string) CtrCreateOption {
 func WithLogPath(path string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 		if path == "" {
-			return errors.Wrapf(ErrInvalidArg, "log path must be set")
+			return errors.Wrapf(config2.ErrInvalidArg, "log path must be set")
 		}
 
 		ctr.config.LogPath = path
@@ -1020,11 +1021,11 @@ func WithLogPath(path string) CtrCreateOption {
 func WithCgroupParent(parent string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if parent == "" {
-			return errors.Wrapf(ErrInvalidArg, "cgroup parent cannot be empty")
+			return errors.Wrapf(config2.ErrInvalidArg, "cgroup parent cannot be empty")
 		}
 
 		ctr.config.CgroupParent = parent
@@ -1037,10 +1038,10 @@ func WithCgroupParent(parent string) CtrCreateOption {
 func WithDNSSearch(searchDomains []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 		if ctr.config.UseImageResolvConf {
-			return errors.Wrapf(ErrInvalidArg, "cannot add DNS search domains if container will not create /etc/resolv.conf")
+			return errors.Wrapf(config2.ErrInvalidArg, "cannot add DNS search domains if container will not create /etc/resolv.conf")
 		}
 		ctr.config.DNSSearch = searchDomains
 		return nil
@@ -1051,16 +1052,16 @@ func WithDNSSearch(searchDomains []string) CtrCreateOption {
 func WithDNS(dnsServers []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 		if ctr.config.UseImageResolvConf {
-			return errors.Wrapf(ErrInvalidArg, "cannot add DNS servers if container will not create /etc/resolv.conf")
+			return errors.Wrapf(config2.ErrInvalidArg, "cannot add DNS servers if container will not create /etc/resolv.conf")
 		}
 		var dns []net.IP
 		for _, i := range dnsServers {
 			result := net.ParseIP(i)
 			if result == nil {
-				return errors.Wrapf(ErrInvalidArg, "invalid IP address %s", i)
+				return errors.Wrapf(config2.ErrInvalidArg, "invalid IP address %s", i)
 			}
 			dns = append(dns, result)
 		}
@@ -1073,10 +1074,10 @@ func WithDNS(dnsServers []string) CtrCreateOption {
 func WithDNSOption(dnsOptions []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 		if ctr.config.UseImageResolvConf {
-			return errors.Wrapf(ErrInvalidArg, "cannot add DNS options if container will not create /etc/resolv.conf")
+			return errors.Wrapf(config2.ErrInvalidArg, "cannot add DNS options if container will not create /etc/resolv.conf")
 		}
 		ctr.config.DNSOption = dnsOptions
 		return nil
@@ -1087,11 +1088,11 @@ func WithDNSOption(dnsOptions []string) CtrCreateOption {
 func WithHosts(hosts []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if ctr.config.UseImageHosts {
-			return errors.Wrapf(ErrInvalidArg, "cannot add hosts if container will not create /etc/hosts")
+			return errors.Wrapf(config2.ErrInvalidArg, "cannot add hosts if container will not create /etc/hosts")
 		}
 
 		ctr.config.HostAdd = hosts
@@ -1104,7 +1105,7 @@ func WithHosts(hosts []string) CtrCreateOption {
 func WithConmonPidFile(path string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 		ctr.config.ConmonPidFile = path
 		return nil
@@ -1116,7 +1117,7 @@ func WithConmonPidFile(path string) CtrCreateOption {
 func WithGroups(groups []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 		ctr.config.Groups = groups
 		return nil
@@ -1134,11 +1135,11 @@ func WithGroups(groups []string) CtrCreateOption {
 func WithUserVolumes(volumes []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if volumes == nil {
-			return ErrInvalidArg
+			return config2.ErrInvalidArg
 		}
 
 		ctr.config.UserVolumes = make([]string, 0, len(volumes))
@@ -1158,7 +1159,7 @@ func WithUserVolumes(volumes []string) CtrCreateOption {
 func WithEntrypoint(entrypoint []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.Entrypoint = make([]string, 0, len(entrypoint))
@@ -1178,7 +1179,7 @@ func WithEntrypoint(entrypoint []string) CtrCreateOption {
 func WithCommand(command []string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.Command = make([]string, 0, len(command))
@@ -1195,13 +1196,13 @@ func WithCommand(command []string) CtrCreateOption {
 func WithRootFS(rootfs string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 		if _, err := os.Stat(rootfs); err != nil {
 			return errors.Wrapf(err, "error checking path %q", rootfs)
 		}
 		if ctr.config.RootfsImageID != "" {
-			return errors.Wrapf(ErrInvalidArg, "cannot set both an image ID and a rootfs for a container")
+			return errors.Wrapf(config2.ErrInvalidArg, "cannot set both an image ID and a rootfs for a container")
 		}
 		ctr.config.Rootfs = rootfs
 		return nil
@@ -1215,7 +1216,7 @@ func WithRootFS(rootfs string) CtrCreateOption {
 func WithCtrNamespace(ns string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.Namespace = ns
@@ -1229,13 +1230,13 @@ func WithCtrNamespace(ns string) CtrCreateOption {
 func WithUseImageResolvConf() CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if len(ctr.config.DNSServer) != 0 ||
 			len(ctr.config.DNSSearch) != 0 ||
 			len(ctr.config.DNSOption) != 0 {
-			return errors.Wrapf(ErrInvalidArg, "not creating resolv.conf conflicts with DNS options")
+			return errors.Wrapf(config2.ErrInvalidArg, "not creating resolv.conf conflicts with DNS options")
 		}
 
 		ctr.config.UseImageResolvConf = true
@@ -1249,11 +1250,11 @@ func WithUseImageResolvConf() CtrCreateOption {
 func WithUseImageHosts() CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		if len(ctr.config.HostAdd) != 0 {
-			return errors.Wrapf(ErrInvalidArg, "not creating /etc/hosts conflicts with adding to the hosts file")
+			return errors.Wrapf(config2.ErrInvalidArg, "not creating /etc/hosts conflicts with adding to the hosts file")
 		}
 
 		ctr.config.UseImageHosts = true
@@ -1268,14 +1269,14 @@ func WithUseImageHosts() CtrCreateOption {
 func WithRestartPolicy(policy string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		switch policy {
 		case RestartPolicyNone, RestartPolicyNo, RestartPolicyOnFailure, RestartPolicyAlways:
 			ctr.config.RestartPolicy = policy
 		default:
-			return errors.Wrapf(ErrInvalidArg, "%q is not a valid restart policy", policy)
+			return errors.Wrapf(config2.ErrInvalidArg, "%q is not a valid restart policy", policy)
 		}
 
 		return nil
@@ -1288,7 +1289,7 @@ func WithRestartPolicy(policy string) CtrCreateOption {
 func WithRestartRetries(tries uint) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.RestartRetries = tries
@@ -1302,7 +1303,7 @@ func WithRestartRetries(tries uint) CtrCreateOption {
 func withIsInfra() CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		ctr.config.IsInfra = true
@@ -1315,7 +1316,7 @@ func withIsInfra() CtrCreateOption {
 func WithNamedVolumes(volumes []*ContainerNamedVolume) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 
 		destinations := make(map[string]bool)
@@ -1325,7 +1326,7 @@ func WithNamedVolumes(volumes []*ContainerNamedVolume) CtrCreateOption {
 			// If they don't we will automatically create them.
 
 			if _, ok := destinations[vol.Dest]; ok {
-				return errors.Wrapf(ErrInvalidArg, "two volumes found with destination %s", vol.Dest)
+				return errors.Wrapf(config2.ErrInvalidArg, "two volumes found with destination %s", vol.Dest)
 			}
 			destinations[vol.Dest] = true
 
@@ -1346,7 +1347,7 @@ func WithNamedVolumes(volumes []*ContainerNamedVolume) CtrCreateOption {
 func WithVolumeName(name string) VolumeCreateOption {
 	return func(volume *Volume) error {
 		if volume.valid {
-			return ErrVolumeFinalized
+			return config2.ErrVolumeFinalized
 		}
 
 		// Check the name against a regex
@@ -1363,7 +1364,7 @@ func WithVolumeName(name string) VolumeCreateOption {
 func WithVolumeLabels(labels map[string]string) VolumeCreateOption {
 	return func(volume *Volume) error {
 		if volume.valid {
-			return ErrVolumeFinalized
+			return config2.ErrVolumeFinalized
 		}
 
 		volume.config.Labels = make(map[string]string)
@@ -1379,7 +1380,7 @@ func WithVolumeLabels(labels map[string]string) VolumeCreateOption {
 func WithVolumeDriver(driver string) VolumeCreateOption {
 	return func(volume *Volume) error {
 		if volume.valid {
-			return ErrVolumeFinalized
+			return config2.ErrVolumeFinalized
 		}
 
 		volume.config.Driver = driver
@@ -1392,7 +1393,7 @@ func WithVolumeDriver(driver string) VolumeCreateOption {
 func WithVolumeOptions(options map[string]string) VolumeCreateOption {
 	return func(volume *Volume) error {
 		if volume.valid {
-			return ErrVolumeFinalized
+			return config2.ErrVolumeFinalized
 		}
 
 		volume.config.Options = make(map[string]string)
@@ -1408,7 +1409,7 @@ func WithVolumeOptions(options map[string]string) VolumeCreateOption {
 func WithVolumeUID(uid int) VolumeCreateOption {
 	return func(volume *Volume) error {
 		if volume.valid {
-			return ErrVolumeFinalized
+			return config2.ErrVolumeFinalized
 		}
 
 		volume.config.UID = uid
@@ -1421,7 +1422,7 @@ func WithVolumeUID(uid int) VolumeCreateOption {
 func WithVolumeGID(gid int) VolumeCreateOption {
 	return func(volume *Volume) error {
 		if volume.valid {
-			return ErrVolumeFinalized
+			return config2.ErrVolumeFinalized
 		}
 
 		volume.config.GID = gid
@@ -1437,7 +1438,7 @@ func WithVolumeGID(gid int) VolumeCreateOption {
 func withSetCtrSpecific() VolumeCreateOption {
 	return func(volume *Volume) error {
 		if volume.valid {
-			return ErrVolumeFinalized
+			return config2.ErrVolumeFinalized
 		}
 
 		volume.config.IsCtrSpecific = true
@@ -1452,7 +1453,7 @@ func withSetCtrSpecific() VolumeCreateOption {
 func WithPodName(name string) PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		// Check the name against a regex
@@ -1470,7 +1471,7 @@ func WithPodName(name string) PodCreateOption {
 func WithPodLabels(labels map[string]string) PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		pod.config.Labels = make(map[string]string)
@@ -1486,7 +1487,7 @@ func WithPodLabels(labels map[string]string) PodCreateOption {
 func WithPodCgroupParent(path string) PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		pod.config.CgroupParent = path
@@ -1502,7 +1503,7 @@ func WithPodCgroupParent(path string) PodCreateOption {
 func WithPodCgroups() PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		pod.config.UsePodCgroup = true
@@ -1519,7 +1520,7 @@ func WithPodCgroups() PodCreateOption {
 func WithPodNamespace(ns string) PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		pod.config.Namespace = ns
@@ -1535,7 +1536,7 @@ func WithPodNamespace(ns string) PodCreateOption {
 func WithPodIPC() PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		pod.config.UsePodIPC = true
@@ -1551,7 +1552,7 @@ func WithPodIPC() PodCreateOption {
 func WithPodNet() PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		pod.config.UsePodNet = true
@@ -1569,7 +1570,7 @@ func WithPodNet() PodCreateOption {
 func WithPodMount() PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		pod.config.UsePodMount = true
@@ -1587,7 +1588,7 @@ func WithPodMount() PodCreateOption {
 func WithPodUser() PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		pod.config.UsePodUser = true
@@ -1603,7 +1604,7 @@ func WithPodUser() PodCreateOption {
 func WithPodPID() PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		pod.config.UsePodPID = true
@@ -1619,7 +1620,7 @@ func WithPodPID() PodCreateOption {
 func WithPodUTS() PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		pod.config.UsePodUTS = true
@@ -1632,7 +1633,7 @@ func WithPodUTS() PodCreateOption {
 func WithInfraContainer() PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 
 		pod.config.InfraContainer.HasInfraContainer = true
@@ -1645,7 +1646,7 @@ func WithInfraContainer() PodCreateOption {
 func WithInfraContainerPorts(bindings []ocicni.PortMapping) PodCreateOption {
 	return func(pod *Pod) error {
 		if pod.valid {
-			return ErrPodFinalized
+			return config2.ErrPodFinalized
 		}
 		pod.config.InfraContainer.PortBindings = bindings
 		return nil
@@ -1656,7 +1657,7 @@ func WithInfraContainerPorts(bindings []ocicni.PortMapping) PodCreateOption {
 func WithHealthCheck(healthCheck *manifest.Schema2HealthConfig) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
-			return ErrCtrFinalized
+			return config2.ErrCtrFinalized
 		}
 		ctr.config.HealthCheckConfig = healthCheck
 		return nil

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"time"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/lock"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/pkg/errors"
@@ -190,7 +191,7 @@ func (p *Pod) CgroupPath() (string, error) {
 // HasContainer checks if a container is present in the pod
 func (p *Pod) HasContainer(id string) (bool, error) {
 	if !p.valid {
-		return false, ErrPodRemoved
+		return false, define.ErrPodRemoved
 	}
 
 	return p.runtime.state.PodHasContainer(p, id)
@@ -202,7 +203,7 @@ func (p *Pod) AllContainersByID() ([]string, error) {
 	defer p.lock.Unlock()
 
 	if !p.valid {
-		return nil, ErrPodRemoved
+		return nil, define.ErrPodRemoved
 	}
 
 	return p.runtime.state.PodContainersByID(p)
@@ -211,7 +212,7 @@ func (p *Pod) AllContainersByID() ([]string, error) {
 // AllContainers retrieves the containers in the pod
 func (p *Pod) AllContainers() ([]*Container, error) {
 	if !p.valid {
-		return nil, ErrPodRemoved
+		return nil, define.ErrPodRemoved
 	}
 	p.lock.Lock()
 	defer p.lock.Unlock()
@@ -280,7 +281,7 @@ func (p *Pod) GetPodStats(previousContainerStats map[string]*ContainerStats) (ma
 		newStats, err := c.GetContainerStats(prevStat)
 		// If the container wasn't running, don't include it
 		// but also suppress the error
-		if err != nil && errors.Cause(err) != ErrCtrStateInvalid {
+		if err != nil && errors.Cause(err) != define.ErrCtrStateInvalid {
 			return nil, err
 		}
 		if err == nil {

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -3,6 +3,7 @@ package libpod
 import (
 	"context"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/events"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -27,7 +28,7 @@ func (p *Pod) Start(ctx context.Context) (map[string]error, error) {
 	defer p.lock.Unlock()
 
 	if !p.valid {
-		return nil, ErrPodRemoved
+		return nil, define.ErrPodRemoved
 	}
 
 	allCtrs, err := p.runtime.state.PodContainers(p)
@@ -47,7 +48,7 @@ func (p *Pod) Start(ctx context.Context) (map[string]error, error) {
 	// If there are no containers without dependencies, we can't start
 	// Error out
 	if len(graph.noDepNodes) == 0 {
-		return nil, errors.Wrapf(ErrNoSuchCtr, "no containers in pod %s have no dependencies, cannot start pod", p.ID())
+		return nil, errors.Wrapf(define.ErrNoSuchCtr, "no containers in pod %s have no dependencies, cannot start pod", p.ID())
 	}
 
 	// Traverse the graph beginning at nodes with no dependencies
@@ -56,7 +57,7 @@ func (p *Pod) Start(ctx context.Context) (map[string]error, error) {
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(ErrCtrExists, "error starting some containers")
+		return ctrErrors, errors.Wrapf(define.ErrCtrExists, "error starting some containers")
 	}
 	defer p.newPodEvent(events.Start)
 	return nil, nil
@@ -88,7 +89,7 @@ func (p *Pod) StopWithTimeout(ctx context.Context, cleanup bool, timeout int) (m
 	defer p.lock.Unlock()
 
 	if !p.valid {
-		return nil, ErrPodRemoved
+		return nil, define.ErrPodRemoved
 	}
 
 	allCtrs, err := p.runtime.state.PodContainers(p)
@@ -136,7 +137,7 @@ func (p *Pod) StopWithTimeout(ctx context.Context, cleanup bool, timeout int) (m
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(ErrCtrExists, "error stopping some containers")
+		return ctrErrors, errors.Wrapf(define.ErrCtrExists, "error stopping some containers")
 	}
 	defer p.newPodEvent(events.Stop)
 	return nil, nil
@@ -159,7 +160,7 @@ func (p *Pod) Pause() (map[string]error, error) {
 	defer p.lock.Unlock()
 
 	if !p.valid {
-		return nil, ErrPodRemoved
+		return nil, define.ErrPodRemoved
 	}
 
 	allCtrs, err := p.runtime.state.PodContainers(p)
@@ -195,7 +196,7 @@ func (p *Pod) Pause() (map[string]error, error) {
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(ErrCtrExists, "error pausing some containers")
+		return ctrErrors, errors.Wrapf(define.ErrCtrExists, "error pausing some containers")
 	}
 	defer p.newPodEvent(events.Pause)
 	return nil, nil
@@ -218,7 +219,7 @@ func (p *Pod) Unpause() (map[string]error, error) {
 	defer p.lock.Unlock()
 
 	if !p.valid {
-		return nil, ErrPodRemoved
+		return nil, define.ErrPodRemoved
 	}
 
 	allCtrs, err := p.runtime.state.PodContainers(p)
@@ -254,7 +255,7 @@ func (p *Pod) Unpause() (map[string]error, error) {
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(ErrCtrExists, "error unpausing some containers")
+		return ctrErrors, errors.Wrapf(define.ErrCtrExists, "error unpausing some containers")
 	}
 
 	defer p.newPodEvent(events.Unpause)
@@ -279,7 +280,7 @@ func (p *Pod) Restart(ctx context.Context) (map[string]error, error) {
 	defer p.lock.Unlock()
 
 	if !p.valid {
-		return nil, ErrPodRemoved
+		return nil, define.ErrPodRemoved
 	}
 
 	allCtrs, err := p.runtime.state.PodContainers(p)
@@ -299,7 +300,7 @@ func (p *Pod) Restart(ctx context.Context) (map[string]error, error) {
 	// If there are no containers without dependencies, we can't start
 	// Error out
 	if len(graph.noDepNodes) == 0 {
-		return nil, errors.Wrapf(ErrNoSuchCtr, "no containers in pod %s have no dependencies, cannot start pod", p.ID())
+		return nil, errors.Wrapf(define.ErrNoSuchCtr, "no containers in pod %s have no dependencies, cannot start pod", p.ID())
 	}
 
 	// Traverse the graph beginning at nodes with no dependencies
@@ -308,7 +309,7 @@ func (p *Pod) Restart(ctx context.Context) (map[string]error, error) {
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(ErrCtrExists, "error stopping some containers")
+		return ctrErrors, errors.Wrapf(define.ErrCtrExists, "error stopping some containers")
 	}
 	p.newPodEvent(events.Stop)
 	p.newPodEvent(events.Start)
@@ -331,7 +332,7 @@ func (p *Pod) Kill(signal uint) (map[string]error, error) {
 	defer p.lock.Unlock()
 
 	if !p.valid {
-		return nil, ErrPodRemoved
+		return nil, define.ErrPodRemoved
 	}
 
 	allCtrs, err := p.runtime.state.PodContainers(p)
@@ -374,7 +375,7 @@ func (p *Pod) Kill(signal uint) (map[string]error, error) {
 	}
 
 	if len(ctrErrors) > 0 {
-		return ctrErrors, errors.Wrapf(ErrCtrExists, "error killing some containers")
+		return ctrErrors, errors.Wrapf(define.ErrCtrExists, "error killing some containers")
 	}
 	defer p.newPodEvent(events.Kill)
 	return nil, nil
@@ -387,7 +388,7 @@ func (p *Pod) Status() (map[string]ContainerStatus, error) {
 	defer p.lock.Unlock()
 
 	if !p.valid {
-		return nil, ErrPodRemoved
+		return nil, define.ErrPodRemoved
 	}
 
 	allCtrs, err := p.runtime.state.PodContainers(p)

--- a/libpod/pod_internal.go
+++ b/libpod/pod_internal.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -52,7 +53,7 @@ func (p *Pod) refresh() error {
 	}
 
 	if !p.valid {
-		return ErrPodRemoved
+		return define.ErrPodRemoved
 	}
 
 	// Retrieve the pod's lock
@@ -76,7 +77,7 @@ func (p *Pod) refresh() error {
 
 			logrus.Debugf("setting pod cgroup to %s", p.state.CgroupPath)
 		default:
-			return errors.Wrapf(ErrInvalidArg, "unknown cgroups manager %s specified", p.runtime.config.CgroupManager)
+			return errors.Wrapf(define.ErrInvalidArg, "unknown cgroups manager %s specified", p.runtime.config.CgroupManager)
 		}
 	}
 

--- a/libpod/pod_top_unsupported.go
+++ b/libpod/pod_top_unsupported.go
@@ -2,7 +2,9 @@
 
 package libpod
 
+import "github.com/containers/libpod/libpod/define"
+
 // GetPodPidInformation is exclusive to linux
 func (p *Pod) GetPodPidInformation(descriptors []string) ([]string, error) {
-	return nil, ErrNotImplemented
+	return nil, define.ErrNotImplemented
 }

--- a/libpod/runtime_cstorage.go
+++ b/libpod/runtime_cstorage.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -56,7 +57,7 @@ func (r *Runtime) RemoveStorageContainer(idOrName string, force bool) error {
 	targetID, err := r.store.Lookup(idOrName)
 	if err != nil {
 		if err == storage.ErrLayerUnknown {
-			return errors.Wrapf(ErrNoSuchCtr, "no container with ID or name %q found", idOrName)
+			return errors.Wrapf(define.ErrNoSuchCtr, "no container with ID or name %q found", idOrName)
 		}
 		return errors.Wrapf(err, "error looking up container %q", idOrName)
 	}
@@ -66,7 +67,7 @@ func (r *Runtime) RemoveStorageContainer(idOrName string, force bool) error {
 	ctr, err := r.store.Container(targetID)
 	if err != nil {
 		if err == storage.ErrContainerUnknown {
-			return errors.Wrapf(ErrNoSuchCtr, "%q does not refer to a container", idOrName)
+			return errors.Wrapf(define.ErrNoSuchCtr, "%q does not refer to a container", idOrName)
 		}
 		return errors.Wrapf(err, "error retrieving container %q", idOrName)
 	}
@@ -77,7 +78,7 @@ func (r *Runtime) RemoveStorageContainer(idOrName string, force bool) error {
 		return err
 	}
 	if exists {
-		return errors.Wrapf(ErrCtrExists, "refusing to remove %q as it exists in libpod as container %s", idOrName, ctr.ID)
+		return errors.Wrapf(define.ErrCtrExists, "refusing to remove %q as it exists in libpod as container %s", idOrName, ctr.ID)
 	}
 
 	if !force {
@@ -92,7 +93,7 @@ func (r *Runtime) RemoveStorageContainer(idOrName string, force bool) error {
 			return errors.Wrapf(err, "error looking up container %q mounts", idOrName)
 		}
 		if timesMounted > 0 {
-			return errors.Wrapf(ErrCtrStateInvalid, "container %q is mounted and cannot be removed without using force", idOrName)
+			return errors.Wrapf(define.ErrCtrStateInvalid, "container %q is mounted and cannot be removed without using force", idOrName)
 		}
 	} else {
 		if _, err := r.store.Unmount(ctr.ID, true); err != nil {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -8,19 +8,16 @@ import (
 	"strings"
 	"time"
 
+	config2 "github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/events"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/storage/pkg/stringid"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
-
-// CtrRemoveTimeout is the default number of seconds to wait after stopping a container
-// before sending the kill signal
-const CtrRemoveTimeout = 10
 
 // Contains the public Runtime API for containers
 
@@ -38,7 +35,7 @@ func (r *Runtime) NewContainer(ctx context.Context, rSpec *spec.Spec, options ..
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, config2.ErrRuntimeStopped
 	}
 	return r.newContainer(ctx, rSpec, options...)
 }
@@ -48,7 +45,7 @@ func (r *Runtime) RestoreContainer(ctx context.Context, rSpec *spec.Spec, config
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, config2.ErrRuntimeStopped
 	}
 
 	ctr, err := r.initContainerVariables(rSpec, config)
@@ -60,7 +57,7 @@ func (r *Runtime) RestoreContainer(ctx context.Context, rSpec *spec.Spec, config
 
 func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConfig) (c *Container, err error) {
 	if rSpec == nil {
-		return nil, errors.Wrapf(ErrInvalidArg, "must provide a valid runtime spec to create container")
+		return nil, errors.Wrapf(config2.ErrInvalidArg, "must provide a valid runtime spec to create container")
 	}
 	ctr := new(Container)
 	ctr.config = new(ContainerConfig)
@@ -92,7 +89,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 
 	ctr.state.BindMounts = make(map[string]string)
 
-	ctr.config.StopTimeout = CtrRemoveTimeout
+	ctr.config.StopTimeout = config2.CtrRemoveTimeout
 
 	ctr.config.OCIRuntime = r.defaultOCIRuntime.name
 
@@ -144,7 +141,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container, restore bo
 	} else {
 		ociRuntime, ok := r.ociRuntimes[ctr.config.OCIRuntime]
 		if !ok {
-			return nil, errors.Wrapf(ErrInvalidArg, "requested OCI runtime %s is not available", ctr.config.OCIRuntime)
+			return nil, errors.Wrapf(config2.ErrInvalidArg, "requested OCI runtime %s is not available", ctr.config.OCIRuntime)
 		}
 		ctr.ociRuntime = ociRuntime
 	}
@@ -177,14 +174,14 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container, restore bo
 					return nil, errors.Wrapf(err, "error retrieving pod %s cgroup", pod.ID())
 				}
 				if podCgroup == "" {
-					return nil, errors.Wrapf(ErrInternal, "pod %s cgroup is not set", pod.ID())
+					return nil, errors.Wrapf(config2.ErrInternal, "pod %s cgroup is not set", pod.ID())
 				}
 				ctr.config.CgroupParent = podCgroup
 			} else {
 				ctr.config.CgroupParent = CgroupfsDefaultCgroupParent
 			}
 		} else if strings.HasSuffix(path.Base(ctr.config.CgroupParent), ".slice") {
-			return nil, errors.Wrapf(ErrInvalidArg, "systemd slice received as cgroup parent when using cgroupfs")
+			return nil, errors.Wrapf(config2.ErrInvalidArg, "systemd slice received as cgroup parent when using cgroupfs")
 		}
 	case SystemdCgroupsManager:
 		if ctr.config.CgroupParent == "" {
@@ -198,10 +195,10 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container, restore bo
 				ctr.config.CgroupParent = SystemdDefaultCgroupParent
 			}
 		} else if len(ctr.config.CgroupParent) < 6 || !strings.HasSuffix(path.Base(ctr.config.CgroupParent), ".slice") {
-			return nil, errors.Wrapf(ErrInvalidArg, "did not receive systemd slice as cgroup parent when using systemd to manage cgroups")
+			return nil, errors.Wrapf(config2.ErrInvalidArg, "did not receive systemd slice as cgroup parent when using systemd to manage cgroups")
 		}
 	default:
-		return nil, errors.Wrapf(ErrInvalidArg, "unsupported CGroup manager: %s - cannot validate cgroup parent", r.config.CgroupManager)
+		return nil, errors.Wrapf(config2.ErrInvalidArg, "unsupported CGroup manager: %s - cannot validate cgroup parent", r.config.CgroupManager)
 	}
 
 	if restore {
@@ -241,7 +238,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container, restore bo
 		if err == nil {
 			// The volume exists, we're good
 			continue
-		} else if errors.Cause(err) != ErrNoSuchVolume {
+		} else if errors.Cause(err) != config2.ErrNoSuchVolume {
 			return nil, errors.Wrapf(err, "error retrieving named volume %s for new container", vol.Name)
 		}
 
@@ -355,7 +352,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 	}
 
 	if !r.valid {
-		return ErrRuntimeStopped
+		return config2.ErrRuntimeStopped
 	}
 
 	// Update the container to get current state
@@ -413,7 +410,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 		}
 		if len(deps) != 0 {
 			depsStr := strings.Join(deps, ", ")
-			return errors.Wrapf(ErrCtrExists, "container %s has dependent containers which must be removed before it: %s", c.ID(), depsStr)
+			return errors.Wrapf(config2.ErrCtrExists, "container %s has dependent containers which must be removed before it: %s", c.ID(), depsStr)
 		}
 	}
 
@@ -496,7 +493,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 			if !volume.IsCtrSpecific() {
 				continue
 			}
-			if err := runtime.removeVolume(ctx, volume, false); err != nil && err != ErrNoSuchVolume && err != ErrVolumeBeingUsed {
+			if err := runtime.removeVolume(ctx, volume, false); err != nil && err != config2.ErrNoSuchVolume && err != config2.ErrVolumeBeingUsed {
 				logrus.Errorf("cleanup volume (%s): %v", v, err)
 			}
 		}
@@ -511,7 +508,7 @@ func (r *Runtime) GetContainer(id string) (*Container, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, config2.ErrRuntimeStopped
 	}
 
 	return r.state.Container(id)
@@ -523,7 +520,7 @@ func (r *Runtime) HasContainer(id string) (bool, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return false, ErrRuntimeStopped
+		return false, config2.ErrRuntimeStopped
 	}
 
 	return r.state.HasContainer(id)
@@ -536,7 +533,7 @@ func (r *Runtime) LookupContainer(idOrName string) (*Container, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, config2.ErrRuntimeStopped
 	}
 	return r.state.LookupContainer(idOrName)
 }
@@ -550,7 +547,7 @@ func (r *Runtime) GetContainers(filters ...ContainerFilter) ([]*Container, error
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, config2.ErrRuntimeStopped
 	}
 
 	ctrs, err := r.state.AllContainers()
@@ -611,7 +608,7 @@ func (r *Runtime) GetLatestContainer() (*Container, error) {
 		return nil, errors.Wrapf(err, "unable to find latest container")
 	}
 	if len(ctrs) == 0 {
-		return nil, ErrNoSuchCtr
+		return nil, config2.ErrNoSuchCtr
 	}
 	for containerIndex, ctr := range ctrs {
 		createdTime := ctr.config.CreatedTime

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/containers/buildah/imagebuildah"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/storage"
@@ -31,7 +32,7 @@ func (r *Runtime) RemoveImage(ctx context.Context, img *image.Image, force bool)
 	defer r.lock.Unlock()
 
 	if !r.valid {
-		return "", ErrRuntimeStopped
+		return "", define.ErrRuntimeStopped
 	}
 
 	// Get all containers, filter to only those using the image, and remove those containers

--- a/libpod/runtime_pod.go
+++ b/libpod/runtime_pod.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
 )
@@ -30,7 +31,7 @@ func (r *Runtime) RemovePod(ctx context.Context, p *Pod, removeCtrs, force bool)
 	defer r.lock.Unlock()
 
 	if !r.valid {
-		return ErrRuntimeStopped
+		return define.ErrRuntimeStopped
 	}
 
 	if !p.valid {
@@ -53,7 +54,7 @@ func (r *Runtime) GetPod(id string) (*Pod, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 
 	return r.state.Pod(id)
@@ -65,7 +66,7 @@ func (r *Runtime) HasPod(id string) (bool, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return false, ErrRuntimeStopped
+		return false, define.ErrRuntimeStopped
 	}
 
 	return r.state.HasPod(id)
@@ -78,7 +79,7 @@ func (r *Runtime) LookupPod(idOrName string) (*Pod, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 
 	return r.state.LookupPod(idOrName)
@@ -93,7 +94,7 @@ func (r *Runtime) Pods(filters ...PodFilter) ([]*Pod, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 
 	pods, err := r.state.AllPods()
@@ -122,7 +123,7 @@ func (r *Runtime) GetAllPods() ([]*Pod, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 
 	return r.state.AllPods()
@@ -137,7 +138,7 @@ func (r *Runtime) GetLatestPod() (*Pod, error) {
 		return nil, errors.Wrapf(err, "unable to get all pods")
 	}
 	if len(pods) == 0 {
-		return nil, ErrNoSuchPod
+		return nil, define.ErrNoSuchPod
 	}
 	for podIndex, pod := range pods {
 		createdTime := pod.config.CreatedTime
@@ -159,7 +160,7 @@ func (r *Runtime) GetRunningPods() ([]*Pod, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 	containers, err := r.GetRunningContainers()
 	if err != nil {
@@ -171,7 +172,7 @@ func (r *Runtime) GetRunningPods() ([]*Pod, error) {
 			pods = append(pods, c.PodID())
 			pod, err := r.GetPod(c.PodID())
 			if err != nil {
-				if errors.Cause(err) == ErrPodRemoved || errors.Cause(err) == ErrNoSuchPod {
+				if errors.Cause(err) == define.ErrPodRemoved || errors.Cause(err) == define.ErrNoSuchPod {
 					continue
 				}
 				return nil, err

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/opencontainers/image-spec/specs-go/v1"
@@ -104,7 +105,7 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, imgID
 // containers in the pod.
 func (r *Runtime) createInfraContainer(ctx context.Context, p *Pod) (*Container, error) {
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 
 	newImage, err := r.ImageRuntime().New(ctx, r.config.InfraImage, "", "", nil, nil, image.SigningOptions{}, false, nil)

--- a/libpod/runtime_pod_unsupported.go
+++ b/libpod/runtime_pod_unsupported.go
@@ -4,13 +4,15 @@ package libpod
 
 import (
 	"context"
+
+	"github.com/containers/libpod/libpod/define"
 )
 
 // NewPod makes a new, empty pod
 func (r *Runtime) NewPod(ctx context.Context, options ...PodCreateOption) (*Pod, error) {
-	return nil, ErrOSNotSupported
+	return nil, define.ErrOSNotSupported
 }
 
 func (r *Runtime) removePod(ctx context.Context, p *Pod, removeCtrs, force bool) error {
-	return ErrOSNotSupported
+	return define.ErrOSNotSupported
 }

--- a/libpod/runtime_volume.go
+++ b/libpod/runtime_volume.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/events"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -26,7 +27,7 @@ func (r *Runtime) RemoveVolume(ctx context.Context, v *Volume, force bool) error
 	defer r.lock.Unlock()
 
 	if !r.valid {
-		return ErrRuntimeStopped
+		return define.ErrRuntimeStopped
 	}
 
 	if !v.valid {
@@ -77,7 +78,7 @@ func (r *Runtime) GetVolume(name string) (*Volume, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 
 	vol, err := r.state.Volume(name)
@@ -103,7 +104,7 @@ func (r *Runtime) HasVolume(name string) (bool, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return false, ErrRuntimeStopped
+		return false, define.ErrRuntimeStopped
 	}
 
 	return r.state.HasVolume(name)
@@ -118,7 +119,7 @@ func (r *Runtime) Volumes(filters ...VolumeFilter) ([]*Volume, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 
 	vols, err := r.state.AllVolumes()
@@ -147,7 +148,7 @@ func (r *Runtime) GetAllVolumes() ([]*Volume, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 
 	return r.state.AllVolumes()
@@ -167,7 +168,7 @@ func (r *Runtime) PruneVolumes(ctx context.Context) ([]string, []error) {
 
 	for _, vol := range vols {
 		if err := r.RemoveVolume(ctx, vol, false); err != nil {
-			if errors.Cause(err) != ErrVolumeBeingUsed && errors.Cause(err) != ErrVolumeRemoved {
+			if errors.Cause(err) != define.ErrVolumeBeingUsed && errors.Cause(err) != define.ErrVolumeRemoved {
 				pruneErrors = append(pruneErrors, err)
 			}
 			continue

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/events"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/pkg/errors"
@@ -20,7 +21,7 @@ func (r *Runtime) NewVolume(ctx context.Context, options ...VolumeCreateOption) 
 	defer r.lock.Unlock()
 
 	if !r.valid {
-		return nil, ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 	return r.newVolume(ctx, options...)
 }
@@ -86,7 +87,7 @@ func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool) error
 		if ok, _ := r.state.HasVolume(v.Name()); !ok {
 			return nil
 		}
-		return ErrVolumeRemoved
+		return define.ErrVolumeRemoved
 	}
 
 	deps, err := r.state.VolumeInUse(v)
@@ -96,7 +97,7 @@ func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool) error
 	if len(deps) != 0 {
 		depsStr := strings.Join(deps, ", ")
 		if !force {
-			return errors.Wrapf(ErrVolumeBeingUsed, "volume %s is being used by the following container(s): %s", v.Name(), depsStr)
+			return errors.Wrapf(define.ErrVolumeBeingUsed, "volume %s is being used by the following container(s): %s", v.Name(), depsStr)
 		}
 
 		// We need to remove all containers using the volume
@@ -105,7 +106,7 @@ func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool) error
 			if err != nil {
 				// If the container's removed, no point in
 				// erroring.
-				if errors.Cause(err) == ErrNoSuchCtr || errors.Cause(err) == ErrCtrRemoved {
+				if errors.Cause(err) == define.ErrNoSuchCtr || errors.Cause(err) == define.ErrCtrRemoved {
 					continue
 				}
 

--- a/libpod/runtime_volume_unsupported.go
+++ b/libpod/runtime_volume_unsupported.go
@@ -4,16 +4,18 @@ package libpod
 
 import (
 	"context"
+
+	"github.com/containers/libpod/libpod/define"
 )
 
 func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool) error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 func (r *Runtime) newVolume(ctx context.Context, options ...VolumeCreateOption) (*Volume, error) {
-	return nil, ErrNotImplemented
+	return nil, define.ErrNotImplemented
 }
 
 func (r *Runtime) NewVolume(ctx context.Context, options ...VolumeCreateOption) (*Volume, error) {
-	return nil, ErrNotImplemented
+	return nil, define.ErrNotImplemented
 }

--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/containerd/cgroups"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/pkg/errors"
 )
 
@@ -26,7 +27,7 @@ func (c *Container) GetContainerStats(previousStats *ContainerStats) (*Container
 	}
 
 	if c.state.State != ContainerStateRunning {
-		return stats, ErrCtrStateInvalid
+		return stats, define.ErrCtrStateInvalid
 	}
 
 	cgroupPath, err := c.CGroupPath()

--- a/libpod/stats_unsupported.go
+++ b/libpod/stats_unsupported.go
@@ -2,7 +2,9 @@
 
 package libpod
 
+import "github.com/containers/libpod/libpod/define"
+
 // GetContainerStats gets the running stats for a given container
 func (c *Container) GetContainerStats(previousStats *ContainerStats) (*ContainerStats, error) {
-	return nil, ErrOSNotSupported
+	return nil, define.ErrOSNotSupported
 }

--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -6,9 +6,10 @@ import (
 
 	istorage "github.com/containers/image/storage"
 	"github.com/containers/image/types"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/storage"
 	"github.com/opencontainers/image-spec/specs-go/v1"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -71,7 +72,7 @@ func (r *storageService) CreateContainerStorage(ctx context.Context, systemConte
 	if imageName != "" {
 		var ref types.ImageReference
 		if containerName == "" {
-			return ContainerInfo{}, ErrEmptyID
+			return ContainerInfo{}, define.ErrEmptyID
 		}
 		// Check if we have the specified image.
 		ref, err := istorage.Transport.ParseStoreReference(r.store, imageID)
@@ -175,7 +176,7 @@ func (r *storageService) CreateContainerStorage(ctx context.Context, systemConte
 
 func (r *storageService) DeleteContainer(idOrName string) error {
 	if idOrName == "" {
-		return ErrEmptyID
+		return define.ErrEmptyID
 	}
 	container, err := r.store.Container(idOrName)
 	if err != nil {
@@ -214,7 +215,7 @@ func (r *storageService) MountContainerImage(idOrName string) (string, error) {
 	container, err := r.store.Container(idOrName)
 	if err != nil {
 		if errors.Cause(err) == storage.ErrContainerUnknown {
-			return "", ErrNoSuchCtr
+			return "", define.ErrNoSuchCtr
 		}
 		return "", err
 	}
@@ -233,7 +234,7 @@ func (r *storageService) MountContainerImage(idOrName string) (string, error) {
 
 func (r *storageService) UnmountContainerImage(idOrName string, force bool) (bool, error) {
 	if idOrName == "" {
-		return false, ErrEmptyID
+		return false, define.ErrEmptyID
 	}
 	container, err := r.store.Container(idOrName)
 	if err != nil {
@@ -260,7 +261,7 @@ func (r *storageService) UnmountContainerImage(idOrName string, force bool) (boo
 
 func (r *storageService) MountedContainerImage(idOrName string) (int, error) {
 	if idOrName == "" {
-		return 0, ErrEmptyID
+		return 0, define.ErrEmptyID
 	}
 	container, err := r.store.Container(idOrName)
 	if err != nil {
@@ -277,7 +278,7 @@ func (r *storageService) GetMountpoint(id string) (string, error) {
 	container, err := r.store.Container(id)
 	if err != nil {
 		if errors.Cause(err) == storage.ErrContainerUnknown {
-			return "", ErrNoSuchCtr
+			return "", define.ErrNoSuchCtr
 		}
 		return "", err
 	}
@@ -293,7 +294,7 @@ func (r *storageService) GetWorkDir(id string) (string, error) {
 	container, err := r.store.Container(id)
 	if err != nil {
 		if errors.Cause(err) == storage.ErrContainerUnknown {
-			return "", ErrNoSuchCtr
+			return "", define.ErrNoSuchCtr
 		}
 		return "", err
 	}
@@ -304,7 +305,7 @@ func (r *storageService) GetRunDir(id string) (string, error) {
 	container, err := r.store.Container(id)
 	if err != nil {
 		if errors.Cause(err) == storage.ErrContainerUnknown {
-			return "", ErrNoSuchCtr
+			return "", define.ErrNoSuchCtr
 		}
 		return "", err
 	}

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/containers/image/signature"
 	"github.com/containers/image/types"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/fsnotify/fsnotify"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
@@ -126,7 +127,7 @@ func WaitForFile(path string, chWait chan error, timeout time.Duration) (bool, e
 				return false, errors.Wrapf(err, "checking file %s", path)
 			}
 		case <-timeoutChan:
-			return false, errors.Wrapf(ErrInternal, "timed out waiting for file %s", path)
+			return false, errors.Wrapf(define.ErrInternal, "timed out waiting for file %s", path)
 		}
 	}
 }
@@ -156,15 +157,15 @@ func sortMounts(m []spec.Mount) []spec.Mount {
 
 func validPodNSOption(p *Pod, ctrPod string) error {
 	if p == nil {
-		return errors.Wrapf(ErrInvalidArg, "pod passed in was nil. Container may not be associated with a pod")
+		return errors.Wrapf(define.ErrInvalidArg, "pod passed in was nil. Container may not be associated with a pod")
 	}
 
 	if ctrPod == "" {
-		return errors.Wrapf(ErrInvalidArg, "container is not a member of any pod")
+		return errors.Wrapf(define.ErrInvalidArg, "container is not a member of any pod")
 	}
 
 	if ctrPod != p.ID() {
-		return errors.Wrapf(ErrInvalidArg, "pod passed in is not the pod the container is associated with")
+		return errors.Wrapf(define.ErrInvalidArg, "pod passed in is not the pod the container is associated with")
 	}
 	return nil
 }

--- a/libpod/util_linux.go
+++ b/libpod/util_linux.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/containerd/cgroups"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/util"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -61,7 +62,7 @@ func assembleSystemdCgroupName(baseSlice, newSlice string) (string, error) {
 	const sliceSuffix = ".slice"
 
 	if !strings.HasSuffix(baseSlice, sliceSuffix) {
-		return "", errors.Wrapf(ErrInvalidArg, "cannot assemble cgroup path with base %q - must end in .slice", baseSlice)
+		return "", errors.Wrapf(define.ErrInvalidArg, "cannot assemble cgroup path with base %q - must end in .slice", baseSlice)
 	}
 
 	noSlice := strings.TrimSuffix(baseSlice, sliceSuffix)

--- a/libpod/util_unsupported.go
+++ b/libpod/util_unsupported.go
@@ -3,27 +3,28 @@
 package libpod
 
 import (
+	"github.com/containers/libpod/libpod/define"
 	"github.com/pkg/errors"
 )
 
 func systemdSliceFromPath(parent, name string) (string, error) {
-	return "", errors.Wrapf(ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
+	return "", errors.Wrapf(define.ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
 }
 
 func makeSystemdCgroup(path string) error {
-	return errors.Wrapf(ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
+	return errors.Wrapf(define.ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
 }
 
 func deleteSystemdCgroup(path string) error {
-	return errors.Wrapf(ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
+	return errors.Wrapf(define.ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
 }
 
 func assembleSystemdCgroupName(baseSlice, newSlice string) (string, error) {
-	return "", errors.Wrapf(ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
+	return "", errors.Wrapf(define.ErrOSNotSupported, "cgroups are not supported on non-linux OSes")
 }
 
 // LabelVolumePath takes a mount path for a volume and gives it an
 // selinux label of either shared or not
 func LabelVolumePath(path string, shared bool) error {
-	return ErrNotImplemented
+	return define.ErrNotImplemented
 }

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/shared"
 	iopodman "github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/varlinkapi/virtwriter"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/docker/docker/pkg/term"
@@ -239,11 +240,11 @@ func (r *LocalRuntime) StopContainers(ctx context.Context, cli *cliconfig.StopVa
 	for _, id := range ids {
 		if _, err := iopodman.StopContainer().Call(r.Conn, id, int64(cli.Timeout)); err != nil {
 			transError := TranslateError(err)
-			if errors.Cause(transError) == libpod.ErrCtrStopped {
+			if errors.Cause(transError) == define.ErrCtrStopped {
 				ok = append(ok, id)
 				continue
 			}
-			if errors.Cause(transError) == libpod.ErrCtrStateInvalid && cli.All {
+			if errors.Cause(transError) == define.ErrCtrStateInvalid && cli.All {
 				ok = append(ok, id)
 				continue
 			}
@@ -476,7 +477,7 @@ func (r *LocalRuntime) Run(ctx context.Context, c *cliconfig.RunValues, exitCode
 }
 
 func ReadExitFile(runtimeTmp, ctrID string) (int, error) {
-	return 0, libpod.ErrNotImplemented
+	return 0, define.ErrNotImplemented
 }
 
 // Ps lists containers based on criteria from user
@@ -662,7 +663,7 @@ func (r *LocalRuntime) Attach(ctx context.Context, c *cliconfig.AttachValues) er
 }
 
 // Checkpoint one or more containers
-func (r *LocalRuntime) Checkpoint(c *cliconfig.CheckpointValues, options libpod.ContainerCheckpointOptions) error {
+func (r *LocalRuntime) Checkpoint(c *cliconfig.CheckpointValues) error {
 	if c.Export != "" {
 		return errors.New("the remote client does not support exporting checkpoints")
 	}
@@ -689,7 +690,7 @@ func (r *LocalRuntime) Checkpoint(c *cliconfig.CheckpointValues, options libpod.
 	}
 
 	for _, id := range ids {
-		if _, err := iopodman.ContainerCheckpoint().Call(r.Conn, id, options.Keep, options.KeepRunning, options.TCPEstablished); err != nil {
+		if _, err := iopodman.ContainerCheckpoint().Call(r.Conn, id, c.Keep, c.Keep, c.TcpEstablished); err != nil {
 			if lastError != nil {
 				fmt.Fprintln(os.Stderr, lastError)
 			}

--- a/pkg/adapter/errors.go
+++ b/pkg/adapter/errors.go
@@ -4,7 +4,7 @@ package adapter
 
 import (
 	iopodman "github.com/containers/libpod/cmd/podman/varlink"
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/pkg/errors"
 )
 
@@ -21,11 +21,11 @@ func TranslateMapErrors(failures map[string]error) map[string]error {
 func TranslateError(err error) error {
 	switch err.(type) {
 	case *iopodman.ContainerNotFound:
-		return errors.Wrap(libpod.ErrNoSuchCtr, err.Error())
+		return errors.Wrap(define.ErrNoSuchCtr, err.Error())
 	case *iopodman.ErrCtrStopped:
-		return errors.Wrap(libpod.ErrCtrStopped, err.Error())
+		return errors.Wrap(define.ErrCtrStopped, err.Error())
 	case *iopodman.InvalidState:
-		return errors.Wrap(libpod.ErrCtrStateInvalid, err.Error())
+		return errors.Wrap(define.ErrCtrStateInvalid, err.Error())
 	}
 	return err
 }

--- a/pkg/adapter/pods_remote.go
+++ b/pkg/adapter/pods_remote.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/varlinkapi"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -509,7 +510,7 @@ func (p *Pod) GetPodStats(previousContainerStats map[string]*libpod.ContainerSta
 		newStats := varlinkapi.ContainerStatsToLibpodContainerStats(stats)
 		// If the container wasn't running, don't include it
 		// but also suppress the error
-		if err != nil && errors.Cause(err) != libpod.ErrCtrStateInvalid {
+		if err != nil && errors.Cause(err) != define.ErrCtrStateInvalid {
 			return nil, err
 		}
 		if err == nil {

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/remoteclientconfig"
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/events"
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/utils"
@@ -527,12 +528,12 @@ func (r *LocalRuntime) SendFileOverVarlink(source string) (string, error) {
 
 // GetAllVolumes retrieves all the volumes
 func (r *LocalRuntime) GetAllVolumes() ([]*libpod.Volume, error) {
-	return nil, libpod.ErrNotImplemented
+	return nil, define.ErrNotImplemented
 }
 
 // RemoveVolume removes a volumes
 func (r *LocalRuntime) RemoveVolume(ctx context.Context, v *libpod.Volume, force, prune bool) error {
-	return libpod.ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 // GetContainers retrieves all containers from the state
@@ -540,14 +541,14 @@ func (r *LocalRuntime) RemoveVolume(ctx context.Context, v *libpod.Volume, force
 // the output. Multiple filters are handled by ANDing their output, so only
 // containers matching all filters are returned
 func (r *LocalRuntime) GetContainers(filters ...libpod.ContainerFilter) ([]*libpod.Container, error) {
-	return nil, libpod.ErrNotImplemented
+	return nil, define.ErrNotImplemented
 }
 
 // RemoveContainer removes the given container
 // If force is specified, the container will be stopped first
 // Otherwise, RemoveContainer will return an error if the container is running
 func (r *LocalRuntime) RemoveContainer(ctx context.Context, c *libpod.Container, force, volumes bool) error {
-	return libpod.ErrNotImplemented
+	return define.ErrNotImplemented
 }
 
 // CreateVolume creates a volume over a varlink connection for the remote client
@@ -771,7 +772,7 @@ func IsImageNotFound(err error) bool {
 
 // HealthCheck executes a container's healthcheck over a varlink connection
 func (r *LocalRuntime) HealthCheck(c *cliconfig.HealthCheckValues) (libpod.HealthCheckStatus, error) {
-	return -1, libpod.ErrNotImplemented
+	return -1, define.ErrNotImplemented
 }
 
 // Events monitors libpod/podman events over a varlink connection

--- a/pkg/spec/containerconfig.go
+++ b/pkg/spec/containerconfig.go
@@ -2,6 +2,7 @@ package createconfig
 
 import (
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -11,9 +12,9 @@ import (
 // container with libpod from a completed CreateConfig struct.
 func (config *CreateConfig) MakeContainerConfig(runtime *libpod.Runtime, pod *libpod.Pod) (*spec.Spec, []libpod.CtrCreateOption, error) {
 	if config.Pod != "" && pod == nil {
-		return nil, nil, errors.Wrapf(libpod.ErrInvalidArg, "pod was specified but no pod passed")
+		return nil, nil, errors.Wrapf(define.ErrInvalidArg, "pod was specified but no pod passed")
 	} else if config.Pod == "" && pod != nil {
-		return nil, nil, errors.Wrapf(libpod.ErrInvalidArg, "pod was given but no pod is specified")
+		return nil, nil, errors.Wrapf(define.ErrInvalidArg, "pod was given but no pod is specified")
 	}
 
 	// Parse volumes flag into OCI spec mounts and libpod Named Volumes.

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/image/manifest"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/namespaces"
 	"github.com/containers/storage"
 	"github.com/cri-o/ocicni/pkg/ocicni"
@@ -331,9 +332,9 @@ func (c *CreateConfig) getContainerCreateOptions(runtime *libpod.Runtime, pod *l
 	if c.IPAddress != "" {
 		ip := net.ParseIP(c.IPAddress)
 		if ip == nil {
-			return nil, errors.Wrapf(libpod.ErrInvalidArg, "cannot parse %s as IP address", c.IPAddress)
+			return nil, errors.Wrapf(define.ErrInvalidArg, "cannot parse %s as IP address", c.IPAddress)
 		} else if ip.To4() == nil {
-			return nil, errors.Wrapf(libpod.ErrInvalidArg, "%s is not an IPv4 address", c.IPAddress)
+			return nil, errors.Wrapf(define.ErrInvalidArg, "%s is not an IPv4 address", c.IPAddress)
 		}
 		options = append(options, libpod.WithStaticIP(ip))
 	}
@@ -371,7 +372,7 @@ func (c *CreateConfig) getContainerCreateOptions(runtime *libpod.Runtime, pod *l
 
 	if c.RestartPolicy != "" {
 		if c.RestartPolicy == "unless-stopped" {
-			return nil, errors.Wrapf(libpod.ErrInvalidArg, "the unless-stopped restart policy is not supported")
+			return nil, errors.Wrapf(define.ErrInvalidArg, "the unless-stopped restart policy is not supported")
 		}
 
 		split := strings.Split(c.RestartPolicy, ":")
@@ -381,7 +382,7 @@ func (c *CreateConfig) getContainerCreateOptions(runtime *libpod.Runtime, pod *l
 				return nil, errors.Wrapf(err, "%s is not a valid number of retries for restart policy", split[1])
 			}
 			if numTries < 0 {
-				return nil, errors.Wrapf(libpod.ErrInvalidArg, "restart policy requires a positive number of retries")
+				return nil, errors.Wrapf(define.ErrInvalidArg, "restart policy requires a positive number of retries")
 			}
 			options = append(options, libpod.WithRestartRetries(uint(numTries)))
 		}

--- a/pkg/varlinkapi/attach.go
+++ b/pkg/varlinkapi/attach.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/varlinkapi/virtwriter"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/remotecommand"
@@ -78,7 +79,7 @@ func (i *LibpodAPI) Attach(call iopodman.VarlinkCall, name string, detachKeys st
 		finalErr = startAndAttach(ctr, streams, detachKeys, resize, errChan)
 	}
 
-	if finalErr != libpod.ErrDetach && finalErr != nil {
+	if finalErr != define.ErrDetach && finalErr != nil {
 		logrus.Error(finalErr)
 	}
 	quitWriter := virtwriter.NewVirtWriteCloser(writer, virtwriter.Quit)

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter/shortcuts"
 	cc "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/storage/pkg/archive"
@@ -119,7 +120,7 @@ func (i *LibpodAPI) GetContainersByContext(call iopodman.VarlinkCall, all, lates
 
 	ctrs, err := shortcuts.GetContainersByContext(all, latest, input, i.Runtime)
 	if err != nil {
-		if errors.Cause(err) == libpod.ErrNoSuchCtr {
+		if errors.Cause(err) == define.ErrNoSuchCtr {
 			return call.ReplyContainerNotFound("", err.Error())
 		}
 		return call.ReplyErrorOccurred(err.Error())
@@ -326,7 +327,7 @@ func (i *LibpodAPI) GetContainerStats(call iopodman.VarlinkCall, name string) er
 	}
 	containerStats, err := ctr.GetContainerStats(&libpod.ContainerStats{})
 	if err != nil {
-		if errors.Cause(err) == libpod.ErrCtrStateInvalid {
+		if errors.Cause(err) == define.ErrCtrStateInvalid {
 			return call.ReplyNoContainerRunning()
 		}
 		return call.ReplyErrorOccurred(err.Error())
@@ -379,7 +380,7 @@ func (i *LibpodAPI) InitContainer(call iopodman.VarlinkCall, name string) error 
 		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	if err := ctr.Init(getContext()); err != nil {
-		if errors.Cause(err) == libpod.ErrCtrStateInvalid {
+		if errors.Cause(err) == define.ErrCtrStateInvalid {
 			return call.ReplyInvalidState(ctr.ID(), err.Error())
 		}
 		return call.ReplyErrorOccurred(err.Error())
@@ -394,10 +395,10 @@ func (i *LibpodAPI) StopContainer(call iopodman.VarlinkCall, name string, timeou
 		return call.ReplyContainerNotFound(name, err.Error())
 	}
 	if err := ctr.StopWithTimeout(uint(timeout)); err != nil {
-		if errors.Cause(err) == libpod.ErrCtrStopped {
+		if errors.Cause(err) == define.ErrCtrStopped {
 			return call.ReplyErrCtrStopped(ctr.ID())
 		}
-		if errors.Cause(err) == libpod.ErrCtrStateInvalid {
+		if errors.Cause(err) == define.ErrCtrStateInvalid {
 			return call.ReplyInvalidState(ctr.ID(), err.Error())
 		}
 		return call.ReplyErrorOccurred(err.Error())
@@ -420,7 +421,7 @@ func (i *LibpodAPI) RestartContainer(call iopodman.VarlinkCall, name string, tim
 // ContainerExists looks in local storage for the existence of a container
 func (i *LibpodAPI) ContainerExists(call iopodman.VarlinkCall, name string) error {
 	_, err := i.Runtime.LookupContainer(name)
-	if errors.Cause(err) == libpod.ErrNoSuchCtr {
+	if errors.Cause(err) == define.ErrNoSuchCtr {
 		return call.ReplyContainerExists(1)
 	}
 	if err != nil {

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/libpod/utils"
@@ -760,7 +761,7 @@ func (i *LibpodAPI) ImagesPrune(call iopodman.VarlinkCall, all bool) error {
 func (i *LibpodAPI) ImageSave(call iopodman.VarlinkCall, options iopodman.ImageSaveOptions) error {
 	newImage, err := i.Runtime.ImageRuntime().NewFromLocal(options.Name)
 	if err != nil {
-		if errors.Cause(err) == libpod.ErrNoSuchImage {
+		if errors.Cause(err) == define.ErrNoSuchImage {
 			return call.ReplyImageNotFound(options.Name, err.Error())
 		}
 		return call.ReplyErrorOccurred(err.Error())


### PR DESCRIPTION
the compilation demands of having libpod in main is a burden for the
remote client compilations.  to combat this, we should move the use of
libpod structs, vars, constants, and functions into the adapter code
where it will only be compiled by the local client.

this should result in cleaner code organization and smaller binaries. it
should also help if we ever need to compile the remote client on
non-Linux operating systems natively (not cross-compiled).

Signed-off-by: baude <bbaude@redhat.com>