### PR TITLE
restore: added --ignore-static-ip option

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -436,6 +436,7 @@ type RestoreValues struct {
 	Import         string
 	Name           string
 	IgnoreRootfs   bool
+	IgnoreStaticIP bool
 }
 
 type RmValues struct {

--- a/cmd/podman/restore.go
+++ b/cmd/podman/restore.go
@@ -46,6 +46,7 @@ func init() {
 	flags.StringVarP(&restoreCommand.Import, "import", "i", "", "Restore from exported checkpoint archive (tar.gz)")
 	flags.StringVarP(&restoreCommand.Name, "name", "n", "", "Specify new name for container restored from exported checkpoint (only works with --import)")
 	flags.BoolVar(&restoreCommand.IgnoreRootfs, "ignore-rootfs", false, "Do not apply root file-system changes when importing from exported checkpoint")
+	flags.BoolVar(&restoreCommand.IgnoreStaticIP, "ignore-static-ip", false, "Ignore IP address set via --static-ip")
 
 	markFlagHiddenForRemoteClient("latest", flags)
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -872,6 +872,7 @@ _podman_container_restore() {
 	  --latest
 	  --tcp-established
 	  --ignore-rootfs
+	  --ignore-static-ip
      "
      case "$prev" in
         -i|--import)

--- a/docs/podman-container-restore.1.md
+++ b/docs/podman-container-restore.1.md
@@ -67,6 +67,15 @@ from a checkpoint tar.gz file it is possible that it also contains all root file
 changes. With **--ignore-rootfs** it is possible to explicitly disable applying these
 root file-system changes to the restored container.
 
+**--ignore-static-ip**
+
+If the container was started with **--ip** the restored container also tries to use that
+IP address and restore fails if that IP address is already in use. This can happen, if
+a container is restored multiple times from an exported checkpoint with **--name, -n**.
+
+Using **--ignore-static-ip** tells Podman to ignore the IP address if it was configured
+with **--ip** during container creation.
+
 ## EXAMPLE
 
 podman container restore mywebserver

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -773,6 +773,11 @@ type ContainerCheckpointOptions struct {
 	// IgnoreRootfs tells the API to not export changes to
 	// the container's root file-system (or to not import)
 	IgnoreRootfs bool
+	// IgnoreStaticIP tells the API to ignore the IP set
+	// during 'podman run' with '--ip'. This is especially
+	// important to be able to restore a container multiple
+	// times with '--import --name'.
+	IgnoreStaticIP bool
 }
 
 // Checkpoint checkpoints a container

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -565,6 +565,7 @@ func (r *LocalRuntime) Restore(ctx context.Context, c *cliconfig.RestoreValues) 
 		TargetFile:     c.Import,
 		Name:           c.Name,
 		IgnoreRootfs:   c.IgnoreRootfs,
+		IgnoreStaticIP: c.IgnoreStaticIP,
 	}
 
 	filterFuncs = append(filterFuncs, func(c *libpod.Container) bool {


### PR DESCRIPTION
If a container is restored multiple times from an exported checkpoint with the help of '--import --name', the restore will fail if during 'podman run' a static container IP was set with '--ip'. The user can tell the restore process to ignore the static IP with '--ignore-static-ip'.