### PR TITLE
Conmon pid file

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -54,6 +54,14 @@ func (r *Runtime) RestoreContainer(ctx context.Context, rSpec *spec.Spec, config
 	}
 	// For an imported checkpoint no one has ever set the StartedTime. Set it now.
 	ctr.state.StartedTime = time.Now()
+
+	// If the path to ConmonPidFile starts with the default value (RunRoot), then
+	// the user has not specified '--conmon-pidfile' during run or create (probably).
+	// In that case reset ConmonPidFile to be set to the default value later.
+	if strings.HasPrefix(ctr.config.ConmonPidFile, r.config.StorageConfig.RunRoot) {
+		ctr.config.ConmonPidFile = ""
+	}
+
 	return r.setupContainer(ctx, ctr)
 }
 

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -375,23 +375,28 @@ var _ = Describe("Podman checkpoint", func() {
 		result := podmanTest.Podman([]string{"container", "checkpoint", "-l", "-e", fileName})
 		result.WaitWithDefaultTimeout()
 
+		// As the container has been started with '--rm' it will be completely
+		// cleaned up after checkpointing.
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
 
-		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
+		// Restore container the first time with different name.
+		// Using '--ignore-static-ip' as for parallel test runs
+		// each containers gets a random IP address via '--ip'.
+		// '--ignore-static-ip' tells the restore to use the next
+		// available IP address.
+		// First restore the container with a new name/ID to make
+		// sure nothing in the restored container depends on the
+		// original container.
+		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName, "-n", "restore_again", "--ignore-static-ip"})
 		result.WaitWithDefaultTimeout()
 
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(1))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring("Up"))
 
-		// Restore container a second time with different name.
-		// Using '--ignore-static-ip' as for parallel test runs
-		// each containers gets a random IP address via '--ip'.
-		// '--ignore-static-ip' tells the restore to use the next
-		// available IP address.
-		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName, "-n", "restore_again", "--ignore-static-ip"})
+		result = podmanTest.Podman([]string{"container", "restore", "-i", fileName})
 		result.WaitWithDefaultTimeout()
 
 		Expect(result.ExitCode()).To(Equal(0))


### PR DESCRIPTION
All containers restored multiple times from the same checkpoint were using the same `conmon.pid` file. Always the last restored container was overwriting the file of the original container. Restoring a container with a new name failed if the original container was not running any more or not restored first.