### PR TITLE
Tweak GOPATH-related symlinking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,8 @@ help:
 .gopathok:
 ifeq ("$(wildcard $(GOPKGDIR))","")
 	mkdir -p "$(GOPKGBASEDIR)"
-	ln -sf "$(CURDIR)" "$(GOPKGBASEDIR)"
-	ln -sf "$(CURDIR)/vendor/github.com/varlink" "$(FIRST_GOPATH)/src/github.com/varlink"
+	ln -sfnT "$(CURDIR)" "$(GOPKGDIR)"
+	ln -sfnT "$(CURDIR)/vendor/github.com/varlink" "$(FIRST_GOPATH)/src/github.com/varlink"
 endif
 	touch $@
 


### PR DESCRIPTION
This change fixes the symlink name when the working directory is
something other than libpod. It also adjusts the symlink command on the
next line to keep things uniform, but that should not lead to a material
change.