### PR TITLE
Allow force removing containers with unavailable OCI runtime

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -461,11 +461,8 @@ func (s *BoltState) LookupContainer(idOrName string) (*Container, error) {
 
 		return s.getContainerFromDB(id, ctr, ctrBucket)
 	})
-	if err != nil {
-		return nil, err
-	}
 
-	return ctr, nil
+	return ctr, err
 }
 
 // HasContainer checks if a container is present in the state

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -380,7 +380,9 @@ func (s *BoltState) getContainerFromDB(id []byte, ctr *Container, ctrsBkt *bolt.
 
 		ociRuntime, ok := s.runtime.ociRuntimes[runtimeName]
 		if !ok {
-			return errors.Wrapf(define.ErrInternal, "container %s was created with OCI runtime %s, but that runtime is not available in the current configuration", ctr.ID(), ctr.config.OCIRuntime)
+			err = errors.Wrapf(define.ErrRuntimeUnavailable, "cannot find OCI runtime %q for container %s", ctr.config.OCIRuntime, ctr.ID())
+			// fall back to the default runtime to allow ctr clean up
+			ociRuntime = s.runtime.defaultOCIRuntime
 		}
 		ctr.ociRuntime = ociRuntime
 	}
@@ -388,7 +390,7 @@ func (s *BoltState) getContainerFromDB(id []byte, ctr *Container, ctrsBkt *bolt.
 	ctr.runtime = s.runtime
 	ctr.valid = valid
 
-	return nil
+	return err
 }
 
 func (s *BoltState) getPodFromDB(id []byte, pod *Pod, podBkt *bolt.Bucket) error {

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -99,4 +99,8 @@ var (
 
 	// ErrOCIRuntime indicates an error from the OCI runtime
 	ErrOCIRuntime = errors.New("OCI runtime error")
+
+	// ErrRuntimeUnavailable indicates that the runtime associated to a container
+	// could not be found in the configuration
+	ErrRuntimeUnavailable = errors.New("runtime not available in the current configuration")
 )

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -386,7 +386,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 			return err
 		}
 		// Need to update container state to make sure we know it's stopped
-		if err := c.waitForExitFileAndSync(); err != nil {
+		if err := c.waitForExitFileAndSync(); err != nil && !force {
 			return err
 		}
 	}
@@ -398,7 +398,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 		}
 
 		// Need to update container state to make sure we know it's stopped
-		if err := c.waitForExitFileAndSync(); err != nil {
+		if err := c.waitForExitFileAndSync(); err != nil && !force {
 			return err
 		}
 	}

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -204,7 +204,16 @@ func (r *LocalRuntime) RemoveContainers(ctx context.Context, cli *cliconfig.RmVa
 	}
 
 	ctrs, err := shortcuts.GetContainersByContext(cli.All, cli.Latest, cli.InputArgs, r.Runtime)
-	if err != nil {
+	switch errors.Cause(err) {
+	case nil:
+		break
+	case define.ErrRuntimeUnavailable:
+		if cli.Force {
+			logrus.WithError(err).Debug("Remove force specified, removing with error")
+			break
+		}
+		fallthrough
+	default:
 		return ok, failures, err
 	}
 


### PR DESCRIPTION
 When the OCI runtime associated to a container could not be found in the configuration, removing that container is not possible. Allow force removing the container by detecting when this happens.

--- 

This typically happens when you create a container with a specific runtime in libpod.conf, and later the runtime name is changed in the the conf, with outcome:
```
$ pd rm -f 06
Error: container 060314dd88dc22cdf6d21b8f8146dcf2481ab158c5a29f79a9ecb81cef2e6d9e was created with OCI runtime my_runtime, but that runtime is not available in the current configuration: internal libpod error
```