### PR TITLE
Fix the syntax in the podman export documentation example

### DIFF
--- a/docs/podman-export.1.md
+++ b/docs/podman-export.1.md
@@ -33,7 +33,7 @@ Print usage statement
 ```
 $ podman export -o redis-container.tar 883504668ec465463bc0fe7e63d53154ac3b696ea8d7b233748918664ea90e57
 
-$ podman export > redis-container.tar 883504668ec465463bc0fe7e63d53154ac3b696ea8d7b233748918664ea90e57
+$ podman export 883504668ec465463bc0fe7e63d53154ac3b696ea8d7b233748918664ea90e57 > redis-container.tar
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
It seems in one of the examples the order of arguments were wrong. I fixed it.