### PR TITLE
Allow info test to work with usernames w/dash

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -33,7 +33,7 @@ RunRoot:
     run_podman info --format=json
 
     expr_nvr="[a-z0-9-]\\\+-[a-z0-9.]\\\+-[a-z0-9]\\\+\."
-    expr_path="/[a-z0-9\\\/.]\\\+\\\$"
+    expr_path="/[a-z0-9\\\-\\\/.]\\\+\\\$"
 
     tests="
 host.BuildahVersion       | [0-9.]


### PR DESCRIPTION
The regular expression used in the `info` test does not allow for
usernames that have a dash, such as `test-user`. This patch adjusts
the regex to allow for a dash.

Fixes #3666.

Signed-off-by: Major Hayden <major@redhat.com>