### PR TITLE
support podman ps filter regular expressions

### DIFF
--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -296,7 +296,11 @@ func generateContainerFilterFuncs(filter, filterValue string, r *libpod.Runtime)
 		}, nil
 	case "name":
 		return func(c *libpod.Container) bool {
-			return strings.Contains(c.Name(), filterValue)
+			match, err := regexp.MatchString(filterValue, c.Name())
+			if err != nil {
+				return false
+			}
+			return match
 		}, nil
 	case "exited":
 		exitCode, err := strconv.ParseInt(filterValue, 10, 32)

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -332,4 +332,30 @@ var _ = Describe("Podman ps", func() {
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(result.OutputToStringArray()[0]).To(Equal(fullCid))
 	})
+
+	It("podman ps filter name regexp", func() {
+		session := podmanTest.Podman([]string{"run", "-d", "--name", "test1", ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		fullCid := session.OutputToString()
+
+		session2 := podmanTest.Podman([]string{"run", "-d", "--name", "test11", ALPINE, "top"})
+		session2.WaitWithDefaultTimeout()
+		Expect(session2.ExitCode()).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"ps", "-aq", "--no-trunc", "--filter", "name=test1"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		output := result.OutputToStringArray()
+		Expect(len(output)).To(Equal(2))
+
+		result = podmanTest.Podman([]string{"ps", "-aq", "--no-trunc", "--filter", "name=test1$"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		output = result.OutputToStringArray()
+		Expect(len(output)).To(Equal(1))
+		Expect(output[0]).To(Equal(fullCid))
+	})
 })


### PR DESCRIPTION
Close #3394 
bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1731107

podman ps --filter use regexp to match the container name.

Signed-off-by: Qi Wang <qiwan@redhat.com>