### PR TITLE
make rmi messages more compatible with docker

### DIFF
--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -28,6 +28,7 @@ import (
 // RemoveImage deletes an image from local storage
 // Images being used by running containers can only be removed if force=true
 func (r *Runtime) RemoveImage(ctx context.Context, img *image.Image, force bool) (string, error) {
+	var returnMessage string
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
@@ -93,7 +94,11 @@ func (r *Runtime) RemoveImage(ctx context.Context, img *image.Image, force bool)
 			err = errStorage
 		}
 	}
-	return img.ID(), err
+	for _, name := range img.Names() {
+		returnMessage = returnMessage + fmt.Sprintf("Untagged: %s\n", name)
+	}
+	returnMessage = returnMessage + fmt.Sprintf("Deleted: %s", img.ID())
+	return returnMessage, err
 }
 
 // Remove containers that are in storage rather than Podman.


### PR DESCRIPTION
in the case where we rmi an image that has only one reponame, we print
out an untagged reponame message.

$ sudo podman rmi busybox
Untagged: docker.io/library/busybox:latest
Deleted: db8ee88ad75f6bdc74663f4992a185e2722fa29573abcc1a19186cc5ec09dceb

Signed-off-by: baude <bbaude@redhat.com>