### PR TITLE
vendor github.com/containers/image@v2.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/containernetworking/cni v0.7.1
 	github.com/containernetworking/plugins v0.8.1
 	github.com/containers/buildah v1.9.0
-	github.com/containers/image v2.0.0+incompatible
+	github.com/containers/image v2.0.1+incompatible
 	github.com/containers/psgo v1.3.1
 	github.com/containers/storage v1.12.13
 	github.com/coreos/bbolt v1.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/containers/buildah v1.9.0 h1:ktVRCGNoVfW8PlTuCKUeh+zGdqn1Nik80DSWvGX+
 github.com/containers/buildah v1.9.0/go.mod h1:1CsiLJvyU+h+wOjnqJJOWuJCVcMxZOr5HN/gHGdzJxY=
 github.com/containers/image v2.0.0+incompatible h1:FTr6Br7jlIKNCKMjSOMbAxKp2keQ0//jzJaYNTVhauk=
 github.com/containers/image v2.0.0+incompatible/go.mod h1:8Vtij257IWSanUQKe1tAeNOm2sRVkSqQTVQ1IlwI3+M=
+github.com/containers/image v2.0.1+incompatible h1:w39mlElA/aSFZ6moFa5N+A4MWu9c8hgdMiMMYnH94Hs=
+github.com/containers/image v2.0.1+incompatible/go.mod h1:8Vtij257IWSanUQKe1tAeNOm2sRVkSqQTVQ1IlwI3+M=
 github.com/containers/psgo v1.3.0 h1:kDhiA4gNNyJ2qCzmOuBf6AmrF/Pp+6Jo98P68R7fB8I=
 github.com/containers/psgo v1.3.0/go.mod h1:7MELvPTW1fj6yMrwD9I1Iasx1vU+hKlRkHXAJ51sFtU=
 github.com/containers/psgo v1.3.1-0.20190626112706-fbef66e4ce92 h1:aVJs/Av0Yc9uNoWnIwmG+6Z+XozuRXFwvLwAOVmwlvI=

--- a/hack/ostree_tag.sh
+++ b/hack/ostree_tag.sh
@@ -2,5 +2,5 @@
 if ! pkg-config glib-2.0 gobject-2.0 ostree-1 libselinux 2> /dev/null ; then
 	echo containers_image_ostree_stub
 else
-	echo ostree
+	echo containers_image_ostree
 fi

--- a/vendor/github.com/containers/image/docker/docker_image_src.go
+++ b/vendor/github.com/containers/image/docker/docker_image_src.go
@@ -138,8 +138,9 @@ func (s *dockerImageSource) GetManifest(ctx context.Context, instanceDigest *dig
 
 func (s *dockerImageSource) fetchManifest(ctx context.Context, tagOrDigest string) ([]byte, string, error) {
 	path := fmt.Sprintf(manifestPath, reference.Path(s.ref.ref), tagOrDigest)
-	headers := make(map[string][]string)
-	headers["Accept"] = manifest.DefaultRequestedManifestMIMETypes
+	headers := map[string][]string{
+		"Accept": manifest.DefaultRequestedManifestMIMETypes,
+	}
 	res, err := s.c.makeRequest(ctx, "GET", path, headers, nil, v2Auth, nil)
 	if err != nil {
 		return nil, "", err
@@ -381,11 +382,9 @@ func deleteImage(ctx context.Context, sys *types.SystemContext, ref dockerRefere
 		return err
 	}
 
-	// When retrieving the digest from a registry >= 2.3 use the following header:
-	//   "Accept": "application/vnd.docker.distribution.manifest.v2+json"
-	headers := make(map[string][]string)
-	headers["Accept"] = []string{manifest.DockerV2Schema2MediaType}
-
+	headers := map[string][]string{
+		"Accept": manifest.DefaultRequestedManifestMIMETypes,
+	}
 	refTail, err := ref.tagOrDigest()
 	if err != nil {
 		return err

--- a/vendor/github.com/containers/image/manifest/docker_schema1.go
+++ b/vendor/github.com/containers/image/manifest/docker_schema1.go
@@ -226,6 +226,7 @@ func (m *Schema1) Inspect(_ func(types.BlobInfo) ([]byte, error)) (*types.ImageI
 	}
 	if s1.Config != nil {
 		i.Labels = s1.Config.Labels
+		i.Env = s1.Config.Env
 	}
 	return i, nil
 }

--- a/vendor/github.com/containers/image/manifest/docker_schema2.go
+++ b/vendor/github.com/containers/image/manifest/docker_schema2.go
@@ -241,6 +241,7 @@ func (m *Schema2) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*t
 	}
 	if s2.Config != nil {
 		i.Labels = s2.Config.Labels
+		i.Env = s2.Config.Env
 	}
 	return i, nil
 }

--- a/vendor/github.com/containers/image/manifest/oci.go
+++ b/vendor/github.com/containers/image/manifest/oci.go
@@ -116,6 +116,7 @@ func (m *OCI1) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*type
 		Architecture:  v1.Architecture,
 		Os:            v1.OS,
 		Layers:        layerInfosToStrings(m.LayerInfos()),
+		Env:           d1.Config.Env,
 	}
 	return i, nil
 }

--- a/vendor/github.com/containers/image/ostree/ostree_dest.go
+++ b/vendor/github.com/containers/image/ostree/ostree_dest.go
@@ -1,4 +1,4 @@
-// +build !containers_image_ostree_stub
+// +build containers_image_ostree
 
 package ostree
 
@@ -218,7 +218,7 @@ func fixFiles(selinuxHnd *C.struct_selabel_handle, root string, dir string, user
 				defer C.free(unsafe.Pointer(fullpathC))
 				res, err = C.lsetfilecon_raw(fullpathC, context)
 				if int(res) < 0 {
-					return errors.Wrapf(err, "cannot setfilecon_raw %s", fullpath)
+					return errors.Wrapf(err, "cannot setfilecon_raw %s to %s", fullpath, C.GoString(context))
 				}
 			}
 		}

--- a/vendor/github.com/containers/image/ostree/ostree_src.go
+++ b/vendor/github.com/containers/image/ostree/ostree_src.go
@@ -1,4 +1,4 @@
-// +build !containers_image_ostree_stub
+// +build containers_image_ostree
 
 package ostree
 

--- a/vendor/github.com/containers/image/ostree/ostree_transport.go
+++ b/vendor/github.com/containers/image/ostree/ostree_transport.go
@@ -1,4 +1,4 @@
-// +build !containers_image_ostree_stub
+// +build containers_image_ostree
 
 package ostree
 

--- a/vendor/github.com/containers/image/pkg/docker/config/config.go
+++ b/vendor/github.com/containers/image/pkg/docker/config/config.go
@@ -56,6 +56,7 @@ func SetAuthentication(sys *types.SystemContext, registry, username, password st
 // If an entry is not found empty strings are returned for the username and password
 func GetAuthentication(sys *types.SystemContext, registry string) (string, string, error) {
 	if sys != nil && sys.DockerAuthConfig != nil {
+		logrus.Debug("Returning credentials from DockerAuthConfig")
 		return sys.DockerAuthConfig.Username, sys.DockerAuthConfig.Password, nil
 	}
 
@@ -76,12 +77,15 @@ func GetAuthentication(sys *types.SystemContext, registry string) (string, strin
 		legacyFormat := path == dockerLegacyPath
 		username, password, err := findAuthentication(registry, path, legacyFormat)
 		if err != nil {
+			logrus.Debugf("Credentials not found")
 			return "", "", err
 		}
 		if username != "" && password != "" {
+			logrus.Debugf("Returning credentials from %s", path)
 			return username, password, nil
 		}
 	}
+	logrus.Debugf("Credentials not found")
 	return "", "", nil
 }
 

--- a/vendor/github.com/containers/image/pkg/sysregistriesv2/system_registries_v2.go
+++ b/vendor/github.com/containers/image/pkg/sysregistriesv2/system_registries_v2.go
@@ -30,10 +30,10 @@ const builtinRegistriesConfPath = "/etc/containers/registries.conf"
 // Endpoint describes a remote location of a registry.
 type Endpoint struct {
 	// The endpoint's remote location.
-	Location string `toml:"location"`
+	Location string `toml:"location,omitempty"`
 	// If true, certs verification will be skipped and HTTP (non-TLS)
 	// connections will be allowed.
-	Insecure bool `toml:"insecure"`
+	Insecure bool `toml:"insecure,omitempty"`
 }
 
 // rewriteReference will substitute the provided reference `prefix` to the
@@ -56,22 +56,22 @@ func (e *Endpoint) rewriteReference(ref reference.Named, prefix string) (referen
 
 // Registry represents a registry.
 type Registry struct {
-	// A registry is an Endpoint too
-	Endpoint
-	// The registry's mirrors.
-	Mirrors []Endpoint `toml:"mirror"`
-	// If true, pulling from the registry will be blocked.
-	Blocked bool `toml:"blocked"`
-	// If true, mirrors will only be used for digest pulls. Pulling images by
-	// tag can potentially yield different images, depending on which endpoint
-	// we pull from.  Forcing digest-pulls for mirrors avoids that issue.
-	MirrorByDigestOnly bool `toml:"mirror-by-digest-only"`
 	// Prefix is used for matching images, and to translate one namespace to
 	// another.  If `Prefix="example.com/bar"`, `location="example.com/foo/bar"`
 	// and we pull from "example.com/bar/myimage:latest", the image will
 	// effectively be pulled from "example.com/foo/bar/myimage:latest".
 	// If no Prefix is specified, it defaults to the specified location.
 	Prefix string `toml:"prefix"`
+	// A registry is an Endpoint too
+	Endpoint
+	// The registry's mirrors.
+	Mirrors []Endpoint `toml:"mirror,omitempty"`
+	// If true, pulling from the registry will be blocked.
+	Blocked bool `toml:"blocked,omitempty"`
+	// If true, mirrors will only be used for digest pulls. Pulling images by
+	// tag can potentially yield different images, depending on which endpoint
+	// we pull from.  Forcing digest-pulls for mirrors avoids that issue.
+	MirrorByDigestOnly bool `toml:"mirror-by-digest-only,omitempty"`
 }
 
 // PullSource consists of an Endpoint and a Reference. Note that the reference is

--- a/vendor/github.com/containers/image/transports/alltransports/ostree.go
+++ b/vendor/github.com/containers/image/transports/alltransports/ostree.go
@@ -1,4 +1,4 @@
-// +build !containers_image_ostree_stub,linux
+// +build containers_image_ostree,linux
 
 package alltransports
 

--- a/vendor/github.com/containers/image/transports/alltransports/ostree_stub.go
+++ b/vendor/github.com/containers/image/transports/alltransports/ostree_stub.go
@@ -1,4 +1,4 @@
-// +build containers_image_ostree_stub !linux
+// +build !containers_image_ostree !linux
 
 package alltransports
 

--- a/vendor/github.com/containers/image/types/types.go
+++ b/vendor/github.com/containers/image/types/types.go
@@ -398,6 +398,7 @@ type ImageInspectInfo struct {
 	Architecture  string
 	Os            string
 	Layers        []string
+	Env           []string
 }
 
 // DockerAuthConfig contains authorization information for connecting to a registry.

--- a/vendor/github.com/containers/image/version/version.go
+++ b/vendor/github.com/containers/image/version/version.go
@@ -8,7 +8,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 0
+	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,7 +62,7 @@ github.com/containers/buildah/docker
 github.com/containers/buildah/pkg/blobcache
 github.com/containers/buildah/pkg/overlay
 github.com/containers/buildah/pkg/unshare
-# github.com/containers/image v2.0.0+incompatible
+# github.com/containers/image v2.0.1+incompatible
 github.com/containers/image/directory
 github.com/containers/image/docker
 github.com/containers/image/docker/archive


### PR DESCRIPTION
* progress bar: use spinners for unknown blob sizes
* use 'containers_image_ostree' as build tag
* ostree: default is no OStree support
* Add "Env" to ImageInspectInfo
* config.go: improve debug message
* config.go: log where credentials come from
* Fix typo in docs/containers-registries.conf.5.md
* docker: delete: support all MIME types
* Try harder in storageImageDestination.TryReusingBlob
* docker: allow deleting OCI images
* ostree: improve error message

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>