### PR TITLE
podman: add --ulimit host

### DIFF
--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -723,6 +723,8 @@ The following example maps uids 0-2000 in the container to the uids 30000-31999 
 
 Ulimit options
 
+You can pass `host` to copy the current configuration from the host.
+
 **--user**, **-u**=*user*
 
 Sets the username or UID used and optionally the groupname or GID for the specified command.

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -759,6 +759,8 @@ The example maps uids 0-2000 in the container to the uids 30000-31999 on the hos
 
 Ulimit options
 
+You can pass `host` to copy the current configuration from the host.
+
 **--user**, **-u**=*user*
 
 Sets the username or UID used and optionally the groupname or GID for the specified command.

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -20,6 +20,12 @@ import (
 
 const cpuPeriod = 100000
 
+type systemUlimit struct {
+	name string
+	max  uint64
+	cur  uint64
+}
+
 func getAvailableGids() (int64, error) {
 	idMap, err := user.ParseIDMapFile("/proc/self/gid_map")
 	if err != nil {
@@ -553,6 +559,20 @@ func addRlimits(config *CreateConfig, g *generate.Generator) error {
 	)
 
 	for _, u := range config.Resources.Ulimit {
+		if u == "host" {
+			if len(config.Resources.Ulimit) != 1 {
+				return errors.New("ulimit can use host only once")
+			}
+			hostLimits, err := getHostRlimits()
+			if err != nil {
+				return err
+			}
+			for _, i := range hostLimits {
+				g.AddProcessRlimits(i.name, i.max, i.cur)
+			}
+			break
+		}
+
 		ul, err := units.ParseUlimit(u)
 		if err != nil {
 			return errors.Wrapf(err, "ulimit option %q requires name=SOFT:HARD, failed to be parsed", u)

--- a/pkg/spec/spec_linux.go
+++ b/pkg/spec/spec_linux.go
@@ -1,0 +1,42 @@
+//+build linux
+
+package createconfig
+
+import (
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+type systemRlimit struct {
+	name  string
+	value int
+}
+
+var systemLimits = []systemRlimit{
+	{"RLIMIT_AS", syscall.RLIMIT_AS},
+	{"RLIMIT_CORE", syscall.RLIMIT_CORE},
+	{"RLIMIT_CPU", syscall.RLIMIT_CPU},
+	{"RLIMIT_DATA", syscall.RLIMIT_DATA},
+	{"RLIMIT_FSIZE", syscall.RLIMIT_FSIZE},
+	{"RLIMIT_NOFILE", syscall.RLIMIT_NOFILE},
+	{"RLIMIT_STACK", syscall.RLIMIT_STACK},
+}
+
+func getHostRlimits() ([]systemUlimit, error) {
+	ret := []systemUlimit{}
+	for _, i := range systemLimits {
+		var l syscall.Rlimit
+		if err := syscall.Getrlimit(i.value, &l); err != nil {
+			return nil, errors.Wrapf(err, "cannot read limits for %s", i.name)
+		}
+		s := systemUlimit{
+			name: i.name,
+			max:  l.Max,
+			cur:  l.Cur,
+		}
+		ret = append(ret, s)
+	}
+	return ret, nil
+
+}

--- a/pkg/spec/spec_unsupported.go
+++ b/pkg/spec/spec_unsupported.go
@@ -1,0 +1,7 @@
+//+build !linux
+
+package createconfig
+
+func getHostRlimits() ([]systemUlimit, error) {
+	return nil, nil
+}


### PR DESCRIPTION
add a simple way to copy ulimit values from the host.

if --ulimit host is used then the current ulimits in place are copied
to the container.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>