### PR TITLE
Touch up input argument error on create

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -80,6 +80,8 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		name := ""
 		if len(c.InputArgs) != 0 {
 			name = c.InputArgs[0]
+		} else {
+			return nil, nil, errors.Errorf("error, no input arguments were provided")
 		}
 		newImage, err := runtime.ImageRuntime().New(ctx, name, rtc.SignaturePolicyPath, GetAuthFile(""), writer, nil, image.SigningOptions{}, false, nil)
 		if err != nil {


### PR DESCRIPTION
Add an error when there are not enough input arguments for remote
create.  Addresses comments in #3656

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>