### PR TITLE
get last container event

### DIFF
--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -2,6 +2,8 @@ package events
 
 import (
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // EventerType ...
@@ -158,3 +160,12 @@ const (
 
 // EventFilter for filtering events
 type EventFilter func(*Event) bool
+
+var (
+	// ErrEventTypeBlank indicates the event log found something done by podman
+	// but it isnt likely an event
+	ErrEventTypeBlank = errors.New("event type blank")
+
+	// ErrEventNotFound indicates that the event was not found in the event log
+	ErrEventNotFound = errors.New("unable to find event")
+)

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -95,6 +95,8 @@ func StringToType(name string) (Type, error) {
 		return System, nil
 	case Volume.String():
 		return Volume, nil
+	case "":
+		return "", ErrEventTypeBlank
 	}
 	return "", errors.Errorf("unknown event type %q", name)
 }

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -101,7 +101,9 @@ func (e EventJournalD) Read(options ReadOptions) error {
 			// We can't decode this event.
 			// Don't fail hard - that would make events unusable.
 			// Instead, log and continue.
-			logrus.Errorf("Unable to decode event: %v", err)
+			if errors.Cause(err) != ErrEventTypeBlank {
+				logrus.Errorf("Unable to decode event: %v", err)
+			}
 			continue
 		}
 		include := true


### PR DESCRIPTION
an internal change in libpod will soon required the ability to lookup
the last container event using the continer name or id and the type of
event.  this pr is in preperation for that need.

Signed-off-by: baude <bbaude@redhat.com>