### PR TITLE
Re-add int64 casts for ctime to fix 32-bit build

### DIFF
--- a/pkg/ctime/ctime_linux.go
+++ b/pkg/ctime/ctime_linux.go
@@ -10,5 +10,6 @@ import (
 
 func created(fi os.FileInfo) time.Time {
 	st := fi.Sys().(*syscall.Stat_t)
-	return time.Unix(st.Ctim.Sec, st.Ctim.Nsec)
+	//nolint
+	return time.Unix(int64(st.Ctim.Sec), int64(st.Ctim.Nsec))
 }


### PR DESCRIPTION
The variables here are 64-bit on 64-bit builds, so the linter recommends stripping them. Unfortunately, they're 32-bit on 32-bit builds, so stripping them breaks that. Readd with a nolint to convince it to not break.