### PR TITLE
Allow the passing of '.' to --dns-search

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -629,6 +629,9 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 
 	// Validate domains are good
 	for _, dom := range c.StringSlice("dns-search") {
+		if dom == "." {
+			continue
+		}
 		if _, err := parse.ValidateDomain(dom); err != nil {
 			return nil, err
 		}

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -41,6 +41,13 @@ var _ = Describe("Podman run dns", func() {
 		session.LineInOuputStartsWith("search foobar.com")
 	})
 
+	It("podman run remove all search domain", func() {
+		session := podmanTest.Podman([]string{"run", "--dns-search=.", ALPINE, "cat", "/etc/resolv.conf"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.LineInOuputStartsWith("search")).To(BeFalse())
+	})
+
 	It("podman run add bad dns server", func() {
 		session := podmanTest.Podman([]string{"run", "--dns=foobar", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
--dns-search is defined to remove all search domains from a container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>