### PR TITLE
rootless: cherry-pick runtime from the system configuration

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -274,6 +274,8 @@ type runtimeConfiguredFrom struct {
 	runtimePath           bool
 	cniPluginDir          bool
 	noPivotRoot           bool
+	runtimeSupportsJSON   bool
+	ociRuntime            bool
 }
 
 func defaultRuntimeConfig() (RuntimeConfig, error) {
@@ -593,6 +595,12 @@ func newRuntimeFromConfig(ctx context.Context, userConfigPath string, options ..
 		if tmpConfig.NoPivotRoot {
 			runtime.configuredFrom.noPivotRoot = true
 		}
+		if tmpConfig.RuntimeSupportsJSON != nil {
+			runtime.configuredFrom.runtimeSupportsJSON = true
+		}
+		if tmpConfig.OCIRuntime != "" {
+			runtime.configuredFrom.ociRuntime = true
+		}
 
 		if _, err := toml.Decode(string(contents), runtime.config); err != nil {
 			return nil, errors.Wrapf(err, "error decoding configuration file %s", configPath)
@@ -633,6 +641,13 @@ func newRuntimeFromConfig(ctx context.Context, userConfigPath string, options ..
 			if !runtime.configuredFrom.noPivotRoot {
 				runtime.config.NoPivotRoot = tmpConfig.NoPivotRoot
 			}
+			if !runtime.configuredFrom.runtimeSupportsJSON {
+				runtime.config.RuntimeSupportsJSON = tmpConfig.RuntimeSupportsJSON
+			}
+			if !runtime.configuredFrom.ociRuntime {
+				runtime.config.OCIRuntime = tmpConfig.OCIRuntime
+			}
+
 			break
 		}
 	}


### PR DESCRIPTION
when creating the default libpod.conf file, be sure the default OCI
runtime is cherry picked from the system configuration.

Closes: https://github.com/containers/libpod/issues/3781

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>