### PR TITLE
Revert "Cirrus: Temp. workaround missing imgprune image"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -286,7 +286,7 @@ image_prune_task:
         - "meta"
 
     container:
-        image: "quay.io/cevich/imgprune:latest"  # see contrib/imgprune
+        image: "quay.io/libpod/imgprune:latest"  # see contrib/imgprune
         cpu: 1
         memory: 1
 

--- a/contrib/imgprune/Dockerfile
+++ b/contrib/imgprune/Dockerfile
@@ -1,4 +1,4 @@
-FROM libpod/imgts:latest
+FROM quay.io/libpod/imgts:latest
 
 RUN yum -y update && \
     yum clean all


### PR DESCRIPTION
Also includes one other occasional/minor flake-fix

This reverts commit 9b2e98f1e872354f0708a86b59e16b8b86e9f8b2.