### PR TITLE
Podman-remote usage message to display `podman-remote` instead of `podman`

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"context"
-	"github.com/containers/libpod/libpod"
 	"io"
 	"os"
+	"path"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/containers/libpod/libpod"
 	_ "github.com/containers/libpod/pkg/hooks/0.1.0"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/version"
@@ -68,7 +69,7 @@ var mainCommands = []*cobra.Command{
 }
 
 var rootCmd = &cobra.Command{
-	Use:  "podman",
+	Use:  path.Base(os.Args[0]),
 	Long: "manage pods and images",
 	RunE: commandRunE(),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
When the user uses remote client, the message prompts the user to use `podman-remote`. This does not apply for Mac usage.

Closes #3503

Signed-off-by: Ashley Cui <ashleycui16@gmail.com>