### PR TITLE
Fix crash for when remote host IP or Username is not set in conf file…

### DIFF
--- a/cmd/podman/remoteclientconfig/configfile.go
+++ b/cmd/podman/remoteclientconfig/configfile.go
@@ -22,7 +22,7 @@ func ReadRemoteConfig(reader io.Reader) (*RemoteConfig, error) {
 	// We need to validate each remote connection has fields filled out
 	for name, conn := range remoteConfig.Connections {
 		if len(conn.Destination) < 1 {
-			return nil, errors.Errorf("connection %s has no destination defined", name)
+			return nil, errors.Errorf("connection %q has no destination defined", name)
 		}
 	}
 	return &remoteConfig, err


### PR DESCRIPTION
… & conf file exists.

When Host IP is not set in podman-remote.conf, error is printed out.
When Username is not set in podman-remote.conf, default username is used.

Closes  #3368

Signed-off-by: Ashley Cui <ashleycui16@gmail.com>