### PR TITLE
During shutdown, don't let Conmon die with Systemd CGroups

### DIFF
--- a/libpod/oci_internal_linux.go
+++ b/libpod/oci_internal_linux.go
@@ -366,7 +366,7 @@ func (r *OCIRuntime) moveConmonToCgroupAndSignal(ctr *Container, cmd *exec.Cmd, 
 		}
 
 		logrus.Infof("Running conmon under slice %s and unitName %s", realCgroupParent, unitName)
-		if err := utils.RunUnderSystemdScope(cmd.Process.Pid, realCgroupParent, unitName); err != nil {
+		if err := utils.RunUnderSystemdScope(cmd.Process.Pid, realCgroupParent, unitName, true); err != nil {
 			logrus.Warnf("Failed to add conmon to systemd sandbox cgroup: %v", err)
 		}
 	} else {

--- a/utils/utils_supported.go
+++ b/utils/utils_supported.go
@@ -3,12 +3,15 @@
 package utils
 
 import (
+	"syscall"
+
 	systemdDbus "github.com/coreos/go-systemd/dbus"
 	"github.com/godbus/dbus"
 )
 
-// RunUnderSystemdScope adds the specified pid to a systemd scope
-func RunUnderSystemdScope(pid int, slice string, unitName string) error {
+// RunUnderSystemdScope adds the specified pid to a systemd scope.
+// If forConmon is set, timeout is increased, and stop signal is set to SIGUSR1.
+func RunUnderSystemdScope(pid int, slice string, unitName string, forConmon bool) error {
 	var properties []systemdDbus.Property
 	conn, err := systemdDbus.New()
 	if err != nil {
@@ -18,6 +21,12 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 	properties = append(properties, newProp("PIDs", []uint32{uint32(pid)}))
 	properties = append(properties, newProp("Delegate", true))
 	properties = append(properties, newProp("DefaultDependencies", false))
+	if forConmon {
+		// 10 minute stop timeout
+		var timeout uint64 = 1000000 * 60 * 10
+		properties = append(properties, newProp("TimeoutStopUSec", &timeout))
+		properties = append(properties, newProp("KillSignal", syscall.SIGUSR1))
+	}
 	ch := make(chan string)
 	_, err = conn.StartTransientUnit(unitName, "replace", properties, ch)
 	if err != nil {


### PR DESCRIPTION
This should immediately hit Conmon with a SIGKILL, preventing potential shutdown ordering issues.