### PR TITLE
Fix parsing of the --tmpfs option

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -496,7 +496,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"systemd", cliconfig.DefaultSystemD,
 		"Run container in systemd mode if the command executable is systemd or init",
 	)
-	createFlags.StringSlice(
+	createFlags.StringArray(
 		"tmpfs", []string{},
 		"Mount a temporary filesystem (`tmpfs`) into a container (default [])",
 	)

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -690,7 +690,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		StopTimeout:   c.Uint("stop-timeout"),
 		Sysctl:        sysctl,
 		Systemd:       systemd,
-		Tmpfs:         c.StringSlice("tmpfs"),
+		Tmpfs:         c.StringArray("tmpfs"),
 		Tty:           tty,
 		User:          user,
 		UsernsMode:    usernsMode,

--- a/cmd/podman/shared/intermediate.go
+++ b/cmd/podman/shared/intermediate.go
@@ -448,7 +448,7 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIRes
 	m["subuidname"] = newCRString(c, "subuidname")
 	m["sysctl"] = newCRStringSlice(c, "sysctl")
 	m["systemd"] = newCRBool(c, "systemd")
-	m["tmpfs"] = newCRStringSlice(c, "tmpfs")
+	m["tmpfs"] = newCRStringArray(c, "tmpfs")
 	m["tty"] = newCRBool(c, "tty")
 	m["uidmap"] = newCRStringSlice(c, "uidmap")
 	m["ulimit"] = newCRStringSlice(c, "ulimit")


### PR DESCRIPTION
With StringSlice, we're seeing individual options added and parsed separately, so `tmpfs:nosuid,nodev` turns into three tmpfs mounts passed into pkg/sec (tmpfs:, nosuid, nodev). Swap to StringArray to tell cobra this can't be split on commas.