### PR TITLE
Fix error message on podman stats on cgroups v1 rootless environments

### DIFF
--- a/cmd/podman/stats.go
+++ b/cmd/podman/stats.go
@@ -134,8 +134,12 @@ func statsCmd(c *cliconfig.StatsValues) error {
 		initialStats, err := ctr.GetContainerStats(&libpod.ContainerStats{})
 		if err != nil {
 			// when doing "all", dont worry about containers that are not running
-			if c.All && errors.Cause(err) == define.ErrCtrRemoved || errors.Cause(err) == define.ErrNoSuchCtr || errors.Cause(err) == define.ErrCtrStateInvalid {
+			cause := errors.Cause(err)
+			if c.All && (cause == define.ErrCtrRemoved || cause == define.ErrNoSuchCtr || cause == define.ErrCtrStateInvalid) {
 				continue
+			}
+			if cause == cgroups.ErrCgroupV1Rootless {
+				err = cause
 			}
 			return err
 		}

--- a/docs/podman-stats.1.md
+++ b/docs/podman-stats.1.md
@@ -9,6 +9,10 @@ podman\-stats - Display a live stream of 1 or more containers' resource usage st
 ## DESCRIPTION
 Display a live stream of one or more containers' resource usage statistics
 
+Note:  Podman stats will not work in rootless environments that use CGroups V1.
+Podman stats relies on CGroup information for statistics, and CGroup v1 is not
+supported for rootless use cases.
+
 ## OPTIONS
 
 **--all**, **-a**
@@ -69,14 +73,14 @@ a9f807ffaacd   frosty_hodgkin   --      3.092MB / 16.7GB    0.02%   -- / --   --
 # podman stats --no-stream --format=json a9f80
 [
     {
-        "id": "a9f807ffaacd",
-        "name": "frosty_hodgkin",
-        "cpu_percent": "--",
-        "mem_usage": "3.092MB / 16.7GB",
-        "mem_percent": "0.02%",
-        "netio": "-- / --",
-        "blocki": "-- / --",
-        "pids": "2"
+	"id": "a9f807ffaacd",
+	"name": "frosty_hodgkin",
+	"cpu_percent": "--",
+	"mem_usage": "3.092MB / 16.7GB",
+	"mem_percent": "0.02%",
+	"netio": "-- / --",
+	"blocki": "-- / --",
+	"pids": "2"
     }
 ]
 ```

--- a/libpod/runtime_pod_linux.go
+++ b/libpod/runtime_pod_linux.go
@@ -204,7 +204,7 @@ func (r *Runtime) removePod(ctx context.Context, p *Pod, removeCtrs, force bool)
 		// Get the conmon CGroup
 		conmonCgroupPath := filepath.Join(p.state.CgroupPath, "conmon")
 		conmonCgroup, err := cgroups.Load(conmonCgroupPath)
-		if err != nil && err != cgroups.ErrCgroupDeleted {
+		if err != nil && err != cgroups.ErrCgroupDeleted && err != cgroups.ErrCgroupV1Rootless {
 			removalErr = errors.Wrapf(err, "error retrieving pod %s conmon cgroup %s", p.ID(), conmonCgroupPath)
 		}
 
@@ -266,7 +266,7 @@ func (r *Runtime) removePod(ctx context.Context, p *Pod, removeCtrs, force bool)
 			// hard - instead, just log errors.
 			conmonCgroupPath := filepath.Join(p.state.CgroupPath, "conmon")
 			conmonCgroup, err := cgroups.Load(conmonCgroupPath)
-			if err != nil && err != cgroups.ErrCgroupDeleted {
+			if err != nil && err != cgroups.ErrCgroupDeleted && err != cgroups.ErrCgroupV1Rootless {
 				if removalErr == nil {
 					removalErr = errors.Wrapf(err, "error retrieving pod %s conmon cgroup", p.ID())
 				} else {
@@ -283,7 +283,7 @@ func (r *Runtime) removePod(ctx context.Context, p *Pod, removeCtrs, force bool)
 				}
 			}
 			cgroup, err := cgroups.Load(p.state.CgroupPath)
-			if err != nil && err != cgroups.ErrCgroupDeleted {
+			if err != nil && err != cgroups.ErrCgroupDeleted && err != cgroups.ErrCgroupV1Rootless {
 				if removalErr == nil {
 					removalErr = errors.Wrapf(err, "error retrieving pod %s cgroup", p.ID())
 				} else {


### PR DESCRIPTION
podman stats does not work in rootless environments with cgroups V1.
Fix error message and document this fact.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

fixes: https://github.com/containers/libpod/issues/3566