### PR TITLE
systemd library conflict with seektail and addmatch

### DIFF
--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -54,14 +54,17 @@ func (e EventJournalD) Read(options ReadOptions) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate event options")
 	}
-	podmanJournal := sdjournal.Match{Field: "SYSLOG_IDENTIFIER", Value: "podman"} //nolint
-	j, err := sdjournal.NewJournal()                                              //nolint
+	j, err := sdjournal.NewJournal() //nolint
 	if err != nil {
 		return err
 	}
-	if err := j.AddMatch(podmanJournal.String()); err != nil {
-		return errors.Wrap(err, "failed to add filter for event log")
-	}
+	// TODO AddMatch and Seek seem to conflict
+	// Issue filed upstream -> https://github.com/coreos/go-systemd/issues/315
+	// Leaving commented code in case upstream fixes things
+	//podmanJournal := sdjournal.Match{Field: "SYSLOG_IDENTIFIER", Value: "podman"} //nolint
+	//if err := j.AddMatch(podmanJournal.String()); err != nil {
+	//	return errors.Wrap(err, "failed to add filter for event log")
+	//}
 	if len(options.Since) == 0 && len(options.Until) == 0 && options.Stream {
 		if err := j.SeekTail(); err != nil {
 			return errors.Wrap(err, "failed to seek end of journal")
@@ -95,6 +98,12 @@ func (e EventJournalD) Read(options ReadOptions) error {
 		entry, err := j.GetEntry()
 		if err != nil {
 			return err
+		}
+		// TODO this keeps us from feeding the podman event parser with
+		// with regular journal content; it can be removed if the above
+		// problem with AddMatch is resolved.
+		if entry.Fields["PODMAN_EVENT"] == "" {
+			continue
 		}
 		newEvent, err := newEventFromJournalEntry(entry)
 		if err != nil {


### PR DESCRIPTION
it looks like the core-os systemd library has some issue when using
seektail and add match.  this patch works around that shortcoming for
the time being.

Fixes: #3616
Signed-off-by: baude <bbaude@redhat.com>