### PR TITLE
Ensure static IP tests use different IPs

### DIFF
--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 	})
 
 	It("Podman create with specified static IP has correct IP", func() {
-		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", "10.88.64.128", ALPINE, "ip", "addr"})
+		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", "10.88.128.192", ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 
@@ -71,7 +71,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 		result = podmanTest.Podman([]string{"logs", "test"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
-		Expect(result.OutputToString()).To(ContainSubstring("10.88.64.128/16"))
+		Expect(result.OutputToString()).To(ContainSubstring("10.88.128.192/16"))
 	})
 
 	It("Podman create two containers with the same IP", func() {


### PR DESCRIPTION
They can run in parallel, which could flake if they both allocate the same address at the same time