### PR TITLE
add make to make installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,12 +333,12 @@ changelog: ## Generate changelog
 
 install: .gopathok install.bin install.remote install.man install.cni install.systemd  ## Install binaries to system locations
 
-install.remote:
+install.remote: podman-remote
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 bin/podman-remote $(DESTDIR)$(BINDIR)/podman-remote
 	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(DESTDIR)$(BINDIR)/podman bin/podman-remote
 
-install.bin:
+install.bin: podman
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 bin/podman $(DESTDIR)$(BINDIR)/podman
 	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(DESTDIR)$(BINDIR)/podman bin/podman

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -443,6 +443,9 @@ done
 sort -u -o devel.file-list devel.file-list
 %endif
 
+# Ensure buildroot is deleted
+rm -rf %{buildroot}
+
 %check
 %if 0%{?with_check} && 0%{?with_unit_test} && 0%{?with_devel}
 %if ! 0%{?with_bundled}


### PR DESCRIPTION
as issue #2702 describes, we want to make podman and podman-remote as
part of make install.

Fixes: #2702

Signed-off-by: baude <bbaude@redhat.com>