### PR TITLE
Support running containers without CGroups

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -135,6 +135,10 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"cgroup namespace to use",
 	)
 	createFlags.String(
+		"cgroups", "enabled",
+		"control container cgroup configuration",
+	)
+	createFlags.String(
 		"cgroup-parent", "",
 		"Optional parent cgroup for the container",
 	)

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -695,6 +695,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		CapDrop:           c.StringSlice("cap-drop"),
 		CidFile:           c.String("cidfile"),
 		Cgroupns:          c.String("cgroupns"),
+		Cgroups:           c.String("cgroups"),
 		CgroupParent:      c.String("cgroup-parent"),
 		Command:           command,
 		UserCommand:       userCommand,

--- a/cmd/podman/shared/intermediate.go
+++ b/cmd/podman/shared/intermediate.go
@@ -370,6 +370,8 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIRes
 	m["blkio-weight-device"] = newCRStringSlice(c, "blkio-weight-device")
 	m["cap-add"] = newCRStringSlice(c, "cap-add")
 	m["cap-drop"] = newCRStringSlice(c, "cap-drop")
+	m["cgroupns"] = newCRString(c, "cgroupns")
+	m["cgroups"] = newCRString(c, "cgroups")
 	m["cgroup-parent"] = newCRString(c, "cgroup-parent")
 	m["cidfile"] = newCRString(c, "cidfile")
 	m["conmon-pidfile"] = newCRString(c, "conmon-pidfile")

--- a/contrib/cirrus/container_test.sh
+++ b/contrib/cirrus/container_test.sh
@@ -126,6 +126,7 @@ if [ $install -eq 1 ]; then
     make TAGS="${TAGS}" install.bin PREFIX=/usr ETCDIR=/etc
     make TAGS="${TAGS}" install.man PREFIX=/usr ETCDIR=/etc
     make TAGS="${TAGS}" install.cni PREFIX=/usr ETCDIR=/etc
+    make TAGS="${TAGS}" install.config PREFIX=/usr ETCDIR=/etc
     make TAGS="${TAGS}" install.systemd PREFIX=/usr ETCDIR=/etc
 fi
 

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -45,6 +45,7 @@ case "$SPECIALMODE" in
         export OCI_RUNTIME=/usr/bin/crun
         make
         make install PREFIX=/usr ETCDIR=/etc
+        make install.config PREFIX=/usr
         make test-binaries
         make local${TESTSUITE}
         ;;
@@ -57,6 +58,7 @@ case "$SPECIALMODE" in
     none)
         make
         make install PREFIX=/usr ETCDIR=/etc
+        make install.config PREFIX=/usr
         make test-binaries
         if [[ "$TEST_REMOTE_CLIENT" == "true" ]]
         then

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -73,6 +73,12 @@ Set the cgroup namespace mode for the container, by default **host** is used.
     **private**: create a new cgroup namespace.
     **ns:<PATH>**: join the namespace at the specified path.
 
+**--cgroups**=*mode*
+
+Determines whether the container will create CGroups.
+Valid values are *enabled* and *disabled*, which the default being *enabled*.
+The *disabled* option will force the container to not create CGroups, and thus conflicts with CGroup options (**--cgroupns** and **--cgroup-parent**).
+
 **--cgroup-parent**=*path*
 
 Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -87,6 +87,12 @@ Set the cgroup namespace mode for the container, by default **host** is used.
     **private**: create a new cgroup namespace.
     **ns:<PATH>**: join the namespace at the specified path.
 
+**--cgroups**=*mode*
+
+Determines whether the container will create CGroups.
+Valid values are *enabled* and *disabled*, which the default being *enabled*.
+The *disabled* option will force the container to not create CGroups, and thus conflicts with CGroup options (**--cgroupns** and **--cgroup-parent**).
+
 **--cgroup-parent**=*cgroup*
 
 Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.

--- a/libpod.conf
+++ b/libpod.conf
@@ -122,6 +122,10 @@ runtime = "runc"
 # libpod will use it for reporting nicer errors.
 runtime_supports_json = ["crun", "runc"]
 
+# List of all the OCI runtimes that support --cgroup-manager=disable to disable
+# creation of CGroups for containers.
+runtime_supports_nocgroups = ["crun"]
+
 # Paths to look for a valid OCI runtime (runc, runv, etc)
 # If the paths are empty or no valid path was found, then the `$PATH`
 # environment variable will be used as the fallback.

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -356,6 +356,9 @@ type ContainerConfig struct {
 	StopTimeout uint `json:"stopTimeout,omitempty"`
 	// Time container was created
 	CreatedTime time.Time `json:"createdTime"`
+	// NoCgroups indicates that the container will not create CGroups. It is
+	// incompatible with CgroupParent.
+	NoCgroups bool `json:"noCgroups,omitempty"`
 	// Cgroup parent of the container
 	CgroupParent string `json:"cgroupParent"`
 	// LogPath log location

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -268,6 +268,11 @@ type InspectContainerHostConfig struct {
 	// populated.
 	// TODO.
 	Cgroup string `json:"Cgroup"`
+	// Cgroups contains the container's CGroup mode.
+	// Allowed values are "default" (container is creating CGroups) and
+	// "disabled" (container is not creating CGroups).
+	// This is Libpod-specific and not included in `docker inspect`.
+	Cgroups string `json:"Cgroups"`
 	// Links is unused, and provided purely for Docker compatibility.
 	Links []string `json:"Links"`
 	// OOMScoreAdj is an adjustment that will be made to the container's OOM
@@ -958,6 +963,11 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 	restartPolicy.Name = c.config.RestartPolicy
 	restartPolicy.MaximumRetryCount = c.config.RestartRetries
 	hostConfig.RestartPolicy = restartPolicy
+	if c.config.NoCgroups {
+		hostConfig.Cgroups = "disabled"
+	} else {
+		hostConfig.Cgroups = "default"
+	}
 
 	hostConfig.Dns = make([]string, 0, len(c.config.DNSServer))
 	for _, dns := range c.config.DNSServer {

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1119,6 +1119,10 @@ func (c *Container) stop(timeout uint) error {
 
 // Internal, non-locking function to pause a container
 func (c *Container) pause() error {
+	if c.config.NoCgroups {
+		return errors.Wrapf(define.ErrNoCgroups, "cannot pause without using CGroups")
+	}
+
 	if err := c.ociRuntime.pauseContainer(c); err != nil {
 		return err
 	}
@@ -1132,6 +1136,10 @@ func (c *Container) pause() error {
 
 // Internal, non-locking function to unpause a container
 func (c *Container) unpause() error {
+	if c.config.NoCgroups {
+		return errors.Wrapf(define.ErrNoCgroups, "cannot unpause without using CGroups")
+	}
+
 	if err := c.ociRuntime.unpauseContainer(c); err != nil {
 		return err
 	}

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -375,7 +375,7 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 	if err != nil {
 		return nil, err
 	}
-	if rootless.IsRootless() && !unified {
+	if (rootless.IsRootless() && !unified) || c.config.NoCgroups {
 		g.SetLinuxCgroupsPath("")
 	} else if c.runtime.config.CgroupManager == SystemdCgroupsManager {
 		// When runc is set to use Systemd as a cgroup manager, it

--- a/libpod/container_top_linux.go
+++ b/libpod/container_top_linux.go
@@ -15,6 +15,10 @@ import (
 // Top gathers statistics about the running processes in a container. It returns a
 // []string for output
 func (c *Container) Top(descriptors []string) ([]string, error) {
+	if c.config.NoCgroups {
+		return nil, errors.Wrapf(define.ErrNoCgroups, "cannot run top on container %s as it did not create a cgroup", c.ID())
+	}
+
 	conStat, err := c.State()
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to look up state for %s", c.ID())

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -61,6 +61,10 @@ var (
 	// the user.
 	ErrDetach = utils.ErrDetach
 
+	// ErrNoCgroups indicates that the container does not have its own
+	// CGroup.
+	ErrNoCgroups = errors.New("this container does not have a cgroup")
+
 	// ErrRuntimeStopped indicates that the runtime has already been shut
 	// down and no further operations can be performed on it
 	ErrRuntimeStopped = errors.New("runtime has already been stopped")

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -48,19 +48,20 @@ const (
 // OCIRuntime represents an OCI-compatible runtime that libpod can call into
 // to perform container operations
 type OCIRuntime struct {
-	name          string
-	path          string
-	conmonPath    string
-	conmonEnv     []string
-	cgroupManager string
-	tmpDir        string
-	exitsDir      string
-	socketsDir    string
-	logSizeMax    int64
-	noPivot       bool
-	reservePorts  bool
-	supportsJSON  bool
-	sdNotify      bool
+	name              string
+	path              string
+	conmonPath        string
+	conmonEnv         []string
+	cgroupManager     string
+	tmpDir            string
+	exitsDir          string
+	socketsDir        string
+	logSizeMax        int64
+	noPivot           bool
+	reservePorts      bool
+	supportsJSON      bool
+	supportsNoCgroups bool
+	sdNotify          bool
 }
 
 // ociError is used to parse the OCI runtime JSON log.  It is not part of the
@@ -73,7 +74,7 @@ type ociError struct {
 
 // Make a new OCI runtime with provided options.
 // The first path that points to a valid executable will be used.
-func newOCIRuntime(name string, paths []string, conmonPath string, runtimeCfg *RuntimeConfig, supportsJSON bool) (*OCIRuntime, error) {
+func newOCIRuntime(name string, paths []string, conmonPath string, runtimeCfg *RuntimeConfig, supportsJSON, supportsNoCgroups bool) (*OCIRuntime, error) {
 	if name == "" {
 		return nil, errors.Wrapf(define.ErrInvalidArg, "the OCI runtime must be provided a non-empty name")
 	}
@@ -93,6 +94,7 @@ func newOCIRuntime(name string, paths []string, conmonPath string, runtimeCfg *R
 	// TODO: probe OCI runtime for feature and enable automatically if
 	// available.
 	runtime.supportsJSON = supportsJSON
+	runtime.supportsNoCgroups = supportsNoCgroups
 
 	foundPath := false
 	for _, path := range paths {

--- a/libpod/oci_linux.go
+++ b/libpod/oci_linux.go
@@ -402,10 +402,12 @@ func (r *OCIRuntime) stopContainer(ctr *Container, timeout uint) error {
 	}
 
 	var args []string
-	if rootless.IsRootless() {
+	if rootless.IsRootless() || ctr.config.NoCgroups {
 		// we don't use --all for rootless containers as the OCI runtime might use
 		// the cgroups to determine the PIDs, but for rootless containers there is
 		// not any.
+		// Same logic for NoCgroups - we can't use cgroups as the user
+		// explicitly requested none be created.
 		args = []string{"kill", ctr.ID(), "KILL"}
 	} else {
 		args = []string{"kill", "--all", ctr.ID(), "KILL"}

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	config2 "github.com/containers/libpod/libpod/define"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/events"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/storage/pkg/stringid"
@@ -35,7 +35,7 @@ func (r *Runtime) NewContainer(ctx context.Context, rSpec *spec.Spec, options ..
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	if !r.valid {
-		return nil, config2.ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 	return r.newContainer(ctx, rSpec, options...)
 }
@@ -45,7 +45,7 @@ func (r *Runtime) RestoreContainer(ctx context.Context, rSpec *spec.Spec, config
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	if !r.valid {
-		return nil, config2.ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 
 	ctr, err := r.initContainerVariables(rSpec, config)
@@ -67,7 +67,7 @@ func (r *Runtime) RestoreContainer(ctx context.Context, rSpec *spec.Spec, config
 
 func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConfig) (c *Container, err error) {
 	if rSpec == nil {
-		return nil, errors.Wrapf(config2.ErrInvalidArg, "must provide a valid runtime spec to create container")
+		return nil, errors.Wrapf(define.ErrInvalidArg, "must provide a valid runtime spec to create container")
 	}
 	ctr := new(Container)
 	ctr.config = new(ContainerConfig)
@@ -100,7 +100,7 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 
 	ctr.state.BindMounts = make(map[string]string)
 
-	ctr.config.StopTimeout = config2.CtrRemoveTimeout
+	ctr.config.StopTimeout = define.CtrRemoveTimeout
 
 	ctr.config.OCIRuntime = r.defaultOCIRuntime.name
 
@@ -152,7 +152,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (c *Contai
 	}()
 
 	ctr.valid = true
-	ctr.state.State = config2.ContainerStateConfigured
+	ctr.state.State = define.ContainerStateConfigured
 	ctr.runtime = r
 
 	if ctr.config.OCIRuntime == "" {
@@ -160,9 +160,16 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (c *Contai
 	} else {
 		ociRuntime, ok := r.ociRuntimes[ctr.config.OCIRuntime]
 		if !ok {
-			return nil, errors.Wrapf(config2.ErrInvalidArg, "requested OCI runtime %s is not available", ctr.config.OCIRuntime)
+			return nil, errors.Wrapf(define.ErrInvalidArg, "requested OCI runtime %s is not available", ctr.config.OCIRuntime)
 		}
 		ctr.ociRuntime = ociRuntime
+	}
+
+	// Check NoCgroups support
+	if ctr.config.NoCgroups {
+		if !ctr.ociRuntime.supportsNoCgroups {
+			return nil, errors.Wrapf(define.ErrInvalidArg, "requested OCI runtime %s is not compatible with NoCgroups", ctr.ociRuntime.name)
+		}
 	}
 
 	var pod *Pod
@@ -183,43 +190,67 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (c *Contai
 		ctr.config.Name = name
 	}
 
-	// Check CGroup parent sanity, and set it if it was not set
-	switch r.config.CgroupManager {
-	case CgroupfsCgroupsManager:
-		if ctr.config.CgroupParent == "" {
-			if pod != nil && pod.config.UsePodCgroup {
-				podCgroup, err := pod.CgroupPath()
-				if err != nil {
-					return nil, errors.Wrapf(err, "error retrieving pod %s cgroup", pod.ID())
-				}
-				if podCgroup == "" {
-					return nil, errors.Wrapf(config2.ErrInternal, "pod %s cgroup is not set", pod.ID())
-				}
-				ctr.config.CgroupParent = podCgroup
-			} else {
-				ctr.config.CgroupParent = CgroupfsDefaultCgroupParent
-			}
-		} else if strings.HasSuffix(path.Base(ctr.config.CgroupParent), ".slice") {
-			return nil, errors.Wrapf(config2.ErrInvalidArg, "systemd slice received as cgroup parent when using cgroupfs")
+	// If CGroups are disabled, we MUST create a PID namespace.
+	// Otherwise, the OCI runtime won't be able to stop our container.
+	if ctr.config.NoCgroups {
+		if ctr.config.Spec.Linux == nil {
+			return nil, errors.Wrapf(define.ErrInvalidArg, "must provide Linux namespace configuration in OCI spec when using NoCgroups")
 		}
-	case SystemdCgroupsManager:
-		if ctr.config.CgroupParent == "" {
-			if pod != nil && pod.config.UsePodCgroup {
-				podCgroup, err := pod.CgroupPath()
-				if err != nil {
-					return nil, errors.Wrapf(err, "error retrieving pod %s cgroup", pod.ID())
+		foundPid := false
+		for _, ns := range ctr.config.Spec.Linux.Namespaces {
+			if ns.Type == spec.PIDNamespace {
+				foundPid = true
+				if ns.Path != "" {
+					return nil, errors.Wrapf(define.ErrInvalidArg, "containers not creating CGroups must create a private PID namespace - cannot use another")
 				}
-				ctr.config.CgroupParent = podCgroup
-			} else if rootless.IsRootless() {
-				ctr.config.CgroupParent = SystemdDefaultRootlessCgroupParent
-			} else {
-				ctr.config.CgroupParent = SystemdDefaultCgroupParent
+				break
 			}
-		} else if len(ctr.config.CgroupParent) < 6 || !strings.HasSuffix(path.Base(ctr.config.CgroupParent), ".slice") {
-			return nil, errors.Wrapf(config2.ErrInvalidArg, "did not receive systemd slice as cgroup parent when using systemd to manage cgroups")
 		}
-	default:
-		return nil, errors.Wrapf(config2.ErrInvalidArg, "unsupported CGroup manager: %s - cannot validate cgroup parent", r.config.CgroupManager)
+		if !foundPid {
+			return nil, errors.Wrapf(define.ErrInvalidArg, "containers not creating CGroups must create a private PID namespace")
+		}
+	}
+
+	// Check CGroup parent sanity, and set it if it was not set.
+	// Only if we're actually configuring CGroups.
+	if !ctr.config.NoCgroups {
+		switch r.config.CgroupManager {
+		case CgroupfsCgroupsManager:
+			if ctr.config.CgroupParent == "" {
+				if pod != nil && pod.config.UsePodCgroup {
+					podCgroup, err := pod.CgroupPath()
+					if err != nil {
+						return nil, errors.Wrapf(err, "error retrieving pod %s cgroup", pod.ID())
+					}
+					if podCgroup == "" {
+						return nil, errors.Wrapf(define.ErrInternal, "pod %s cgroup is not set", pod.ID())
+					}
+					ctr.config.CgroupParent = podCgroup
+				} else {
+					ctr.config.CgroupParent = CgroupfsDefaultCgroupParent
+				}
+			} else if strings.HasSuffix(path.Base(ctr.config.CgroupParent), ".slice") {
+				return nil, errors.Wrapf(define.ErrInvalidArg, "systemd slice received as cgroup parent when using cgroupfs")
+			}
+		case SystemdCgroupsManager:
+			if ctr.config.CgroupParent == "" {
+				if pod != nil && pod.config.UsePodCgroup {
+					podCgroup, err := pod.CgroupPath()
+					if err != nil {
+						return nil, errors.Wrapf(err, "error retrieving pod %s cgroup", pod.ID())
+					}
+					ctr.config.CgroupParent = podCgroup
+				} else if rootless.IsRootless() {
+					ctr.config.CgroupParent = SystemdDefaultRootlessCgroupParent
+				} else {
+					ctr.config.CgroupParent = SystemdDefaultCgroupParent
+				}
+			} else if len(ctr.config.CgroupParent) < 6 || !strings.HasSuffix(path.Base(ctr.config.CgroupParent), ".slice") {
+				return nil, errors.Wrapf(define.ErrInvalidArg, "did not receive systemd slice as cgroup parent when using systemd to manage cgroups")
+			}
+		default:
+			return nil, errors.Wrapf(define.ErrInvalidArg, "unsupported CGroup manager: %s - cannot validate cgroup parent", r.config.CgroupManager)
+		}
 	}
 
 	if ctr.restoreFromCheckpoint {
@@ -262,7 +293,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (c *Contai
 			ctrNamedVolumes = append(ctrNamedVolumes, dbVol)
 			// The volume exists, we're good
 			continue
-		} else if errors.Cause(err) != config2.ErrNoSuchVolume {
+		} else if errors.Cause(err) != define.ErrNoSuchVolume {
 			return nil, errors.Wrapf(err, "error retrieving named volume %s for new container", vol.Name)
 		}
 
@@ -386,7 +417,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 	}
 
 	if !r.valid {
-		return config2.ErrRuntimeStopped
+		return define.ErrRuntimeStopped
 	}
 
 	// Update the container to get current state
@@ -402,7 +433,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 		}
 	}
 
-	if c.state.State == config2.ContainerStatePaused {
+	if c.state.State == define.ContainerStatePaused {
 		if err := c.ociRuntime.killContainer(c, 9); err != nil {
 			return err
 		}
@@ -416,7 +447,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 	}
 
 	// Check that the container's in a good state to be removed
-	if c.state.State == config2.ContainerStateRunning {
+	if c.state.State == define.ContainerStateRunning {
 		if err := c.stop(c.StopTimeout()); err != nil {
 			return errors.Wrapf(err, "cannot remove container %s as it could not be stopped", c.ID())
 		}
@@ -439,7 +470,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 		}
 		if len(deps) != 0 {
 			depsStr := strings.Join(deps, ", ")
-			return errors.Wrapf(config2.ErrCtrExists, "container %s has dependent containers which must be removed before it: %s", c.ID(), depsStr)
+			return errors.Wrapf(define.ErrCtrExists, "container %s has dependent containers which must be removed before it: %s", c.ID(), depsStr)
 		}
 	}
 
@@ -483,8 +514,8 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 	// Delete the container.
 	// Not needed in Configured and Exited states, where the container
 	// doesn't exist in the runtime
-	if c.state.State != config2.ContainerStateConfigured &&
-		c.state.State != config2.ContainerStateExited {
+	if c.state.State != define.ContainerStateConfigured &&
+		c.state.State != define.ContainerStateExited {
 		if err := c.delete(ctx); err != nil {
 			if cleanupErr == nil {
 				cleanupErr = err
@@ -514,7 +545,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 			if !volume.IsCtrSpecific() {
 				continue
 			}
-			if err := runtime.removeVolume(ctx, volume, false); err != nil && err != config2.ErrNoSuchVolume && err != config2.ErrVolumeBeingUsed {
+			if err := runtime.removeVolume(ctx, volume, false); err != nil && err != define.ErrNoSuchVolume && err != define.ErrVolumeBeingUsed {
 				logrus.Errorf("cleanup volume (%s): %v", v, err)
 			}
 		}
@@ -529,7 +560,7 @@ func (r *Runtime) GetContainer(id string) (*Container, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, config2.ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 
 	return r.state.Container(id)
@@ -541,7 +572,7 @@ func (r *Runtime) HasContainer(id string) (bool, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return false, config2.ErrRuntimeStopped
+		return false, define.ErrRuntimeStopped
 	}
 
 	return r.state.HasContainer(id)
@@ -554,7 +585,7 @@ func (r *Runtime) LookupContainer(idOrName string) (*Container, error) {
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, config2.ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 	return r.state.LookupContainer(idOrName)
 }
@@ -568,7 +599,7 @@ func (r *Runtime) GetContainers(filters ...ContainerFilter) ([]*Container, error
 	defer r.lock.RUnlock()
 
 	if !r.valid {
-		return nil, config2.ErrRuntimeStopped
+		return nil, define.ErrRuntimeStopped
 	}
 
 	ctrs, err := r.state.AllContainers()
@@ -601,7 +632,7 @@ func (r *Runtime) GetAllContainers() ([]*Container, error) {
 func (r *Runtime) GetRunningContainers() ([]*Container, error) {
 	running := func(c *Container) bool {
 		state, _ := c.State()
-		return state == config2.ContainerStateRunning
+		return state == define.ContainerStateRunning
 	}
 	return r.GetContainers(running)
 }
@@ -629,7 +660,7 @@ func (r *Runtime) GetLatestContainer() (*Container, error) {
 		return nil, errors.Wrapf(err, "unable to find latest container")
 	}
 	if len(ctrs) == 0 {
-		return nil, config2.ErrNoSuchCtr
+		return nil, define.ErrNoSuchCtr
 	}
 	for containerIndex, ctr := range ctrs {
 		createdTime := ctr.config.CreatedTime

--- a/libpod/stats.go
+++ b/libpod/stats.go
@@ -19,6 +19,10 @@ func (c *Container) GetContainerStats(previousStats *ContainerStats) (*Container
 	stats.ContainerID = c.ID()
 	stats.Name = c.Name()
 
+	if c.config.NoCgroups {
+		return nil, errors.Wrapf(define.ErrNoCgroups, "cannot run top on container %s as it did not create a cgroup", c.ID())
+	}
+
 	if !c.batched {
 		c.lock.Lock()
 		defer c.lock.Unlock()

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -64,6 +64,7 @@ type CreateConfig struct {
 	CidFile            string
 	ConmonPidFile      string
 	Cgroupns           string
+	Cgroups            string
 	CgroupParent       string            // cgroup-parent
 	Command            []string          // Full command that will be used
 	UserCommand        []string          // User-entered command (or image CMD)
@@ -205,6 +206,9 @@ func (c *CreateConfig) getContainerCreateOptions(runtime *libpod.Runtime, pod *l
 	if c.Pod != "" {
 		logrus.Debugf("adding container to pod %s", c.Pod)
 		options = append(options, runtime.WithPod(pod))
+	}
+	if c.Cgroups == "disabled" {
+		options = append(options, libpod.WithNoCgroups())
 	}
 	if len(c.PortBindings) > 0 {
 		portBindings, err = c.CreatePortBindings()

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -396,6 +396,18 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 		}
 	}
 
+	switch config.Cgroups {
+	case "disabled":
+		if addedResources {
+			return nil, errors.New("cannot specify resource limits when cgroups are disabled is specified")
+		}
+		configSpec.Linux.Resources = &spec.LinuxResources{}
+	case "enabled", "":
+		// Do nothing
+	default:
+		return nil, errors.New("unrecognized option for cgroups; supported are 'default' and 'disabled'")
+	}
+
 	// Add annotations
 	if configSpec.Annotations == nil {
 		configSpec.Annotations = make(map[string]string)


### PR DESCRIPTION
Presently requires `crun` to test, but I'm working up patches to `runc` as well.

Add support for a `--no-cgroups` flag, which disables container creation of CGroups. This is mainly intended for use with systemd unit files - you'd manage the container from a unit file (for example, one generated by `generate systemd`), without CGroups set, so systemd has sole control of resource limits, shutdown ordering, etc.