### PR TITLE
Handle images which contain no layers

### DIFF
--- a/cmd/podman/tree.go
+++ b/cmd/podman/tree.go
@@ -72,7 +72,11 @@ func printTree(imageInfo *image.InfoImage, layerInfoMap map[string]*image.LayerI
 	fmt.Printf("Image ID: %s\n", imageInfo.ID[:12])
 	fmt.Printf("Tags:\t %s\n", imageInfo.Tags)
 	fmt.Printf("Size:\t %v\n", units.HumanSizeWithPrecision(float64(*size), 4))
-	fmt.Printf(fmt.Sprintf("Image Layers\n"))
+	if img.TopLayer() != "" {
+		fmt.Printf("Image Layers\n")
+	} else {
+		fmt.Printf("No Image Layers\n")
+	}
 
 	if !whatRequires {
 		// fill imageInfo with layers associated with image.


### PR DESCRIPTION
This fixes some of our handling of images which have no layers, i.e., those whose TopLayer is set to an empty value.  Should address large parts (if not all) of #3304.