### PR TITLE
speed up rootless tests

### DIFF
--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containers/libpod/pkg/rootless"
 	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -58,6 +59,9 @@ var _ = Describe("Podman push", func() {
 	It("podman push to local registry", func() {
 		if podmanTest.Host.Arch == "ppc64le" {
 			Skip("No registry image for ppc64le")
+		}
+		if rootless.IsRootless() {
+			podmanTest.RestoreArtifact(registry)
 		}
 		lock := GetPortLock("5000")
 		defer lock.Unlock()

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi all images", func() {
-		podmanTest.PullImages([]string{nginx})
+		podmanTest.RestoreArtifact(nginx)
 		session := podmanTest.PodmanNoCache([]string{"rmi", "-a"})
 		session.WaitWithDefaultTimeout()
 		images := podmanTest.PodmanNoCache([]string{"images"})
@@ -66,7 +66,7 @@ var _ = Describe("Podman rmi", func() {
 	})
 
 	It("podman rmi all images forcibly with short options", func() {
-		podmanTest.PullImages([]string{nginx})
+		podmanTest.RestoreArtifact(nginx)
 		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/tree_test.go
+++ b/test/e2e/tree_test.go
@@ -37,10 +37,6 @@ var _ = Describe("Podman image tree", func() {
 		if podmanTest.RemoteTest {
 			Skip("Does not work on remote client")
 		}
-		session := podmanTest.PodmanNoCache([]string{"pull", "docker.io/library/busybox:latest"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-
 		dockerfile := `FROM docker.io/library/busybox:latest
 RUN mkdir hello
 RUN touch test.txt
@@ -48,7 +44,7 @@ ENV foo=bar
 `
 		podmanTest.BuildImage(dockerfile, "test:latest", "true")
 
-		session = podmanTest.PodmanNoCache([]string{"image", "tree", "test:latest"})
+		session := podmanTest.PodmanNoCache([]string{"image", "tree", "test:latest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.PodmanNoCache([]string{"image", "tree", "--whatrequires", "docker.io/library/busybox:latest"})


### PR DESCRIPTION
when running integrations tests as rootless, several tests still
unnecessarily pull images which is costly in terms of time.

Signed-off-by: baude <bbaude@redhat.com>