### PR TITLE
Adjust read count so that a newline can be added afterwards

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -276,7 +276,7 @@ static void __attribute__((constructor)) init()
           return;
         }
 
-      r = TEMP_FAILURE_RETRY (read (fd, buf, sizeof (buf)));
+      r = TEMP_FAILURE_RETRY (read (fd, buf, sizeof (buf) - 1));
       close (fd);
       if (r < 0)
         {


### PR DESCRIPTION
To avoid that

    buf[r] = '\0';

writes outside of the buffer
decrement the read count by one. 

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>