### PR TITLE
[WIP] Dont shutdown stores for read-only podman actions

### DIFF
--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -64,7 +64,7 @@ func cpCmd(c *cliconfig.CpValues) error {
 		return errors.Errorf("you must provide a source path and a destination path")
 	}
 
-	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand, false)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -84,7 +84,7 @@ func inspectCmd(c *cliconfig.InspectValues) error {
 		return errors.Errorf("you cannot provide additional arguments with --latest")
 	}
 
-	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := adapter.GetRuntimeReadOnlyStore(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -15,20 +15,20 @@ import (
 
 // GetRuntimeMigrate gets a libpod runtime that will perform a migration of existing containers
 func GetRuntimeMigrate(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(ctx, c, false, true)
+	return getRuntime(ctx, c, false, true, false)
 }
 
 // GetRuntimeRenumber gets a libpod runtime that will perform a lock renumber
 func GetRuntimeRenumber(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(ctx, c, true, false)
+	return getRuntime(ctx, c, true, false, false)
 }
 
 // GetRuntime generates a new libpod runtime configured by command line options
-func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(ctx, c, false, false)
+func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand, closeStoreReadOnly bool) (*libpod.Runtime, error) {
+	return getRuntime(ctx, c, false, false, closeStoreReadOnly)
 }
 
-func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber bool, migrate bool) (*libpod.Runtime, error) {
+func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber bool, migrate bool, closeStoreReadonly bool) (*libpod.Runtime, error) {
 	options := []libpod.RuntimeOption{}
 	storageOpts := storage.StoreOptions{}
 	storageSet := false
@@ -135,6 +135,9 @@ func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber bool, 
 		options = append(options, libpod.WithHooksDir(c.GlobalFlags.HooksDir...))
 	}
 
+	if closeStoreReadonly {
+		options = append(options, libpod.WithCloseStoreAsReadOnly(closeStoreReadonly))
+	}
 	// TODO flag to set CNI plugins dir?
 
 	// TODO I dont think these belong here?

--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -144,7 +144,7 @@ func setupRootless(cmd *cobra.Command, args []string) error {
 
 	// if there is no pid file, try to join existing containers, and create a pause process.
 
-	runtime, err := libpodruntime.GetRuntime(getContext(), &podmanCmd)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &podmanCmd, false)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -61,7 +61,7 @@ type jsonMountPoint struct {
 }
 
 func mountCmd(c *cliconfig.MountValues) error {
-	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand, false)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/refresh.go
+++ b/cmd/podman/refresh.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func refreshCmd(c *cliconfig.RefreshValues) error {
-	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand, false)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/runlabel.go
+++ b/cmd/podman/runlabel.go
@@ -91,7 +91,7 @@ func runlabelCmd(c *cliconfig.RunlabelValues) error {
 	}
 
 	opts := make(map[string]string)
-	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand, false)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/sign.go
+++ b/cmd/podman/sign.go
@@ -56,7 +56,7 @@ func signCmd(c *cliconfig.SignValues) error {
 	if len(args) < 1 {
 		return errors.Errorf("at least one image name must be specified")
 	}
-	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand, false)
 	if err != nil {
 		return errors.Wrapf(err, "could not create runtime")
 	}

--- a/cmd/podman/stats.go
+++ b/cmd/podman/stats.go
@@ -89,7 +89,7 @@ func statsCmd(c *cliconfig.StatsValues) error {
 		return errors.Errorf("you must specify --all, --latest, or at least one container")
 	}
 
-	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand, false)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/system_df.go
+++ b/cmd/podman/system_df.go
@@ -102,7 +102,7 @@ func init() {
 }
 
 func dfSystemCmd(c *cliconfig.SystemDfValues) error {
-	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand, false)
 	if err != nil {
 		return errors.Wrapf(err, "Could not get runtime")
 	}

--- a/cmd/podman/trust_set_show.go
+++ b/cmd/podman/trust_set_show.go
@@ -74,7 +74,7 @@ File(s) must exist before using this command`)
 }
 
 func showTrustCmd(c *cliconfig.ShowTrustValues) error {
-	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand, false)
 	if err != nil {
 		return errors.Wrapf(err, "could not create runtime")
 	}
@@ -131,7 +131,7 @@ func showTrustCmd(c *cliconfig.ShowTrustValues) error {
 }
 
 func setTrustCmd(c *cliconfig.SetTrustValues) error {
-	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand, false)
 	if err != nil {
 		return errors.Wrapf(err, "could not create runtime")
 	}

--- a/cmd/podman/varlink.go
+++ b/cmd/podman/varlink.go
@@ -79,7 +79,7 @@ func varlinkCmd(c *cliconfig.VarlinkValues) error {
 	timeout := time.Duration(c.Timeout) * time.Millisecond
 
 	// Create a single runtime for varlink
-	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand, false)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1663,3 +1663,13 @@ func WithHealthCheck(healthCheck *manifest.Schema2HealthConfig) CtrCreateOption 
 		return nil
 	}
 }
+
+// WithCloseStoreAsReadOnly opts out of closing container storage
+func WithCloseStoreAsReadOnly(readonly bool) RuntimeOption {
+	return func(rt *Runtime) error {
+		if readonly {
+			rt.closeStoreAsReadOnly = true
+		}
+		return nil
+	}
+}

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -120,6 +120,10 @@ type Runtime struct {
 
 	// mechanism to read and write even logs
 	eventer events.Eventer
+
+	// readWriteCloseStore is bool used to determine whether we should be telling
+	// the store to do a filesystem sync when closing the store
+	closeStoreAsReadOnly bool
 }
 
 // RuntimeConfig contains configuration options used to set up the runtime
@@ -1131,7 +1135,8 @@ func (r *Runtime) Shutdown(force bool) error {
 	}
 
 	var lastError error
-	if r.store != nil {
+	if r.store != nil && !r.closeStoreAsReadOnly {
+		logrus.Debug("Closing container storage")
 		if _, err := r.store.Shutdown(force); err != nil {
 			lastError = errors.Wrapf(err, "Error shutting down container storage")
 		}

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -58,9 +58,18 @@ type Volume struct {
 // VolumeFilter is for filtering volumes on the client
 type VolumeFilter func(*Volume) bool
 
+// GetRuntimeReadOnlyStore returns a LocalRuntime struct with the actual runtime embedded in it
+func GetRuntimeReadOnlyStore(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
+	return getRuntime(ctx, c, true)
+}
+
 // GetRuntime returns a LocalRuntime struct with the actual runtime embedded in it
 func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
-	runtime, err := libpodruntime.GetRuntime(ctx, c)
+	return getRuntime(ctx, c, false)
+}
+
+func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, closeStoreAsReadonly bool) (*LocalRuntime, error) {
+	runtime, err := libpodruntime.GetRuntime(ctx, c, closeStoreAsReadonly)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -50,6 +50,11 @@ type LocalRuntime struct {
 	*RemoteRuntime
 }
 
+// GetRuntimeReadOnlyStore returns a LocalRuntime struct with the actual runtime embedded in it
+func GetRuntimeReadOnlyStore(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
+	return GetRuntime(ctx, c)
+}
+
 // GetRuntime returns a LocalRuntime struct with the actual runtime embedded in it
 func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
 	var (


### PR DESCRIPTION
For read-only actions in podman like ps, inspect, and info, we can avoid
the perf penalty for closing storage.  The store will just unlocked.

$ time sudo podman.before inspect 4476 > /dev/null
real 0m7.701s

$ time sudo podman inspect 4476 > /dev/null
real 0m0.874s

Signed-off-by: baude <bbaude@redhat.com>