### PR TITLE
fix --dns and --network conflict

### DIFF
--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
@@ -75,6 +76,16 @@ func createInit(c *cliconfig.PodmanCommand) error {
 
 	if c.IsSet("privileged") && c.IsSet("security-opt") {
 		logrus.Warn("setting security options with --privileged has no effect")
+	}
+
+	var setNet string
+	if c.IsSet("network") {
+		setNet = c.String("network")
+	} else if c.IsSet("net") {
+		setNet = c.String("net")
+	}
+	if (c.IsSet("dns") || c.IsSet("dns-opt") || c.IsSet("dns-search")) && (setNet == "none" || strings.HasPrefix(setNet, "container:")) {
+		return errors.Errorf("conflicting options: dns and the network mode.")
 	}
 
 	// Docker-compatibility: the "-h" flag for run/create is reserved for

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -206,7 +206,7 @@ Limit write rate (IO per second) to a device (e.g. --device-write-iops=/dev/sda:
 
 **--dns**=*dns*
 
-Set custom DNS servers
+Set custom DNS servers. Invalid if using **--dns** and **--network** that is set to 'none' or 'container:<name|id>'.
 
 This option can be used to override the DNS
 configuration passed to the container. Typically this is necessary when the
@@ -218,11 +218,11 @@ The **/etc/resolv.conf** file in the image will be used without changes.
 
 **--dns-option**=*option*
 
-Set custom DNS options
+Set custom DNS options. Invalid if using **--dns-option** and **--network** that is set to 'none' or 'container:<name|id>'.
 
 **--dns-search**=*domain*
 
-Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)
+Set custom DNS search domains. Invalid if using **--dns-search** and **--network** that is set to 'none' or 'container:<name|id>'. (Use --dns-search=. if you don't wish to set the search domain)
 
 **--entrypoint**=*"command"* | *'["command", "arg1", ...]'*
 
@@ -491,7 +491,7 @@ This works for both background and foreground containers.
 
 **--network**, **--net**="*bridge*"
 
-Set the Network mode for the container
+Set the Network mode for the container. Invalid if using **--dns**, **--dns-option**, or **--dns-search** with **--network** that is set to 'none' or 'container:<name|id>'.
                 'bridge': create a network stack on the default bridge
                 'none': no networking
                 'container:<name|id>': reuse another container's network stack

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -212,7 +212,7 @@ Limit write rate (IO per second) to a device (e.g. --device-write-iops=/dev/sda:
 
 **--dns**=*dns*
 
-Set custom DNS servers
+Set custom DNS servers. Invalid if using **--dns** with **--network** that is set to 'none' or 'container:<name|id>'.
 
 This option can be used to override the DNS
 configuration passed to the container. Typically this is necessary when the
@@ -224,11 +224,11 @@ The **/etc/resolv.conf** file in the image will be used without changes.
 
 **--dns-option**=*option*
 
-Set custom DNS options
+Set custom DNS options. Invalid if using **--dns-option** with **--network** that is set to 'none' or 'container:<name|id>'.
 
 **--dns-search**=*domain*
 
-Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)
+Set custom DNS search domains. Invalid if using **--dns-search** and **--network** that is set to 'none' or 'container:<name|id>'. (Use --dns-search=. if you don't wish to set the search domain)
 
 **--entrypoint**=*"command"* | *'["command", "arg1", ...]'*
 
@@ -502,9 +502,9 @@ to the container with **--name** then it will generate a random
 string name. The name is useful any place you need to identify a container.
 This works for both background and foreground containers.
 
-**--network**, **--net**=*mode*
+**--network**, **--net**=*node*
 
-Set the Network mode for the container:
+Set the Network mode for the container. Invalid if using **--dns**, **--dns-option**, or **--dns-search** with **--network** that is set to 'none' or 'container:<name|id>'.
 - `bridge`: create a network stack on the default bridge
 - `none`: no networking
 - `container:<name|id>`: reuse another container's network stack

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -94,4 +94,22 @@ var _ = Describe("Podman run dns", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.LineInOutputContains("foobar")).To(BeTrue())
 	})
+
+	It("podman run mutually excludes --dns* and --network", func() {
+		session := podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "container:ALPINE", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+
+		session = podmanTest.Podman([]string{"run", "--dns-opt=1.2.3.4", "--network", "container:ALPINE", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+
+		session = podmanTest.Podman([]string{"run", "--dns-search=foobar.com", "--network", "none", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+
+		session = podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "host", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To((Equal(0)))
+	})
 })


### PR DESCRIPTION
Close #3553
This PR makes --dns and --network flag mutually exclusive for podman build and create. Returns conflict error if both flags are set.

Signed-off-by: Qi Wang <qiwan@redhat.com>