### PR TITLE
make localsystem: wipe all user config state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,8 @@ localintegration: varlink_generate test-binaries ginkgo
 remoteintegration: varlink_generate test-binaries ginkgo-remote
 
 localsystem:
+	# Wipe existing config, database, and cache: start with clean slate.
+	$(RM) -rf ${HOME}/.local/share/containers ${HOME}/.config/containers
 	if timeout -v 1 true; then PODMAN=./bin/podman bats test/system/; else echo "Skipping localsystem: 'timeout -v' unavailable'"; fi
 
 remotesystem:


### PR DESCRIPTION
CI is experiencing failures in the system_test step, caused by
podman commands issuing the following warning:

   time="2019-07-09T13:30:19-04:00" level=error msg="User-selected graph driver \"overlay\" overwritten by graph driver \"vfs\" from database - delete libpod local files to resolve

Hypothesis: integration tests, which run just before us, are
leaving user config files in an unstable state.

Workaround: delete all user cache and config and db before
running system tests. This should be safe, and should be
a NOP when running as root.

Signed-off-by: Ed Santiago <santiago@redhat.com>