### PR TITLE
Don't log errors to the screen when XDG_RUNTIME_DIR is not set

### DIFF
--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -26,7 +26,7 @@ func GetRootlessRuntimeDir() (string, error) {
 		if runtimeDir == "" {
 			tmpDir := filepath.Join("/run", "user", uid)
 			if err := os.MkdirAll(tmpDir, 0700); err != nil {
-				logrus.Errorf("unable to make temp dir %s", tmpDir)
+				logrus.Debugf("unable to make temp dir %s", tmpDir)
 			}
 			st, err := os.Stat(tmpDir)
 			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && st.Mode().Perm() == 0700 {
@@ -36,7 +36,7 @@ func GetRootlessRuntimeDir() (string, error) {
 		if runtimeDir == "" {
 			tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("run-%s", uid))
 			if err := os.MkdirAll(tmpDir, 0700); err != nil {
-				logrus.Errorf("unable to make temp dir %s", tmpDir)
+				logrus.Debugf("unable to make temp dir %s", tmpDir)
 			}
 			st, err := os.Stat(tmpDir)
 			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && st.Mode().Perm() == 0700 {


### PR DESCRIPTION
Drop errors to debug when trying to setup the runtimetmpdir.  If the tool
can not setup a runtime dir, it will error out with a correct message
no need to put errors on the screen, when the tool actually succeeds.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>