### PR TITLE
Move random IP code for tests from checkpoint to common

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -3,12 +3,9 @@
 package integration
 
 import (
-	"math/rand"
 	"net"
 	"os"
 	"os/exec"
-	"strconv"
-	"time"
 
 	"github.com/containers/libpod/pkg/criu"
 	. "github.com/containers/libpod/test/utils"
@@ -17,12 +14,8 @@ import (
 )
 
 func getRunString(input []string) []string {
-	// To avoid IP collisions of initialize random seed for random IP addresses
-	rand.Seed(time.Now().UnixNano())
-	ip3 := strconv.Itoa(rand.Intn(230) + GinkgoParallelNode())
-	ip4 := strconv.Itoa(rand.Intn(230) + GinkgoParallelNode())
 	// CRIU does not work with seccomp correctly on RHEL7 : seccomp=unconfined
-	runString := []string{"run", "-it", "--security-opt", "seccomp=unconfined", "-d", "--ip", "10.88." + ip3 + "." + ip4}
+	runString := []string{"run", "-it", "--security-opt", "seccomp=unconfined", "-d", "--ip", GetRandomIPAddress()}
 	return append(runString, input...)
 }
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -337,6 +339,18 @@ func GetPortLock(port string) storage.Locker {
 	}
 	lock.Lock()
 	return lock
+}
+
+// GetRandomIPAddress returns a random IP address to avoid IP
+// collisions during parallel tests
+func GetRandomIPAddress() string {
+	// To avoid IP collisions of initialize random seed for random IP addresses
+	rand.Seed(time.Now().UnixNano())
+	// Add GinkgoParallelNode() on top of the IP address
+	// in case of the same random seed
+	ip3 := strconv.Itoa(rand.Intn(230) + GinkgoParallelNode())
+	ip4 := strconv.Itoa(rand.Intn(230) + GinkgoParallelNode())
+	return "10.88." + ip3 + "." + ip4
 }
 
 // RunTopContainer runs a simple container in the background that

--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -60,7 +60,8 @@ var _ = Describe("Podman create with --ip flag", func() {
 	})
 
 	It("Podman create with specified static IP has correct IP", func() {
-		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", "10.88.64.128", ALPINE, "ip", "addr"})
+		ip := GetRandomIPAddress()
+		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 
@@ -71,14 +72,15 @@ var _ = Describe("Podman create with --ip flag", func() {
 		result = podmanTest.Podman([]string{"logs", "test"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
-		Expect(result.OutputToString()).To(ContainSubstring("10.88.64.128/16"))
+		Expect(result.OutputToString()).To(ContainSubstring(ip + "/16"))
 	})
 
 	It("Podman create two containers with the same IP", func() {
-		result := podmanTest.Podman([]string{"create", "--name", "test1", "--ip", "10.88.64.128", ALPINE, "sleep", "999"})
+		ip := GetRandomIPAddress()
+		result := podmanTest.Podman([]string{"create", "--name", "test1", "--ip", ip, ALPINE, "sleep", "999"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
-		result = podmanTest.Podman([]string{"create", "--name", "test2", "--ip", "10.88.64.128", ALPINE, "ip", "addr"})
+		result = podmanTest.Podman([]string{"create", "--name", "test2", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		result = podmanTest.Podman([]string{"start", "test1"})

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -56,17 +56,19 @@ var _ = Describe("Podman run with --ip flag", func() {
 	})
 
 	It("Podman run with specified static IP has correct IP", func() {
-		result := podmanTest.Podman([]string{"run", "-ti", "--ip", "10.88.63.2", ALPINE, "ip", "addr"})
+		ip := GetRandomIPAddress()
+		result := podmanTest.Podman([]string{"run", "-ti", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
-		Expect(result.OutputToString()).To(ContainSubstring("10.88.63.2/16"))
+		Expect(result.OutputToString()).To(ContainSubstring(ip + "/16"))
 	})
 
 	It("Podman run two containers with the same IP", func() {
-		result := podmanTest.Podman([]string{"run", "-d", "--ip", "10.88.64.128", ALPINE, "sleep", "999"})
+		ip := GetRandomIPAddress()
+		result := podmanTest.Podman([]string{"run", "-d", "--ip", ip, ALPINE, "sleep", "999"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
-		result = podmanTest.Podman([]string{"run", "-ti", "--ip", "10.88.64.128", ALPINE, "ip", "addr"})
+		result = podmanTest.Podman([]string{"run", "-ti", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).ToNot(Equal(0))
 	})


### PR DESCRIPTION
The function to generate random IP addresses during ginkgo tests in the checkpoint test code is moved to common and all tests using hardcoded IP addresses have been changed to use random IP addresses to reduce test errors when running the tests in parallel.

@mheon: as discussed in #3652