### PR TITLE
Remove umount command from remote client.

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -19,6 +19,7 @@ func getMainCommands() []*cobra.Command {
 		_refreshCommand,
 		_searchCommand,
 		_statsCommand,
+		_umountCommand,
 		_unshareCommand,
 	}
 

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -59,7 +59,6 @@ var mainCommands = []*cobra.Command{
 	_stopCommand,
 	_tagCommand,
 	_topCommand,
-	_umountCommand,
 	_unpauseCommand,
 	_versionCommand,
 	_waitCommand,


### PR DESCRIPTION
Since there is no mount command in remote, it does not make sense to have umount.

Signed-off-by: Ashley Cui <ashleycui16@gmail.com>