### PR TITLE
pod top test: reenable

### DIFF
--- a/test/system/200-pod-top.bats
+++ b/test/system/200-pod-top.bats
@@ -3,8 +3,6 @@
 load helpers
 
 @test "podman pod top - containers in different PID namespaces" {
-    skip "this test is not reliable. Reenable once pod-top is fixed."
-
     # With infra=false, we don't get a /pause container (we also
     # don't pull k8s.gcr.io/pause )
     no_infra='--infra=false'
@@ -28,9 +26,6 @@ load helpers
 
     # By default (podman pod create w/ default --infra) there should be
     # a /pause container.
-    # FIXME: sometimes there is, sometimes there isn't. If anyone ever
-    # actually figures this out, please either reenable this line or
-    # remove it entirely.
     if [ -z "$no_infra" ]; then
         is "$output" ".*0 \+1 \+0 \+[0-9. ?s]\+/pause" "there is a /pause container"
     fi


### PR DESCRIPTION
It looks like #2780 is fixed: an overnight run yielded no
instances of 'pod top' returning incomplete output.

Signed-off-by: Ed Santiago <santiago@redhat.com>