### PR TITLE
Correctly set FinishedTime for checkpointed container

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -636,6 +636,7 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 		}
 	}
 
+	c.state.FinishedTime = time.Now()
 	return c.save()
 }
 


### PR DESCRIPTION
During 'podman container checkpoint' the finished time was not set. This resulted in a strange container status after checkpointing:

 `Exited (0) 292 years ago`

During checkpointing FinishedTime is now set to time.now().