### PR TITLE
Add support for --env-host

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,7 +376,7 @@ author hold special privileges on the github repository.  Others can be used by 
   will cause Cirrus CI to ***NOT*** execute tests for the PR or after merge.  This
   is useful in only one instance:  Your changes are absolutely not exercised by
   any test.  For example, documentation changes.  ***IMPORTANT NOTE*** **Other
-  automation may interpret the lack of test results as "PASSED" and unintentionall
+  automation may interpret the lack of test results as "PASSED" and unintentional
   merge a PR.  Consider also using `/hold` in a comment, to add additional
   protection.**
 

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -221,6 +221,9 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"env", "e", []string{},
 		"Set environment variables in container",
 	)
+	createFlags.Bool(
+		"env-host", false, "Use all current host environment variables in container",
+	)
 	createFlags.StringSlice(
 		"env-file", []string{},
 		"Read in a file of environment variables",

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -483,6 +483,16 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 
 	// ENVIRONMENT VARIABLES
 	env := EnvVariablesFromData(data)
+	if c.Bool("env-host") {
+		for _, e := range os.Environ() {
+			pair := strings.SplitN(e, "=", 2)
+			if _, ok := env[pair[0]]; !ok {
+				if len(pair) > 1 {
+					env[pair[0]] = pair[1]
+				}
+			}
+		}
+	}
 	if err := parse.ReadKVStrings(env, c.StringSlice("env-file"), c.StringArray("env")); err != nil {
 		return nil, errors.Wrapf(err, "unable to process environment variables")
 	}

--- a/cmd/podman/shared/intermediate.go
+++ b/cmd/podman/shared/intermediate.go
@@ -393,6 +393,7 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIRes
 	m["dns-search"] = newCRStringSlice(c, "dns-search")
 	m["entrypoint"] = newCRString(c, "entrypoint")
 	m["env"] = newCRStringArray(c, "env")
+	m["env-host"] = newCRBool(c, "env-host")
 	m["env-file"] = newCRStringSlice(c, "env-file")
 	m["expose"] = newCRStringSlice(c, "expose")
 	m["gidmap"] = newCRStringSlice(c, "gidmap")

--- a/cmd/podman/shared/parse/parse.go
+++ b/cmd/podman/shared/parse/parse.go
@@ -112,9 +112,22 @@ func parseEnv(env map[string]string, line string) error {
 	if len(data) > 1 {
 		env[name] = data[1]
 	} else {
-		// if only a pass-through variable is given, clean it up.
-		val, _ := os.LookupEnv(name)
-		env[name] = val
+		if strings.HasSuffix(name, "*") {
+			name = strings.TrimSuffix(name, "*")
+			for _, e := range os.Environ() {
+				part := strings.SplitN(e, "=", 2)
+				if len(part) < 2 {
+					continue
+				}
+				if strings.HasPrefix(part[0], name) {
+					env[part[0]] = part[1]
+				}
+			}
+		} else {
+			// if only a pass-through variable is given, clean it up.
+			val, _ := os.LookupEnv(name)
+			env[name] = val
+		}
 	}
 	return nil
 }

--- a/cmd/podman/system_df.go
+++ b/cmd/podman/system_df.go
@@ -546,7 +546,7 @@ func imagesVerboseOutput(ctx context.Context, metaData dfMetaData) error {
 		"Created":    "CREATED",
 		"Size":       "SIZE",
 		"SharedSize": "SHARED SIZE",
-		"UniqueSize": "UNQUE SIZE",
+		"UniqueSize": "UNIQUE SIZE",
 		"Containers": "CONTAINERS",
 	}
 	imagesVerboseDiskUsage, err := getImageVerboseDiskUsage(ctx, metaData.images, metaData.imagesUsedbyCtrMap)

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1740,6 +1740,7 @@ _podman_container_run() {
 		--dns-search
 		--entrypoint
 		--env -e
+		--env-host
 		--env-file
 		--expose
 		--gidmap

--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -339,7 +339,7 @@ environment variable.  `export BUILDAH_RUNTIME=/usr/local/bin/runc`
 
 **--runtime-flag**=*flag*
 
-Adds global flags for the container rutime. To list the supported flags, please
+Adds global flags for the container runtime. To list the supported flags, please
 consult the manpages of the selected container runtime (`runc` is the default
 runtime, the manpage to consult is `runc(8)`).
 
@@ -394,7 +394,7 @@ Require HTTPS and verify certificates when talking to container registries (defa
 Specifies resource limits to apply to processes launched when processing `RUN` instructions.
 This option can be specified multiple times.  Recognized resource types
 include:
-  "core": maximimum core dump size (ulimit -c)
+  "core": maximum core dump size (ulimit -c)
   "cpu": maximum CPU time (ulimit -t)
   "data": maximum size of a process's data segment (ulimit -d)
   "fsize": maximum size of new files (ulimit -f)
@@ -422,7 +422,7 @@ process.
 **--userns-uid-map**=*mapping*
 
 Directly specifies a UID mapping which should be used to set ownership, at the
-filesytem level, on the working container's contents.
+filesystem level, on the working container's contents.
 Commands run when handling `RUN` instructions will default to being run in
 their own user namespaces, configured using the UID and GID maps.
 
@@ -443,7 +443,7 @@ use the same numeric values as the GID map.
 **--userns-gid-map**=*mapping*
 
 Directly specifies a GID mapping which should be used to set ownership, at the
-filesytem level, on the working container's contents.
+filesystem level, on the working container's contents.
 Commands run when handling `RUN` instructions will default to being run in
 their own user namespaces, configured using the UID and GID maps.
 
@@ -464,7 +464,7 @@ use the same numeric values as the UID map.
 **--userns-uid-map-user**=*user*
 
 Specifies that a UID mapping which should be used to set ownership, at the
-filesytem level, on the working container's contents, can be found in entries
+filesystem level, on the working container's contents, can be found in entries
 in the `/etc/subuid` file which correspond to the specified user.
 Commands run when handling `RUN` instructions will default to being run in
 their own user namespaces, configured using the UID and GID maps.
@@ -475,7 +475,7 @@ suitable user name to use as the default setting for this option.
 **--userns-gid-map-group**=*group*
 
 Specifies that a GID mapping which should be used to set ownership, at the
-filesytem level, on the working container's contents, can be found in entries
+filesystem level, on the working container's contents, can be found in entries
 in the `/etc/subgid` file which correspond to the specified group.
 Commands run when handling `RUN` instructions will default to being run in
 their own user namespaces, configured using the UID and GID maps.
@@ -565,7 +565,7 @@ Use `df <source-dir>` to determine the source mount and then use
 `findmnt -o TARGET,PROPAGATION <source-mount-dir>` to determine propagation
 properties of source mount, if `findmnt` utility is not available, the source mount point
 can be determined by looking at the mount entry in `/proc/self/mountinfo`. Look
-at `optional fields` and see if any propagaion properties are specified.
+at `optional fields` and see if any propagation properties are specified.
 `shared:X` means the mount is `shared`, `master:X` means the mount is `slave` and if
 nothing is there that means the mount is `private`.
 

--- a/docs/podman-cp.1.md
+++ b/docs/podman-cp.1.md
@@ -7,7 +7,7 @@ podman\-cp - Copy files/folders between a container and the local filesystem
 **podman cp** [*options*] [*container*:]*src_path* [*container*:]*dest_path*
 
 ## DESCRIPTION
-Copies the contents of **src_path** to the **dest_path**. You can copy from the containers's filesystem to the local machine or the reverse, from the local filesystem to the container.
+Copies the contents of **src_path** to the **dest_path**. You can copy from the container's filesystem to the local machine or the reverse, from the local filesystem to the container.
 If - is specified for either the SRC_PATH or DEST_PATH, you can also stream a tar archive from STDIN or to STDOUT.
 
 The CONTAINER can be a running or stopped container. The **src_path** or **dest_path** can be a file or directory.

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -245,13 +245,15 @@ You need to specify multi option commands in the form of a json string.
 
 Set environment variables
 
-This option allows you to specify arbitrary
-environment variables that are available for the process that will be launched
-inside of the container.
+This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container. If you specify a environment variable without a value, podman will check the host environment for a value or set the environment to "".  See **Environment** note below for precedence.
+
+**--env-host**=*true|false*
+
+Use host environment inside of the container. See **Environment** note below for precedence.
 
 **--env-file**=*file*
 
-Read in a line delimited file of environment variables
+Read in a line delimited file of environment variables. See **Environment** note below for precedence.
 
 **--expose**=*port*
 
@@ -900,6 +902,19 @@ Rootless podman works better if the fuse-overlayfs and slirp4netns packages are 
 The fuse-overlay package provides a userspace overlay storage driver, otherwise users need to use
 the vfs storage driver, which is diskspace expensive and does not perform well. slirp4netns is
 required for VPN, without it containers need to be run with the --net=host flag.
+
+## ENVIRONMENT
+
+Environment variables within containers can be set using multiple different options:  This section describes the presidence.
+
+Presidence Order:
+	   **--env-host** : Host environment of the process executing podman is added.
+
+	   Container image : Any enviroment variables specified in the contianer image.
+
+	   **--env-file** : Any environment variables specfied via env-files.  If multiple files specified, then they override each other in order of entry.
+
+	   **--env** : Any environment variables specified will overide previous settings.
 
 ## FILES
 

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -245,7 +245,9 @@ You need to specify multi option commands in the form of a json string.
 
 Set environment variables
 
-This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container. If you specify a environment variable without a value, podman will check the host environment for a value or set the environment to "".  See **Environment** note below for precedence.
+This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container. If you specify a environment variable without a value, podman will check the host environment for a value or set the environment to "". If you specify a environment variable ending in --*--, podman will search the host environment for variables starting with the prefix and add them to the container.  If you want to add an environment variable with a ***** following it, then you need to set a value.
+
+See **Environment** note below for precedence.
 
 **--env-host**=*true|false*
 
@@ -905,16 +907,16 @@ required for VPN, without it containers need to be run with the --net=host flag.
 
 ## ENVIRONMENT
 
-Environment variables within containers can be set using multiple different options:  This section describes the presidence.
+Environment variables within containers can be set using multiple different options:  This section describes the precedence.
 
-Presidence Order:
+Precedence Order:
 	   **--env-host** : Host environment of the process executing podman is added.
 
-	   Container image : Any enviroment variables specified in the contianer image.
+	   Container image : Any enviroment variables specified in the container image.
 
-	   **--env-file** : Any environment variables specfied via env-files.  If multiple files specified, then they override each other in order of entry.
+	   **--env-file** : Any environment variables specified via env-files.  If multiple files specified, then they override each other in order of entry.
 
-	   **--env** : Any environment variables specified will overide previous settings.
+	   **--env** : Any environment variables specified will override previous settings.
 
 ## FILES
 

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -316,7 +316,7 @@ those.  This option is only needed when the host system must use a proxy but
 the container should not use any proxy.  Proxy environment variables specified
 for the container in any other way will override the values that would have
 been passed thru from the host.  (Other ways to specify the proxy for the
-container include passing the values with the `--env` flag, or hardcoding the
+container include passing the values with the `--env` flag, or hard coding the
 proxy environment at container build time.)
 
 For example, to disable passing these environment variables from host to
@@ -634,7 +634,7 @@ Security Options
 "seccomp=unconfined" : Turn off seccomp confinement for the container
 "seccomp=profile.json :  White listed syscalls seccomp Json file to be used as a seccomp filter
 
-Note: Labelling can be disabled for all containers by setting label=false in the **libpod.conf** (`/etc/containers/libpod.conf`) file.
+Note: Labeling can be disabled for all containers by setting label=false in the **libpod.conf** (`/etc/containers/libpod.conf`) file.
 
 **--shm-size**=*size*
 
@@ -912,7 +912,7 @@ Environment variables within containers can be set using multiple different opti
 Precedence Order:
 	   **--env-host** : Host environment of the process executing podman is added.
 
-	   Container image : Any enviroment variables specified in the container image.
+	   Container image : Any environment variables specified in the container image.
 
 	   **--env-file** : Any environment variables specified via env-files.  If multiple files specified, then they override each other in order of entry.
 

--- a/docs/podman-generate-kube.1.md
+++ b/docs/podman-generate-kube.1.md
@@ -147,4 +147,4 @@ status:
 podman(1), podman-container(1), podman-pod(1), podman-play-kube(1)
 
 ## HISTORY
-Decemeber 2018, Originally compiled by Brent Baude (bbaude at redhat dot com)
+December 2018, Originally compiled by Brent Baude (bbaude at redhat dot com)

--- a/docs/podman-generate-systemd.1.md
+++ b/docs/podman-generate-systemd.1.md
@@ -23,7 +23,7 @@ Use the name of the container for the start, stop, and description in the unit f
 Override the default stop timeout for the container with the given value.
 
 **--restart-policy**=*policy*
-Set the SystemD restart policy.  The restart-policy must be one of: "no", "on-success", "on-failure", "on-abnormal",
+Set the systemd restart policy.  The restart-policy must be one of: "no", "on-success", "on-failure", "on-abnormal",
 "on-watchdog", "on-abort", or "always".  The default policy is *on-failure*.
 
 ## Examples

--- a/docs/podman-image-sign.1.md
+++ b/docs/podman-image-sign.1.md
@@ -7,7 +7,7 @@ podman-image-sign - Create a signature for an image
 **podman image sign** [*options*] *image* [*image* ...]
 
 ## DESCRIPTION
-**podmain image sign** will create a local signature for one or more local images that have
+**podman image sign** will create a local signature for one or more local images that have
 been pulled from a registry. The signature will be written to a directory
 derived from the registry configuration files in /etc/containers/registries.d. By default, the signature will be written into /var/lib/containers/sigstore directory.
 
@@ -39,8 +39,8 @@ docker:
   privateregistry.example.com:
     sigstore: file:///var/lib/containers/sigstore
 
-When signing an image preceeded with the registry name 'privateregistry.example.com',
-the signature will be written into subdirectories of
+When signing an image preceded with the registry name 'privateregistry.example.com',
+the signature will be written into sub-directories of
 /var/lib/containers/sigstore/privateregistry.example.com. The use of 'sigstore' also means
 the signature will be 'read' from that same location on a pull-related function.
 

--- a/docs/podman-load.1.md
+++ b/docs/podman-load.1.md
@@ -8,7 +8,7 @@ podman\-load - Load an image from a container image archive into container stora
 
 ## DESCRIPTION
 **podman load** loads an image from either an **oci-archive** or **docker-archive** stored on the local machine into container storage. **podman load** reads from stdin by default or a file if the **input** option is set.
-You can also specify a name for the image if the archive does not contain a named reference, of if you want an additonal name for the local image.
+You can also specify a name for the image if the archive does not contain a named reference, of if you want an additional name for the local image.
 
 The **quiet** option suppresses the progress output when set.
 Note: `:` is a restricted character and cannot be part of the file name.

--- a/docs/podman-mount.1.md
+++ b/docs/podman-mount.1.md
@@ -1,7 +1,7 @@
 % podman-mount(1)
 
 ## NAME
-podman\-mount - Mount the specifed working containers' root filesystem
+podman\-mount - Mount the specified working containers' root filesystem
 
 ## SYNOPSIS
 **podman mount** [*container* ...]

--- a/docs/podman-play-kube.1.md
+++ b/docs/podman-play-kube.1.md
@@ -62,4 +62,4 @@ $ podman play kube demo.yml
 podman(1), podman-container(1), podman-pod(1), podman-generate-kube(1), podman-play(1)
 
 ## HISTORY
-Decemeber 2018, Originally compiled by Brent Baude (bbaude at redhat dot com)
+December 2018, Originally compiled by Brent Baude (bbaude at redhat dot com)

--- a/docs/podman-pod-create.1.md
+++ b/docs/podman-pod-create.1.md
@@ -64,7 +64,7 @@ NOTE: This cannot be modified once the pod is created.
 
 **--share**=*namespace*
 
-A comma deliminated list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared. The namespaces to choose from are ipc, net, pid, user, uts.
+A comma delimited list of kernel namespaces to share. If none or "" is specified, no namespaces will be shared. The namespaces to choose from are ipc, net, pid, user, uts.
 
 The operator can identify a pod in three ways:
 UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”)

--- a/docs/podman-pod-stats.1.md
+++ b/docs/podman-pod-stats.1.md
@@ -47,7 +47,7 @@ Valid placeholders for the Go template are listed below:
 | .BlockIO        | Block IO          |
 | .PIDS           | Number of PIDs    |
 
-When using a GO template, you may preceed the format with `table` to print headers.
+When using a GO template, you may precede the format with `table` to print headers.
 ## EXAMPLE
 
 ```

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -252,13 +252,15 @@ You need to specify multi option commands in the form of a json string.
 
 Set environment variables
 
-This option allows you to specify arbitrary
-environment variables that are available for the process that will be launched
-inside of the container.
+This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container. If you specify a environment variable without a value, podman will check the host environment for a value or set the environment to "".  See **Environment** note below for precedence.
+
+**--env-host**=*true|false*
+
+Use host environment inside of the container. See **Environment** note below for precedence.
 
 **--env-file**=*file*
 
-Read in a line delimited file of environment variables
+Read in a line delimited file of environment variables. See **Environment** note below for precedence.
 
 **--expose**=*port*
 
@@ -1184,6 +1186,20 @@ Rootless podman works better if the fuse-overlayfs and slirp4netns packages are 
 The fuse-overlay package provides a userspace overlay storage driver, otherwise users need to use
 the vfs storage driver, which is diskspace expensive and does not perform well. slirp4netns is
 required for VPN, without it containers need to be run with the --net=host flag.
+
+## ENVIRONMENT
+
+Environment variables within containers can be set using multiple different options:  This section describes the presidence.
+
+Presidence Order:
+
+	   **--env-host** : Host environment of the process executing podman is added.
+
+	   Container image : Any enviroment variables specified in the contianer image.
+
+	   **--env-file** : Any environment variables specfied via env-files.  If multiple files specified, then they override each other in order of entry.
+
+	   **--env** : Any environment variables specified will overide previous settings.
 
 ## FILES
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -252,7 +252,9 @@ You need to specify multi option commands in the form of a json string.
 
 Set environment variables
 
-This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container. If you specify a environment variable without a value, podman will check the host environment for a value or set the environment to "".  See **Environment** note below for precedence.
+This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container. If you specify a environment variable without a value, podman will check the host environment for a value or set the environment to "". If you specify a environment variable ending in --*--, podman will search the host environment for variables starting with the prefix and add them to the container.  If you want to add an environment variable with a ***** following it, then you need to set a value.
+
+See **Environment** note below for precedence.
 
 **--env-host**=*true|false*
 
@@ -1189,17 +1191,17 @@ required for VPN, without it containers need to be run with the --net=host flag.
 
 ## ENVIRONMENT
 
-Environment variables within containers can be set using multiple different options:  This section describes the presidence.
+Environment variables within containers can be set using multiple different options:  This section describes the precedence.
 
-Presidence Order:
+Precedence Order:
 
 	   **--env-host** : Host environment of the process executing podman is added.
 
-	   Container image : Any enviroment variables specified in the contianer image.
+	   Container image : Any enviroment variables specified in the container image.
 
-	   **--env-file** : Any environment variables specfied via env-files.  If multiple files specified, then they override each other in order of entry.
+	   **--env-file** : Any environment variables specified via env-files.  If multiple files specified, then they override each other in order of entry.
 
-	   **--env** : Any environment variables specified will overide previous settings.
+	   **--env** : Any environment variables specified will override previous settings.
 
 ## FILES
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -323,7 +323,7 @@ those.  This option is only needed when the host system must use a proxy but
 the container should not use any proxy.  Proxy environment variables specified
 for the container in any other way will override the values that would have
 been passed thru from the host.  (Other ways to specify the proxy for the
-container include passing the values with the `--env` flag, or hardcoding the
+container include passing the values with the `--env` flag, or hard coding the
 proxy environment at container build time.)
 
 For example, to disable passing these environment variables from host to
@@ -655,7 +655,7 @@ Security Options
 - `seccomp=unconfined` : Turn off seccomp confinement for the container
 - `seccomp=profile.json` :  White listed syscalls seccomp Json file to be used as a seccomp filter
 
-Note: Labelling can be disabled for all containers by setting label=false in the **libpod.conf** (`/etc/containers/libpod.conf`) file.
+Note: Labeling can be disabled for all containers by setting label=false in the **libpod.conf** (`/etc/containers/libpod.conf`) file.
 
 **--shm-size**=*size*
 
@@ -1197,7 +1197,7 @@ Precedence Order:
 
 	   **--env-host** : Host environment of the process executing podman is added.
 
-	   Container image : Any enviroment variables specified in the container image.
+	   Container image : Any environment variables specified in the container image.
 
 	   **--env-file** : Any environment variables specified via env-files.  If multiple files specified, then they override each other in order of entry.
 

--- a/docs/podman-stats.1.md
+++ b/docs/podman-stats.1.md
@@ -48,7 +48,7 @@ Valid placeholders for the Go template are listed below:
 | .BlockIO        | Block IO          |
 | .PIDS           | Number of PIDs    |
 
-When using a GO template, you may preceed the format with `table` to print headers.
+When using a GO template, you may precede the format with `table` to print headers.
 
 ## EXAMPLE
 

--- a/docs/podman-system-df.1.md
+++ b/docs/podman-system-df.1.md
@@ -28,7 +28,7 @@ Local Volumes   1       1        22B     0B (0%)
 $ podman system df -v
 Images space usage:
 
-REPOSITORY                 TAG      IMAGE ID       CREATED       SIZE     SHARED SIZE   UNQUE SIZE   CONTAINERS
+REPOSITORY                 TAG      IMAGE ID       CREATED       SIZE     SHARED SIZE   UNIQUE SIZE   CONTAINERS
 docker.io/library/alpine   latest   5cb3aa00f899   2 weeks ago   5.79MB   0B            5.79MB       5
 
 Containers space usage:

--- a/docs/podman-volume-inspect.1.md
+++ b/docs/podman-volume-inspect.1.md
@@ -8,7 +8,7 @@ podman\-volume\-inspect - Inspect one or more volumes
 
 ## DESCRIPTION
 
-Display detailed information on one or more volumes. The output can be formated using
+Display detailed information on one or more volumes. The output can be formatted using
 the **--format** flag and a Go template. To get detailed information about all the
 existing volumes, use the **--all** flag.
 

--- a/install.md
+++ b/install.md
@@ -158,7 +158,7 @@ After that enable user namespaces:
 sudo sysctl kernel.unprivileged_userns_clone=1
 ```
 
-To enable the user namespaces permanenty:
+To enable the user namespaces permanently:
 
 ```
 echo 'kernel.unprivileged_userns_clone=1' > /etc/sysctl.d/userns.conf

--- a/rootless.md
+++ b/rootless.md
@@ -2,7 +2,7 @@
 
 The following list categorizes the known issues and irregularities with running Podman as a non-root user.  Although currently functional, there is still a number of work items that are under consideration to be added.  These proposed changes are in varying degrees of design and development.
 
-Contributors are more than welcomed to help with this work.  If you decide to carve off a piece and work on it, please create an issue in [GitHub](https://github.com/containers/libpod/issues), and assign it to yourself.  If you find other unexpected behaviour with rootless Podman and feel it’s warranted, please feel free to update this document.
+Contributors are more than welcomed to help with this work.  If you decide to carve off a piece and work on it, please create an issue in [GitHub](https://github.com/containers/libpod/issues), and assign it to yourself.  If you find other unexpected behavior with rootless Podman and feel it’s warranted, please feel free to update this document.
 
 * Podman can not create containers that bind to ports < 1024.
   * The kernel does not allow processes without CAP_NET_BIND_SERVICE to bind to low ports.

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -224,6 +224,22 @@ var _ = Describe("Podman run", func() {
 		Expect(match).Should(BeTrue())
 	})
 
+	It("podman run --host-env environment test", func() {
+		os.Setenv("FOO", "BAR")
+		session := podmanTest.Podman([]string{"run", "--rm", "--env-host", ALPINE, "printenv", "FOO"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ := session.GrepString("BAR")
+		Expect(match).Should(BeTrue())
+
+		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO=BAR1", "--env-host", ALPINE, "printenv", "FOO"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ = session.GrepString("BAR1")
+		Expect(match).Should(BeTrue())
+		os.Unsetenv("FOO")
+	})
+
 	It("podman run limits test", func() {
 		SkipIfRootless()
 		session := podmanTest.Podman([]string{"run", "--rm", "--ulimit", "rtprio=99", "--cap-add=sys_nice", fedoraMinimal, "cat", "/proc/self/sched"})


### PR DESCRIPTION
This flag passes the host environment into the container.  The basic idea is to
leak all environment variables from the host into the container.

Environment variables from the image, and passed in via --env and --env-file
will override the host environment.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>