### PR TITLE
fix import not ignoring url path

### DIFF
--- a/cmd/podman/import.go
+++ b/cmd/podman/import.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/shared/parse"
 	"github.com/containers/libpod/pkg/adapter"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -69,8 +70,11 @@ func importCmd(c *cliconfig.ImportValues) error {
 		return errors.Errorf("too many arguments. Usage TARBALL [REFERENCE]")
 	}
 
-	if err := parse.ValidateFileName(source); err != nil {
-		return err
+	errFileName := parse.ValidateFileName(source)
+	errURL := parse.ValidURL(source)
+
+	if errFileName != nil && errURL != nil {
+		return multierror.Append(errFileName, errURL)
 	}
 
 	quiet := c.Quiet

--- a/cmd/podman/shared/parse/parse.go
+++ b/cmd/podman/shared/parse/parse.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -159,6 +160,15 @@ func parseEnvFile(env map[string]string, filename string) error {
 func ValidateFileName(filename string) error {
 	if strings.Contains(filename, ":") {
 		return errors.Errorf("invalid filename (should not contain ':') %q", filename)
+	}
+	return nil
+}
+
+// ValidURL checks a string urlStr is a url or not
+func ValidURL(urlStr string) error {
+	_, err := url.ParseRequestURI(urlStr)
+	if err != nil {
+		return errors.Wrapf(err, "invalid url path: %q", urlStr)
 	}
 	return nil
 }


### PR DESCRIPTION
fix #3609
 This PR allows the program to continue if the input is a valid URL.
Podman import used to check filename to only allow tarball path as a file. It should also allow an URL as the doc mentioned.

Signed-off-by: Qi Wang <qiwan@redhat.com>