### PR TITLE
Fix incorrect use of realloc()

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -137,7 +137,7 @@ get_cmd_line_args (pid_t pid)
         {
           allocated += 512;
           char *tmp = realloc (buffer, allocated);
-          if (buffer == NULL)
+          if (tmp == NULL)
             {
               free (buffer);
               return NULL;


### PR DESCRIPTION
An example of correct use of realloc() can be seen in 

./vendor/github.com/containers/buildah/pkg/unshare/unshare.c

Modify the code to match that.

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>