### PR TITLE
implement 'make remotesystem'

### DIFF
--- a/test/system/001-basic.bats
+++ b/test/system/001-basic.bats
@@ -13,6 +13,14 @@ function setup() {
 @test "podman version emits reasonable output" {
     run_podman version
 
+    # First line of podman-remote is "Client:<blank>".
+    # Just delete it (i.e. remove the first entry from the 'lines' array)
+    if is_remote; then
+        if expr "${lines[0]}" : "Client:" >/dev/null; then
+            lines=("${lines[@]:1}")
+        fi
+    fi
+
     is "${lines[0]}" "Version:[ ]\+[1-9][0-9.]\+" "Version line 1"
     is "$output" ".*Go Version: \+"               "'Go Version' in output"
     is "$output" ".*RemoteAPI Version: \+"        "API version in output"

--- a/test/system/070-build.bats
+++ b/test/system/070-build.bats
@@ -6,10 +6,8 @@
 load helpers
 
 @test "podman build - basic test" {
-    if [[ "$PODMAN" =~ -remote ]]; then
-        if [ "$(id -u)" -ne 0 ]; then
-            skip "unreliable with podman-remote and rootless; #2972"
-        fi
+    if is_remote && is_rootless; then
+        skip "unreliable with podman-remote and rootless; #2972"
     fi
 
     rand_filename=$(random_string 20)

--- a/test/system/200-pod-top.bats
+++ b/test/system/200-pod-top.bats
@@ -3,6 +3,8 @@
 load helpers
 
 @test "podman pod top - containers in different PID namespaces" {
+    skip_if_remote "podman-pod does not work with podman-remote"
+
     # With infra=false, we don't get a /pause container (we also
     # don't pull k8s.gcr.io/pause )
     no_infra='--infra=false'

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -28,6 +28,8 @@ on failure.
 
 * `skip_if_rootless` - if rootless, skip this test with a helpful message.
 
+* `skip_if_remote` - like the above, but skip if testing `podman-remote`
+
 * `random_string` - returns a pseudorandom alphanumeric string
 
 Test files are of the form `NNN-name.bats` where NNN is a three-digit

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -216,26 +216,31 @@ function wait_for_ready {
 ###############################################################################
 # BEGIN miscellaneous tools
 
+# Shortcuts for common needs:
+function is_rootless() {
+    [ "$(id -u)" -ne 0 ]
+}
+
+function is_remote() {
+    [[ "$PODMAN" =~ -remote ]]
+}
+
 ######################
 #  skip_if_rootless  #  ...with an optional message
 ######################
 function skip_if_rootless() {
-    if [ "$(id -u)" -eq 0 ]; then
-        return
+    if is_rootless; then
+        skip "${1:-not applicable under rootless podman}"
     fi
-
-    skip "${1:-not applicable under rootless podman}"
 }
 
 ####################
 #  skip_if_remote  #  ...with an optional message
 ####################
 function skip_if_remote() {
-    if [[ ! "$PODMAN" =~ -remote ]]; then
-        return
+    if is_remote; then
+        skip "${1:-test does not work with podman-remote}"
     fi
-
-    skip "${1:-test does not work with podman-remote}"
 }
 
 #########################


### PR DESCRIPTION
podman-remote rm now works; that's the only thing we were
waiting for to enable podman-remote (varlink) system tests.

Add a (too-complicated, sorry) Makefile target that will
define a random socket path, start the podman varlink server,
and run the test suite using podman-remote.

Also: add two convenience functions, is_rootless and is_remote,
and use those in skip_if_rootless/if_remote and elsewhere

Also: workarounds for broken tests:
 - basic version test: podman-remote emits an empty 'Client'
   line. Just ignore it.
 - looks like 'podman-remote pod' doesn't work; skip test.

Also: minor documentation update

Signed-off-by: Ed Santiago <santiago@redhat.com>