### PR TITLE
fix system df crashes on unnamed images

### DIFF
--- a/cmd/podman/system_df.go
+++ b/cmd/podman/system_df.go
@@ -460,11 +460,11 @@ func getImageVerboseDiskUsage(ctx context.Context, images []*image.Image, images
 		}
 		var repo string
 		var tag string
-		if len(img.Names()) == 0 {
-			repo = "<none>"
-			tag = "<none>"
+		var repotags []string
+		if len(img.Names()) != 0 {
+			repotags = []string{img.Names()[0]}
 		}
-		repopairs, err := image.ReposToMap([]string{img.Names()[0]})
+		repopairs, err := image.ReposToMap(repotags)
 		if err != nil {
 			logrus.Errorf("error finding tag/digest for %s", img.ID())
 		}


### PR DESCRIPTION
close #3711
if the image is unnamed, pass an nil slice to the parse repotags function instead of getting the image name by index.

after this patch, unnamed images will be shown as <none>

```
Images space usage:

REPOSITORY                    TAG      IMAGE ID       CREATED        SIZE     SHARED SIZE   UNIQUE SIZE   CONTAINERS
docker.io/library/ubuntu      bionic   3556258649b2   11 days ago    66.6MB   0B            66.6MB        0
<none>                        <none>   dd8a8db2c79b   11 days ago    986MB    66.6MB        919MB         0

```

Signed-off-by: Qi Wang <qiwan@redhat.com>