### PR TITLE
Fix handling of healthcheck from image

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -117,20 +117,26 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 					}
 
 					if healthCheck != nil {
-						// apply defaults if image doesn't override them
-						if healthCheck.Interval == 0 {
-							healthCheck.Interval = 30 * time.Second
-						}
-						if healthCheck.Timeout == 0 {
-							healthCheck.Timeout = 30 * time.Second
-						}
-						/* Docker default is 0s, so the following would be a no-op
-						if healthCheck.StartPeriod == 0 {
-							healthCheck.StartPeriod = 0 * time.Second
-						}
-						*/
-						if healthCheck.Retries == 0 {
-							healthCheck.Retries = 3
+						hcCommand := healthCheck.Test
+						if len(hcCommand) < 1 || hcCommand[0] == "" || hcCommand[0] == "NONE" {
+							// disable health check
+							healthCheck = nil
+						} else {
+							// apply defaults if image doesn't override them
+							if healthCheck.Interval == 0 {
+								healthCheck.Interval = 30 * time.Second
+							}
+							if healthCheck.Timeout == 0 {
+								healthCheck.Timeout = 30 * time.Second
+							}
+							/* Docker default is 0s, so the following would be a no-op
+							if healthCheck.StartPeriod == 0 {
+								healthCheck.StartPeriod = 0 * time.Second
+							}
+							*/
+							if healthCheck.Retries == 0 {
+								healthCheck.Retries = 3
+							}
 						}
 					}
 				}

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -115,6 +115,24 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 					if err != nil {
 						return nil, nil, errors.Wrapf(err, "unable to get healthcheck for %s", c.InputArgs[0])
 					}
+
+					if healthCheck != nil {
+						// apply defaults if image doesn't override them
+						if healthCheck.Interval == 0 {
+							healthCheck.Interval = 30 * time.Second
+						}
+						if healthCheck.Timeout == 0 {
+							healthCheck.Timeout = 30 * time.Second
+						}
+						/* Docker default is 0s, so the following would be a no-op
+						if healthCheck.StartPeriod == 0 {
+							healthCheck.StartPeriod = 0 * time.Second
+						}
+						*/
+						if healthCheck.Retries == 0 {
+							healthCheck.Retries = 3
+						}
+					}
 				}
 			}
 		}

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -123,6 +123,9 @@ func (c *Container) runHealthCheck() (HealthCheckStatus, error) {
 		// command supplied on command line - pass as-is
 		newCommand = hcCommand
 	}
+	if len(newCommand) < 1 || newCommand[0] == "" {
+		return HealthCheckNotDefined, errors.Errorf("container %s has no defined healthcheck", c.ID())
+	}
 	captureBuffer := bufio.NewWriter(&capture)
 	hcw := hcWriteCloser{
 		captureBuffer,

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -107,14 +107,20 @@ func (c *Container) runHealthCheck() (HealthCheckStatus, error) {
 		capture       bytes.Buffer
 		inStartPeriod bool
 	)
-	hcStatus, err := checkHealthCheckCanBeRun(c)
-	if err != nil {
-		return hcStatus, err
-	}
 	hcCommand := c.HealthCheckConfig().Test
-	if len(hcCommand) > 0 && hcCommand[0] == "CMD-SHELL" {
-		newCommand = []string{"sh", "-c", strings.Join(hcCommand[1:], " ")}
-	} else {
+	if len(hcCommand) < 1 {
+		return HealthCheckNotDefined, errors.Errorf("container %s has no defined healthcheck", c.ID())
+	}
+	switch hcCommand[0] {
+	case "", "NONE":
+		return HealthCheckNotDefined, errors.Errorf("container %s has no defined healthcheck", c.ID())
+	case "CMD":
+		newCommand = hcCommand[1:]
+	case "CMD-SHELL":
+		// TODO: SHELL command from image not available in Container - use Docker default
+		newCommand = []string{"/bin/sh", "-c", strings.Join(hcCommand[1:], " ")}
+	default:
+		// command supplied on command line - pass as-is
 		newCommand = hcCommand
 	}
 	captureBuffer := bufio.NewWriter(&capture)


### PR DESCRIPTION
1. proposed fix for #3525 cmd/podman/shared/create.go:
If the image doesn't provide any options, e.g. interval, timeout, etc.,
then apply the standard defaults when creating the container. Now podman
correctly schedules the healtcheck service & timer for the container.
 
2. proposed fix for #3507 libpod/healthcheck.go
    - remove duplicate check, already called in HealthCheck()
    - reject zero-length command list
    - check for Docker command list, starting with NONE, CMD or CMD-SHELL
    - otherwise pass command list as-is to container
