### PR TITLE
Add user systemd service and socket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SHAREDIR_CONTAINERS ?= ${PREFIX}/share/containers
 ETCDIR ?= /etc
 TMPFILESDIR ?= ${PREFIX}/lib/tmpfiles.d
 SYSTEMDDIR ?= ${PREFIX}/lib/systemd/system
+USERSYSTEMDDIR ?= ${PREFIX}/lib/systemd/user
 BUILDFLAGS ?=
 BUILDTAGS ?= \
 	$(shell hack/apparmor_tag.sh) \
@@ -395,9 +396,11 @@ install.docker: docker-docs
 	install ${SELINUXOPT} -m 644 docs/docker*.1 -t $(DESTDIR)$(MANDIR)/man1
 
 install.systemd:
-	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR} ${DESTDIR}${TMPFILESDIR}
+	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR}  ${DESTDIR}${USERSYSTEMDDIR} ${DESTDIR}${TMPFILESDIR}
 	install ${SELINUXOPT} -m 644 contrib/varlink/io.podman.socket ${DESTDIR}${SYSTEMDDIR}/io.podman.socket
+	install ${SELINUXOPT} -m 644 contrib/varlink/io.podman.socket ${DESTDIR}${USERSYSTEMDDIR}/io.podman.socket
 	install ${SELINUXOPT} -m 644 contrib/varlink/io.podman.service ${DESTDIR}${SYSTEMDDIR}/io.podman.service
+	install ${SELINUXOPT} -m 644 contrib/varlink/io.podman.service ${DESTDIR}${USERSYSTEMDDIR}/io.podman.service
 	install ${SELINUXOPT} -m 644 contrib/varlink/podman.conf ${DESTDIR}${TMPFILESDIR}/podman.conf
 
 uninstall:

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -389,6 +389,7 @@ popd
 
 %install
 install -dp %{buildroot}%{_unitdir}
+install -dp %{buildroot}%{_usr}/lib/systemd/user
 PODMAN_VERSION=%{version} %{__make} PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir} \
         install.bin \
         install.remote \
@@ -487,6 +488,8 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/vendor:%{gopath}
 %{_datadir}/containers/%{repo}.conf
 %{_unitdir}/io.podman.service
 %{_unitdir}/io.podman.socket
+%{_usr}/lib/systemd/user/io.podman.service
+%{_usr}/lib/systemd/user/io.podman.socket
 %{_usr}/lib/tmpfiles.d/%{name}.conf
 
 %if 0%{?with_devel}

--- a/contrib/varlink/io.podman.service
+++ b/contrib/varlink/io.podman.service
@@ -6,7 +6,8 @@ Documentation=man:podman-varlink(1)
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/podman varlink unix:/run/podman/io.podman
+ExecStart=/usr/bin/podman varlink unix:%t/podman/io.podman
+KillMode=none
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/varlink/io.podman.socket
+++ b/contrib/varlink/io.podman.socket
@@ -3,7 +3,7 @@ Description=Podman Remote API Socket
 Documentation=man:podman-varlink(1)
 
 [Socket]
-ListenStream=/run/podman/io.podman
+ListenStream=%t/podman/io.podman
 SocketMode=0600
 
 [Install]


### PR DESCRIPTION
This enables user to interact with varlink.
Before this PR user could only do `sudo varlink call unix:/run/podman/io.podman/io.podman.ListContainer` to list containers owned by root. With this PR a normal user can also call `varlink call unix:/run/user/1000/podman/io.podman/io.podman.ListContainers` which lists user owned containers.

I have one problem though. Can someone please give me some hints, I admit I don't really understand how and why `pause.pid` is used, but it seems it causes some problem. Here is how to reproduce my problem:

This works just fine after I start my machine. Steps I do:
1. `systemctl --user start io.podman.socket`
2. `varlink call unix:/run/user/1000/podman/io.podman/io.podman.ListContainers`
```
 "containers": [
    {
      "command": [
        "/bin/bash"
      ],
      "containerrunning": false,
      "createdat": "2019-07-29T10:25:30+02:00",
      "id": "11d619fcd6ec3d4f9f6ebe663c87d270797980703089af594a4a13fd82b5f3d4",
      "image": "docker.io/library/fedora:latest",
      "imageid": "d09302f77cfcc3e867829d80ff47f9e7738ffef69730d54ec44341a9fb1d359b",
      "labels": {
        "maintainer": "Clement Verna <cverna@fedoraproject.org>"
      },
      "mounts": [
        {
...
```
3. When I do any other varlink call (for example the same as in 2.) I get `Unable to connect: CannotConnect`
```
$ systemctl --user status io.podman.socket
● io.podman.socket - Podman Remote API Socket
   Loaded: loaded (/usr/lib/systemd/user/io.podman.socket; disabled; vendor preset: enabled)
   Active: failed (Result: service-start-limit-hit) since Mon 2019-07-29 10:35:00 CEST; 7s ago
     Docs: man:podman-varlink(1)
   Listen: /run/user/1000/podman/io.podman (Stream)

Jul 29 10:34:16 dhcppc4 systemd[1338]: Listening on Podman Remote API Socket.
Jul 29 10:35:00 dhcppc4 systemd[1338]: io.podman.socket: Failed with result 'service-start-limit-hit'.

$ systemctl --user status io.podman.service
● io.podman.service - Podman Remote API Service
   Loaded: loaded (/usr/lib/systemd/user/io.podman.service; disabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Mon 2019-07-29 10:35:00 CEST; 19s ago
     Docs: man:podman-varlink(1)
  Process: 16351 ExecStart=/usr/bin/podman varlink unix:/run/user/1000/podman/io.podman (code=exited, status=1/FAILURE)
 Main PID: 16351 (code=exited, status=1/FAILURE)

Jul 29 10:35:00 dhcppc4 systemd[1338]: Started Podman Remote API Service.
Jul 29 10:35:00 dhcppc4 podman[16351]: time="2019-07-29T10:35:00+02:00" level=error msg="cannot join pause process.  You may need to remove /run/user/1000/libpod/pause.pid and stop all containers"
Jul 29 10:35:00 dhcppc4 podman[16351]: time="2019-07-29T10:35:00+02:00" level=error msg="you can use `system migrate` to recreate the pause process"
Jul 29 10:35:00 dhcppc4 podman[16351]: time="2019-07-29T10:35:00+02:00" level=error msg="open /proc/16176/ns/user: no such file or directory"
Jul 29 10:35:00 dhcppc4 systemd[1338]: io.podman.service: Main process exited, code=exited, status=1/FAILURE
Jul 29 10:35:00 dhcppc4 systemd[1338]: io.podman.service: Failed with result 'exit-code'.
Jul 29 10:35:00 dhcppc4 systemd[1338]: io.podman.service: Start request repeated too quickly.
Jul 29 10:35:00 dhcppc4 systemd[1338]: io.podman.service: Failed with result 'exit-code'.
Jul 29 10:35:00 dhcppc4 systemd[1338]: Failed to start Podman Remote API Service.
```

Removing ` /run/user/1000/libpod/pause.pid` and restarting both socket and service I can get it to the same state as after boot, but doing varlink call gets it back to the same failed state. (varlink call returns `Connection closed.`)

If I reboot the machine I can do exactly one varlink call and then get back to this failed state.

