### PR TITLE
golangci-lint phase 4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -103,7 +103,7 @@ gating_task:
         # N/B: entrypoint.sh resets $GOSRC (same as make clean)
         - '/usr/local/bin/entrypoint.sh install.tools |& ${TIMESTAMP}'
         - '/usr/local/bin/entrypoint.sh validate |& ${TIMESTAMP}'
-        - '/usr/local/bin/entrypoint.sh lint |& ${TIMESTAMP}'
+        - '/usr/local/bin/entrypoint.sh golangci-lint |& ${TIMESTAMP}'
 
     # This task builds Podman with different buildtags to ensure the build does
     # not break.  It also verifies all sub-commands have man pages.

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,9 @@ lint: .gopathok varlink_generate ## Execute the source code linter
 	@echo "checking lint"
 	@./.tool/lint
 
+golangci-lint: .gopathok varlink_generate .install.golangci-lint
+	$(GOBIN)/golangci-lint run --tests=false
+
 gofmt: ## Verify the source code gofmt
 	find . -name '*.go' ! -path './vendor/*' -exec gofmt -s -w {} \+
 	git diff --exit-code
@@ -360,7 +363,7 @@ uninstall:
 	GIT_CHECK_EXCLUDE="./vendor" $(GOBIN)/git-validation -v -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..$(HEAD)
 
 .PHONY: install.tools
-install.tools: .install.gitvalidation .install.gometalinter .install.md2man .install.ginkgo ## Install needed tools
+install.tools: .install.gitvalidation .install.gometalinter .install.md2man .install.ginkgo .install.golangci-lint ## Install needed tools
 
 define go-get
 	env GO111MODULE=off \
@@ -384,6 +387,11 @@ endef
 		git checkout e8d801238da6f0dfd14078d68f9b53fa50a7eeb5; \
 		$(GO) install github.com/alecthomas/gometalinter; \
 		$(GOBIN)/gometalinter --install; \
+	fi
+
+.install.golangci-lint: .gopathok
+	if [ ! -x "$(GOBIN)/golangci-lint" ]; then \
+		curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOBIN)/ v1.17.1; \
 	fi
 
 .install.md2man: .gopathok
@@ -444,6 +452,7 @@ vendor:
 	gofmt \
 	help \
 	install \
+	golangci-lint \
 	lint \
 	pause \
 	uninstall \

--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -308,16 +308,6 @@ func buildCmd(c *cliconfig.BuildValues) error {
 	return runtime.Build(getContext(), c, options, dockerfiles)
 }
 
-// Tail returns a string slice after the first element unless there are
-// not enough elements, then it returns an empty slice.  This is to replace
-// the urfavecli Tail method for args
-func Tail(a []string) []string {
-	if len(a) >= 2 {
-		return a[1:]
-	}
-	return []string{}
-}
-
 // useLayers returns false if BUILDAH_LAYERS is set to "0" or "false"
 // otherwise it returns true
 func useLayers() string {

--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -51,7 +51,6 @@ type imagesOptions struct {
 	outputformat string
 	sort         string
 	all          bool
-	useReadOnly  bool
 }
 
 // Type declaration and functions for sorting the images output

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -963,24 +963,16 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 	}
 
 	hostConfig.DnsOptions = make([]string, 0, len(c.config.DNSOption))
-	for _, opt := range c.config.DNSOption {
-		hostConfig.DnsOptions = append(hostConfig.DnsOptions, opt)
-	}
+	hostConfig.DnsOptions = append(hostConfig.DnsOptions, c.config.DNSOption...)
 
 	hostConfig.DnsSearch = make([]string, 0, len(c.config.DNSSearch))
-	for _, search := range c.config.DNSSearch {
-		hostConfig.DnsSearch = append(hostConfig.DnsSearch, search)
-	}
+	hostConfig.DnsSearch = append(hostConfig.DnsSearch, c.config.DNSSearch...)
 
 	hostConfig.ExtraHosts = make([]string, 0, len(c.config.HostAdd))
-	for _, host := range c.config.HostAdd {
-		hostConfig.ExtraHosts = append(hostConfig.ExtraHosts, host)
-	}
+	hostConfig.ExtraHosts = append(hostConfig.ExtraHosts, c.config.HostAdd...)
 
 	hostConfig.GroupAdd = make([]string, 0, len(c.config.Groups))
-	for _, group := range c.config.Groups {
-		hostConfig.GroupAdd = append(hostConfig.GroupAdd, group)
-	}
+	hostConfig.GroupAdd = append(hostConfig.GroupAdd, c.config.Groups...)
 
 	hostConfig.SecurityOpt = []string{}
 	if ctrSpec.Process != nil {

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -38,26 +38,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// imageConversions is used to cache image "cast" types
-type imageConversions struct {
-	imgRef   types.Image
-	storeRef types.ImageReference
-}
-
 // Image is the primary struct for dealing with images
 // It is still very much a work in progress
 type Image struct {
 	// Adding these two structs for now but will cull when we near
 	// completion of this library.
-	imageConversions
+	imgRef   types.Image
+	storeRef types.ImageReference
 	inspect.ImageData
 	inspect.ImageResult
-	inspectInfo *types.ImageInspectInfo
-	InputName   string
-	//runtime   *libpod.Runtime
+	inspectInfo  *types.ImageInspectInfo
+	InputName    string
 	image        *storage.Image
 	imageruntime *Runtime
-	repotagsMap  map[string][]string
 }
 
 // Runtime contains the store

--- a/pkg/adapter/terminal_linux.go
+++ b/pkg/adapter/terminal_linux.go
@@ -16,7 +16,7 @@ import (
 // StartAttachCtr starts and (if required) attaches to a container
 // if you change the signature of this function from os.File to io.Writer, it will trigger a downstream
 // error. we may need to just lint disable this one.
-func StartAttachCtr(ctx context.Context, ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys string, sigProxy bool, startContainer bool, recursive bool) error {
+func StartAttachCtr(ctx context.Context, ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys string, sigProxy bool, startContainer bool, recursive bool) error { //nolint-interfacer
 	resize := make(chan remotecommand.TerminalSize)
 
 	haveTerminal := terminal.IsTerminal(int(os.Stdin.Fd()))

--- a/pkg/util/utils_linux.go
+++ b/pkg/util/utils_linux.go
@@ -39,8 +39,8 @@ func FindDeviceNodes() (map[string]string, error) {
 		if !ok {
 			return errors.Errorf("Could not convert stat output for use")
 		}
-		major := uint64(sysstat.Rdev / 256)
-		minor := uint64(sysstat.Rdev % 256)
+		major := sysstat.Rdev / 256
+		minor := sysstat.Rdev % 256
 
 		nodes[fmt.Sprintf("%d:%d", major, minor)] = path
 


### PR DESCRIPTION
clean up some final linter issues and add a make target for
golangci-lint. in addition, begin running the tests are part of the
gating tasks in cirrus ci.

we cannot fully shift over to the new linter until we fix the image on
the openshift side.  for short term, we will use both

Signed-off-by: baude <bbaude@redhat.com>