### PR TITLE
Cirrus: Temp. workaround missing imgprune image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -292,7 +292,7 @@ image_prune_task:
         - "meta"
 
     container:
-        image: "quay.io/libpod/imgprune:latest"  # see contrib/imgprune
+        image: "quay.io/cevich/imgprune:latest"  # see contrib/imgprune
         cpu: 1
         memory: 1
 


### PR DESCRIPTION
Fixes #3618

The 'image_prune' task only runs on master, post-merge and
is currently failing for all builds.  This is because it
references a non-existent image.  The person with access
to add/enable this image is on PTO.  Fix this by temporarily
using a hand-built image until an automatic build can be added.

Signed-off-by: Chris Evich <cevich@redhat.com>