### PR TITLE
Add ability to evict a container

### DIFF
--- a/API.md
+++ b/API.md
@@ -41,6 +41,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func Diff(name: string) DiffInfo](#Diff)
 
+[func EvictContainer(name: string, removeVolumes: bool) string](#EvictContainer)
+
 [func ExecContainer(opts: ExecOpts) ](#ExecContainer)
 
 [func ExportContainer(name: string, path: string) string](#ExportContainer)
@@ -445,6 +447,22 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.DeleteUnusedImages
 
 method Diff(name: [string](https://godoc.org/builtin#string)) [DiffInfo](#DiffInfo)</div>
 Diff returns a diff between libpod objects
+### <a name="EvictContainer"></a>func EvictContainer
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method EvictContainer(name: [string](https://godoc.org/builtin#string), removeVolumes: [bool](https://godoc.org/builtin#bool)) [string](https://godoc.org/builtin#string)</div>
+EvictContainer requires the name or ID of a container as well as a boolean that
+indicates to remove builtin volumes. Upon successful eviction of the container,
+its ID is returned.  If the container cannot be found by name or ID,
+a [ContainerNotFound](#ContainerNotFound) error will be returned.
+See also [RemoveContainer](RemoveContainer).
+#### Example
+~~~
+$ varlink call -m unix:/run/podman/io.podman/io.podman.EvictContainer '{"name": "62f4fd98cb57"}'
+{
+  "container": "62f4fd98cb57f529831e8f90610e54bba74bd6f02920ffb485e15376ed365c20"
+}
+~~~
 ### <a name="ExecContainer"></a>func ExecContainer
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -953,10 +971,12 @@ ReceiveFile allows the host to send a remote client a file
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
 method RemoveContainer(name: [string](https://godoc.org/builtin#string), force: [bool](https://godoc.org/builtin#bool), removeVolumes: [bool](https://godoc.org/builtin#bool)) [string](https://godoc.org/builtin#string)</div>
-RemoveContainer requires the name or ID of container as well a boolean representing whether a running container can be stopped and removed, and a boolean
+RemoveContainer requires the name or ID of a container as well as a boolean that
+indicates whether a container should be forcefully removed (e.g., by stopping it), and a boolean
 indicating whether to remove builtin volumes. Upon successful removal of the
 container, its ID is returned.  If the
 container cannot be found by name or ID, a [ContainerNotFound](#ContainerNotFound) error will be returned.
+See also [EvictContainer](EvictContainer).
 #### Example
 ~~~
 $ varlink call -m unix:/run/podman/io.podman/io.podman.RemoveContainer '{"name": "62f4fd98cb57"}'

--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -13,7 +13,7 @@ var (
 	rmCommand     cliconfig.RmValues
 	rmDescription = fmt.Sprintf(`Removes one or more containers from the host. The container name or ID can be used.
 
-  Command does not remove images. Running containers will not be removed without the -f option.`)
+  Command does not remove images. Running or unusable containers will not be removed without the -f option.`)
 	_rmCommand = &cobra.Command{
 		Use:   "rm [flags] CONTAINER [CONTAINER...]",
 		Short: "Remove one or more containers",
@@ -29,7 +29,8 @@ var (
 		},
 		Example: `podman rm imageID
   podman rm mywebserver myflaskserver 860a4b23
-  podman rm --force --all`,
+  podman rm --force --all
+  podman rm -f c684f0d469f2`,
 	}
 )
 
@@ -39,7 +40,7 @@ func init() {
 	rmCommand.SetUsageTemplate(UsageTemplate())
 	flags := rmCommand.Flags()
 	flags.BoolVarP(&rmCommand.All, "all", "a", false, "Remove all containers")
-	flags.BoolVarP(&rmCommand.Force, "force", "f", false, "Force removal of a running container.  The default is false")
+	flags.BoolVarP(&rmCommand.Force, "force", "f", false, "Force removal of a running or unusable container.  The default is false")
 	flags.BoolVarP(&rmCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&rmCommand.Storage, "storage", false, "Remove container from storage library")
 	flags.BoolVarP(&rmCommand.Volumes, "volumes", "v", false, "Remove the volumes associated with the container")

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -727,10 +727,12 @@ method GetAttachSockets(name: string) -> (sockets: Sockets)
 # or name, a [ContainerNotFound](#ContainerNotFound) error is returned.
 method WaitContainer(name: string, interval: int) -> (exitcode: int)
 
-# RemoveContainer requires the name or ID of container as well a boolean representing whether a running container can be stopped and removed, and a boolean
+# RemoveContainer requires the name or ID of a container as well as a boolean that
+# indicates whether a container should be forcefully removed (e.g., by stopping it), and a boolean
 # indicating whether to remove builtin volumes. Upon successful removal of the
 # container, its ID is returned.  If the
 # container cannot be found by name or ID, a [ContainerNotFound](#ContainerNotFound) error will be returned.
+# See also [EvictContainer](EvictContainer).
 # #### Example
 # ~~~
 # $ varlink call -m unix:/run/podman/io.podman/io.podman.RemoveContainer '{"name": "62f4fd98cb57"}'
@@ -739,6 +741,20 @@ method WaitContainer(name: string, interval: int) -> (exitcode: int)
 # }
 # ~~~
 method RemoveContainer(name: string, force: bool, removeVolumes: bool) -> (container: string)
+
+# EvictContainer requires the name or ID of a container as well as a boolean that
+# indicates to remove builtin volumes. Upon successful eviction of the container,
+# its ID is returned.  If the container cannot be found by name or ID,
+# a [ContainerNotFound](#ContainerNotFound) error will be returned.
+# See also [RemoveContainer](RemoveContainer).
+# #### Example
+# ~~~
+# $ varlink call -m unix:/run/podman/io.podman/io.podman.EvictContainer '{"name": "62f4fd98cb57"}'
+# {
+#   "container": "62f4fd98cb57f529831e8f90610e54bba74bd6f02920ffb485e15376ed365c20"
+# }
+# ~~~
+method EvictContainer(name: string, removeVolumes: bool) -> (container: string)
 
 # DeleteStoppedContainers will delete all containers that are not running. It will return a list the deleted
 # container IDs.  See also [RemoveContainer](RemoveContainer).

--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -9,7 +9,8 @@ podman\-rm - Remove one or more containers
 **podman container rm** [*options*] *container*
 
 ## DESCRIPTION
-**podman rm** will remove one or more containers from the host.  The container name or ID can be used.  This does not remove images.  Running containers will not be removed without the `-f` option
+**podman rm** will remove one or more containers from the host.  The container name or ID can be used.  This does not remove images.
+Running or unusable containers will not be removed without the `-f` option.
 
 ## OPTIONS
 
@@ -19,9 +20,11 @@ Remove all containers.  Can be used in conjunction with -f as well.
 
 **--force**, **-f**
 
-Force the removal of running and paused containers.  Forcing a containers removal also
+Force the removal of running and paused containers. Forcing a container removal also
 removes containers from container storage even if the container is not known to podman.
 Containers could have been created by a different container engine.
+In addition, forcing can be used to remove unusable containers, e.g. containers
+whose OCI runtime has become unavailable.
 
 **--latest**, **-l**
 

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -112,6 +112,10 @@ var (
 	// that was not found
 	ErrOCIRuntimeNotFound = errors.New("OCI runtime command not found error")
 
+	// ErrOCIRuntimeUnavailable indicates that the OCI runtime associated to a container
+	// could not be found in the configuration
+	ErrOCIRuntimeUnavailable = errors.New("OCI runtime not available in the current configuration")
+
 	// ErrConmonOutdated indicates the version of conmon found (whether via the configuration or $PATH)
 	// is out of date for the current podman version
 	ErrConmonOutdated = errors.New("outdated conmon version")

--- a/libpod/runtime_cstorage.go
+++ b/libpod/runtime_cstorage.go
@@ -60,6 +60,12 @@ func (r *Runtime) RemoveStorageContainer(idOrName string, force bool) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
+	return r.removeStorageContainer(idOrName, force)
+}
+
+// Internal function to remove the container storage without
+// locking the runtime.
+func (r *Runtime) removeStorageContainer(idOrName string, force bool) error {
 	targetID, err := r.store.Lookup(idOrName)
 	if err != nil {
 		if err == storage.ErrLayerUnknown {

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -58,6 +58,9 @@ type State interface {
 	// If the container is not in the set namespace, an error will be
 	// returned.
 	Container(id string) (*Container, error)
+	// Return a container ID from the database by full or partial ID or full
+	// name.
+	LookupContainerID(idOrName string) (string, error)
 	// Return a container from the database by full or partial ID or full
 	// name.
 	// Containers not in the set namespace will be ignored.
@@ -97,6 +100,9 @@ type State interface {
 	// If a namespace is set, only containers within the namespace will be
 	// returned.
 	AllContainers() ([]*Container, error)
+
+	// Return a container config from the database by full ID
+	GetContainerConfig(id string) (*ContainerConfig, error)
 
 	// PLEASE READ FULL DESCRIPTION BEFORE USING.
 	// Rewrite a container's configuration.

--- a/libpod/state_test.go
+++ b/libpod/state_test.go
@@ -452,12 +452,18 @@ func TestLookupContainerWithEmptyIDFails(t *testing.T) {
 	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
 		_, err := state.LookupContainer("")
 		assert.Error(t, err)
+
+		_, err = state.LookupContainerID("")
+		assert.Error(t, err)
 	})
 }
 
 func TestLookupNonexistentContainerFails(t *testing.T) {
 	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
 		_, err := state.LookupContainer("does not exist")
+		assert.Error(t, err)
+
+		_, err = state.LookupContainerID("does not exist")
 		assert.Error(t, err)
 	})
 }
@@ -472,8 +478,11 @@ func TestLookupContainerByFullID(t *testing.T) {
 
 		retrievedCtr, err := state.LookupContainer(testCtr.ID())
 		assert.NoError(t, err)
-
 		testContainersEqual(t, retrievedCtr, testCtr, true)
+
+		retrievedID, err := state.LookupContainerID(testCtr.ID())
+		assert.NoError(t, err)
+		assert.Equal(t, retrievedID, testCtr.ID())
 	})
 }
 
@@ -487,8 +496,11 @@ func TestLookupContainerByUniquePartialID(t *testing.T) {
 
 		retrievedCtr, err := state.LookupContainer(testCtr.ID()[0:8])
 		assert.NoError(t, err)
-
 		testContainersEqual(t, retrievedCtr, testCtr, true)
+
+		retrievedID, err := state.LookupContainerID(testCtr.ID()[0:8])
+		assert.NoError(t, err)
+		assert.Equal(t, retrievedID, testCtr.ID())
 	})
 }
 
@@ -507,6 +519,9 @@ func TestLookupContainerByNonUniquePartialIDFails(t *testing.T) {
 
 		_, err = state.LookupContainer(testCtr1.ID()[0:8])
 		assert.Error(t, err)
+
+		_, err = state.LookupContainerID(testCtr1.ID()[0:8])
+		assert.Error(t, err)
 	})
 }
 
@@ -520,8 +535,11 @@ func TestLookupContainerByName(t *testing.T) {
 
 		retrievedCtr, err := state.LookupContainer(testCtr.Name())
 		assert.NoError(t, err)
-
 		testContainersEqual(t, retrievedCtr, testCtr, true)
+
+		retrievedID, err := state.LookupContainerID(testCtr.Name())
+		assert.NoError(t, err)
+		assert.Equal(t, retrievedID, testCtr.ID())
 	})
 }
 
@@ -535,6 +553,9 @@ func TestLookupCtrByPodNameFails(t *testing.T) {
 
 		_, err = state.LookupContainer(testPod.Name())
 		assert.Error(t, err)
+
+		_, err = state.LookupContainerID(testPod.Name())
+		assert.Error(t, err)
 	})
 }
 
@@ -547,6 +568,9 @@ func TestLookupCtrByPodIDFails(t *testing.T) {
 		assert.NoError(t, err)
 
 		_, err = state.LookupContainer(testPod.ID())
+		assert.Error(t, err)
+
+		_, err = state.LookupContainerID(testPod.ID())
 		assert.Error(t, err)
 	})
 }
@@ -565,8 +589,11 @@ func TestLookupCtrInSameNamespaceSucceeds(t *testing.T) {
 
 		ctr, err := state.LookupContainer(testCtr.ID())
 		assert.NoError(t, err)
-
 		testContainersEqual(t, ctr, testCtr, true)
+
+		ctrID, err := state.LookupContainerID(testCtr.ID())
+		assert.NoError(t, err)
+		assert.Equal(t, ctrID, testCtr.ID())
 	})
 }
 
@@ -583,6 +610,9 @@ func TestLookupCtrInDifferentNamespaceFails(t *testing.T) {
 		state.SetNamespace("test2")
 
 		_, err = state.LookupContainer(testCtr.ID())
+		assert.Error(t, err)
+
+		_, err = state.LookupContainerID(testCtr.ID())
 		assert.Error(t, err)
 	})
 }
@@ -606,8 +636,11 @@ func TestLookupContainerMatchInDifferentNamespaceSucceeds(t *testing.T) {
 
 		ctr, err := state.LookupContainer("000")
 		assert.NoError(t, err)
-
 		testContainersEqual(t, ctr, testCtr2, true)
+
+		ctrID, err := state.LookupContainerID("000")
+		assert.NoError(t, err)
+		assert.Equal(t, ctrID, testCtr2.ID())
 	})
 }
 
@@ -3597,5 +3630,32 @@ func TestSaveAndUpdatePodSameNamespace(t *testing.T) {
 		assert.NoError(t, err)
 
 		testPodsEqual(t, testPod, statePod, false)
+	})
+}
+
+func TestGetContainerConfigSucceeds(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+		testCtr, err := getTestCtr1(manager)
+		assert.NoError(t, err)
+
+		err = state.AddContainer(testCtr)
+		assert.NoError(t, err)
+
+		ctrCfg, err := state.GetContainerConfig(testCtr.ID())
+		assert.NoError(t, err)
+		assert.Equal(t, ctrCfg, testCtr.Config())
+	})
+}
+
+func TestGetContainerConfigEmptyIDFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+		_, err := state.GetContainerConfig("")
+		assert.Error(t, err)
+	})
+}
+func TestGetContainerConfigNonExistentIDFails(t *testing.T) {
+	runForAllStates(t, func(t *testing.T, state State, manager lock.Manager) {
+		_, err := state.GetContainerConfig("does not exist")
+		assert.Error(t, err)
 	})
 }

--- a/libpod/util_linux.go
+++ b/libpod/util_linux.go
@@ -5,6 +5,7 @@ package libpod
 import (
 	"fmt"
 	"strings"
+	"syscall"
 
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/cgroups"
@@ -12,6 +13,7 @@ import (
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 // systemdSliceFromPath makes a new systemd slice under the given parent with
@@ -106,4 +108,15 @@ func LabelVolumePath(path string, shared bool) error {
 		return errors.Wrapf(err, "error setting selinux label for %s to %q as %s", path, mountLabel, permString)
 	}
 	return nil
+}
+
+// Unmount umounts a target directory
+func Unmount(mount string) {
+	if err := unix.Unmount(mount, unix.MNT_DETACH); err != nil {
+		if err != syscall.EINVAL {
+			logrus.Warnf("failed to unmount %s : %v", mount, err)
+		} else {
+			logrus.Debugf("failed to unmount %s : %v", mount, err)
+		}
+	}
 }

--- a/libpod/util_unsupported.go
+++ b/libpod/util_unsupported.go
@@ -28,3 +28,7 @@ func assembleSystemdCgroupName(baseSlice, newSlice string) (string, error) {
 func LabelVolumePath(path string, shared bool) error {
 	return define.ErrNotImplemented
 }
+
+func Unmount(mount string) error {
+	return define.ErrNotImplemented
+}

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -508,7 +508,16 @@ func (i *LibpodAPI) RemoveContainer(call iopodman.VarlinkCall, name string, forc
 		return call.ReplyErrorOccurred(err.Error())
 	}
 	return call.ReplyRemoveContainer(ctr.ID())
+}
 
+// EvictContainer ...
+func (i *LibpodAPI) EvictContainer(call iopodman.VarlinkCall, name string, removeVolumes bool) error {
+	ctx := getContext()
+	id, err := i.Runtime.EvictContainer(ctx, name, removeVolumes)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyEvictContainer(id)
 }
 
 // DeleteStoppedContainers ...


### PR DESCRIPTION
Add ability to evict a container when it becomes unusable. This may
happen when the host setup changes after a container creation, making it
impossible for that container to be used or removed.

--- 

This may happen when you create a container with a specific runtime in libpod.conf, and later the runtime name is changed in the the conf, with outcome:
```bash
$ sudo podman run -d --runtime foo-runtime alpine sleep 12345
add950497c58b4004aee3a6077658615882f8487f9dca4a337fad14c01fb4077

$ sudo sed -i "s/foo-runtime/bar-runtime/" /etc/containers/libpod.conf

$ sudo podman ps -a
ERRO[0000] Error retrieving container add950497c58b4004aee3a6077658615882f8487f9dca4a337fad14c01fb4077 from the database: cannot find OCI runtime "foo-runtime" for container add950497c58b4004aee3a6077658615882f8487f9dca4a337fad14c01fb4077: runtime not available in the current configuration
CONTAINER ID  IMAGE                        COMMAND               CREATED      STATUS                     PORTS                                          NAMES
50c843e037fe  localhost/cups-epson:latest  cupsd -f              2 hours ago  Exited (0) 31 minutes ago  0.0.0.0:6631->631/tcp, 0.0.0.0:3000->3000/tcp  suspicious_germain
c684f0d469f2  k8s.gcr.io/pause:3.1                               9 days ago   Exited (0) 31 minutes ago  0.0.0.0:6631->631/tcp, 0.0.0.0:3000->3000/tcp  e812f6be094a-infra

$ sudo podman rm -ff ad
add950497c58b4004aee3a6077658615882f8487f9dca4a337fad14c01fb4077


```