### PR TITLE
Improved hooks monitoring 

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -4,7 +4,6 @@ package hooks
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -137,27 +136,4 @@ func (m *Manager) Hooks(config *rspec.Spec, annotations map[string]string, hasBi
 	}
 
 	return extensionStageHooks, nil
-}
-
-// remove remove a hook by name.
-func (m *Manager) remove(hook string) (ok bool) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	_, ok = m.hooks[hook]
-	if ok {
-		delete(m.hooks, hook)
-	}
-	return ok
-}
-
-// add adds a hook by path
-func (m *Manager) add(path string) (err error) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	hook, err := Read(path, m.extensionStages)
-	if err != nil {
-		return err
-	}
-	m.hooks[filepath.Base(path)] = hook
-	return nil
 }

--- a/pkg/hooks/monitor_test.go
+++ b/pkg/hooks/monitor_test.go
@@ -226,7 +226,28 @@ func TestMonitorTwoDirGood(t *testing.T) {
 		assert.Equal(t, primaryInjected, config.Hooks) // masked by primary
 	})
 
-	t.Run("bad-primary-addition", func(t *testing.T) {
+	primaryPath2 := filepath.Join(primaryDir, "0a.json") //0a because it will be before a.json alphabetically
+
+	t.Run("bad-primary-new-addition", func(t *testing.T) {
+		err = ioutil.WriteFile(primaryPath2, []byte("{\"version\": \"-1\"}"), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(100 * time.Millisecond) // wait for monitor to notice
+
+		config := &rspec.Spec{}
+		fmt.Println("expected: ", config.Hooks)
+		expected := primaryInjected // 0a.json is bad, a.json is still good
+		_, err = manager.Hooks(config, map[string]string{}, false)
+		fmt.Println("actual: ", config.Hooks)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, expected, config.Hooks)
+	})
+
+	t.Run("bad-primary-same-addition", func(t *testing.T) {
 		err = ioutil.WriteFile(primaryPath, []byte("{\"version\": \"-1\"}"), 0644)
 		if err != nil {
 			t.Fatal(err)
@@ -235,7 +256,7 @@ func TestMonitorTwoDirGood(t *testing.T) {
 		time.Sleep(100 * time.Millisecond) // wait for monitor to notice
 
 		config := &rspec.Spec{}
-		expected := config.Hooks
+		expected := fallbackInjected
 		_, err = manager.Hooks(config, map[string]string{}, false)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/hooks/read.go
+++ b/pkg/hooks/read.go
@@ -67,7 +67,7 @@ func ReadDir(path string, extensionStages []string, hooks map[string]*current.Ho
 	if err != nil {
 		return err
 	}
-
+	res := err
 	for _, file := range files {
 		filePath := filepath.Join(path, file.Name())
 		hook, err := Read(filePath, extensionStages)
@@ -80,12 +80,17 @@ func ReadDir(path string, extensionStages []string, hooks map[string]*current.Ho
 					continue
 				}
 			}
-			return err
+			if res == nil {
+				res = err
+			} else {
+				res = errors.Wrapf(res, "%v", err)
+			}
+			continue
 		}
 		hooks[file.Name()] = hook
 		logrus.Debugf("added hook %s", filePath)
 	}
-	return nil
+	return res
 }
 
 func init() {


### PR DESCRIPTION
...to work for specific edge cases with a simpler solution.
Re-reads hooks directories after any changes are detected by the watchers.
Added monitoring test for adding a different invalid hook to primary directory.
Some issues with prior code:
- `ReadDir` would stop when it encounters an invalid hook, rather than registering an error but continuing to read the valid hook.
- Wouldn’t account for Rename and Chmod events.
- After doing a `mv` of the hooks file instead of `rm`, it would still think the hooks file is in the directory, but it has been moved to another location.
- If a hook file was renamed, it would register the renamed file as a separate hook and not delete the original, so it would then execute the hook twice - once for the renamed file, and once for the original name which it did not delete.

Signed-off-by: samc24 <sam.chaturvedi24@gmail.com>