### PR TITLE
cgroupsv2: do not enable controllers for the last component

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -187,8 +187,12 @@ func createCgroupv2Path(path string) (Err error) {
 				}()
 			}
 		}
-		if err := ioutil.WriteFile(filepath.Join(current, "cgroup.subtree_control"), resByte, 0755); err != nil {
-			return errors.Wrapf(err, "write %s", filepath.Join(current, "cgroup.subtree_control"))
+		// We enable the controllers for all the path components except the last one.  It is not allowed to add
+		// PIDs if there are already enabled controllers.
+		if i < len(elements[3:])-1 {
+			if err := ioutil.WriteFile(filepath.Join(current, "cgroup.subtree_control"), resByte, 0755); err != nil {
+				return errors.Wrapf(err, "write %s", filepath.Join(current, "cgroup.subtree_control"))
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
do not automatically enable the controllers for the last path
component.  It is necessary as once there are enabled controllers in a
cgroup, it won't possible to add processes to it.

Fix conmon being moved to the correct cgroup path when using
--cgroup-manager cgroupfs.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>