### PR TITLE
rootless: drop some superflous checks

### DIFF
--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -78,7 +78,7 @@ func podCreateCmd(c *cliconfig.PodCreateValues) error {
 	if !c.Infra && c.Flag("share").Changed && c.Share != "none" && c.Share != "" {
 		return errors.Errorf("You cannot share kernel namespaces on the pod level without an infra container")
 	}
-	if c.Flag("pod-id-file").Changed && os.Geteuid() == 0 {
+	if c.Flag("pod-id-file").Changed {
 		podIdFile, err = util.OpenExclusiveFile(c.PodIDFile)
 		if err != nil && os.IsExist(err) {
 			return errors.Errorf("pod id file exists. Ensure another pod is not using it or delete %s", c.PodIDFile)

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -55,7 +55,7 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		rootfs = c.InputArgs[0]
 	}
 
-	if c.IsSet("cidfile") && os.Geteuid() == 0 {
+	if c.IsSet("cidfile") {
 		cidFile, err = util.OpenExclusiveFile(c.String("cidfile"))
 		if err != nil && os.IsExist(err) {
 			return nil, nil, errors.Errorf("container id file exists. Ensure another container is not using it or delete %s", c.String("cidfile"))
@@ -70,8 +70,8 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 	imageName := ""
 	var data *inspect.ImageData = nil
 
-	// Set the storage if we are running as euid == 0 and there is no rootfs specified
-	if rootfs == "" && os.Geteuid() == 0 {
+	// Set the storage if there is no rootfs specified
+	if rootfs == "" {
 		var writer io.Writer
 		if !c.Bool("quiet") {
 			writer = os.Stderr

--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -238,11 +238,6 @@ func (config *CreateConfig) parseVolumes(runtime *libpod.Runtime) ([]spec.Mount,
 // Conflicts are resolved simply - the last container specified wins.
 // Container names may be suffixed by mount options after a colon.
 func (config *CreateConfig) getVolumesFrom(runtime *libpod.Runtime) (map[string]spec.Mount, map[string]*libpod.ContainerNamedVolume, error) {
-	// TODO: This can probably be disabled now
-	if os.Geteuid() != 0 {
-		return nil, nil, nil
-	}
-
 	// Both of these are maps of mount destination to mount type.
 	// We ensure that each destination is only mounted to once in this way.
 	finalMounts := make(map[string]spec.Mount)


### PR DESCRIPTION
after we moved to using a single user namespace, Podman joins it much earlier than it used to do.  

Drop some `os.Geteuid() == 0` checks as Podman is already running with euid==0 at this point