### PR TITLE
runtime: drop spurious message log

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -439,9 +439,12 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 		}
 	} else {
 		if err := r.state.RemoveContainer(c); err != nil {
-			cleanupErr = err
+			if cleanupErr == nil {
+				cleanupErr = err
+			} else {
+				logrus.Errorf("removing container: %v", err)
+			}
 		}
-		logrus.Errorf("removing container: %v", err)
 	}
 
 	// Set container as invalid so it can no longer be used


### PR DESCRIPTION
fix a regression introduced by 1d36501f961889f554daf3c696fe95443ef211b6

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>