### PR TITLE
CONTRIBUTING.md: fix project paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,18 +48,12 @@ First you need to fork this project on GitHub.
 
 Be sure to have [defined your `$GOPATH` environment variable](https://github.com/golang/go/wiki/GOPATH).
 
-Create a path that correspond to your clone `mkdir -p $GOPATH/github.com/<you>`.
+Create a path that corresponds to the go import paths of libpod: `mkdir -p $GOPATH/src/github.com/containers`.
 
-Clone your fork locally:
+Then clone your fork locally:
 ```shell
-$ git clone git@github.com:<you>/libpod github.com/<you> $GOPATH/github.com/<you>/libpod
-$ cd $GOPATH/github.com/<you>/libpod
-```
-
-You can also use `go get` to clone your fork:
-```shell
-$ go get github.com:<you>/libpod
-$ cd $GOPATH/github.com/<you>/libpod
+$ git clone git@github.com:<you>/libpod $GOPATH/src/github.com/containers/libpod
+$ cd $GOPATH/src/github.com/containers/libpod
 ```
 
 ### Deal with make


### PR DESCRIPTION
The paths to the local libpod tree where missing the `./src` part which
ultimately lead to compilation errors.  Also place the git trees into
containers/libpod and not into the user's GitHub root.

Reported in #podman on IRC.
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>