### PR TITLE
Vendor latest OCICNI version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/coreos/go-iptables v0.4.1
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a
-	github.com/cri-o/ocicni v0.0.0-20190328132530-0c180f981b27
+	github.com/cri-o/ocicni v0.1.1-0.20190702175919-7762645d18ca
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.7.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cri-o/ocicni v0.0.0-20190328132530-0c180f981b27 h1:c3yt54JU7t7bzcae8YwI6+TvbWeQWrBfDxYi7zL9XPE=
 github.com/cri-o/ocicni v0.0.0-20190328132530-0c180f981b27/go.mod h1:BO0al9TKber3XUTucLzKgoG5sq8qiOB41H7zSdfw6r8=
+github.com/cri-o/ocicni v0.1.1-0.20190702175919-7762645d18ca h1:CJstDqYy9ClWuPcDHMTCAiUS+ckekluYetGR2iYYWuo=
+github.com/cri-o/ocicni v0.1.1-0.20190702175919-7762645d18ca/go.mod h1:BO0al9TKber3XUTucLzKgoG5sq8qiOB41H7zSdfw6r8=
 github.com/cyphar/filepath-securejoin v0.2.1 h1:5DPkzz/0MwUpvR4fxASKzgApeq2OMFY5FfYtrX28Coo=
 github.com/cyphar/filepath-securejoin v0.2.1/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -28,21 +28,23 @@ import (
 
 // Get an OCICNI network config
 func (r *Runtime) getPodNetwork(id, name, nsPath string, networks []string, ports []ocicni.PortMapping, staticIP net.IP) ocicni.PodNetwork {
+	defaultNetwork := r.netPlugin.GetDefaultNetworkName()
 	network := ocicni.PodNetwork{
-		Name:         name,
-		Namespace:    name, // TODO is there something else we should put here? We don't know about Kube namespaces
-		ID:           id,
-		NetNS:        nsPath,
-		PortMappings: ports,
-		Networks:     networks,
+		Name:      name,
+		Namespace: name, // TODO is there something else we should put here? We don't know about Kube namespaces
+		ID:        id,
+		NetNS:     nsPath,
+		Networks:  networks,
+		RuntimeConfig: map[string]ocicni.RuntimeConfig{
+			defaultNetwork: {PortMappings: ports},
+		},
 	}
 
 	if staticIP != nil {
-		defaultNetwork := r.netPlugin.GetDefaultNetworkName()
-
 		network.Networks = []string{defaultNetwork}
-		network.NetworkConfig = make(map[string]ocicni.NetworkConfig)
-		network.NetworkConfig[defaultNetwork] = ocicni.NetworkConfig{IP: staticIP.String()}
+		network.RuntimeConfig = map[string]ocicni.RuntimeConfig{
+			defaultNetwork: {IP: staticIP.String(), PortMappings: ports},
+		}
 	}
 
 	return network

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -153,7 +153,7 @@ github.com/coreos/go-systemd/sdjournal
 github.com/coreos/go-systemd/journal
 # github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 github.com/coreos/pkg/dlopen
-# github.com/cri-o/ocicni v0.0.0-20190328132530-0c180f981b27
+# github.com/cri-o/ocicni v0.1.1-0.20190702175919-7762645d18ca
 github.com/cri-o/ocicni/pkg/ocicni
 # github.com/cyphar/filepath-securejoin v0.2.2
 github.com/cyphar/filepath-securejoin


### PR DESCRIPTION
This is needed for dual stack IPv6 support within CRI-O. Because the API
changed within OCICNI, we have to adapt the internal linux networking as
well.