### PR TITLE
fix bug convert volume host path to absolute

### DIFF
--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -211,6 +211,13 @@ func (config *CreateConfig) parseVolumes(runtime *libpod.Runtime) ([]spec.Mount,
 			}
 			mount.Options = opts
 		}
+		if mount.Type == TypeBind {
+			absSrc, err := filepath.Abs(mount.Source)
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "error getting absolute path of %s", mount.Source)
+			}
+			mount.Source = absSrc
+		}
 		finalMounts = append(finalMounts, mount)
 	}
 	finalVolumes := make([]*libpod.ContainerNamedVolume, 0, len(baseVolumes))


### PR DESCRIPTION
fix #3504 If --volume host:dest host is not a named volume, convert the host to a absolute directory path.

Signed-off-by: Qi Wang <qiwan@redhat.com>