### PR TITLE
When populating CMD, do not include Entrypoint

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -588,6 +588,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		workDir = data.Config.WorkingDir
 	}
 
+	userCommand := []string{}
 	entrypoint := configureEntrypoint(c, data)
 	// Build the command
 	// If we have an entry point, it goes first
@@ -597,9 +598,11 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 	if len(inputCommand) > 0 {
 		// User command overrides data CMD
 		command = append(command, inputCommand...)
+		userCommand = append(userCommand, inputCommand...)
 	} else if data != nil && len(data.Config.Cmd) > 0 && !c.IsSet("entrypoint") {
 		// If not user command, add CMD
 		command = append(command, data.Config.Cmd...)
+		userCommand = append(userCommand, data.Config.Cmd...)
 	}
 
 	if data != nil && len(command) == 0 {
@@ -680,6 +683,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		Cgroupns:          c.String("cgroupns"),
 		CgroupParent:      c.String("cgroup-parent"),
 		Command:           command,
+		UserCommand:       userCommand,
 		Detach:            c.Bool("detach"),
 		Devices:           c.StringSlice("device"),
 		DNSOpt:            c.StringSlice("dns-opt"),

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -64,8 +64,9 @@ type CreateConfig struct {
 	CidFile            string
 	ConmonPidFile      string
 	Cgroupns           string
-	CgroupParent       string // cgroup-parent
-	Command            []string
+	CgroupParent       string            // cgroup-parent
+	Command            []string          // Full command that will be used
+	UserCommand        []string          // User-entered command (or image CMD)
 	Detach             bool              // detach
 	Devices            []string          // device
 	DNSOpt             []string          //dns-opt
@@ -230,8 +231,8 @@ func (c *CreateConfig) getContainerCreateOptions(runtime *libpod.Runtime, pod *l
 		options = append(options, libpod.WithNamedVolumes(namedVolumes))
 	}
 
-	if len(c.Command) != 0 {
-		options = append(options, libpod.WithCommand(c.Command))
+	if len(c.UserCommand) != 0 {
+		options = append(options, libpod.WithCommand(c.UserCommand))
 	}
 
 	// Add entrypoint unconditionally

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -218,4 +218,17 @@ var _ = Describe("Podman create", func() {
 		match, _ := check.GrepString("foobar")
 		Expect(match).To(BeTrue())
 	})
+
+	It("podman run entrypoint and cmd test", func() {
+		name := "test101"
+		create := podmanTest.Podman([]string{"create", "--name", name, redis})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(Equal(0))
+
+		ctrJSON := podmanTest.InspectContainer(name)
+		Expect(len(ctrJSON)).To(Equal(1))
+		Expect(len(ctrJSON[0].Config.Cmd)).To(Equal(1))
+		Expect(ctrJSON[0].Config.Cmd[0]).To(Equal("redis-server"))
+		Expect(ctrJSON[0].Config.Entrypoint).To(Equal("docker-entrypoint.sh"))
+	})
 })


### PR DESCRIPTION
Previously, we use CreateConfig's Command to populate container Command (which is used as CMD for Inspect and Commit). Unfortunately, CreateConfig's Command is the container's full command, including a prepend of Entrypoint - so we duplicate Entrypoint for images that include it.

Maintain a separate UserCommand in CreateConfig that does not include the entrypoint, and use that instead.

Fixes #3708