### PR TITLE
fix `podman -v` regression

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -91,7 +91,7 @@ func init() {
 	rootCmd.Version = version.Version
 	// Override default --help information of `--version` global flag
 	var dummyVersion bool
-	rootCmd.PersistentFlags().BoolVar(&dummyVersion, "version", false, "Version for podman")
+	rootCmd.Flags().BoolVarP(&dummyVersion, "version", "v", false, "Version of podman")
 	rootCmd.AddCommand(mainCommands...)
 	rootCmd.AddCommand(getMainCommands()...)
 }

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	. "github.com/containers/libpod/test/utils"
+	"github.com/containers/libpod/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -37,6 +38,26 @@ var _ = Describe("Podman version", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 2))
+		ok, _ := session.GrepString(version.Version)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("podman -v", func() {
+		SkipIfRemote()
+		session := podmanTest.Podman([]string{"-v"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		ok, _ := session.GrepString(version.Version)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("podman --version", func() {
+		SkipIfRemote()
+		session := podmanTest.Podman([]string{"--version"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		ok, _ := session.GrepString(version.Version)
+		Expect(ok).To(BeTrue())
 	})
 
 	It("podman version --format json", func() {


### PR DESCRIPTION
Re-add the shortflag for --version and add e2e tests to avoid regressing
in the future.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>