### PR TITLE
enable windows remote client

### DIFF
--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -1,4 +1,5 @@
 // +build !remoteclient
+// +build linux
 
 package main
 

--- a/cmd/podman/main_remote.go
+++ b/cmd/podman/main_remote.go
@@ -3,14 +3,8 @@
 package main
 
 import (
-	"fmt"
-	"os"
 	"os/user"
-	"path/filepath"
 
-	"github.com/containers/libpod/pkg/util"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -29,49 +23,6 @@ func init() {
 	// rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.VarlinkAddress, "varlink-address", adapter.DefaultAddress, "address of the varlink socket")
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.LogLevel, "log-level", "error", "Log messages above specified level: debug, info, warn, error, fatal or panic. Logged to ~/.config/containers/podman.log")
 	rootCmd.PersistentFlags().BoolVar(&MainGlobalOpts.Syslog, "syslog", false, "Output logging information to syslog as well as the console")
-}
-
-func setSyslog() error {
-	var err error
-	cfgHomeDir := os.Getenv("XDG_CONFIG_HOME")
-	if cfgHomeDir == "" {
-		if cfgHomeDir, err = util.GetRootlessConfigHomeDir(); err != nil {
-			return err
-		}
-		if err = os.Setenv("XDG_CONFIG_HOME", cfgHomeDir); err != nil {
-			return errors.Wrapf(err, "cannot set XDG_CONFIG_HOME")
-		}
-	}
-	path := filepath.Join(cfgHomeDir, "containers")
-
-	// Log to file if not using syslog
-
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if err := os.MkdirAll(path, 0750); err != nil {
-			fmt.Fprintf(os.Stderr, "%v", err)
-			return err
-		}
-	}
-
-	// Update path to include file name
-	path = filepath.Join(path, "podman.log")
-
-	// Create the log file if doesn't exist. And append to it if it already exists.
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0640)
-	if err != nil {
-		// Cannot open log file. Logging to stderr
-		fmt.Fprintf(os.Stderr, "%v", err)
-		return err
-	} else {
-		formatter := new(logrus.TextFormatter)
-		formatter.FullTimestamp = true
-		logrus.SetFormatter(formatter)
-		logrus.SetOutput(file)
-	}
-
-	// Note this message is only logged if --log-level >= Info!
-	logrus.Infof("Logging level set to %s", logrus.GetLevel().String())
-	return nil
 }
 
 func profileOn(cmd *cobra.Command) error {

--- a/cmd/podman/main_remote_supported.go
+++ b/cmd/podman/main_remote_supported.go
@@ -1,0 +1,57 @@
+// +build remoteclient
+// +build linux darwin
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/libpod/pkg/util"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func setSyslog() error {
+	var err error
+	cfgHomeDir := os.Getenv("XDG_CONFIG_HOME")
+	if cfgHomeDir == "" {
+		if cfgHomeDir, err = util.GetRootlessConfigHomeDir(); err != nil {
+			return err
+		}
+		if err = os.Setenv("XDG_CONFIG_HOME", cfgHomeDir); err != nil {
+			return errors.Wrapf(err, "cannot set XDG_CONFIG_HOME")
+		}
+	}
+	path := filepath.Join(cfgHomeDir, "containers")
+
+	// Log to file if not using syslog
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if err := os.MkdirAll(path, 0750); err != nil {
+			fmt.Fprintf(os.Stderr, "%v", err)
+			return err
+		}
+	}
+
+	// Update path to include file name
+	path = filepath.Join(path, "podman.log")
+
+	// Create the log file if doesn't exist. And append to it if it already exists.
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0640)
+	if err != nil {
+		// Cannot open log file. Logging to stderr
+		fmt.Fprintf(os.Stderr, "%v", err)
+		return err
+	} else {
+		formatter := new(logrus.TextFormatter)
+		formatter.FullTimestamp = true
+		logrus.SetFormatter(formatter)
+		logrus.SetOutput(file)
+	}
+
+	// Note this message is only logged if --log-level >= Info!
+	logrus.Infof("Logging level set to %s", logrus.GetLevel().String())
+	return nil
+}

--- a/cmd/podman/main_remote_windows.go
+++ b/cmd/podman/main_remote_windows.go
@@ -1,0 +1,7 @@
+// +build remoteclient,windows
+
+package main
+
+func setSyslog() error {
+	return nil
+}

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 	"time"
@@ -68,6 +69,12 @@ func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*LocalRuntime,
 		cmd:    c.GlobalFlags,
 	}
 	configPath := remoteclientconfig.GetConfigFilePath()
+	// Check if the basedir for configPath exists and if not, create it.
+	if _, err := os.Stat(filepath.Dir(configPath)); os.IsNotExist(err) {
+		if mkdirErr := os.MkdirAll(filepath.Dir(configPath), 0750); mkdirErr != nil {
+			return nil, mkdirErr
+		}
+	}
 	if len(c.GlobalFlags.RemoteConfigFilePath) > 0 {
 		configPath = c.GlobalFlags.RemoteConfigFilePath
 		customConfig = true

--- a/pkg/util/utils_windows.go
+++ b/pkg/util/utils_windows.go
@@ -6,29 +6,31 @@ import (
 	"github.com/pkg/errors"
 )
 
+var errNotImplemented = errors.New("not yet implemented")
+
 // IsCgroup2UnifiedMode returns whether we are running in cgroup 2 unified mode.
 func IsCgroup2UnifiedMode() (bool, error) {
-	return false, errors.New("this function is not implemented for windows")
+	return false, errors.Wrap(errNotImplemented, "IsCgroup2Unified")
 }
 
 // GetContainerPidInformationDescriptors returns a string slice of all supported
 // format descriptors of GetContainerPidInformation.
 func GetContainerPidInformationDescriptors() ([]string, error) {
-	return nil, errors.New("this function is not implemented for windows")
+	return nil, errors.Wrap(errNotImplemented, "GetContainerPidInformationDescriptors")
 }
 
 // GetRootlessPauseProcessPidPath returns the path to the file that holds the pid for
 // the pause process
 func GetRootlessPauseProcessPidPath() (string, error) {
-	return "", errors.New("this function is not implemented for windows")
+	return "", errors.Wrap(errNotImplemented, "GetRootlessPauseProcessPidPath")
 }
 
 // GetRootlessRuntimeDir returns the runtime directory when running as non root
 func GetRootlessRuntimeDir() (string, error) {
-	return "", errors.New("this function is not implemented for windows")
+	return "", errors.Wrap(errNotImplemented, "GetRootlessRuntimeDir")
 }
 
 // GetRootlessConfigHomeDir returns the config home directory when running as non root
 func GetRootlessConfigHomeDir() (string, error) {
-	return "", errors.New("this function is not implemented for windows")
+	return "", errors.Wrap(errNotImplemented, "GetRootlessConfigHomeDir")
 }


### PR DESCRIPTION
rework an error path so that users can run the windows remote client.

also, create the basedir path for the podman-remote.conf file if it does
not exist already.

Signed-off-by: baude <bbaude@redhat.com>