### PR TITLE
Add remote exec

### DIFF
--- a/API.md
+++ b/API.md
@@ -1591,6 +1591,8 @@ user [?string](#?string)
 workdir [?string](#?string)
 
 env [?[]string](#?[]string)
+
+detachKeys [?string](#?string)
 ### <a name="Image"></a>type Image
 
 

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
-	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -70,11 +69,5 @@ func execCmd(c *cliconfig.ExecValues) error {
 	defer runtime.DeferredShutdown(false)
 
 	exitCode, err = runtime.ExecContainer(getContext(), c)
-	if errors.Cause(err) == define.ErrOCIRuntimePermissionDenied {
-		exitCode = 126
-	}
-	if errors.Cause(err) == define.ErrOCIRuntimeNotFound {
-		exitCode = 127
-	}
 	return err
 }

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -514,7 +514,9 @@ type ExecOpts(
     # workdir to run command in container
     workdir: ?string,
     # slice of keyword=value environment variables
-    env: ?[]string
+    env: ?[]string,
+    # string of detach keys
+    detachKeys: ?string
 )
 
 # GetVersion returns version and build information of the podman service

--- a/libpod/define/exec_codes.go
+++ b/libpod/define/exec_codes.go
@@ -1,0 +1,13 @@
+package define
+
+const (
+	// ExecErrorCodeGeneric is the default error code to return from an exec session if libpod failed
+	// prior to calling the runtime
+	ExecErrorCodeGeneric = 125
+	// ExecErrorCodeCannotInvoke is the error code to return when the runtime fails to invoke a command
+	// an example of this can be found by trying to execute a directory:
+	// `podman exec -l /etc`
+	ExecErrorCodeCannotInvoke = 126
+	// ExecErrorCodeNotFound is the error code to return when a command cannot be found
+	ExecErrorCodeNotFound = 127
+)

--- a/libpod/define/exec_codes.go
+++ b/libpod/define/exec_codes.go
@@ -1,5 +1,9 @@
 package define
 
+import (
+	"github.com/pkg/errors"
+)
+
 const (
 	// ExecErrorCodeGeneric is the default error code to return from an exec session if libpod failed
 	// prior to calling the runtime
@@ -11,3 +15,16 @@ const (
 	// ExecErrorCodeNotFound is the error code to return when a command cannot be found
 	ExecErrorCodeNotFound = 127
 )
+
+// TranslateExecErrorToExitCode takes an error and checks whether it
+// has a predefined exit code associated. If so, it returns that, otherwise it returns
+// the exit code originally stated in libpod.Exec()
+func TranslateExecErrorToExitCode(originalEC int, err error) int {
+	if errors.Cause(err) == ErrOCIRuntimePermissionDenied {
+		return ExecErrorCodeCannotInvoke
+	}
+	if errors.Cause(err) == ErrOCIRuntimeNotFound {
+		return ExecErrorCodeNotFound
+	}
+	return originalEC
+}

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -1001,13 +1001,7 @@ func (r *LocalRuntime) ExecContainer(ctx context.Context, cli *cliconfig.ExecVal
 	streams.AttachError = true
 
 	ec, err = ExecAttachCtr(ctx, ctr.Container, cli.Tty, cli.Privileged, envs, cmd, cli.User, cli.Workdir, streams, cli.PreserveFDs, cli.DetachKeys)
-	if errors.Cause(err) == define.ErrOCIRuntimePermissionDenied {
-		ec = 126
-	}
-	if errors.Cause(err) == define.ErrOCIRuntimeNotFound {
-		ec = 127
-	}
-	return ec, err
+	return define.TranslateExecErrorToExitCode(ec, err), err
 }
 
 // Prune removes stopped containers

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -1000,7 +1000,14 @@ func (r *LocalRuntime) ExecContainer(ctx context.Context, cli *cliconfig.ExecVal
 	streams.AttachOutput = true
 	streams.AttachError = true
 
-	return ExecAttachCtr(ctx, ctr.Container, cli.Tty, cli.Privileged, envs, cmd, cli.User, cli.Workdir, streams, cli.PreserveFDs, cli.DetachKeys)
+	ec, err = ExecAttachCtr(ctx, ctr.Container, cli.Tty, cli.Privileged, envs, cmd, cli.User, cli.Workdir, streams, cli.PreserveFDs, cli.DetachKeys)
+	if errors.Cause(err) == define.ErrOCIRuntimePermissionDenied {
+		ec = 126
+	}
+	if errors.Cause(err) == define.ErrOCIRuntimeNotFound {
+		ec = 127
+	}
+	return ec, err
 }
 
 // Prune removes stopped containers

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -997,7 +997,7 @@ func (r *LocalRuntime) Commit(ctx context.Context, c *cliconfig.CommitValues, co
 func (r *LocalRuntime) ExecContainer(ctx context.Context, cli *cliconfig.ExecValues) (int, error) {
 	var (
 		oldTermState *term.State
-		ec           int = 125
+		ec           int = define.ExecErrorCodeGeneric
 	)
 	// default invalid command exit code
 	// Validate given environment variables

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -1054,15 +1054,14 @@ func (r *LocalRuntime) ExecContainer(ctx context.Context, cli *cliconfig.ExecVal
 	if err != nil {
 		return ec, errors.Wrapf(err, "Exec operation failed for %s", cli.InputArgs)
 	}
-
 	ecChan := make(chan int, 1)
 	errChan := configureVarlinkAttachStdio(r.Conn.Reader, r.Conn.Writer, inputStream, os.Stdout, oldTermState, resize, ecChan)
 
 	select {
-		case err = <-errChan:
-			break
-		case ec = <-ecChan:
-			break
+	case ec = <-ecChan:
+		break
+	case err = <-errChan:
+		break
 	}
 
 	return ec, err

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -1068,7 +1068,7 @@ func (r *LocalRuntime) ExecContainer(ctx context.Context, cli *cliconfig.ExecVal
 }
 
 func configureVarlinkAttachStdio(reader *bufio.Reader, writer *bufio.Writer, stdin *os.File, stdout *os.File, oldTermState *term.State, resize chan remotecommand.TerminalSize, ecChan chan int) chan error {
-	var errChan chan error
+	errChan := make(chan error, 1)
 	// These are the special writers that encode input from the client.
 	varlinkStdinWriter := virtwriter.NewVirtWriteCloser(writer, virtwriter.ToStdin)
 	varlinkResizeWriter := virtwriter.NewVirtWriteCloser(writer, virtwriter.TerminalResize)

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -1017,7 +1017,6 @@ func (r *LocalRuntime) ExecContainer(ctx context.Context, cli *cliconfig.ExecVal
 
 	// Check if we are attached to a terminal. If we are, generate resize
 	// events, and set the terminal to raw mode
-	// TODO FIXME tty
 	if haveTerminal && cli.Tty {
 		cancel, oldTermState, err := handleTerminalAttach(ctx, resize)
 		if err != nil {
@@ -1038,6 +1037,7 @@ func (r *LocalRuntime) ExecContainer(ctx context.Context, cli *cliconfig.ExecVal
 		User:       &cli.User,
 		Workdir:    &cli.Workdir,
 		Env:        &envs,
+		DetachKeys: &cli.DetachKeys,
 	}
 
 	inputStream := os.Stdin

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -735,7 +735,6 @@ func (r *LocalRuntime) attach(ctx context.Context, stdin, stdout *os.File, cid s
 		term.SetRawTerminal(os.Stdin.Fd())
 	}
 
-	// TODO add detach keys support
 	reply, err := iopodman.Attach().Send(r.Conn, varlink.Upgrade, cid, detachKeys, start)
 	if err != nil {
 		restoreTerminal(oldTermState)

--- a/pkg/adapter/terminal_linux.go
+++ b/pkg/adapter/terminal_linux.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/containers/libpod/libpod"
-	"github.com/docker/docker/pkg/term"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/terminal"
@@ -107,26 +106,4 @@ func StartAttachCtr(ctx context.Context, ctr *libpod.Container, stdout, stderr, 
 	}
 
 	return nil
-}
-
-func handleTerminalAttach(ctx context.Context, resize chan remotecommand.TerminalSize) (context.CancelFunc, *term.State, error) {
-	logrus.Debugf("Handling terminal attach")
-
-	subCtx, cancel := context.WithCancel(ctx)
-
-	resizeTty(subCtx, resize)
-
-	oldTermState, err := term.SaveState(os.Stdin.Fd())
-	if err != nil {
-		// allow caller to not have to do any cleaning up if we error here
-		cancel()
-		return nil, nil, errors.Wrapf(err, "unable to save terminal state")
-	}
-
-	logrus.SetFormatter(&RawTtyFormatter{})
-	if _, err := term.SetRawTerminal(os.Stdin.Fd()); err != nil {
-		return cancel, nil, err
-	}
-
-	return cancel, oldTermState, nil
 }

--- a/pkg/varlinkapi/attach.go
+++ b/pkg/varlinkapi/attach.go
@@ -68,7 +68,7 @@ func (i *LibpodAPI) Attach(call iopodman.VarlinkCall, name string, detachKeys st
 	reader, writer, _, pw, streams := setupStreams(call)
 
 	go func() {
-		if err := virtwriter.Reader(reader, nil, nil, pw, resize); err != nil {
+		if err := virtwriter.Reader(reader, nil, nil, pw, resize, nil); err != nil {
 			errChan <- err
 		}
 	}()
@@ -83,7 +83,7 @@ func (i *LibpodAPI) Attach(call iopodman.VarlinkCall, name string, detachKeys st
 		logrus.Error(finalErr)
 	}
 
-	if err = virtwriter.HangUp(writer); err != nil {
+	if err = virtwriter.HangUp(writer, 0); err != nil {
 		logrus.Errorf("Failed to HANG-UP attach to %s: %s", ctr.ID(), err.Error())
 	}
 	return call.Writer.Flush()

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -837,15 +837,9 @@ func (i *LibpodAPI) ExecContainer(call iopodman.VarlinkCall, opts iopodman.ExecO
 
 	ecErr := <-ecErrChan
 
-	exitCode := ecErr.ExitCode
-	if errors.Cause(ecErr.Error) == define.ErrOCIRuntimePermissionDenied {
-		exitCode = define.ExecErrorCodeCannotInvoke
-	}
-	if errors.Cause(ecErr.Error) == define.ErrOCIRuntimeNotFound {
-		exitCode = define.ExecErrorCodeNotFound
-	}
+	exitCode := define.TranslateExecErrorToExitCode(int(ecErr.ExitCode), ecErr.Error)
 
-	if err = virtwriter.HangUp(writer, exitCode); err != nil {
+	if err = virtwriter.HangUp(writer, uint32(exitCode)); err != nil {
 		logrus.Errorf("ExecContainer failed to HANG-UP on %s: %s", ctr.ID(), err.Error())
 	}
 

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -800,51 +800,46 @@ func (i *LibpodAPI) ExecContainer(call iopodman.VarlinkCall, opts iopodman.ExecO
 	call.ReplyExecContainer()
 
 	resizeChan := make(chan remotecommand.TerminalSize)
-	errChan := make(chan error)
 
 	reader, writer, _, pipeWriter, streams := setupStreams(call)
 	//reader, _, _, pipeWriter, streams := setupStreams(call)
-	ecChan := make(chan uint32, 1)
+	type ExitCodeError struct {
+		ExitCode uint32
+		Error    error
+	}
+	ecErrChan := make(chan ExitCodeError, 1)
 
 	go func() {
-		fmt.Printf("ExecContainer Start Reader\n")
 		if err := virtwriter.Reader(reader, nil, nil, pipeWriter, resizeChan, nil); err != nil {
-			//fmt.Printf("ExecContainer Reader err %s, %s\n", err.Error(), errors.Cause(err).Error())
-			errChan <- errors.Wrapf(err, "error")
+			ecErrChan <- ExitCodeError{
+				125, //TODO FIXME magic number, define package?
+				err,
+			}
 		}
 	}()
 
-	fmt.Printf("ExecContainer Start ctr.Exec\n")
-	// TODO detach keys and resize
-	// TODO add handling for exit code
-	// TODO capture exit code and return to main thread
+	// TODO FIXME detach keys
 	go func() {
 		ec, err := ctr.Exec(opts.Tty, opts.Privileged, envs, opts.Cmd, user, workDir, streams, 0, resizeChan, "")
 		if err != nil {
 			logrus.Errorf("ExecContainer Exec err %s, %s\n", err.Error(), errors.Cause(err).Error())
-			errChan <-err
 		}
-		ecChan <-uint32(ec)
-
+		ecErrChan <- ExitCodeError{
+			uint32(ec),
+			err,
+		}
 	}()
 
-	ec := uint32(125)
-	var execErr error
-	select {
-		case execErr = <-errChan:
-			fmt.Println(execErr.Error())
-		case ec = <-ecChan:
-			fmt.Println("found", ec)
-	}
+	ecErr := <-ecErrChan
 
-	// TODO FIXME prevent all of vthese conversions
-	if err = virtwriter.HangUp(writer, int(ec)); err != nil {
+	// TODO FIXME prevent all of these conversions
+	if err = virtwriter.HangUp(writer, int(ecErr.ExitCode)); err != nil {
 		logrus.Errorf("ExecContainer failed to HANG-UP on %s: %s", ctr.ID(), err.Error())
 	}
-	defer fmt.Println("Succeeded in exec'ing")
+
 	if err := call.Writer.Flush(); err != nil {
 		logrus.Errorf("Exec Container err: %s", err.Error())
 	}
 
-	return execErr
+	return ecErr.Error
 }

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -808,7 +808,7 @@ func (i *LibpodAPI) ExecContainer(call iopodman.VarlinkCall, opts iopodman.ExecO
 	resizeChan := make(chan remotecommand.TerminalSize)
 
 	reader, writer, _, pipeWriter, streams := setupStreams(call)
-	//reader, _, _, pipeWriter, streams := setupStreams(call)
+
 	type ExitCodeError struct {
 		ExitCode uint32
 		Error    error
@@ -837,8 +837,7 @@ func (i *LibpodAPI) ExecContainer(call iopodman.VarlinkCall, opts iopodman.ExecO
 
 	ecErr := <-ecErrChan
 
-	// TODO FIXME prevent all of these conversions
-	exitCode := int(ecErr.ExitCode)
+	exitCode := ecErr.ExitCode
 	if errors.Cause(ecErr.Error) == define.ErrOCIRuntimePermissionDenied {
 		exitCode = define.ExecErrorCodeCannotInvoke
 	}

--- a/pkg/varlinkapi/virtwriter/virtwriter.go
+++ b/pkg/varlinkapi/virtwriter/virtwriter.go
@@ -113,7 +113,7 @@ func Reader(r *bufio.Reader, output, errput, input io.Writer, resize chan remote
 			if output != nil {
 				_, err := io.CopyN(output, r, messageSize)
 				if err != nil {
-					return errors.Wrapf(err, "issue stdout")
+					return err
 				}
 			}
 		case ToStderr:
@@ -121,14 +121,13 @@ func Reader(r *bufio.Reader, output, errput, input io.Writer, resize chan remote
 				_, err := io.CopyN(errput, r, messageSize)
 				if err != nil {
 					return err
-					return errors.Wrapf(err, "issue stderr")
 				}
 			}
 		case ToStdin:
 			if input != nil {
 				_, err := io.CopyN(input, r, messageSize)
 				if err != nil {
-					return errors.Wrapf(err, "issue stdin")
+					return err
 				}
 			}
 		case TerminalResize:
@@ -138,13 +137,13 @@ func Reader(r *bufio.Reader, output, errput, input io.Writer, resize chan remote
 					_, err = io.ReadFull(r, out)
 
 					if err != nil {
-						return errors.Wrapf(err, "issue resizing")
+						return err
 					}
 				}
 				// Resize events come over in bytes, need to be reserialized
 				resizeEvent := remotecommand.TerminalSize{}
 				if err := json.Unmarshal(out, &resizeEvent); err != nil {
-					return errors.Wrapf(err, "issue resizing")
+					return err
 				}
 				resize <- resizeEvent
 			}
@@ -154,7 +153,7 @@ func Reader(r *bufio.Reader, output, errput, input io.Writer, resize chan remote
 				_, err = io.ReadFull(r, out)
 
 				if err != nil {
-					return errors.Wrapf(err, "issue quitting")
+					return err
 				}
 			}
 			if execEcChan != nil {

--- a/pkg/varlinkapi/virtwriter/virtwriter.go
+++ b/pkg/varlinkapi/virtwriter/virtwriter.go
@@ -171,11 +171,11 @@ func Reader(r *bufio.Reader, output, errput, input io.Writer, resize chan remote
 }
 
 // HangUp sends message to peer to close connection
-func HangUp(writer *bufio.Writer, ec int) (err error) {
+func HangUp(writer *bufio.Writer, ec uint32) (err error) {
 	n := 0
 	msg := make([]byte, 4)
 
-	binary.BigEndian.PutUint32(msg, uint32(ec))
+	binary.BigEndian.PutUint32(msg, ec)
 
 	writeQuit := NewVirtWriteCloser(writer, Quit)
 	if n, err = writeQuit.Write(msg); err != nil {

--- a/pkg/varlinkapi/virtwriter/virtwriter.go
+++ b/pkg/varlinkapi/virtwriter/virtwriter.go
@@ -89,9 +89,13 @@ func (v VirtWriteCloser) Write(input []byte) (int, error) {
 }
 
 // Reader decodes the content that comes over the wire and directs it to the proper destination.
-func Reader(r *bufio.Reader, output io.Writer, errput io.Writer, input io.Writer, resize chan remotecommand.TerminalSize) error {
+func Reader(r *bufio.Reader, output, errput, input io.Writer, resize chan remotecommand.TerminalSize, execEcChan chan int) error {
 	var messageSize int64
 	headerBytes := make([]byte, 8)
+
+	if r == nil {
+		return errors.Errorf("Reader must not be nil")
+	}
 
 	for {
 		n, err := io.ReadFull(r, headerBytes)
@@ -106,43 +110,56 @@ func Reader(r *bufio.Reader, output io.Writer, errput io.Writer, input io.Writer
 
 		switch IntToSocketDest(int(headerBytes[0])) {
 		case ToStdout:
-			_, err := io.CopyN(output, r, messageSize)
-			if err != nil {
-				return err
-			}
-		case ToStderr:
-			_, err := io.CopyN(errput, r, messageSize)
-			if err != nil {
-				return err
-			}
-		case ToStdin:
-			_, err := io.CopyN(input, r, messageSize)
-			if err != nil {
-				return err
-			}
-		case TerminalResize:
-			out := make([]byte, messageSize)
-			if messageSize > 0 {
-				_, err = io.ReadFull(r, out)
-
+			if output != nil {
+				_, err := io.CopyN(output, r, messageSize)
 				if err != nil {
-					return err
+						return errors.Wrapf(err, "issue stdout")
 				}
 			}
-			// Resize events come over in bytes, need to be reserialized
-			resizeEvent := remotecommand.TerminalSize{}
-			if err := json.Unmarshal(out, &resizeEvent); err != nil {
-				return err
+		case ToStderr:
+			if errput != nil {
+				_, err := io.CopyN(errput, r, messageSize)
+				if err != nil {
+					return err
+						return errors.Wrapf(err, "issue stderr")
+				}
 			}
-			resize <- resizeEvent
+		case ToStdin:
+			if input != nil {
+				_, err := io.CopyN(input, r, messageSize)
+				if err != nil {
+						return errors.Wrapf(err, "issue stdin")
+				}
+			}
+		case TerminalResize:
+			if resize != nil {
+				out := make([]byte, messageSize)
+				if messageSize > 0 {
+					_, err = io.ReadFull(r, out)
+
+					if err != nil {
+						return errors.Wrapf(err, "issue resizing")
+					}
+				}
+				// Resize events come over in bytes, need to be reserialized
+				resizeEvent := remotecommand.TerminalSize{}
+				if err := json.Unmarshal(out, &resizeEvent); err != nil {
+					return errors.Wrapf(err, "issue resizing")
+				}
+				resize <- resizeEvent
+			}
 		case Quit:
 			out := make([]byte, messageSize)
 			if messageSize > 0 {
 				_, err = io.ReadFull(r, out)
 
 				if err != nil {
-					return err
+					return errors.Wrapf(err, "issue quitting")
 				}
+			}
+			if execEcChan != nil {
+				ecInt := binary.BigEndian.Uint32(out)
+				execEcChan <-int(ecInt)
 			}
 			return nil
 
@@ -154,9 +171,12 @@ func Reader(r *bufio.Reader, output io.Writer, errput io.Writer, input io.Writer
 }
 
 // HangUp sends message to peer to close connection
-func HangUp(writer *bufio.Writer) (err error) {
+func HangUp(writer *bufio.Writer, ec int) (err error) {
 	n := 0
-	msg := []byte("HANG-UP")
+	msg := make([]byte, 4)
+
+	binary.LittleEndian.PutUint32(msg, uint32(ec))
+
 
 	writeQuit := NewVirtWriteCloser(writer, Quit)
 	if n, err = writeQuit.Write(msg); err != nil {

--- a/pkg/varlinkapi/virtwriter/virtwriter.go
+++ b/pkg/varlinkapi/virtwriter/virtwriter.go
@@ -113,7 +113,7 @@ func Reader(r *bufio.Reader, output, errput, input io.Writer, resize chan remote
 			if output != nil {
 				_, err := io.CopyN(output, r, messageSize)
 				if err != nil {
-						return errors.Wrapf(err, "issue stdout")
+					return errors.Wrapf(err, "issue stdout")
 				}
 			}
 		case ToStderr:
@@ -121,14 +121,14 @@ func Reader(r *bufio.Reader, output, errput, input io.Writer, resize chan remote
 				_, err := io.CopyN(errput, r, messageSize)
 				if err != nil {
 					return err
-						return errors.Wrapf(err, "issue stderr")
+					return errors.Wrapf(err, "issue stderr")
 				}
 			}
 		case ToStdin:
 			if input != nil {
 				_, err := io.CopyN(input, r, messageSize)
 				if err != nil {
-						return errors.Wrapf(err, "issue stdin")
+					return errors.Wrapf(err, "issue stdin")
 				}
 			}
 		case TerminalResize:
@@ -159,7 +159,7 @@ func Reader(r *bufio.Reader, output, errput, input io.Writer, resize chan remote
 			}
 			if execEcChan != nil {
 				ecInt := binary.BigEndian.Uint32(out)
-				execEcChan <-int(ecInt)
+				execEcChan <- int(ecInt)
 			}
 			return nil
 
@@ -175,8 +175,7 @@ func HangUp(writer *bufio.Writer, ec int) (err error) {
 	n := 0
 	msg := make([]byte, 4)
 
-	binary.LittleEndian.PutUint32(msg, uint32(ec))
-
+	binary.BigEndian.PutUint32(msg, uint32(ec))
 
 	writeQuit := NewVirtWriteCloser(writer, Quit)
 	if n, err = writeQuit.Write(msg); err != nil {

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -77,8 +77,6 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec environment test", func() {
-		// passing environment variables is not supported in the remote client
-		SkipIfRemote()
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
@@ -110,8 +108,8 @@ var _ = Describe("Podman exec", func() {
 		match, _ := session.GrepString("BAR")
 		Expect(match).Should(BeTrue())
 		os.Unsetenv("FOO")
-
 	})
+
 	It("podman exec exit code", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -1,5 +1,3 @@
-// +build !remoteclient
-
 package integration
 
 import (


### PR DESCRIPTION
Make appropriate changes to varlink exec api and containers_remote to implement remote exec.
Update the exec e2e tests to run with remote exec.

~Note, there currently exists one flaw with this implementation, where running a shell in -ti and calling exit causes the runtime to exit with 130 and print an ugly message. not sure why this happens in remote and not local. Stay tuned, but I figured I'd get this out there for review in the meantime~
Edit: the above is no longer a problem, and this is ready for review