### PR TITLE
generate authfile path if nokeyring specified

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -53,7 +53,7 @@ func init() {
 	flags.BoolVar(&loginCommand.StdinPassword, "password-stdin", false, "Take the password from stdin")
 	// Disabled flags for the remote client
 	if !remote {
-		flags.StringVar(&loginCommand.Authfile, "authfile", shared.GetAuthFile(""), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+		flags.StringVar(&loginCommand.Authfile, "authfile", shared.GetAuthFile(""), "Path of the authentication file or 'nokeyring'. Use REGISTRY_AUTH_FILE environment variable to override")
 		flags.StringVar(&loginCommand.CertDir, "cert-dir", "", "Pathname of a directory containing TLS certificates and keys used to connect to the registry")
 		flags.BoolVar(&loginCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 	}
@@ -71,7 +71,7 @@ func loginCmd(c *cliconfig.LoginValues) error {
 	}
 	server := registryFromFullName(scrubServer(args[0]))
 
-	sc := image.GetSystemContext("", c.Authfile, false)
+	sc := image.GetSystemContext("", shared.GetAuthFile(c.Authfile), false)
 	if c.Flag("tls-verify").Changed {
 		sc.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!c.TlsVerify)
 	}

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -42,10 +42,10 @@ each of stdin, stdout, and stderr.
 
 **--authfile**=*path*
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Podman will use the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
-Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
-environment variable. `export REGISTRY_AUTH_FILE=path` (Not available for remote commands)
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--blkio-weight**=*weight*
 

--- a/docs/podman-login.1.md
+++ b/docs/podman-login.1.md
@@ -10,8 +10,13 @@ podman\-login - Login to a container registry
 **podman login** logs into a specified registry server with the correct username
 and password. **podman login** reads in the username and password from STDIN.
 The username and password can also be set using the **username** and **password** flags.
-The path of the authentication file can be specified by the user by setting the **authfile**
-flag. The default path used is **${XDG\_RUNTIME_DIR}/containers/auth.json**.
+The authentication storage can be set by the **authfile** option.
+By default, the authentication storage is the kernel keyring. If the system does not
+support kernel keyring, Podman will use the authentication file.
+The path of the authentication file can be specified by the user by setting the **authfile** option
+or REGISTRY\_AUTH\_FILE environment variable. The default path used is **${XDG\_RUNTIME_DIR}/containers/auth.json**.
+If the **authfile** is set to "nokeyring", Podman will use the default authentication path or the
+file set by REGISTRY\_AUTH\_FILE environment variable.
 
 **podman [GLOBAL OPTIONS]**
 
@@ -35,10 +40,9 @@ Username for registry
 
 **--authfile**=*path*
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json (Not available for remote commands)
+Path of the authentication file or "nokeyring". By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Podman will use the authentication file.  If **authfile** is set to "nokeyring", Podman will use the default authentication file ${XDG_\RUNTIME\_DIR}/containers/auth.json or the value of REGISTRY\_AUTH\_FILE environment variable (Not available for remote commands)
 
-Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
-environment variable. `export REGISTRY_AUTH_FILE=path`
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--get-login**
 

--- a/docs/podman-logout.1.md
+++ b/docs/podman-logout.1.md
@@ -7,10 +7,11 @@ podman\-logout - Logout of a container registry
 **podman logout** [*options*] *registry*
 
 ## DESCRIPTION
-**podman logout** logs out of a specified registry server by deleting the cached credentials
-stored in the **auth.json** file. The path of the authentication file can be overridden by the user by setting the **authfile** flag.
+**podman logout** logs out of a specified registry server by deleting the cached credentials stored in the kernel keyring.
+If the system does not support kernel keyring or the authorization state is not found there, Podman will check the authentication file.
+The path of the authentication file can be overridden by the user by setting the **authfile** flag.
 The default path used is **${XDG\_RUNTIME_DIR}/containers/auth.json**.
-All the cached credentials can be removed by setting the **all** flag.
+All the authentication file cached credentials can be removed by setting the **all** flag.
 
 **podman [GLOBAL OPTIONS]**
 
@@ -22,10 +23,11 @@ All the cached credentials can be removed by setting the **all** flag.
 
 **--authfile**=*path*
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json (Not available for remote commands)
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Podman will use the authentication file.
+Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
-Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
-environment variable. `export REGISTRY_AUTH_FILE=path`
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--all**, **-a**
 

--- a/docs/podman-play-kube.1.md
+++ b/docs/podman-play-kube.1.md
@@ -19,11 +19,10 @@ Note: HostPath volume types created by play kube will be given an SELinux privat
 
 **--authfile**=*path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Podman will use the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
-Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
-environment variable. `export REGISTRY_AUTH_FILE=path`
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--cert-dir**=*path*
 

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -53,11 +53,10 @@ Note: When using the all-tags flag, Podman will not iterate over the search regi
 
 **--authfile**=*path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Podman will use the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
-Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
-environment variable. `export REGISTRY_AUTH_FILE=path`
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--cert-dir**=*path*
 

--- a/docs/podman-push.1.md
+++ b/docs/podman-push.1.md
@@ -46,11 +46,10 @@ Image stored in local container/storage
 
 **--authfile**=*path*
 
-Path of the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Podman will use the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
 If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
-Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
-environment variable. `export REGISTRY_AUTH_FILE=path`
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--creds**=*[username[:password]]*
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -56,10 +56,10 @@ each of stdin, stdout, and stderr.
 
 **--authfile**[=*path*]
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json (Not available for remote commands)
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Podman will use the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
-Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
-environment variable. `export REGISTRY_AUTH_FILE=path`
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--blkio-weight**=*weight*
 

--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -27,10 +27,10 @@ Note, searching without a search term will only work for registries that impleme
 
 **--authfile**=*path*
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json (Not available for remote commands)
+Path of the authentication file. By default, the authentication storage is the kernel keyring. If the system does not support kernel keyring, Podman will use the authentication file. Default is ${XDG_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
 
-Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
-environment variable. `export REGISTRY_AUTH_FILE=path`
+Note: The default path of the authentication file can also be overridden by setting the REGISTRY_AUTH_FILE environment variable. `export REGISTRY_AUTH_FILE=path`
 
 **--filter**, **-f**=*filter*
 

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -236,4 +236,18 @@ var _ = Describe("Podman login and logout", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
+
+	It("podman login with --authfile=nokeyring", func() {
+		session := podmanTest.Podman([]string{"login", "--username", "podmantest", "--password", "test", "--authfile", "nokeyring", server})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"push", ALPINE, testImg})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"logout", server})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
This PR allows --authfile to be "nokeyring".
Returns empty string if both --authfile and REGISTRY_AUTH_FILE are not set.
Returns filepath if one of --authfile or REGISTRY_AUTH_FILE is set to a filepath. If --authfile and REGISTRY_AUTH_FILE are filepath, we respect --authfile

Signed-off-by: Qi Wang <qiwan@redhat.com>