### PR TITLE
Ensure locks are freed when ctr/pod creation fails

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 - Fixed a bug where running Podman as root with `sudo -E` would not work after running rootless Podman at least once
 - Fixed a bug where options for `tmpfs` volumes added with the `--tmpfs` flag were being ignored
 - Fixed a bug where images with no layers could not properly be displayed and removed by Podman
+- Fixed a bug where locks were not properly freed on failure to create a container or pod
 
 ### Misc
 - Updated containers/storage to v1.12.13

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -132,6 +132,14 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container, restore bo
 	ctr.config.LockID = ctr.lock.ID()
 	logrus.Debugf("Allocated lock %d for container %s", ctr.lock.ID(), ctr.ID())
 
+	defer func() {
+		if err != nil {
+			if err2 := ctr.lock.Free(); err2 != nil {
+				logrus.Errorf("Error freeing lock for container after creation failed: %v", err2)
+			}
+		}
+	}()
+
 	ctr.valid = true
 	ctr.state.State = config2.ContainerStateConfigured
 	ctr.runtime = r


### PR DESCRIPTION
If we don't do this, we can leak locks on every failure, and that is very, very bad - can render Podman unusable without a 'system renumber' being run.