### PR TITLE
Fix possible runtime panic if image history len is zero

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -1298,7 +1298,10 @@ func (i *Image) Comment(ctx context.Context, manifestType string) (string, error
 	if err != nil {
 		return "", err
 	}
-	return ociv1Img.History[0].Comment, nil
+	if len(ociv1Img.History) > 0 {
+		return ociv1Img.History[0].Comment, nil
+	}
+	return "", nil
 }
 
 // Save writes a container image to the filesystem


### PR DESCRIPTION
We now return an empty string for the `Comment` field if an OCI v1 image
contains no history.

---

**Note:** I was not able to reproduce this issue with podman itself, but my experiments with using libpod within CRI-O triggered the issue from a single test in critest: https://circleci.com/api/v1.1/project/github/openSUSE/cri-o/15009/output/103/0?file=true