### PR TITLE
Remove exec PID files after use to prevent memory leaks

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -305,6 +305,11 @@ func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir 
 	if err != nil {
 		if exited {
 			// If the runtime exited, propagate the error we got from the process.
+			// We need to remove PID files to ensure no memory leaks
+			if err2 := os.Remove(pidFile); err2 != nil {
+				logrus.Errorf("Error removing exit file for container %s exec session %s: %v", c.ID(), sessionID, err2)
+			}
+
 			return err
 		}
 		return errors.Wrapf(err, "timed out waiting for runtime to create pidfile for exec session in container %s", c.ID())
@@ -312,6 +317,10 @@ func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir 
 
 	// Pidfile exists, read it
 	contents, err := ioutil.ReadFile(pidFile)
+	// We need to remove PID files to ensure no memory leaks
+	if err2 := os.Remove(pidFile); err2 != nil {
+		logrus.Errorf("Error removing exit file for container %s exec session %s: %v", c.ID(), sessionID, err2)
+	}
 	if err != nil {
 		// We don't know the PID of the exec session
 		// However, it may still be alive


### PR DESCRIPTION
We have another patch running to do the same for exit files, with a much more in-depth explanation of why it's necessary. Suffice to say that persistent files in tmpfs tied to container CGroups lead to significant memory allocations that last for the lifetime of the file.

I don't think I got all the error cases here, but I'm hesitant to put in a defer, due to the long-running nature of the exec function.