### PR TITLE
Change backend code for 'volume inspect'

### DIFF
--- a/API.md
+++ b/API.md
@@ -1975,8 +1975,6 @@ mountPoint [string](https://godoc.org/builtin#string)
 driver [string](https://godoc.org/builtin#string)
 
 options [map[string]](#map[string])
-
-scope [string](https://godoc.org/builtin#string)
 ### <a name="VolumeCreateOpts"></a>type VolumeCreateOpts
 
 

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -7,8 +7,7 @@ type Volume (
   labels: [string]string,
   mountPoint: string,
   driver: string,
-  options: [string]string,
-  scope: string
+  options: [string]string
 )
 
 type NotImplemented (

--- a/cmd/podman/volume_create.go
+++ b/cmd/podman/volume_create.go
@@ -38,7 +38,6 @@ func init() {
 	flags.StringVar(&volumeCreateCommand.Driver, "driver", "", "Specify volume driver name (default local)")
 	flags.StringSliceVarP(&volumeCreateCommand.Label, "label", "l", []string{}, "Set metadata for a volume (default [])")
 	flags.StringSliceVarP(&volumeCreateCommand.Opt, "opt", "o", []string{}, "Set driver specific options (default [])")
-
 }
 
 func volumeCreateCmd(c *cliconfig.VolumeCreateValues) error {

--- a/cmd/podman/volume_inspect.go
+++ b/cmd/podman/volume_inspect.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+
+	"github.com/containers/buildah/pkg/formats"
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
@@ -53,5 +56,24 @@ func volumeInspectCmd(c *cliconfig.VolumeInspectValues) error {
 	if err != nil {
 		return err
 	}
-	return generateVolLsOutput(vols, volumeLsOptions{Format: c.Format})
+
+	switch c.Format {
+	case "", formats.JSONString:
+		// Normal format - JSON string
+		jsonOut, err := json.MarshalIndent(vols, "", "     ")
+		if err != nil {
+			return errors.Wrapf(err, "error marshalling inspect JSON")
+		}
+		fmt.Println(string(jsonOut))
+	default:
+		// It's a Go template.
+		interfaces := make([]interface{}, len(vols))
+		for i, vol := range vols {
+			interfaces[i] = vol
+		}
+		out := formats.StdoutTemplateArray{Output: interfaces, Template: c.Format}
+		return out.Out()
+	}
+
+	return nil
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1362,6 +1362,17 @@ func WithNamedVolumes(volumes []*ContainerNamedVolume) CtrCreateOption {
 	}
 }
 
+// WithHealthCheck adds the healthcheck to the container config
+func WithHealthCheck(healthCheck *manifest.Schema2HealthConfig) CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+		ctr.config.HealthCheckConfig = healthCheck
+		return nil
+	}
+}
+
 // Volume Creation Options
 
 // WithVolumeName sets the name of the volume.
@@ -1381,6 +1392,19 @@ func WithVolumeName(name string) VolumeCreateOption {
 	}
 }
 
+// WithVolumeDriver sets the volume's driver.
+// It is presently not implemented, but will be supported in a future Podman
+// release.
+func WithVolumeDriver(driver string) VolumeCreateOption {
+	return func(volume *Volume) error {
+		if volume.valid {
+			return define.ErrVolumeFinalized
+		}
+
+		return define.ErrNotImplemented
+	}
+}
+
 // WithVolumeLabels sets the labels of the volume.
 func WithVolumeLabels(labels map[string]string) VolumeCreateOption {
 	return func(volume *Volume) error {
@@ -1392,19 +1416,6 @@ func WithVolumeLabels(labels map[string]string) VolumeCreateOption {
 		for key, value := range labels {
 			volume.config.Labels[key] = value
 		}
-
-		return nil
-	}
-}
-
-// WithVolumeDriver sets the driver of the volume.
-func WithVolumeDriver(driver string) VolumeCreateOption {
-	return func(volume *Volume) error {
-		if volume.valid {
-			return define.ErrVolumeFinalized
-		}
-
-		volume.config.Driver = driver
 
 		return nil
 	}
@@ -1670,17 +1681,6 @@ func WithInfraContainerPorts(bindings []ocicni.PortMapping) PodCreateOption {
 			return define.ErrPodFinalized
 		}
 		pod.config.InfraContainer.PortBindings = bindings
-		return nil
-	}
-}
-
-// WithHealthCheck adds the healthcheck to the container config
-func WithHealthCheck(healthCheck *manifest.Schema2HealthConfig) CtrCreateOption {
-	return func(ctr *Container) error {
-		if ctr.valid {
-			return define.ErrCtrFinalized
-		}
-		ctr.config.HealthCheckConfig = healthCheck
 		return nil
 	}
 }

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/events"
@@ -42,14 +43,10 @@ func (r *Runtime) newVolume(ctx context.Context, options ...VolumeCreateOption) 
 	if volume.config.Name == "" {
 		volume.config.Name = stringid.GenerateNonCryptoID()
 	}
-	// TODO: support for other volume drivers
 	if volume.config.Driver == "" {
 		volume.config.Driver = "local"
 	}
-	// TODO: determine when the scope is global and set it to that
-	if volume.config.Scope == "" {
-		volume.config.Scope = "local"
-	}
+	volume.config.CreatedTime = time.Now()
 
 	// Create the mountpoint of this volume
 	volPathRoot := filepath.Join(r.config.VolumePath, volume.config.Name)

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -1,5 +1,9 @@
 package libpod
 
+import (
+	"time"
+)
+
 // Volume is the type used to create named volumes
 // TODO: all volumes should be created using this and the Volume API
 type Volume struct {
@@ -15,10 +19,10 @@ type VolumeConfig struct {
 	Name string `json:"name"`
 
 	Labels        map[string]string `json:"labels"`
-	MountPoint    string            `json:"mountPoint"`
 	Driver        string            `json:"driver"`
+	MountPoint    string            `json:"mountPoint"`
+	CreatedTime   time.Time         `json:"createdAt,omitempty"`
 	Options       map[string]string `json:"options"`
-	Scope         string            `json:"scope"`
 	IsCtrSpecific bool              `json:"ctrSpecific"`
 	UID           int               `json:"uid"`
 	GID           int               `json:"gid"`
@@ -27,6 +31,18 @@ type VolumeConfig struct {
 // Name retrieves the volume's name
 func (v *Volume) Name() string {
 	return v.config.Name
+}
+
+// Driver retrieves the volume's driver.
+func (v *Volume) Driver() string {
+	return v.config.Driver
+}
+
+// Scope retrieves the volume's scope.
+// Libpod does not implement volume scoping, and this is provided solely for
+// Docker compatability. It returns only "local".
+func (v *Volume) Scope() string {
+	return "local"
 }
 
 // Labels returns the volume's labels
@@ -43,11 +59,6 @@ func (v *Volume) MountPoint() string {
 	return v.config.MountPoint
 }
 
-// Driver returns the volume's driver
-func (v *Volume) Driver() string {
-	return v.config.Driver
-}
-
 // Options return the volume's options
 func (v *Volume) Options() map[string]string {
 	options := make(map[string]string)
@@ -58,14 +69,25 @@ func (v *Volume) Options() map[string]string {
 	return options
 }
 
-// Scope returns the scope of the volume
-func (v *Volume) Scope() string {
-	return v.config.Scope
-}
-
 // IsCtrSpecific returns whether this volume was created specifically for a
 // given container. Images with this set to true will be removed when the
 // container is removed with the Volumes parameter set to true.
 func (v *Volume) IsCtrSpecific() bool {
 	return v.config.IsCtrSpecific
+}
+
+// UID returns the UID the volume will be created as.
+func (v *Volume) UID() int {
+	return v.config.UID
+}
+
+// GID returns the GID the volume will be created as.
+func (v *Volume) GID() int {
+	return v.config.GID
+}
+
+// CreatedTime returns the time the volume was created at. It was not tracked
+// for some time, so older volumes may not contain one.
+func (v *Volume) CreatedTime() time.Time {
+	return v.config.CreatedTime
 }

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -40,7 +40,7 @@ func (v *Volume) Driver() string {
 
 // Scope retrieves the volume's scope.
 // Libpod does not implement volume scoping, and this is provided solely for
-// Docker compatability. It returns only "local".
+// Docker compatibility. It returns only "local".
 func (v *Volume) Scope() string {
 	return "local"
 }

--- a/libpod/volume_inspect.go
+++ b/libpod/volume_inspect.go
@@ -19,7 +19,7 @@ type InspectVolumeData struct {
 	// CreatedAt is the date and time the volume was created at. This is not
 	// stored for older Libpod volumes; if so, it will be omitted.
 	CreatedAt time.Time `json:"CreatedAt,omitempty"`
-	// Status is presently unused and provided only for Docker compatability.
+	// Status is presently unused and provided only for Docker compatibility.
 	// In the future it will be used to return information on the volume's
 	// current state.
 	Status map[string]string `json:"Status,omitempty"`
@@ -27,7 +27,7 @@ type InspectVolumeData struct {
 	// can be passed during volume creation to provide information for third
 	// party tools.
 	Labels map[string]string `json:"Labels"`
-	// Scope is unused and provided solely for Docker compatability. It is
+	// Scope is unused and provided solely for Docker compatibility. It is
 	// unconditionally set to "local".
 	Scope string `json:"Scope"`
 	// Options is a set of options that were used when creating the volume.

--- a/libpod/volume_inspect.go
+++ b/libpod/volume_inspect.go
@@ -1,0 +1,70 @@
+package libpod
+
+import (
+	"time"
+
+	"github.com/containers/libpod/libpod/define"
+)
+
+// InspectVolumeData is the output of Inspect() on a volume. It is matched to
+// the format of 'docker volume inspect'.
+type InspectVolumeData struct {
+	// Name is the name of the volume.
+	Name string `json:"Name"`
+	// Driver is the driver used to create the volume.
+	// This will be properly implemented in a future version.
+	Driver string `json:"Driver"`
+	// Mountpoint is the path on the host where the volume is mounted.
+	Mountpoint string `json:"Mountpoint"`
+	// CreatedAt is the date and time the volume was created at. This is not
+	// stored for older Libpod volumes; if so, it will be omitted.
+	CreatedAt time.Time `json:"CreatedAt,omitempty"`
+	// Status is presently unused and provided only for Docker compatability.
+	// In the future it will be used to return information on the volume's
+	// current state.
+	Status map[string]string `json:"Status,omitempty"`
+	// Labels includes the volume's configured labels, key:value pairs that
+	// can be passed during volume creation to provide information for third
+	// party tools.
+	Labels map[string]string `json:"Labels"`
+	// Scope is unused and provided solely for Docker compatability. It is
+	// unconditionally set to "local".
+	Scope string `json:"Scope"`
+	// Options is a set of options that were used when creating the volume.
+	// It is presently not used.
+	Options map[string]string `json:"Options"`
+	// UID is the UID that the volume was created with.
+	UID int `json:"UID,omitempty"`
+	// GID is the GID that the volume was created with.
+	GID int `json:"GID,omitempty"`
+	// ContainerSpecific indicates that the volume was created as part of a
+	// specific container, and will be removed when that container is
+	// removed.
+	ContainerSpecific bool `json:"ContainerSpecific,omitempty"`
+}
+
+// Inspect provides detailed information about the configuration of the given
+// volume.
+func (v *Volume) Inspect() (*InspectVolumeData, error) {
+	if !v.valid {
+		return nil, define.ErrVolumeRemoved
+	}
+
+	data := new(InspectVolumeData)
+
+	data.Name = v.config.Name
+	data.Driver = v.config.Driver
+	data.Mountpoint = v.config.MountPoint
+	data.CreatedAt = v.config.CreatedTime
+	data.Labels = make(map[string]string)
+	for k, v := range v.config.Labels {
+		data.Labels[k] = v
+	}
+	data.Scope = v.Scope()
+	data.Options = make(map[string]string)
+	data.UID = v.config.UID
+	data.GID = v.config.GID
+	data.ContainerSpecific = v.config.IsCtrSpecific
+
+	return data, nil
+}

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -661,7 +661,6 @@ func varlinkVolumeToVolume(r *LocalRuntime, volumes []iopodman.Volume) []*Volume
 			MountPoint: v.MountPoint,
 			Driver:     v.Driver,
 			Options:    v.Options,
-			Scope:      v.Scope,
 		}
 		n := remoteVolume{
 			Runtime: r,

--- a/pkg/adapter/volumes_remote.go
+++ b/pkg/adapter/volumes_remote.go
@@ -29,5 +29,5 @@ func (v *Volume) MountPoint() string {
 
 // Scope returns the scope for an adapter.volume
 func (v *Volume) Scope() string {
-	return v.config.Scope
+	return "local"
 }

--- a/pkg/varlinkapi/volumes.go
+++ b/pkg/varlinkapi/volumes.go
@@ -68,7 +68,6 @@ func (i *LibpodAPI) GetVolumes(call iopodman.VarlinkCall, args []string, all boo
 			MountPoint: v.MountPoint(),
 			Name:       v.Name(),
 			Options:    v.Options(),
-			Scope:      v.Scope(),
 		}
 		volumes = append(volumes, newVol)
 	}


### PR DESCRIPTION
Right now, `podman volume inspect` JSON's the internal volume configuration, then prints it.

This is really not healthy from a maintenance perspective - it forces our internal data format to be the same as what we display to the world, and further forces us to maintain the internal format exactly identical to Docker. It's definitely not good practice, and not sustainable as I start to modify the way volumes work to allow for volume plugins and NFS/other filesystem backed volumes.

Make a new internal `Inspect` function for volumes, and use that instead. This clears the way for further volume enhancements.