### PR TITLE
Add handling for empty LogDriver

### DIFF
--- a/libpod/oci_internal_linux.go
+++ b/libpod/oci_internal_linux.go
@@ -278,6 +278,10 @@ func (r *OCIRuntime) sharedConmonArgs(ctr *Container, cuuid, bundlePath, pidPath
 		// No case here should happen except JSONLogging, but keep this here in case the options are extended
 		logrus.Errorf("%s logging specified but not supported. Choosing k8s-file logging instead", ctr.LogDriver())
 		fallthrough
+	case "":
+		// to get here, either a user would specify `--log-driver ""`, or this came from another place in libpod
+		// since the former case is obscure, and the latter case isn't an error, let's silently fallthrough
+		fallthrough
 	case KubernetesLogging:
 		logDriver = fmt.Sprintf("%s:%s", KubernetesLogging, logPath)
 	}


### PR DESCRIPTION
There are two cases logdriver can be empty, if it wasn't set by libpod, or if the user did --log-driver ""
The latter case is an odd one, and the former is very possible and already handled for LogPath.
Instead of printing an error for an entirely reasonable codepath, let's supress the error


Note: this was discovered by using play kube, which definitely should not print this error, an alternative to fixing it here is adding the case in play kube, but I think it's better to handle it in libpod/oci*.