### PR TITLE
Fix rootless detection error for pause & unpause

### DIFF
--- a/cmd/podman/pause.go
+++ b/cmd/podman/pause.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-	"os"
-
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -39,7 +38,7 @@ func init() {
 }
 
 func pauseCmd(c *cliconfig.PauseValues) error {
-	if os.Geteuid() != 0 {
+	if rootless.IsRootless() && !remoteclient {
 		return errors.New("pause is not supported for rootless containers")
 	}
 

--- a/cmd/podman/unpause.go
+++ b/cmd/podman/unpause.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-	"os"
-
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -38,7 +37,7 @@ func init() {
 }
 
 func unpauseCmd(c *cliconfig.UnpauseValues) error {
-	if os.Geteuid() != 0 {
+	if rootless.IsRootless() && !remoteclient {
 		return errors.New("unpause is not supported for rootless containers")
 	}
 


### PR DESCRIPTION
Previously, when pause & unpause were run on rootless, the error message that pause was unsupported for rootless was not being thrown. When running remote, even if remote host was root, unsupported rootless error was being thrown.

Now, the error shows up when appropriate.

Signed-off-by: Ashley Cui <ashleycui16@gmail.com>