### PR TITLE
fix create&run getting --authfile from cli

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -83,7 +83,7 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		} else {
 			return nil, nil, errors.Errorf("error, no input arguments were provided")
 		}
-		newImage, err := runtime.ImageRuntime().New(ctx, name, rtc.SignaturePolicyPath, GetAuthFile(""), writer, nil, image.SigningOptions{}, false, nil)
+		newImage, err := runtime.ImageRuntime().New(ctx, name, rtc.SignaturePolicyPath, GetAuthFile(c.String("authfile")), writer, nil, image.SigningOptions{}, false, nil)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/podman/shared/intermediate.go
+++ b/cmd/podman/shared/intermediate.go
@@ -366,6 +366,7 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIRes
 	m["add-host"] = newCRStringSlice(c, "add-host")
 	m["annotation"] = newCRStringSlice(c, "annotation")
 	m["attach"] = newCRStringSlice(c, "attach")
+	m["authfile"] = newCRString(c, "authfile")
 	m["blkio-weight"] = newCRString(c, "blkio-weight")
 	m["blkio-weight-device"] = newCRStringSlice(c, "blkio-weight-device")
 	m["cap-add"] = newCRStringSlice(c, "cap-add")

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -127,6 +127,10 @@ var _ = Describe("Podman login and logout", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
+		session = podmanTest.Podman([]string{"run", "--authfile", authFile, testImg})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
 		session = podmanTest.Podman([]string{"logout", "--authfile", authFile, server})
 	})
 


### PR DESCRIPTION
close #3730  
Add flag `--authfile` to create and run so Podman can read authfile path from not only environment variable REGISTRY_AUTH_FILE but also CLI

Signed-off-by: Qi Wang <qiwan@redhat.com>