### PR TITLE
Add DefaultContent API to retrieve apparmor profile content

### DIFF
--- a/pkg/apparmor/apparmor_linux.go
+++ b/pkg/apparmor/apparmor_linux.go
@@ -4,6 +4,7 @@ package apparmor
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -102,6 +103,18 @@ func InstallDefault(name string) error {
 
 	pipe.Close()
 	return cmd.Wait()
+}
+
+// DefaultContent returns the default profile content as byte slice. The
+// profile is named as the provided `name`. The function errors if the profile
+// generation fails.
+func DefaultContent(name string) ([]byte, error) {
+	p := profileData{Name: name}
+	var bytes bytes.Buffer
+	if err := p.generateDefault(&bytes); err != nil {
+		return nil, err
+	}
+	return bytes.Bytes(), nil
 }
 
 // IsLoaded checks if a profile with the given name has been loaded into the

--- a/pkg/apparmor/apparmor_linux_test.go
+++ b/pkg/apparmor/apparmor_linux_test.go
@@ -78,10 +78,12 @@ Copyright 2009-2012 Canonical Ltd.
 	}
 }
 
-func TestInstallDefault(t *testing.T) {
-	profile := "libpod-default-testing"
-	aapath := "/sys/kernel/security/apparmor/"
+const (
+	aapath  = "/sys/kernel/security/apparmor/"
+	profile = "libpod-default-testing"
+)
 
+func TestInstallDefault(t *testing.T) {
 	if _, err := os.Stat(aapath); err != nil {
 		t.Skip("AppArmor isn't available in this environment")
 	}
@@ -126,4 +128,13 @@ func TestInstallDefault(t *testing.T) {
 		t.Fatalf("Couldn't remove AppArmor profile '%s': %v", profile, err)
 	}
 	checkLoaded(false)
+}
+
+func TestDefaultContent(t *testing.T) {
+	if _, err := os.Stat(aapath); err != nil {
+		t.Skip("AppArmor isn't available in this environment")
+	}
+	if err := DefaultContent(profile); err != nil {
+		t.Fatalf("Couldn't retrieve default AppArmor profile content '%s': %v", profile, err)
+	}
 }

--- a/pkg/apparmor/apparmor_unsupported.go
+++ b/pkg/apparmor/apparmor_unsupported.go
@@ -24,3 +24,8 @@ func CheckProfileAndLoadDefault(name string) (string, error) {
 	}
 	return "", ErrApparmorUnsupported
 }
+
+// DefaultContent dummy.
+func DefaultContent(name string) ([]byte, error) {
+	return nil, nil
+}


### PR DESCRIPTION
The default apparmor profile is not stored on disk which causes
confusion when debugging the content of the profile. To solve this, we
now add an additional API which returns the profile as byte slice.