### PR TITLE
add eventlogger to info

### DIFF
--- a/API.md
+++ b/API.md
@@ -1721,6 +1721,8 @@ kernel [string](https://godoc.org/builtin#string)
 os [string](https://godoc.org/builtin#string)
 
 uptime [string](https://godoc.org/builtin#string)
+
+eventlogger [string](https://godoc.org/builtin#string)
 ### <a name="InfoPodmanBinary"></a>type InfoPodmanBinary
 
 InfoPodman provides details on the podman binary

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -228,7 +228,8 @@ type InfoHost (
     hostname: string,
     kernel: string,
     os: string,
-    uptime: string
+    uptime: string,
+    eventlogger: string
 )
 
 # InfoGraphStatus describes the detailed status of the storage driver

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -53,6 +53,8 @@ type Eventer interface {
 	Write(event Event) error
 	// Read an event from the backend
 	Read(options ReadOptions) error
+	// String returns the type of event logger
+	String() string
 }
 
 // ReadOptions describe the attributes needed to read event logs

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -146,3 +146,8 @@ func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) { /
 	}
 	return &newEvent, nil
 }
+
+// String returns a string representation of the logger
+func (e EventJournalD) String() string {
+	return Journald.String()
+}

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -71,3 +71,8 @@ func (e EventLogFile) Read(options ReadOptions) error {
 	close(options.EventChannel)
 	return nil
 }
+
+// String returns a string representation of the logger
+func (e EventLogFile) String() string {
+	return LogFile.String()
+}

--- a/libpod/events/nullout.go
+++ b/libpod/events/nullout.go
@@ -17,6 +17,10 @@ func (e EventToNull) Read(options ReadOptions) error {
 // NewNullEventer returns a new null eventer.  You should only do this for
 // the purposes on internal libpod testing.
 func NewNullEventer() Eventer {
-	e := EventToNull{}
-	return e
+	return EventToNull{}
+}
+
+// String returns a string representation of the logger
+func (e EventToNull) String() string {
+	return "none"
 }

--- a/libpod/info.go
+++ b/libpod/info.go
@@ -102,7 +102,7 @@ func (r *Runtime) hostInfo() (map[string]interface{}, error) {
 		return nil, errors.Wrapf(err, "error getting hostname")
 	}
 	info["hostname"] = host
-
+	info["eventlogger"] = r.eventer.String()
 	return info, nil
 }
 

--- a/pkg/adapter/client.go
+++ b/pkg/adapter/client.go
@@ -16,7 +16,7 @@ var remoteEndpoint *Endpoint
 
 func (r RemoteRuntime) RemoteEndpoint() (remoteEndpoint *Endpoint, err error) {
 	remoteConfigConnections, err := remoteclientconfig.ReadRemoteConfig(r.config)
-	if errors.Cause(err) != remoteclientconfig.ErrNoConfigationFile {
+	if err != nil && errors.Cause(err) != remoteclientconfig.ErrNoConfigationFile {
 		return nil, err
 	}
 	// If the user defines an env variable for podman_varlink_bridge
@@ -68,7 +68,6 @@ func (r RemoteRuntime) Connect() (*varlink.Connection, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	switch ep.Type {
 	case DirectConnection:
 		return varlink.NewConnection(ep.Connection)

--- a/pkg/varlinkapi/system.go
+++ b/pkg/varlinkapi/system.go
@@ -61,6 +61,7 @@ func (i *LibpodAPI) GetInfo(call iopodman.VarlinkCall) error {
 		Kernel:          host["kernel"].(string),
 		Os:              host["os"].(string),
 		Uptime:          host["uptime"].(string),
+		Eventlogger:     host["eventlogger"].(string),
 	}
 	podmanInfo.Host = infoHost
 	store := info[1].Data


### PR DESCRIPTION
to help with future debugging, we now display the type of event logger
being used inside podman info -> host.

Signed-off-by: baude <bbaude@redhat.com>