### PR TITLE
Healthcheck doc and completion fixes

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1807,10 +1807,11 @@ _podman_container_run() {
 	if [ "$command" = "run" -o "$subcommand" = "run" ] ; then
 		options_with_args="$options_with_args
 			--detach-keys
-			--health-cmd
-			--health-interval
-			--health-retries
-			--health-timeout
+			--healthcheck-command
+			--healthcheck-interval
+			--healthcheck-retries
+			--healthcheck-start-period
+			--healthcheck-timeout
 		"
 		boolean_options="$boolean_options
 			--detach -d

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1815,7 +1815,6 @@ _podman_container_run() {
 		"
 		boolean_options="$boolean_options
 			--detach -d
-			--no-healthcheck
 			--rm
 			--sig-proxy=false
 		"

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -266,7 +266,7 @@ The following example maps uids 0-2000 in the container to the uids 30000-31999 
 
 Add additional groups to run as
 
-**--healthcheck**=*command*
+**--healthcheck-command**=*command*
 
 Set or alter a healthcheck command for a container. The command is a command to be executed inside your
 container that determines your container health.  The command is required for other healthcheck options

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -272,6 +272,8 @@ Set or alter a healthcheck command for a container. The command is a command to 
 container that determines your container health.  The command is required for other healthcheck options
 to be applied.  A value of `none` disables existing healthchecks.
 
+Healthchecks currently only work when running as root.
+
 **--healthcheck-interval**=*interval*
 
 Set an interval for the healthchecks (a value of `disable` results in no automatic timer setup) (default "30s")

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -279,6 +279,8 @@ Set or alter a healthcheck command for a container. The command is a command to 
 container that determines your container health.  The command is required for other healthcheck options
 to be applied.  A value of `none` disables existing healthchecks.
 
+Healthchecks currently only work when running as root.
+
 **--healthcheck-interval**=*interval*
 
 Set an interval for the healthchecks (a value of `disable` results in no automatic timer setup) (default "30s")

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -273,7 +273,7 @@ The example maps gids 0-2000 in the container to the gids 30000-31999 on the hos
 
 Add additional groups to run as
 
-**--healthcheck**=*command*
+**--healthcheck-command**=*command*
 
 Set or alter a healthcheck command for a container. The command is a command to be executed inside your
 container that determines your container health.  The command is required for other healthcheck options


### PR DESCRIPTION
The `--healthcheck-*` docs and completion has some issues in `podman version 1.4.2` on Fedora 30:
- Bash completion completes `--health-*`. Although this would be compatible with [Docker CLI] (is podman still aiming for this?), the actual implementation is `--healthcheck-*`.
- `--healthcheck-command=command` is documented as `--healthcheck=command`.
- `--no-healthcheck` has currently(?) no implementation, while it's offered by bash completion.
- It's nowhere mentioned that healthchecks only [work when running as root].

This change attempts to address all the above.

Let me know if any of this needs adjustment.

[Docker CLI]: https://docs.docker.com/engine/reference/run/#healthcheck
[work when running as root]: https://developers.redhat.com/blog/2019/04/18/monitoring-container-vitality-and-availability-with-podman/