### PR TITLE
fix search output limit

### DIFF
--- a/docs/podman-search.1.md
+++ b/docs/podman-search.1.md
@@ -11,8 +11,8 @@ podman\-search - Search a registry for an image
 The user can specify which registry to search by prefixing the registry in the search term
 (example **registry.fedoraproject.org/fedora**), default is the registries in the
 **registries.search** table in the config file - **/etc/containers/registries.conf**.
-The number of results can be limited using the **--limit** flag. If more than one registry
-is being searched, the limit will be applied to each registry. The output can be filtered
+The default number of results is 25. The number of results can be limited using the **--limit** flag.
+If more than one registry is being searched, the limit will be applied to each registry. The output can be filtered
 using the **--filter** flag. To get all available images in a registry without a specific
 search term, the user can just enter the registry name with a trailing "/" (example **registry.fedoraproject.org/**).
 Note, searching without a search term will only work for registries that implement the v2 API.

--- a/libpod/image/search.go
+++ b/libpod/image/search.go
@@ -162,8 +162,11 @@ func searchImageInRegistry(term string, registry string, options SearchOptions) 
 	if len(results) < limit {
 		limit = len(results)
 	}
-	if options.Limit != 0 && options.Limit < len(results) {
-		limit = options.Limit
+	if options.Limit != 0 {
+		limit = len(results)
+		if options.Limit < len(results) {
+			limit = options.Limit
+		}
 	}
 
 	paramsArr := []SearchResult{}

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -118,10 +118,20 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search limit flag", func() {
-		search := podmanTest.Podman([]string{"search", "--limit", "3", "docker.io/alpine"})
+		search := podmanTest.Podman([]string{"search", "docker.io/alpine"})
+		search.WaitWithDefaultTimeout()
+		Expect(search.ExitCode()).To(Equal(0))
+		Expect(len(search.OutputToStringArray())).To(Equal(26))
+
+		search = podmanTest.Podman([]string{"search", "--limit", "3", "docker.io/alpine"})
 		search.WaitWithDefaultTimeout()
 		Expect(search.ExitCode()).To(Equal(0))
 		Expect(len(search.OutputToStringArray())).To(Equal(4))
+
+		search = podmanTest.Podman([]string{"search", "--limit", "30", "docker.io/alpine"})
+		search.WaitWithDefaultTimeout()
+		Expect(search.ExitCode()).To(Equal(0))
+		Expect(len(search.OutputToStringArray())).To(Equal(31))
 	})
 
 	It("podman search with filter stars", func() {


### PR DESCRIPTION
close https://bugzilla.redhat.com/show_bug.cgi?id=1732280
From the bug Podman search returns 25 results even when limit option `--limit` is larger than 25(maxQueries). They want Podman to return `--limit` results.

This PR fixes the number of output result.
if --limit not set, return MIN(maxQueries, len(res))
if --limit is set, return MIN(option, len(res))

Signed-off-by: Qi Wang <qiwan@redhat.com>