### PR TITLE
build: use the configured runtime

### DIFF
--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -288,9 +288,8 @@ func (r *LocalRuntime) Build(ctx context.Context, c *cliconfig.BuildValues, opti
 	options.CommonBuildOpts = commonOpts
 	options.SystemContext = systemContext
 
-	if c.Flag("runtime").Changed {
-		options.Runtime = r.GetOCIRuntimePath()
-	}
+	options.Runtime = r.GetOCIRuntimePath()
+
 	if c.Quiet {
 		options.ReportWriter = ioutil.Discard
 	}


### PR DESCRIPTION
Now buildah honors the runtime configured with podman.

Closes: https://github.com/giuseppe/crun/issues/69

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>