### PR TITLE
restore: correctly set StartedTime

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -52,6 +52,8 @@ func (r *Runtime) RestoreContainer(ctx context.Context, rSpec *spec.Spec, config
 	if err != nil {
 		return nil, errors.Wrapf(err, "error initializing container variables")
 	}
+	// For an imported checkpoint no one has ever set the StartedTime. Set it now.
+	ctr.state.StartedTime = time.Now()
 	return r.setupContainer(ctx, ctr)
 }
 


### PR DESCRIPTION
A container restored from an exported checkpoint did not have its StartedTime set. Which resulted in a status like 'Up 292 years ago' after the restore.

This just sets the StartedTime to time.Now() if a container is restored from an exported checkpoint.