### PR TITLE
configure runtime without store

### DIFF
--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -60,7 +60,7 @@ func execCmd(c *cliconfig.ExecValues) error {
 		argStart = 0
 	}
 	cmd := args[argStart:]
-	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := adapter.GetRuntimeNoStore(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/cmd/podman/exists.go
+++ b/cmd/podman/exists.go
@@ -107,7 +107,7 @@ func containerExistsCmd(c *cliconfig.ContainerExistsValues) error {
 	if len(args) > 1 || len(args) < 1 {
 		return errors.New("you may only check for the existence of one container at a time")
 	}
-	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := adapter.GetRuntimeNoStore(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}
@@ -126,7 +126,7 @@ func podExistsCmd(c *cliconfig.PodExistsValues) error {
 	if len(args) > 1 || len(args) < 1 {
 		return errors.New("you may only check for the existence of one pod at a time")
 	}
-	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := adapter.GetRuntimeNoStore(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}

--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -15,20 +15,25 @@ import (
 
 // GetRuntimeMigrate gets a libpod runtime that will perform a migration of existing containers
 func GetRuntimeMigrate(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(ctx, c, false, true)
+	return getRuntime(ctx, c, false, true, false)
 }
 
 // GetRuntimeRenumber gets a libpod runtime that will perform a lock renumber
 func GetRuntimeRenumber(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(ctx, c, true, false)
+	return getRuntime(ctx, c, true, false, false)
 }
 
 // GetRuntime generates a new libpod runtime configured by command line options
 func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(ctx, c, false, false)
+	return getRuntime(ctx, c, false, false, false)
 }
 
-func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber bool, migrate bool) (*libpod.Runtime, error) {
+// GetRuntimeNoStore generates a new libpod runtime configured by command line options
+func GetRuntimeNoStore(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
+	return getRuntime(ctx, c, false, false, true)
+}
+
+func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber, migrate, noStore bool) (*libpod.Runtime, error) {
 	options := []libpod.RuntimeOption{}
 	storageOpts := storage.StoreOptions{}
 	storageSet := false
@@ -89,6 +94,9 @@ func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber bool, 
 		options = append(options, libpod.WithStorageConfig(storageOpts))
 	}
 
+	if !storageSet && noStore {
+		options = append(options, libpod.WithNoStore())
+	}
 	// TODO CLI flags for image config?
 	// TODO CLI flag for signature policy?
 

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -300,6 +300,15 @@ func WithTmpDir(dir string) RuntimeOption {
 	}
 }
 
+// WithNoStore sets a bool on the runtime that we do not need
+// any containers storage.
+func WithNoStore() RuntimeOption {
+	return func(rt *Runtime) error {
+		rt.noStore = true
+		return nil
+	}
+}
+
 // WithMaxLogSize sets the maximum size of container logs.
 // Positive sizes are limits in bytes, -1 is unlimited.
 func WithMaxLogSize(limit int64) RuntimeOption {

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -58,12 +58,26 @@ type Volume struct {
 // VolumeFilter is for filtering volumes on the client
 type VolumeFilter func(*Volume) bool
 
+// GetRuntimeNoStore returns a localruntime struct wit an embedded runtime but
+// without a configured storage.
+func GetRuntimeNoStore(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
+	runtime, err := libpodruntime.GetRuntimeNoStore(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	return getRuntime(runtime)
+}
+
 // GetRuntime returns a LocalRuntime struct with the actual runtime embedded in it
 func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
 	runtime, err := libpodruntime.GetRuntime(ctx, c)
 	if err != nil {
 		return nil, err
 	}
+	return getRuntime(runtime)
+}
+
+func getRuntime(runtime *libpod.Runtime) (*LocalRuntime, error) {
 	return &LocalRuntime{
 		Runtime: runtime,
 	}, nil

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -50,6 +50,12 @@ type LocalRuntime struct {
 	*RemoteRuntime
 }
 
+// GetRuntimeNoStore returns a LocalRuntime struct with the actual runtime embedded in it
+// The nostore is ignored
+func GetRuntimeNoStore(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
+	return GetRuntime(ctx, c)
+}
+
 // GetRuntime returns a LocalRuntime struct with the actual runtime embedded in it
 func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime, error) {
 	var (


### PR DESCRIPTION
some podman commands do not require the use of a container/image store.
in those cases, it is more effecient to not open the store, because that
results in having to also close the store which can be costly when the
system is under heavy write I/O loads.

Signed-off-by: baude <bbaude@redhat.com>