### PR TITLE
Small cirrus and image-build fixes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,11 +40,6 @@ env:
     #### base-images (pre-existing in GCE)
     ####
     BUILT_IMAGE_SUFFIX: "-${CIRRUS_REPO_NAME}-${CIRRUS_BUILD_ID}"
-    # Git commits to use while building dependencies into cache-images
-    FEDORA_CNI_COMMIT: "412b6d31280682bb4fab4446f113c22ff1886554"
-    CNI_COMMIT: "7480240de9749f9a0a5c8614b17f1f03e0c06ab9"
-    CONMON_COMMIT: "6f3572558b97bc60dd8f8c7f0807748e6ce2c440"
-    CRIU_COMMIT: "c74b83cd49c00589c0c0468ba5fe685b67fdbd0a"
     # Special image w/ nested-libvirt + tools for creating new cache and base images
     IMAGE_BUILDER_CACHE_IMAGE_NAME: "image-builder-image-1541772081"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -535,6 +535,9 @@ success_task:
 
 release_task:
 
+    # Never do this when building images
+    only_if: $CIRRUS_CHANGE_MESSAGE !=~ '.*\*\*\*\s*CIRRUS:\s*TEST\s*IMAGES\s*\*\*\*.*'
+
     # TODO: Uncomment both to not affect pass/fail status of entire job?
     # allow_failures: $CI == "true"
     # skip_notifications: $CI == "true"

--- a/contrib/cirrus/build_vm_images.sh
+++ b/contrib/cirrus/build_vm_images.sh
@@ -62,17 +62,6 @@ URI="gs://packer-import${POST_MERGE_BUCKET_SUFFIX}/manifest${BUILT_IMAGE_SUFFIX}
 gsutil cp packer-manifest.json "$URI"
 
 # Ensure any background 'gcloud compute images update' processes finish
-set +e  # need 'wait' exit code to avoid race
-while [[ -n "$(jobs)" ]]
-do
-    wait -n
-    RET=$?
-    if [[ "$RET" -eq "127" ]] || \   # Avoid TOCTOU race w/ jobs + wait
-       [[ "$RET" -eq "0" ]]
-    then
-        continue
-    fi
-    die $RET "Required base-image metadata update failed"
-done
+wait  # CentOS has no -n option :(
 
 echo "Finished. A JSON manifest of produced images is available at $URI"

--- a/contrib/cirrus/build_vm_images.sh
+++ b/contrib/cirrus/build_vm_images.sh
@@ -32,7 +32,7 @@ for base_image_var in $BASE_IMAGE_VARS
 do
     # See entrypoint.sh in contrib/imgts and contrib/imgprune
     # These updates can take a while, run them in the background, check later
-    gcloud compute images update "$image" \
+    gcloud compute images update \
         --update-labels=last-used=$(date +%s) \
         --update-labels=build-id=$CIRRUS_BUILD_ID \
         --update-labels=repo-ref=$CIRRUS_CHANGE_IN_REPO \

--- a/contrib/cirrus/check_image.sh
+++ b/contrib/cirrus/check_image.sh
@@ -36,10 +36,12 @@ do
         "$(systemctl list-unit-files --no-legend $REQ_UNIT)" = "$REQ_UNIT enabled" || let "RET+=1"
 done
 
-# Exits zero if any unit matching pattern is running
-UNIT_STATUS=$(systemctl is-active $EVIL_UNITS; echo $?)
-item_test "No interfering background units are active:" \
-    "$UNIT_STATUS" -ne "0" || let "RET+=1"
+for evil_unit in $EVIL_UNITS
+do
+    # Exits zero if any unit matching pattern is running
+    unit_status=$(systemctl is-active $evil_unit &> /dev/null; echo $?)
+    item_test "No $evil_unit unit is present or active:" "$unit_status" -ne "0" || let "RET+=1"
+done
 
 echo "Total failed tests: $RET"
 exit $RET

--- a/contrib/cirrus/check_image.sh
+++ b/contrib/cirrus/check_image.sh
@@ -4,26 +4,26 @@ set -eo pipefail
 
 source $(dirname $0)/lib.sh
 
-RET=0
+NFAILS=0
 echo "Validating VM image"
 
 MIN_SLASH_GIGS=50
 read SLASH_DEVICE SLASH_FSTYPE SLASH_SIZE JUNK <<<$(findmnt --df --first-only --noheadings / | cut -d '.' -f 1)
 SLASH_SIZE_GIGS=$(echo "$SLASH_SIZE" | sed -r -e 's/G|g//')
-item_test "Minimum available disk space" $SLASH_SIZE_GIGS -gt $MIN_SLASH_GIGS || let "RET+=1"
+item_test "Minimum available disk space" $SLASH_SIZE_GIGS -gt $MIN_SLASH_GIGS || let "NFAILS+=1"
 
 MIN_MEM_MB=2000
 read JUNK TOTAL USED MEM_FREE JUNK <<<$(free -tm | tail -1)
-item_test 'Minimum available memory' $MEM_FREE -ge $MIN_MEM_MB || let "RET+=1"
+item_test 'Minimum available memory' $MEM_FREE -ge $MIN_MEM_MB || let "NFAILS+=1"
 
 # We're testing a custom-built podman; make sure there isn't a distro-provided
 # binary anywhere; that could potentially taint our results.
-item_test "remove_packaged_podman_files() did it's job" -z "$(type -P podman)" || let "RET+=1"
+item_test "remove_packaged_podman_files() did it's job" -z "$(type -P podman)" || let "NFAILS+=1"
 
 MIN_ZIP_VER='3.0'
 VER_RE='.+([[:digit:]]+\.[[:digit:]]+).+'
 ACTUAL_VER=$(zip --version 2>&1 | egrep -m 1 "Zip$VER_RE" | sed -r -e "s/$VER_RE/\\1/")
-item_test "minimum zip version" "$MIN_ZIP_VER" = $(echo -e "$MIN_ZIP_VER\n$ACTUAL_VER" | sort -V | head -1) || let "RET+=1"
+item_test "minimum zip version" "$MIN_ZIP_VER" = $(echo -e "$MIN_ZIP_VER\n$ACTUAL_VER" | sort -V | head -1) || let "NFAILS+=1"
 
 for REQ_UNIT in google-accounts-daemon.service \
                 google-clock-skew-daemon.service \
@@ -33,15 +33,21 @@ for REQ_UNIT in google-accounts-daemon.service \
                 google-startup-scripts.service
 do
     item_test "required $REQ_UNIT enabled" \
-        "$(systemctl list-unit-files --no-legend $REQ_UNIT)" = "$REQ_UNIT enabled" || let "RET+=1"
+        "$(systemctl list-unit-files --no-legend $REQ_UNIT)" = "$REQ_UNIT enabled" || let "NFAILS+=1"
 done
 
 for evil_unit in $EVIL_UNITS
 do
     # Exits zero if any unit matching pattern is running
     unit_status=$(systemctl is-active $evil_unit &> /dev/null; echo $?)
-    item_test "No $evil_unit unit is present or active:" "$unit_status" -ne "0" || let "RET+=1"
+    item_test "No $evil_unit unit is present or active:" "$unit_status" -ne "0" || let "NFAILS+=1"
 done
 
-echo "Total failed tests: $RET"
-exit $RET
+if [[ "$OS_RELEASE_ID" == "ubuntu" ]] && [[ -x "/usr/lib/cri-o-runc/sbin/runc" ]]
+then
+    SAMESAME=$(diff --brief /usr/lib/cri-o-runc/sbin/runc /usr/bin/runc &> /dev/null; echo $?)
+    item_test "On ubuntu /usr/bin/runc is /usr/lib/cri-o-runc/sbin/runc" "$SAMESAME" -eq "0" || let "NFAILS+=1"
+fi
+
+echo "Total failed tests: $NFAILS"
+exit $NFAILS

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -358,11 +358,14 @@ systemd_banish(){
     set +e  # Not all of these exist on every platform
     for unit in $EVIL_UNITS
     do
-        ooe.sh sudo systemctl stop $unit
-        ooe.sh sudo systemctl disable $unit
-        ooe.sh sudo systemctl disable $unit.timer
-        ooe.sh sudo systemctl mask $unit
-        ooe.sh sudo systemctl mask $unit.timer
+        echo "Banishing $unit (ignoring errors)"
+        (
+            sudo systemctl stop $unit
+            sudo systemctl disable $unit
+            sudo systemctl disable $unit.timer
+            sudo systemctl mask $unit
+            sudo systemctl mask $unit.timer
+        ) &> /dev/null
     done
     set -e
 }

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -34,7 +34,14 @@ done
 #       (see docs).
 cd "${GOSRC}/"
 case "${OS_REL_VER}" in
-    ubuntu-18) ;;
+    ubuntu-18)
+        CRIO_RUNC_PATH="/usr/lib/cri-o-runc/sbin/runc"
+        if dpkg -L cri-o-runc | grep -m 1 -q "$CRIO_RUNC_PATH"
+        then
+            echo "Linking $CRIO_RUNC_PATH to /usr/bin/runc for ease of testing."
+            ln -f "$CRIO_RUNC_PATH" "/usr/bin/runc"
+        fi
+        ;;
     fedora-30) ;;
     fedora-29) ;;
     centos-7)  # Current VM is an image-builder-image no local podman/testing


### PR DESCRIPTION
* Kill tha SHAs!
* Squash a gcloud typo
* Fix impossible 'wait -n'
* Fix evil-service banishment test
* Fix env. var collision on `$RET` in VM image intg. test
* Deal with runc not being where it is expected on Ubuntu
* Never try to release binaries when test-building VM images

***CIRRUS: TEST IMAGES***