### PR TITLE
golangci-lint cleanup

### DIFF
--- a/libpod/oci_attach_linux.go
+++ b/libpod/oci_attach_linux.go
@@ -188,7 +188,9 @@ func setupStdioChannels(streams *AttachStreams, conn *net.UnixConn, detachKeys [
 		var err error
 		if streams.AttachInput {
 			_, err = utils.CopyDetachable(conn, streams.InputStream, detachKeys)
-			conn.CloseWrite()
+			if connErr := conn.CloseWrite(); connErr != nil {
+				logrus.Errorf("unable to close conn: %q", connErr)
+			}
 		}
 		stdinDone <- err
 	}()


### PR DESCRIPTION
a PR slipped through without running the new linter.  this cleans things
up for the master branch.

Signed-off-by: baude <bbaude@redhat.com>