### PR TITLE
Include changes to the container's root file-system in the checkpoint archive

### DIFF
--- a/cmd/podman/checkpoint.go
+++ b/cmd/podman/checkpoint.go
@@ -46,6 +46,7 @@ func init() {
 	flags.BoolVarP(&checkpointCommand.All, "all", "a", false, "Checkpoint all running containers")
 	flags.BoolVarP(&checkpointCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.StringVarP(&checkpointCommand.Export, "export", "e", "", "Export the checkpoint image to a tar.gz")
+	flags.BoolVar(&checkpointCommand.IgnoreRootfs, "ignore-rootfs", false, "Do not include root file-system changes when exporting")
 	markFlagHiddenForRemoteClient("latest", flags)
 }
 

--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -92,6 +92,7 @@ type CheckpointValues struct {
 	All            bool
 	Latest         bool
 	Export         string
+	IgnoreRootfs   bool
 }
 
 type CommitValues struct {
@@ -433,6 +434,7 @@ type RestoreValues struct {
 	TcpEstablished bool
 	Import         string
 	Name           string
+	IgnoreRootfs   bool
 }
 
 type RmValues struct {

--- a/cmd/podman/restore.go
+++ b/cmd/podman/restore.go
@@ -45,6 +45,7 @@ func init() {
 	flags.BoolVar(&restoreCommand.TcpEstablished, "tcp-established", false, "Restore a container with established TCP connections")
 	flags.StringVarP(&restoreCommand.Import, "import", "i", "", "Restore from exported checkpoint archive (tar.gz)")
 	flags.StringVarP(&restoreCommand.Name, "name", "n", "", "Specify new name for container restored from exported checkpoint (only works with --import)")
+	flags.BoolVar(&restoreCommand.IgnoreRootfs, "ignore-rootfs", false, "Do not apply root file-system changes when importing from exported checkpoint")
 
 	markFlagHiddenForRemoteClient("latest", flags)
 }
@@ -59,6 +60,10 @@ func restoreCmd(c *cliconfig.RestoreValues, cmd *cobra.Command) error {
 		return errors.Wrapf(err, "could not get runtime")
 	}
 	defer runtime.DeferredShutdown(false)
+
+	if c.Import == "" && c.IgnoreRootfs {
+		return errors.Errorf("--ignore-rootfs can only be used with --import")
+	}
 
 	if c.Import == "" && c.Name != "" {
 		return errors.Errorf("--name can only be used with --import")

--- a/cmd/podman/restore.go
+++ b/cmd/podman/restore.go
@@ -61,7 +61,7 @@ func restoreCmd(c *cliconfig.RestoreValues, cmd *cobra.Command) error {
 	defer runtime.DeferredShutdown(false)
 
 	if c.Import == "" && c.Name != "" {
-		return errors.Errorf("--name can only used with --import")
+		return errors.Errorf("--name can only be used with --import")
 	}
 
 	if c.Name != "" && c.TcpEstablished {

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -758,6 +758,7 @@ _podman_container_checkpoint() {
      -R
      --leave-running
      --tcp-established
+     --ignore-rootfs
      "
      case "$prev" in
         -e|--export)
@@ -870,6 +871,7 @@ _podman_container_restore() {
 	  -l
 	  --latest
 	  --tcp-established
+	  --ignore-rootfs
      "
      case "$prev" in
         -i|--import)

--- a/docs/podman-container-checkpoint.1.md
+++ b/docs/podman-container-checkpoint.1.md
@@ -42,7 +42,15 @@ connections.
 
 Export the checkpoint to a tar.gz file. The exported checkpoint can be used
 to import the container on another system and thus enabling container live
-migration.
+migration. This checkpoint archive also includes all changes to the container's
+root file-system, if not explicitly disabled using **--ignore-rootfs**
+
+**--ignore-rootfs**
+
+This only works in combination with **--export, -e**. If a checkpoint is
+exported to a tar.gz file it is possible with the help of **--ignore-rootfs**
+to explicitly disable including changes to the root file-system into
+the checkpoint archive file.
 
 ## EXAMPLE
 

--- a/docs/podman-container-restore.1.md
+++ b/docs/podman-container-restore.1.md
@@ -60,6 +60,13 @@ address to the container it was using before checkpointing as each IP address ca
 be used once and the restored container will have another IP address. This also means
 that **--name, -n** cannot be used in combination with **--tcp-established**.
 
+**--ignore-rootfs**
+
+This is only available in combination with **--import, -i**. If a container is restored
+from a checkpoint tar.gz file it is possible that it also contains all root file-system
+changes. With **--ignore-rootfs** it is possible to explicitly disable applying these
+root file-system changes to the restored container.
+
 ## EXAMPLE
 
 podman container restore mywebserver

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -799,6 +799,9 @@ type ContainerCheckpointOptions struct {
 	// checkpoint archive a new name should be used for the
 	// restored container
 	Name string
+	// IgnoreRootfs tells the API to not export changes to
+	// the container's root file-system (or to not import)
+	IgnoreRootfs bool
 }
 
 // Checkpoint checkpoints a container

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -792,10 +792,8 @@ type ContainerCheckpointOptions struct {
 	// TCPEstablished tells the API to checkpoint a container
 	// even if it contains established TCP connections
 	TCPEstablished bool
-	// Export tells the API to write the checkpoint image to
-	// the filename set in TargetFile
-	// Import tells the API to read the checkpoint image from
-	// the filename set in TargetFile
+	// TargetFile tells the API to read (or write) the checkpoint image
+	// from (or to) the filename set in TargetFile
 	TargetFile string
 	// Name tells the API that during restore from an exported
 	// checkpoint archive a new name should be used for the

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -510,41 +510,44 @@ func (c *Container) addNamespaceContainer(g *generate.Generator, ns LinuxNS, ctr
 	return nil
 }
 
-func (c *Container) exportCheckpoint(dest string) (err error) {
+func (c *Container) exportCheckpoint(dest string, ignoreRootfs bool) (err error) {
 	if (len(c.config.NamedVolumes) > 0) || (len(c.Dependencies()) > 0) {
 		return errors.Errorf("Cannot export checkpoints of containers with named volumes or dependencies")
 	}
 	logrus.Debugf("Exporting checkpoint image of container %q to %q", c.ID(), dest)
 
+	includeFiles := []string{
+		"checkpoint",
+		"artifacts",
+		"ctr.log",
+		"config.dump",
+		"spec.dump",
+		"network.status"}
+
 	// Get root file-system changes included in the checkpoint archive
 	rootfsDiffPath := filepath.Join(c.bundlePath(), "rootfs-diff.tar")
-	rootfsDiffFile, err := os.Create(rootfsDiffPath)
-	if err != nil {
-		return errors.Wrapf(err, "error creating root file-system diff file %q", rootfsDiffPath)
+	if !ignoreRootfs {
+		rootfsDiffFile, err := os.Create(rootfsDiffPath)
+		if err != nil {
+			return errors.Wrapf(err, "error creating root file-system diff file %q", rootfsDiffPath)
+		}
+		tarStream, err := c.runtime.GetDiffTarStream("", c.ID())
+		if err != nil {
+			return errors.Wrapf(err, "error exporting root file-system diff to %q", rootfsDiffPath)
+		}
+		_, err = io.Copy(rootfsDiffFile, tarStream)
+		if err != nil {
+			return errors.Wrapf(err, "error exporting root file-system diff to %q", rootfsDiffPath)
+		}
+		tarStream.Close()
+		rootfsDiffFile.Close()
+		includeFiles = append(includeFiles, "rootfs-diff.tar")
 	}
-	tarStream, err := c.runtime.GetDiffTarStream("", c.ID())
-	if err != nil {
-		return errors.Wrapf(err, "error exporting root file-system diff to %q", rootfsDiffPath)
-	}
-	_, err = io.Copy(rootfsDiffFile, tarStream)
-	if err != nil {
-		return errors.Wrapf(err, "error exporting root file-system diff to %q", rootfsDiffPath)
-	}
-	tarStream.Close()
-	rootfsDiffFile.Close()
-
 
 	input, err := archive.TarWithOptions(c.bundlePath(), &archive.TarOptions{
 		Compression:      archive.Gzip,
 		IncludeSourceDir: true,
-		IncludeFiles: []string{
-			"checkpoint",
-			"artifacts",
-			"ctr.log",
-			"config.dump",
-			"spec.dump",
-			"rootfs-diff.tar",
-			"network.status"},
+		IncludeFiles:     includeFiles,
 	})
 
 	if err != nil {
@@ -627,7 +630,7 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 	}
 
 	if options.TargetFile != "" {
-		if err = c.exportCheckpoint(options.TargetFile); err != nil {
+		if err = c.exportCheckpoint(options.TargetFile, options.IgnoreRootfs); err != nil {
 			return err
 		}
 	}
@@ -816,17 +819,19 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 	}
 
 	// Before actually restarting the container, apply the root file-system changes
-	rootfsDiffPath := filepath.Join(c.bundlePath(), "rootfs-diff.tar")
-	if _, err := os.Stat(rootfsDiffPath); err == nil {
-		// Only do this if a rootfs-diff.tar actually exists
-		rootfsDiffFile, err := os.Open(rootfsDiffPath)
-		if err != nil {
-			return errors.Wrapf(err, "Failed to open root file-system diff file %s", rootfsDiffPath)
+	if !options.IgnoreRootfs {
+		rootfsDiffPath := filepath.Join(c.bundlePath(), "rootfs-diff.tar")
+		if _, err := os.Stat(rootfsDiffPath); err == nil {
+			// Only do this if a rootfs-diff.tar actually exists
+			rootfsDiffFile, err := os.Open(rootfsDiffPath)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to open root file-system diff file %s", rootfsDiffPath)
+			}
+			if err := c.runtime.ApplyDiffTarStream(c.ID(), rootfsDiffFile); err != nil {
+				return errors.Wrapf(err, "Failed to apply root file-system diff file %s", rootfsDiffPath)
+			}
+			rootfsDiffFile.Close()
 		}
-		if err := c.runtime.ApplyDiffTarStream(c.ID(), rootfsDiffFile); err != nil {
-			return errors.Wrapf(err, "Failed to apply root file-system diff file %s", rootfsDiffPath)
-		}
-		rootfsDiffFile.Close()
 	}
 
 	if err := c.ociRuntime.createContainer(c, c.config.CgroupParent, &options); err != nil {

--- a/pkg/adapter/checkpoint_restore.go
+++ b/pkg/adapter/checkpoint_restore.go
@@ -55,6 +55,7 @@ func crImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, input stri
 			"checkpoint",
 			"artifacts",
 			"ctr.log",
+			"rootfs-diff.tar",
 			"network.status",
 		},
 	}

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -524,6 +524,10 @@ func (r *LocalRuntime) Checkpoint(c *cliconfig.CheckpointValues) error {
 		KeepRunning:    c.LeaveRunning,
 		TCPEstablished: c.TcpEstablished,
 		TargetFile:     c.Export,
+		IgnoreRootfs:   c.IgnoreRootfs,
+	}
+	if c.Export == "" && c.IgnoreRootfs {
+		return errors.Errorf("--ignore-rootfs can only be used with --export")
 	}
 	if c.All {
 		containers, err = r.Runtime.GetRunningContainers()
@@ -560,6 +564,7 @@ func (r *LocalRuntime) Restore(ctx context.Context, c *cliconfig.RestoreValues) 
 		TCPEstablished: c.TcpEstablished,
 		TargetFile:     c.Import,
 		Name:           c.Name,
+		IgnoreRootfs:   c.IgnoreRootfs,
 	}
 
 	filterFuncs = append(filterFuncs, func(c *libpod.Container) bool {

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -668,6 +668,9 @@ func (r *LocalRuntime) Checkpoint(c *cliconfig.CheckpointValues) error {
 	if c.Export != "" {
 		return errors.New("the remote client does not support exporting checkpoints")
 	}
+	if c.IgnoreRootfs {
+		return errors.New("the remote client does not support --ignore-rootfs")
+	}
 
 	var lastError error
 	ids, err := iopodman.GetContainersByContext().Call(r.Conn, c.All, c.Latest, c.InputArgs)
@@ -707,6 +710,9 @@ func (r *LocalRuntime) Checkpoint(c *cliconfig.CheckpointValues) error {
 func (r *LocalRuntime) Restore(ctx context.Context, c *cliconfig.RestoreValues) error {
 	if c.Import != "" {
 		return errors.New("the remote client does not support importing checkpoints")
+	}
+	if c.IgnoreRootfs {
+		return errors.New("the remote client does not support --ignore-rootfs")
 	}
 
 	var lastError error


### PR DESCRIPTION
One limitation of Podman's container migration feature was that it was problematic to migrate containers which changed their root file-system. The recommendation until now was to mount all directories which the container potentially changes with `--tmpfs`. Everything in a `--tmpfs` was already included in the checkpoint archive.

To make it easier for the users to migrate a container, without first mounting all directories with possible changes with `--tmpfs`, this now adds container root file-system changes to the checkpoint archive.

To extract the changes to the container's root file-system the functionality behind `podman diff` is used. There were discussion about using `podman commit`, but that would mean that the restored container is now referencing another storage top layer than it was started with. Using `podman diff` makes it possible to have the restored container the same as possible as the original container.

If the root file-system changes are very large or unnecessary for the container migration there is now a new option for checkpoint and restore called: `--ignore-rootfs`. This option tells Podman to not include the root file-system changes in the checkpoint archive during checkpointing, or if they are part of the checkpoint archive to ignore the root file-system changes during restore.