### PR TITLE
Cirrus: Disable most periodic services/timers

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,9 +31,9 @@ env:
     ####
     #### Cache-image names to test with
     ###
-    FEDORA_CACHE_IMAGE_NAME: "fedora-30-libpod-5744029755506688"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-29-libpod-5744029755506688"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-18-libpod-5744029755506688"
+    FEDORA_CACHE_IMAGE_NAME: "fedora-30-libpod-5925244995371008"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-29-libpod-5925244995371008"
+    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-18-libpod-5925244995371008"
 
     ####
     #### Variables for composing new cache-images (used in PR testing) from

--- a/contrib/cirrus/check_image.sh
+++ b/contrib/cirrus/check_image.sh
@@ -36,4 +36,10 @@ do
         "$(systemctl list-unit-files --no-legend $REQ_UNIT)" = "$REQ_UNIT enabled" || let "RET+=1"
 done
 
+# Exits zero if any unit matching pattern is running
+UNIT_STATUS=$(systemctl is-active $EVIL_UNITS; echo $?)
+item_test "No interfering background units are active:" \
+    "$UNIT_STATUS" -ne "0" || let "RET+=1"
+
+echo "Total failed tests: $RET"
 exit $RET

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -350,6 +350,20 @@ remove_packaged_podman_files(){
     done
 }
 
+systemd_banish(){
+    echo "Disabling periodic services that could destabalize testing:"
+    set +e  # Not all of these exist on every platform
+    for unit in cron atd apt-daily-upgrade apt-daily fstrim motd-news systemd-tmpfiles-clean
+    do
+        ooe.sh sudo systemctl stop $unit
+        ooe.sh sudo systemctl disable $unit
+        ooe.sh sudo systemctl disable $unit.timer
+        ooe.sh sudo systemctl mask $unit
+        ooe.sh sudo systemctl mask $unit.timer
+    done
+    set -e
+}
+
 _finalize(){
     set +e  # Don't fail at the very end
     set +e  # make errors non-fatal

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -78,6 +78,9 @@ ROOTLESS_ENV_RE='(CIRRUS_.+)|(ROOTLESS_.+)|(.+_IMAGE.*)|(.+_BASE)|(.*DIRPATH)|(.
 # Unsafe env. vars for display
 SECRET_ENV_RE='(IRCID)|(ACCOUNT)|(^GC[EP]..+)|(SSH)'
 
+# Names of systemd units which should never be running
+EVIL_UNITS="cron crond atd apt-daily-upgrade apt-daily fstrim motd-news systemd-tmpfiles-clean"
+
 SPECIALMODE="${SPECIALMODE:-none}"
 TEST_REMOTE_CLIENT="${TEST_REMOTE_CLIENT:-false}"
 export CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-podman}
@@ -351,9 +354,9 @@ remove_packaged_podman_files(){
 }
 
 systemd_banish(){
-    echo "Disabling periodic services that could destabalize testing:"
+    echo "Disabling periodic services that could destabilize testing:"
     set +e  # Not all of these exist on every platform
-    for unit in cron atd apt-daily-upgrade apt-daily fstrim motd-news systemd-tmpfiles-clean
+    for unit in $EVIL_UNITS
     do
         ooe.sh sudo systemctl stop $unit
         ooe.sh sudo systemctl disable $unit

--- a/contrib/cirrus/packer/fedora_base-setup.sh
+++ b/contrib/cirrus/packer/fedora_base-setup.sh
@@ -27,6 +27,9 @@ ooe.sh systemctl enable rngd
 echo "Setting cloud-init service to start after google-network-daemon.service"
 cp -v $GOSRC/$PACKER_BASE/cloud-init/fedora/cloud-init.service /etc/systemd/system/
 
+# Ensure there are no disruptive periodic services enabled by default in image
+systemd_banish
+
 rh_finalize
 
 echo "SUCCESS!"

--- a/contrib/cirrus/packer/fedora_setup.sh
+++ b/contrib/cirrus/packer/fedora_setup.sh
@@ -76,6 +76,9 @@ ooe.sh sudo dnf install -y \
     xz \
     zip
 
+# Ensure there are no disruptive periodic services enabled by default in image
+systemd_banish
+
 sudo /tmp/libpod/hack/install_catatonit.sh
 
 rh_finalize

--- a/contrib/cirrus/packer/ubuntu_setup.sh
+++ b/contrib/cirrus/packer/ubuntu_setup.sh
@@ -100,6 +100,9 @@ ooe.sh sudo update-grub
 sudo /tmp/libpod/hack/install_catatonit.sh
 ooe.sh sudo make -C /tmp/libpod install.libseccomp.sudo
 
+# Ensure there are no disruptive periodic services enabled by default in image
+systemd_banish
+
 ubuntu_finalize
 
 echo "SUCCESS!"


### PR DESCRIPTION
Depends on #3534

For CI testing, it's important to remove as much variability from the
overall system as possible.  This permits focusing just on problems
closely related to code-changes.  To this end, and because VMs are very
short-lived (2 hours at most), disable all systemd services and timers
which perform periodic activities.

Signed-off-by: Chris Evich <cevich@redhat.com>