### PR TITLE
Set -env variables as appropriate

### DIFF
--- a/cmd/podman/shared/parse/parse.go
+++ b/cmd/podman/shared/parse/parse.go
@@ -126,8 +126,9 @@ func parseEnv(env map[string]string, line string) error {
 			}
 		} else {
 			// if only a pass-through variable is given, clean it up.
-			val, _ := os.LookupEnv(name)
-			env[name] = val
+			if val, ok := os.LookupEnv(name); ok {
+				env[name] = val
+			}
 		}
 	}
 	return nil

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -253,9 +253,9 @@ You need to specify multi option commands in the form of a json string.
 
 Set environment variables
 
-This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container. If you specify a environment variable without a value, podman will check the host environment for a value or set the environment to "". If you specify a environment variable ending in --*--, podman will search the host environment for variables starting with the prefix and add them to the container.  If you want to add an environment variable with a ***** following it, then you need to set a value.
+This option allows arbitrary environment variables that are available for the process to be launched inside of the container.  If an environment variable is specified without a value, Podman will check the host environment for a value and set the variable only if it is set on the host.  If an environment variable ending in __*__ is specified, Podman will search the host environment for variables starting with the prefix and will add those variables to the container.  If an environment variable with a trailing ***** is specified, then a value must be supplied.
 
-See **Environment** note below for precedence.
+See [**Environment**](#environment) note below for precedence and examples.
 
 **--env-host**=*true|false*
 
@@ -932,6 +932,19 @@ Precedence Order:
 	   **--env-file** : Any environment variables specified via env-files.  If multiple files specified, then they override each other in order of entry.
 
 	   **--env** : Any environment variables specified will override previous settings.
+
+Create containers and set the environment ending with a __*__ and a *****
+
+```
+$ export ENV1=a
+$ podman create --name ctr --env ENV* alpine printenv ENV1
+$ podman start --attach ctr
+a
+
+$ podman create --name ctr --env ENV*****=b alpine printenv ENV*****
+$ podman start --attach ctr
+b
+```
 
 ## FILES
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -260,9 +260,9 @@ You need to specify multi option commands in the form of a json string.
 
 Set environment variables
 
-This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container. If you specify a environment variable without a value, podman will check the host environment for a value or set the environment to "". If you specify a environment variable ending in --*--, podman will search the host environment for variables starting with the prefix and add them to the container.  If you want to add an environment variable with a ***** following it, then you need to set a value.
+This option allows arbitrary environment variables that are available for the process to be launched inside of the container.  If an environment variable is specified without a value, Podman will check the host environment for a value and set the variable only if it is set on the host.  If an environment variable ending in __*__ is specified, Podman will search the host environment for variables starting with the prefix and will add those variables to the container.  If an environment variable with a trailing ***** is specified, then a value must be supplied.
 
-See **Environment** note below for precedence.
+See [**Environment**](#environment) note below for precedence and examples.
 
 **--env-host**=*true|false*
 
@@ -1218,6 +1218,17 @@ Precedence Order:
 	   **--env-file** : Any environment variables specified via env-files.  If multiple files specified, then they override each other in order of entry.
 
 	   **--env** : Any environment variables specified will override previous settings.
+
+Run containers and set the environment ending with a __*__ and a *****
+
+```
+$ export ENV1=a
+$ $ podman run --env ENV* alpine printenv ENV1
+a
+
+$ podman run --env ENV*****=b alpine printenv ENV*****
+b
+```
 
 ## FILES
 

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -213,6 +213,11 @@ var _ = Describe("Podman run", func() {
 		Expect(match).Should(BeTrue())
 		os.Unsetenv("FOO")
 
+		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO", ALPINE, "printenv", "FOO"})
+		session.WaitWithDefaultTimeout()
+		Expect(len(session.OutputToString())).To(Equal(0))
+		Expect(session.ExitCode()).To(Equal(1))
+
 		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))


### PR DESCRIPTION
close #3648

podman create and podman run do not set --env value if the environment is not present with a value

Signed-off-by: Qi Wang <qiwan@redhat.com>