### PR TITLE
Update libpod.conf to be more friendly to NixOS

### DIFF
--- a/libpod.conf
+++ b/libpod.conf
@@ -12,7 +12,8 @@ conmon_path = [
 	    "/usr/bin/conmon",
 	    "/usr/sbin/conmon",
 	    "/usr/local/bin/conmon",
-	    "/usr/local/sbin/conmon"
+	    "/usr/local/sbin/conmon",
+	    "/run/current-system/sw/bin/conmon",
 ]
 
 # Environment variables to pass into conmon
@@ -128,7 +129,8 @@ runc = [
 	    "/usr/local/sbin/runc",
 	    "/sbin/runc",
 	    "/bin/runc",
-	    "/usr/lib/cri-o-runc/sbin/runc"
+	    "/usr/lib/cri-o-runc/sbin/runc",
+	    "/run/current-system/sw/bin/runc",
 ]
 
 crun = [

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -293,6 +293,7 @@ func defaultRuntimeConfig() (RuntimeConfig, error) {
 				"/sbin/runc",
 				"/bin/runc",
 				"/usr/lib/cri-o-runc/sbin/runc",
+				"/run/current-system/sw/bin/runc",
 			},
 		},
 		ConmonPath: []string{
@@ -302,6 +303,7 @@ func defaultRuntimeConfig() (RuntimeConfig, error) {
 			"/usr/sbin/conmon",
 			"/usr/local/bin/conmon",
 			"/usr/local/sbin/conmon",
+			"/run/current-system/sw/bin/conmon",
 		},
 		ConmonEnvVars: []string{
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",


### PR DESCRIPTION
NixOS links the current system state to `/run/current-system`, so we
have to add these paths to the configuration files as well to work out
of the box.

Follow up of: https://github.com/NixOS/nixpkgs/pull/63658