### PR TITLE
honor libpod.conf in /usr/share/containers

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -52,7 +52,7 @@ const (
 var (
 	// InstallPrefix is the prefix where podman will be installed.
 	// It can be overridden at build time.
-	installPrefix = "/usr/local"
+	installPrefix = "/usr"
 	// EtcDir is the sysconfdir where podman should look for system config files.
 	// It can be overridden at build time.
 	etcDir = "/etc"


### PR DESCRIPTION
we should be looking for the libpod.conf file in /usr/share/containers
and not in /usr/local.  packages of podman should drop the default
libpod.conf in /usr/share.  the override remains /etc/containers/ as
well.

Fixes: #3702

Signed-off-by: baude <bbaude@redhat.com>