### PR TITLE
add make to make installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,12 +333,12 @@ changelog: ## Generate changelog
 
 install: .gopathok install.bin install.remote install.man install.cni install.systemd  ## Install binaries to system locations
 
-install.remote:
+install.remote: podman-remote
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 bin/podman-remote $(DESTDIR)$(BINDIR)/podman-remote
 	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(DESTDIR)$(BINDIR)/podman bin/podman-remote
 
-install.bin:
+install.bin: podman
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 bin/podman $(DESTDIR)$(BINDIR)/podman
 	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(DESTDIR)$(BINDIR)/podman bin/podman

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -354,8 +354,12 @@ providing packages with %{import_path} prefix.
 %prep
 %autosetup -Sgit -n %{repo}-%{shortcommit0}
 
-# untar cri-o
+# untar conmon
 tar zxf %{SOURCE1}
+
+sed -i 's/install.remote: podman-remote/install.remote:/' Makefile
+sed -i 's/install.bin: podman/install.bin:/' Makefile
+sed -i 's/install.man: docs/install.man:/' Makefile
 
 %build
 mkdir _build


### PR DESCRIPTION
as issue #2702 describes, we want to make podman and podman-remote as
part of make install.

Fixes: #2702

Signed-off-by: baude <bbaude@redhat.com>

avoid `make` in `make install` in the rpmbuild process.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


Obsoletes: https://github.com/containers/libpod/pull/3726 and https://github.com/containers/libpod/pull/3703