### PR TITLE
rootless: Rearrange setup of rootless containers

### DIFF
--- a/libpod/oci_internal_linux.go
+++ b/libpod/oci_internal_linux.go
@@ -131,9 +131,14 @@ func (r *OCIRuntime) createOCIContainer(ctr *Container, restoreOptions *Containe
 	}
 
 	if ctr.config.NetMode.IsSlirp4netns() {
-		ctr.rootlessSlirpSyncR, ctr.rootlessSlirpSyncW, err = os.Pipe()
-		if err != nil {
-			return errors.Wrapf(err, "failed to create rootless network sync pipe")
+		if ctr.config.PostConfigureNetNS {
+			ctr.rootlessSlirpSyncR, ctr.rootlessSlirpSyncW, err = os.Pipe()
+			if err != nil {
+				return errors.Wrapf(err, "failed to create rootless network sync pipe")
+			}
+		} else {
+			defer errorhandling.CloseQuiet(ctr.rootlessSlirpSyncR)
+			defer errorhandling.CloseQuiet(ctr.rootlessSlirpSyncW)
 		}
 		// Leak one end in conmon, the other one will be leaked into slirp4netns
 		cmd.ExtraFiles = append(cmd.ExtraFiles, ctr.rootlessSlirpSyncW)

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -99,7 +99,9 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, imgID
 	if isRootless {
 		netmode = "slirp4netns"
 	}
-	options = append(options, WithNetNS(p.config.InfraContainer.PortBindings, isRootless, netmode, networks))
+	// PostConfigureNetNS should not be set since user namespace sharing is not implemented
+	// and rootless networking no longer supports post configuration setup
+	options = append(options, WithNetNS(p.config.InfraContainer.PortBindings, false, netmode, networks))
 
 	return r.newContainer(ctx, g.Config, options...)
 }

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -152,8 +152,9 @@ func NewNS() (ns.NetNS, error) {
 
 		// bind mount the netns from the current thread (from /proc) onto the
 		// mount point. This causes the namespace to persist, even when there
-		// are no threads in the ns.
-		err = unix.Mount(getCurrentThreadNetNSPath(), nsPath, "none", unix.MS_BIND, "")
+		// are no threads in the ns. Make this a shared mount; it needs to be
+		// back-propogated to the host
+		err = unix.Mount(getCurrentThreadNetNSPath(), nsPath, "none", unix.MS_BIND|unix.MS_SHARED|unix.MS_REC, "")
 		if err != nil {
 			err = fmt.Errorf("failed to bind mount ns at %s: %v", nsPath, err)
 		}

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -23,23 +23,42 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
 
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/libpod/pkg/util"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
-const nsRunDir = "/var/run/netns"
+// get NSRunDir returns the dir of where to create the netNS. When running
+// rootless, it needs to be at a location writable by user.
+func getNSRunDir() (string, error) {
+	if rootless.IsRootless() {
+		rootlessDir, err := util.GetRuntimeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(rootlessDir, "netns"), nil
+	}
+	return "/var/run/netns", nil
+}
 
 // NewNS creates a new persistent (bind-mounted) network namespace and returns
 // an object representing that namespace, without switching to it.
 func NewNS() (ns.NetNS, error) {
 
+	nsRunDir, err := getNSRunDir()
+	if err != nil {
+		return nil, err
+	}
+
 	b := make([]byte, 16)
-	_, err := rand.Reader.Read(b)
+	_, err = rand.Reader.Read(b)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate random netns name: %v", err)
 	}
@@ -127,7 +146,7 @@ func NewNS() (ns.NetNS, error) {
 		// Put this thread back to the orig ns, since it might get reused (pre go1.10)
 		defer func() {
 			if err := origNS.Set(); err != nil {
-				logrus.Errorf("unable to set namespace: %q", err)
+				logrus.Warnf("unable to set namespace: %q", err)
 			}
 		}()
 
@@ -150,6 +169,11 @@ func NewNS() (ns.NetNS, error) {
 
 // UnmountNS unmounts the NS held by the netns object
 func UnmountNS(ns ns.NetNS) error {
+	nsRunDir, err := getNSRunDir()
+	if err != nil {
+		return err
+	}
+
 	nsPath := ns.Path()
 	// Only unmount if it's been bind-mounted (don't touch namespaces in /proc...)
 	if strings.HasPrefix(nsPath, nsRunDir) {

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -275,7 +275,7 @@ func (c *CreateConfig) getContainerCreateOptions(runtime *libpod.Runtime, pod *l
 		options = append(options, libpod.WithNetNSFrom(connectedCtr))
 	} else if !c.NetMode.IsHost() && !c.NetMode.IsNone() {
 		hasUserns := c.UsernsMode.IsContainer() || c.UsernsMode.IsNS() || len(c.IDMappings.UIDMap) > 0 || len(c.IDMappings.GIDMap) > 0
-		postConfigureNetNS := c.NetMode.IsSlirp4netns() || (hasUserns && !c.UsernsMode.IsHost())
+		postConfigureNetNS := hasUserns && !c.UsernsMode.IsHost()
 		options = append(options, libpod.WithNetNS(portBindings, postConfigureNetNS, string(c.NetMode), networks))
 	}
 

--- a/rootless.md
+++ b/rootless.md
@@ -27,7 +27,6 @@ can easily fail
 * Can not use overlayfs driver, but does support fuse-overlayfs
   * Ubuntu supports non root overlay, but no other Linux distros do.
 * Only other supported driver is VFS.
-* No KATA Container support
 * No CNI Support
   * CNI wants to modify IPTables, plus other network manipulation that requires CAP_SYS_ADMIN.
   * There is potential we could probably do some sort of blacklisting of the relevant plugins, and add a new plugin for rootless networking - slirp4netns as one example and there may be others

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -156,4 +156,124 @@ var _ = Describe("Podman mount", func() {
 		umount.WaitWithDefaultTimeout()
 		Expect(umount.ExitCode()).To(Equal(0))
 	})
+
+	It("podman list mounted container", func() {
+		setup := podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+		cid := setup.OutputToString()
+
+		lmount := podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount.WaitWithDefaultTimeout()
+		Expect(lmount.ExitCode()).To(Equal(0))
+		Expect(lmount.OutputToString()).To(Equal(""))
+
+		mount := podmanTest.Podman([]string{"mount", cid})
+		mount.WaitWithDefaultTimeout()
+		Expect(mount.ExitCode()).To(Equal(0))
+
+		lmount = podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount.WaitWithDefaultTimeout()
+		Expect(lmount.ExitCode()).To(Equal(0))
+		Expect(lmount.OutputToString()).To(ContainSubstring(cid))
+
+		umount := podmanTest.Podman([]string{"umount", cid})
+		umount.WaitWithDefaultTimeout()
+		Expect(umount.ExitCode()).To(Equal(0))
+	})
+
+	It("podman list running container", func() {
+		SkipIfRootless()
+
+		setup := podmanTest.Podman([]string{"run", "-dt", ALPINE, "top"})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+		cid := setup.OutputToString()
+
+		lmount := podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount.WaitWithDefaultTimeout()
+		Expect(lmount.ExitCode()).To(Equal(0))
+		Expect(lmount.OutputToString()).To(ContainSubstring(cid))
+
+		stop := podmanTest.Podman([]string{"stop", cid})
+		stop.WaitWithDefaultTimeout()
+		Expect(stop.ExitCode()).To(Equal(0))
+
+		lmount = podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount.WaitWithDefaultTimeout()
+		Expect(lmount.ExitCode()).To(Equal(0))
+		Expect(lmount.OutputToString()).To(Equal(""))
+	})
+
+	It("podman list mulitple mounted containers", func() {
+		SkipIfRootless()
+
+		setup := podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+		cid1 := setup.OutputToString()
+
+		setup = podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+		cid2 := setup.OutputToString()
+
+		setup = podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+		cid3 := setup.OutputToString()
+
+		lmount := podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount.WaitWithDefaultTimeout()
+		Expect(lmount.ExitCode()).To(Equal(0))
+		Expect(lmount.OutputToString()).To(Equal(""))
+
+		mount := podmanTest.Podman([]string{"mount", cid1, cid3})
+		mount.WaitWithDefaultTimeout()
+		Expect(mount.ExitCode()).To(Equal(0))
+
+		lmount = podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount.WaitWithDefaultTimeout()
+		Expect(lmount.ExitCode()).To(Equal(0))
+		Expect(lmount.OutputToString()).To(ContainSubstring(cid1))
+		Expect(lmount.OutputToString()).ToNot(ContainSubstring(cid2))
+		Expect(lmount.OutputToString()).To(ContainSubstring(cid3))
+
+		umount := podmanTest.Podman([]string{"umount", cid1, cid3})
+		umount.WaitWithDefaultTimeout()
+		Expect(umount.ExitCode()).To(Equal(0))
+
+		lmount = podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount.WaitWithDefaultTimeout()
+		Expect(lmount.ExitCode()).To(Equal(0))
+		Expect(lmount.OutputToString()).To(Equal(""))
+
+	})
+
+	It("podman list mounted container", func() {
+		SkipIfRootless()
+
+		setup := podmanTest.Podman([]string{"create", ALPINE, "ls"})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+		cid := setup.OutputToString()
+
+		lmount := podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount.WaitWithDefaultTimeout()
+		Expect(lmount.ExitCode()).To(Equal(0))
+		Expect(lmount.OutputToString()).To(Equal(""))
+
+		mount := podmanTest.Podman([]string{"mount", cid})
+		mount.WaitWithDefaultTimeout()
+		Expect(mount.ExitCode()).To(Equal(0))
+
+		lmount = podmanTest.Podman([]string{"mount", "--notruncate"})
+		lmount.WaitWithDefaultTimeout()
+		Expect(lmount.ExitCode()).To(Equal(0))
+		Expect(lmount.OutputToString()).To(ContainSubstring(cid))
+
+		umount := podmanTest.Podman([]string{"umount", cid})
+		umount.WaitWithDefaultTimeout()
+		Expect(umount.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
This commit removes the previous cleanup in the stop functionality. It was originally added because the pipe wasn't closing on the kill to conmon, so the slirp4netns process wasn't stopping. This was fixed in this [commit](https://github.com/containers/libpod/commit/6997dc14886b62c5baef50ba38ce2538ee238019), and now the restart works with reentering the previous network namespace.
 
In order to run Podman with VM-based runtimes unprivileged, the
network must be set up prior to the container creation. Therefore
this commit modifies Podman to run rootless containers by:
  1. create a network namespace
  2. pass the netns persistent mount path to the slirp4netns
     to create the tap inferface
  3. pass the netns path to the OCI spec, so the runtime can
     enter the netns

Closes #2897

Signed-off-by: Gabi Beyer <gabrielle.n.beyer@intel.com>