### PR TITLE
Add runtime and conmon path discovery

### DIFF
--- a/docs/libpod.conf.5.md
+++ b/docs/libpod.conf.5.md
@@ -16,10 +16,10 @@ libpod to manage containers.
   Default OCI runtime to use if nothing is specified in **runtimes**
 
 **runtimes**
-  For each OCI runtime, specify a list of paths to look for.  The first one found is used.
+  For each OCI runtime, specify a list of paths to look for.  The first one found is used. If the paths are empty or no valid path was found, then the `$PATH` environment variable will be used as the fallback.
 
 **conmon_path**=""
-  Paths to search for the Conmon container manager binary
+  Paths to search for the conmon container manager binary. If the paths are empty or no valid path was found, then the `$PATH` environment variable will be used as the fallback.
 
 **conmon_env_vars**=""
   Environment variables to pass into Conmon

--- a/libpod.conf
+++ b/libpod.conf
@@ -4,7 +4,9 @@
 # Default transport method for pulling and pushing for images
 image_default_transport = "docker://"
 
-# Paths to look for the Conmon container manager binary
+# Paths to look for the conmon container manager binary.
+# If the paths are empty or no valid path was found, then the `$PATH`
+# environment variable will be used as the fallback.
 conmon_path = [
 	    "/usr/libexec/podman/conmon",
 	    "/usr/local/libexec/podman/conmon",
@@ -121,6 +123,8 @@ runtime = "runc"
 runtime_supports_json = ["runc"]
 
 # Paths to look for a valid OCI runtime (runc, runv, etc)
+# If the paths are empty or no valid path was found, then the `$PATH`
+# environment variable will be used as the fallback.
 [runtimes]
 runc = [
 	    "/usr/bin/runc",

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -106,8 +106,19 @@ func newOCIRuntime(name string, paths []string, conmonPath string, runtimeCfg *R
 		}
 		foundPath = true
 		runtime.path = path
+		logrus.Debugf("using runtime %q", path)
 		break
 	}
+
+	// Search the $PATH as last fallback
+	if !foundPath {
+		if foundRuntime, err := exec.LookPath(name); err == nil {
+			foundPath = true
+			runtime.path = foundRuntime
+			logrus.Debugf("using runtime %q from $PATH: %q", name, foundRuntime)
+		}
+	}
+
 	if !foundPath {
 		return nil, errors.Wrapf(define.ErrInvalidArg, "no valid executable found for OCI runtime %s", name)
 	}


### PR DESCRIPTION
The `$PATH` environment variable will now used as fallback if no valid
runtime or conmon path matches. The debug logs has been updated to state
the used executable.
