### PR TITLE
podman-container-runlabel(1): drop note

### DIFF
--- a/docs/podman-container-runlabel.1.md
+++ b/docs/podman-container-runlabel.1.md
@@ -20,8 +20,6 @@ If the container image has a LABEL INSTALL instruction like the following:
 If the container image does not have the desired label, an error message will be displayed along with a non-zero
 return code.  If the image is not found in local storage, Podman will attempt to pull it first.
 
-Note: Podman will always ensure that `podman` is the first argument of the command being executed.
-
 **LABEL**
 The label name specified via the command.
 


### PR DESCRIPTION
Drop the note that Podman ensures to always be the first command.
Runlabels allows for executing any command on the host - which is
something we don't necessarily need to advertise or encourage.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>