### PR TITLE
Adjust name of Podman CNI network bridge

### DIFF
--- a/cni/87-podman-bridge.conflist
+++ b/cni/87-podman-bridge.conflist
@@ -2,28 +2,37 @@
     "cniVersion": "0.4.0",
     "name": "podman",
     "plugins": [
-      {
-        "type": "bridge",
-        "bridge": "cni0",
-        "isGateway": true,
-        "ipMasq": true,
-        "ipam": {
-            "type": "host-local",
-            "subnet": "10.88.0.0/16",
-            "routes": [
-                { "dst": "0.0.0.0/0" }
-            ]
-        }
-      },
-      {
-        "type": "portmap",
-        "capabilities": {
-          "portMappings": true
-        }
-      },
-      {
-        "type": "firewall",
-	"backend": "iptables"
-      }
+	{
+            "type": "bridge",
+            "bridge": "cni-podman0",
+            "isGateway": true,
+            "ipMasq": true,
+            "ipam": {
+		"type": "host-local",
+		"routes": [
+		    {
+			"dst": "0.0.0.0/0"
+		    }
+		],
+		"ranges": [
+		    [
+			{
+			    "subnet": "10.88.0.0/16",
+			    "gateway": "10.88.0.1"
+			}
+		    ]
+		]
+            }
+	},
+	{
+            "type": "portmap",
+            "capabilities": {
+		"portMappings": true
+            }
+	},
+	{
+            "type": "firewall",
+	    "backend": "iptables"
+	}
     ]
 }


### PR DESCRIPTION
Both Podman and CRI-O set up CNI bridges with the name 'cni0'. If both our CNI conflist and the CRI-O conflist are installed, whoever runs first will win - that is, they will configure the bridge, and everyone will use it. Problem: the CRI-O CNI config conflicts with ours and results in containers with no networking. Solution: rename our bridge so we don't conflict with CRI-O.