### PR TITLE
WIP - dns: prepend dns server to resolv.conf

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1082,9 +1082,8 @@ func (c *Container) generateResolvConf() (string, error) {
 	}
 	if len(c.config.DNSServer) > 0 {
 		// We store DNS servers as net.IP, so need to convert to string
-		nameservers = []string{}
 		for _, server := range c.config.DNSServer {
-			nameservers = append(nameservers, server.String())
+			nameservers = append([]string{server.String()}, nameservers...)
 		}
 	}
 


### PR DESCRIPTION
Prepend the dns server passed via the `--dns` flag to the resolv.conf
instead of creating a new one with only this server.  This will allow
for dns across networks.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@praveenkumar asked if that's possible, so I figured to open a PR directly to kick off a discussion.

@baude @mheon @rhatdan PTAL