### PR TITLE
Implement healthcheck for remote client

### DIFF
--- a/API.md
+++ b/API.md
@@ -87,6 +87,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func GetVolumes(args: []string, all: bool) Volume](#GetVolumes)
 
+[func HealthCheckRun(nameOrID: string) string](#HealthCheckRun)
+
 [func HistoryImage(name: string) ImageHistory](#HistoryImage)
 
 [func ImageExists(name: string) int](#ImageExists)
@@ -681,6 +683,12 @@ GetVersion returns version and build information of the podman service
 
 method GetVolumes(args: [[]string](#[]string), all: [bool](https://godoc.org/builtin#bool)) [Volume](#Volume)</div>
 GetVolumes gets slice of the volumes on a remote host
+### <a name="HealthCheckRun"></a>func HealthCheckRun
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method HealthCheckRun(nameOrID: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+HealthCheckRun executes defined container's healthcheck command
+and returns the container's health status.
 ### <a name="HistoryImage"></a>func HistoryImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 

--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -71,10 +71,3 @@ func getSystemSubCommands() []*cobra.Command {
 		_migrateCommand,
 	}
 }
-
-// Commands that the local client implements
-func getHealthcheckSubCommands() []*cobra.Command {
-	return []*cobra.Command{
-		_healthcheckrunCommand,
-	}
-}

--- a/cmd/podman/commands_remoteclient.go
+++ b/cmd/podman/commands_remoteclient.go
@@ -47,8 +47,3 @@ func getTrustSubCommands() []*cobra.Command {
 func getSystemSubCommands() []*cobra.Command {
 	return []*cobra.Command{}
 }
-
-// Commands that the remoteclient implements
-func getHealthcheckSubCommands() []*cobra.Command {
-	return []*cobra.Command{}
-}

--- a/cmd/podman/healthcheck.go
+++ b/cmd/podman/healthcheck.go
@@ -16,11 +16,12 @@ var healthcheckCommand = cliconfig.PodmanCommand{
 }
 
 // Commands that are universally implemented
-var healthcheckCommands []*cobra.Command
+var healthcheckCommands = []*cobra.Command{
+	_healthcheckrunCommand,
+}
 
 func init() {
 	healthcheckCommand.AddCommand(healthcheckCommands...)
-	healthcheckCommand.AddCommand(getHealthcheckSubCommands()...)
 	healthcheckCommand.SetUsageTemplate(UsageTemplate())
 	rootCmd.AddCommand(healthcheckCommand.Command)
 }

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -544,6 +544,10 @@ method GetContainersByStatus(status: []string) -> (containerS: []Container)
 
 method Top (nameOrID: string, descriptors: []string) -> (top: []string)
 
+# HealthCheckRun executes defined container's healthcheck command
+# and returns the container's health status.
+method HealthCheckRun (nameOrID: string) -> (healthCheckStatus: string)
+
 # GetContainer returns information about a single container.  If a container
 # with the given id doesn't exist, a [ContainerNotFound](#ContainerNotFound)
 # error will be returned.  See also [ListContainers](ListContainers) and

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -21,7 +21,7 @@ import (
 	"github.com/containers/image/types"
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/remoteclientconfig"
-	"github.com/containers/libpod/cmd/podman/varlink"
+	iopodman "github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/events"
@@ -812,7 +812,7 @@ func IsImageNotFound(err error) bool {
 
 // HealthCheck executes a container's healthcheck over a varlink connection
 func (r *LocalRuntime) HealthCheck(c *cliconfig.HealthCheckValues) (string, error) {
-	return "", define.ErrNotImplemented
+	return iopodman.HealthCheckRun().Call(r.Conn, c.InputArgs[0])
 }
 
 // Events monitors libpod/podman events over a varlink connection

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/containers/libpod/cmd/podman/shared"
-	"github.com/containers/libpod/cmd/podman/varlink"
+	iopodman "github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/logs"
@@ -863,4 +863,17 @@ func (i *LibpodAPI) ExecContainer(call iopodman.VarlinkCall, opts iopodman.ExecO
 	}
 
 	return ecErr.Error
+}
+
+//HealthCheckRun executes defined container's healthcheck command and returns the container's health status.
+func (i *LibpodAPI) HealthCheckRun(call iopodman.VarlinkCall, nameOrID string) error {
+	hcStatus, err := i.Runtime.HealthCheck(nameOrID)
+	if err != nil && hcStatus != libpod.HealthCheckFailure {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	status := libpod.HealthCheckUnhealthy
+	if hcStatus == libpod.HealthCheckSuccess {
+		status = libpod.HealthCheckHealthy
+	}
+	return call.ReplyHealthCheckRun(status)
 }

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -1,5 +1,3 @@
-// +build !remoteclient
-
 package integration
 
 import (


### PR DESCRIPTION
Previously unimplemented. Works the same way the local one does, except its remote. 

Signed-off-by: Ashley Cui <ashleycui16@gmail.com>