### PR TITLE
cgroup: fix regression when running systemd

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -471,9 +471,9 @@ func (c *Container) setupSystemd(mounts []spec.Mount, g generate.Generator) erro
 		return err
 	}
 
-	g.RemoveMount("/sys/fs/cgroup")
-
 	if unified {
+		g.RemoveMount("/sys/fs/cgroup")
+
 		sourcePath := filepath.Join("/sys/fs/cgroup")
 		systemdMnt := spec.Mount{
 			Destination: "/sys/fs/cgroup",
@@ -483,31 +483,13 @@ func (c *Container) setupSystemd(mounts []spec.Mount, g generate.Generator) erro
 		}
 		g.AddMount(systemdMnt)
 	} else {
-		// rootless containers have no write access to /sys/fs/cgroup, so don't
-		// add any mount into the container.
-		if !rootless.IsRootless() {
-			cgroupPath, err := c.CGroupPath()
-			if err != nil {
-				return err
-			}
-			sourcePath := filepath.Join("/sys/fs/cgroup", cgroupPath)
-
-			systemdMnt := spec.Mount{
-				Destination: "/sys/fs/cgroup",
-				Type:        "bind",
-				Source:      sourcePath,
-				Options:     []string{"bind", "private"},
-			}
-			g.AddMount(systemdMnt)
-		} else {
-			systemdMnt := spec.Mount{
-				Destination: "/sys/fs/cgroup",
-				Type:        "bind",
-				Source:      "/sys/fs/cgroup",
-				Options:     []string{"bind", "nodev", "noexec", "nosuid"},
-			}
-			g.AddMount(systemdMnt)
+		systemdMnt := spec.Mount{
+			Destination: "/sys/fs/cgroup/systemd",
+			Type:        "bind",
+			Source:      "/sys/fs/cgroup/systemd",
+			Options:     []string{"bind", "nodev", "noexec", "nosuid"},
 		}
+		g.AddMount(systemdMnt)
 	}
 
 	return nil


### PR DESCRIPTION
commit 223fe64dc0a592fd44e0c9fde9f9e0ca087d566f introduced the
regression.

When running on cgroups v1, bind mount only /sys/fs/cgroup/systemd as
rw, as the code did earlier.

Also, simplify the rootless code as it doesn't require any special
handling when using --systemd.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1737554

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>