### PR TITLE
System tests: resolve hang in rawhide rootless

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -133,7 +133,9 @@ function run_podman() {
 
     # stdout is only emitted upon error; this echo is to help a debugger
     echo "\$ $PODMAN $*"
-    run timeout --foreground -v --kill=10 $PODMAN_TIMEOUT $PODMAN "$@"
+    # BATS hangs if a subprocess remains and keeps FD 3 open; this happens
+    # if podman crashes unexpectedly without cleaning up subprocesses.
+    run timeout --foreground -v --kill=10 $PODMAN_TIMEOUT $PODMAN "$@" 3>/dev/null
     # without "quotes", multiple lines are glommed together into one
     if [ -n "$output" ]; then
         echo "$output"


### PR DESCRIPTION
Fedora CI tests are failing on rawhide under kernel
5.3.0-0.rc1.git3.1.fc31 (rhbz#1736758). But there's
another insidious failure, a 4-hour hang in the
rootless tests on the same CI system. The culprit
line is in the podman build test, but it's actually
BATS itself that hangs, not the build command -- which
suggests that it's the usual FD 3 problem (see BATS README).
It would seem that podman is forking a process that
inherits fd 3 but that process is not getting cleaned
up when podman crashes upon encountering the kernel bug.

Today it's podman build, tomorrow it might be something
else. Let's just run all podman invocations in run_podman
with a non-bats FD 3.

Signed-off-by: Ed Santiago <santiago@redhat.com>