### PR TITLE
Add Second partition for storage-drive testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,9 +30,9 @@ env:
     ####
     #### Cache-image names to test with
     ###
-    FEDORA_CACHE_IMAGE_NAME: "fedora-30-libpod-5479475851034624"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-29-libpod-5479475851034624"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-18-libpod-5479475851034624"
+    FEDORA_CACHE_IMAGE_NAME: "fedora-30-libpod-5789386598252544"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-29-libpod-5789386598252544"
+    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-18-libpod-5789386598252544"
 
     ####
     #### Variables for composing new cache-images (used in PR testing) from
@@ -47,6 +47,7 @@ env:
     ####
     SPECIALMODE: "none"  # don't do anything special
     TEST_REMOTE_CLIENT: false  # don't test remote client by default
+    ADD_SECOND_PARTITION: false  # will certainly fail inside containers
 
     ####
     #### Credentials and other secret-sauces, decrypted at runtime when authorized.
@@ -322,6 +323,7 @@ testing_task:
     timeout_in: 120m
 
     env:
+        ADD_SECOND_PARTITION: true
         matrix:
             TEST_REMOTE_CLIENT: true
             TEST_REMOTE_CLIENT: false
@@ -357,6 +359,7 @@ special_testing_rootless_task:
     only_if: $CIRRUS_CHANGE_MESSAGE !=~ '.*\*\*\*\s*CIRRUS:\s*TEST\s*IMAGES\s*\*\*\*.*'
 
     env:
+        ADD_SECOND_PARTITION: true
         SPECIALMODE: 'rootless'  # See docs
 
         matrix:
@@ -388,6 +391,7 @@ special_testing_in_podman_task:
     only_if: $CIRRUS_CHANGE_MESSAGE !=~ '.*\*\*\*\s*CIRRUS:\s*TEST\s*IMAGES\s*\*\*\*.*'
 
     env:
+        ADD_SECOND_PARTITION: true
         SPECIALMODE: 'in_podman'  # See docs
 
     timeout_in: 60m
@@ -481,6 +485,7 @@ verify_test_built_images_task:
             image_name: "ubuntu-18${BUILT_IMAGE_SUFFIX}"
 
     env:
+        ADD_SECOND_PARTITION: true
         matrix:
             TEST_REMOTE_CLIENT: true
             TEST_REMOTE_CLIENT: false

--- a/contrib/cirrus/add_second_partition.sh
+++ b/contrib/cirrus/add_second_partition.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# N/B: This script could mega f*!@up your disks if run by mistake.
+#      it is left without the execute-bit on purpose!
+
+# $SLASH_DEVICE is the disk device to be f*xtuP
+SLASH_DEVICE="/dev/sda"  # Always the case on GCP
+
+# The unallocated space results from the difference in disk-size between VM Image
+# and runtime request.  The check_image.sh test includes a minimum-space check,
+# with the Image size set initially lower by contrib/cirrus/packer/libpod_images.yml
+NEW_PART_START="50%"
+NEW_PART_END="100%"
+
+set -eo pipefail
+
+source $(dirname $0)/lib.sh
+
+if [[ ! -r "/root" ]] || [[ -r "/root/second_partition_ready" ]]
+then
+    echo "Warning: Ignoring attempted execution of $(basename $0)"
+    exit 0
+fi
+
+[[ -n "type -P parted" ]] || \
+    die 2 "The parted command is required."
+
+[[ ! -b ${SLASH_DEVICE}2 ]] || \
+    die 5 "Found unexpected block device ${SLASH_DEVICE}2"
+
+PPRINTCMD="parted --script ${SLASH_DEVICE} print"
+FINDMNTCMD="findmnt --source=${SLASH_DEVICE}1 --mountpoint=/ --canonicalize --evaluate --first-only --noheadings"
+TMPF=$(mktemp -p '' $(basename $0)_XXXX)
+trap "rm -f $TMPF" EXIT
+
+if $FINDMNTCMD | tee $TMPF | egrep -q "^/\s+${SLASH_DEVICE}1"
+then
+    echo "Repartitioning original partition table:"
+    $PPRINTCMD
+else
+    die 6 "Unexpected output from '$FINDMNTCMD': $(<$TMPF)"
+fi
+
+echo "Adding partition offset within unpartitioned space."
+parted --script --align optimal /dev/sda unit % mkpart primary "" "" "$NEW_PART_START" "$NEW_PART_END"
+
+echo "New partition table:"
+$PPRINTCMD
+
+echo "Growing ${SLASH_DEVICE}1 meet start of ${SLASH_DEVICE}2"
+growpart ${SLASH_DEVICE} 1
+
+FSTYPE=$(findmnt --first-only --noheadings --output FSTYPE ${SLASH_DEVICE}1)
+echo "Expanding $FSTYPE filesystem on ${SLASH_DEVICE}1"
+case $FSTYPE in
+    ext*) resize2fs ${SLASH_DEVICE}1 ;;
+    *) die 11 "Script $(basename $0) doesn't know how to resize a $FSTYPE filesystem." ;;
+esac
+
+# Must happen last - signals completion to other tooling
+echo "Recording newly available disk partition device into /root/second_partition_ready"
+echo "${SLASH_DEVICE}2" > /root/second_partition_ready

--- a/contrib/cirrus/build_vm_images.sh
+++ b/contrib/cirrus/build_vm_images.sh
@@ -62,6 +62,6 @@ URI="gs://packer-import${POST_MERGE_BUCKET_SUFFIX}/manifest${BUILT_IMAGE_SUFFIX}
 gsutil cp packer-manifest.json "$URI"
 
 # Ensure any background 'gcloud compute images update' processes finish
-wait  # CentOS has no -n option :(
+wait  # No -n option in CentOS, this is the best that can be done :(
 
 echo "Finished. A JSON manifest of produced images is available at $URI"

--- a/contrib/cirrus/check_image.sh
+++ b/contrib/cirrus/check_image.sh
@@ -7,7 +7,7 @@ source $(dirname $0)/lib.sh
 NFAILS=0
 echo "Validating VM image"
 
-MIN_SLASH_GIGS=50
+MIN_SLASH_GIGS=30
 read SLASH_DEVICE SLASH_FSTYPE SLASH_SIZE JUNK <<<$(findmnt --df --first-only --noheadings / | cut -d '.' -f 1)
 SLASH_SIZE_GIGS=$(echo "$SLASH_SIZE" | sed -r -e 's/G|g//')
 item_test "Minimum available disk space" $SLASH_SIZE_GIGS -gt $MIN_SLASH_GIGS || let "NFAILS+=1"

--- a/contrib/cirrus/packer/cloud-init/fedora/cloud.cfg.d/40_enable_root.cfg
+++ b/contrib/cirrus/packer/cloud-init/fedora/cloud.cfg.d/40_enable_root.cfg
@@ -1,0 +1,1 @@
+disable_root: 0

--- a/contrib/cirrus/packer/cloud-init/fedora/cloud.cfg.d/50_custom_disk_setup.cfg
+++ b/contrib/cirrus/packer/cloud-init/fedora/cloud.cfg.d/50_custom_disk_setup.cfg
@@ -1,0 +1,4 @@
+#cloud-config
+growpart:
+    mode: false
+resize_rootfs: false

--- a/contrib/cirrus/packer/cloud-init/ubuntu/cloud.cfg.d/40_enable_root.cfg
+++ b/contrib/cirrus/packer/cloud-init/ubuntu/cloud.cfg.d/40_enable_root.cfg
@@ -1,0 +1,1 @@
+../../fedora/cloud.cfg.d/40_enable_root.cfg

--- a/contrib/cirrus/packer/libpod_images.yml
+++ b/contrib/cirrus/packer/libpod_images.yml
@@ -33,7 +33,7 @@ builders:
       image_name: '{{build_name}}{{user `BUILT_IMAGE_SUFFIX`}}'
       image_family: '{{build_name}}-libpod'
       source_image: '{{user `UBUNTU_BASE_IMAGE`}}'
-      disk_size: 20
+      disk_size: 20  # REQUIRED: Runtime allocation > this value
       project_id: '{{user `GCP_PROJECT_ID`}}'
       service_account_email: '{{user `SERVICE_ACCOUNT`}}'
       communicator: 'ssh'

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -42,8 +42,11 @@ case "${OS_REL_VER}" in
             ln -f "$CRIO_RUNC_PATH" "/usr/bin/runc"
         fi
         ;;
-    fedora-30) ;;
-    fedora-29) ;;
+    fedora-30) ;&  # continue to next item
+    fedora-29)
+        if [[ "$ADD_SECOND_PARTITION" == "true" ]]; then
+            bash "$SCRIPT_BASE/add_second_partition.sh"; fi
+        ;;
     centos-7)  # Current VM is an image-builder-image no local podman/testing
         echo "No further setup required for VM image building"
         exit 0


### PR DESCRIPTION
This is mainly/initially to support use of Cirrus-CI
in https://github.com/containers/storage since that setup
re-uses the VM images from this project. However, it also
opens doors here, if libpod ever needs/wants to do things
with a dedicated storage device and/or storage-drivers.

Depends on #3632 