### PR TITLE
Set correct SELinux label on restored containers

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -157,6 +157,9 @@ type Container struct {
 	// being checkpointed. If requestedIP is set it will be used instead
 	// of config.StaticIP.
 	requestedIP net.IP
+
+	// This is true if a container is restored from a checkpoint.
+	restoreFromCheckpoint bool
 }
 
 // ContainerState contains the current state of the container

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -351,6 +351,16 @@ func (c *Container) setupStorage(ctx context.Context) error {
 		},
 		LabelOpts: c.config.LabelOpts,
 	}
+	if c.restoreFromCheckpoint {
+		// If restoring from a checkpoint, the root file-system
+		// needs to be mounted with the same SELinux labels as
+		// it was mounted previously.
+		if options.Flags == nil {
+			options.Flags = make(map[string]interface{})
+		}
+		options.Flags["ProcessLabel"] = c.config.ProcessLabel
+		options.Flags["MountLabel"] = c.config.MountLabel
+	}
 	if c.config.Privileged {
 		privOpt := func(opt string) bool {
 			for _, privopt := range []string{"nodev", "nosuid", "noexec"} {


### PR DESCRIPTION
Restoring a container from a checkpoint archive mounted the container's root file-system with a new SELinux mountlabel which resulted in a container running with a different label then the root file-system.

This tells the storage setup to use the mountlabel which is stored in the checkpoint archive.

The easiest way to reproduce this bug is to run 'podman exec' on a restored container.

This also includes a new checkpoint/restore test case doing a 'podman exec' after 'podman container restore'. Unfortunately the test does not trigger the error as the tests running under ginkgo are not under the same SELinux confinement as the actual containers. At least that is how understand it.