### PR TITLE
Cirrus: Fix #3543: Failure in 'release' task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -476,13 +476,13 @@ verify_test_built_images_task:
     always:
         <<: *standardlogs
 
-
-# Post message to IRC if everything passed
+# Post message to IRC if everything passed PR testing
 success_task:
 
     only_if: $CIRRUS_BRANCH != 'master'
 
-    depends_on:  # ignores any dependent task conditions
+    # ignores any dependent task conditions, include everything except 'release'
+    depends_on: &alltasks
         - "gating"
         - "vendor"
         - "varlink_api"
@@ -515,8 +515,7 @@ release_task:
     # allow_failures: $CI == "true"
     # skip_notifications: $CI == "true"
 
-    depends_on:
-        - "success"
+    depends_on: *alltasks
 
     gce_instance:
         image_name: "${IMAGE_BUILDER_CACHE_IMAGE_NAME}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -215,7 +215,8 @@ build_each_commit_task:
     on_failure:
         failed_master_script: '$CIRRUS_WORKING_DIR/$SCRIPT_BASE/notice_master_failure.sh'
 
-build_without_cgo:
+
+build_without_cgo_task:
 
     depends_on:
         - "gating"
@@ -486,6 +487,7 @@ success_task:
         - "vendor"
         - "varlink_api"
         - "build_each_commit"
+        - "build_without_cgo"
         - "meta"
         - "testing"
         - "special_testing_rootless"
@@ -493,7 +495,6 @@ success_task:
         - "special_testing_cross"
         - "test_build_cache_images"
         - "verify_test_built_images"
-        - "build_without_cgo"
 
     env:
         CIRRUS_WORKING_DIR: "/usr/src/libpod"


### PR DESCRIPTION
Normally when testing PRs, the final task to run is 'success'.  It's
purpose is three-fold:

- Notify on IRC that a PR passed all testing.
- Block merging of a PR unless all dependent tasks are successful.
- When successful, publish cached binary release archives.

Mistakenly, the 'release' task was not made dependent upon the 'success'
task.  Since 'success' only runs for PRs, this was causing post-merge
failures due to the 'release' task not finding any release archives -
the tasks which generate them are still running.

Fix this by making the 'release' task depend upon the same items as
the 'success' task.  This will ensure it only runs as the very last
step, for both PRs and on branches (post-merge).

Signed-off-by: Chris Evich <cevich@redhat.com>

Fixes #3543