### PR TITLE
Fix a bug where ctrs could not be removed from pods

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -431,10 +431,12 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 		// If we're removing the pod, the container will be evicted
 		// from the state elsewhere
 		if !removePod {
-			if cleanupErr == nil {
-				cleanupErr = err
-			} else {
-				logrus.Errorf("removing container from pod: %v", err)
+			if err := r.state.RemoveContainerFromPod(pod, c); err != nil {
+				if cleanupErr == nil {
+					cleanupErr = err
+				} else {
+					logrus.Errorf("removing container from pod: %v", err)
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
Using pod removal worked, but container removal was missing the most critical step - the actual removal. Must have been accidentally removed during a refactor.

Fixes #3556