### PR TITLE
cgroups: support creating cgroupsv2 paths

### DIFF
--- a/pkg/cgroups/blkio.go
+++ b/pkg/cgroups/blkio.go
@@ -30,7 +30,7 @@ func (c *blkioHandler) Apply(ctr *CgroupControl, res *spec.LinuxResources) error
 // Create the cgroup
 func (c *blkioHandler) Create(ctr *CgroupControl) (bool, error) {
 	if ctr.cgroup2 {
-		return false, fmt.Errorf("io create not implemented for cgroup v2")
+		return false, nil
 	}
 	return ctr.createCgroupDirectory(Blkio)
 }

--- a/pkg/cgroups/cpu.go
+++ b/pkg/cgroups/cpu.go
@@ -61,7 +61,7 @@ func (c *cpuHandler) Apply(ctr *CgroupControl, res *spec.LinuxResources) error {
 // Create the cgroup
 func (c *cpuHandler) Create(ctr *CgroupControl) (bool, error) {
 	if ctr.cgroup2 {
-		return false, fmt.Errorf("cpu create not implemented for cgroup v2")
+		return false, nil
 	}
 	return ctr.createCgroupDirectory(CPU)
 }

--- a/pkg/cgroups/cpu.go
+++ b/pkg/cgroups/cpu.go
@@ -98,15 +98,24 @@ func (c *cpuHandler) Stat(ctr *CgroupControl, m *Metrics) error {
 	} else {
 		usage.Total, err = readAcct(ctr, "cpuacct.usage")
 		if err != nil {
-			return err
+			if !os.IsNotExist(errors.Cause(err)) {
+				return err
+			}
+			usage.Total = 0
 		}
 		usage.Kernel, err = readAcct(ctr, "cpuacct.usage_sys")
 		if err != nil {
-			return err
+			if !os.IsNotExist(errors.Cause(err)) {
+				return err
+			}
+			usage.Kernel = 0
 		}
 		usage.PerCPU, err = readAcctList(ctr, "cpuacct.usage_percpu")
 		if err != nil {
-			return err
+			if !os.IsNotExist(errors.Cause(err)) {
+				return err
+			}
+			usage.PerCPU = nil
 		}
 	}
 	m.CPU = CPUMetrics{Usage: usage}

--- a/pkg/cgroups/memory.go
+++ b/pkg/cgroups/memory.go
@@ -26,7 +26,7 @@ func (c *memHandler) Apply(ctr *CgroupControl, res *spec.LinuxResources) error {
 // Create the cgroup
 func (c *memHandler) Create(ctr *CgroupControl) (bool, error) {
 	if ctr.cgroup2 {
-		return false, fmt.Errorf("memory create not implemented for cgroup v2")
+		return false, nil
 	}
 	return ctr.createCgroupDirectory(Memory)
 }

--- a/pkg/cgroups/pids.go
+++ b/pkg/cgroups/pids.go
@@ -35,9 +35,6 @@ func (c *pidHandler) Apply(ctr *CgroupControl, res *spec.LinuxResources) error {
 
 // Create the cgroup
 func (c *pidHandler) Create(ctr *CgroupControl) (bool, error) {
-	if ctr.cgroup2 {
-		return false, fmt.Errorf("pid create not implemented for cgroup v2")
-	}
 	return ctr.createCgroupDirectory(Pids)
 }
 


### PR DESCRIPTION
drop the limitation of not supporting creating new cgroups v2 paths.
Every controller enabled /sys/fs/cgroup will be propagated down to the
created path.  This won't work for rootless cgroupsv2, but it is not
an issue for now, as this code is used only by CRI-O.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>