### PR TITLE
Remove --tmpfs size default

### DIFF
--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -715,7 +715,7 @@ $ podman run -d --tmpfs /tmp:rw,size=787448k,mode=1777 my_image
 This command mounts a `tmpfs` at `/tmp` within the container.  The supported mount
 options are the same as the Linux default `mount` flags. If you do not specify
 any options, the systems uses the following options:
-`rw,noexec,nosuid,nodev,size=65536k`.
+`rw,noexec,nosuid,nodev`.
 
 **--tty**, **-t**=*true|false*
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -752,7 +752,7 @@ $ podman run -d --tmpfs /tmp:rw,size=787448k,mode=1777 my_image
 This command mounts a `tmpfs` at `/tmp` within the container.  The supported mount
 options are the same as the Linux default `mount` flags. If you do not specify
 any options, the systems uses the following options:
-`rw,noexec,nosuid,nodev,size=65536k`.
+`rw,noexec,nosuid,nodev`.
 
 **--tty**, **-t**=*true|false*
 

--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -168,14 +168,14 @@ func (config *CreateConfig) parseVolumes(runtime *libpod.Runtime) ([]spec.Mount,
 		"/run":     false,
 	}
 	if config.ReadOnlyRootfs && config.ReadOnlyTmpfs {
-		options := []string{"rw", "rprivate", "nosuid", "nodev", "tmpcopyup", "size=65536k"}
+		options := []string{"rw", "rprivate", "nosuid", "nodev", "tmpcopyup"}
 		for dest := range readonlyTmpfs {
 			if _, ok := baseMounts[dest]; ok {
 				continue
 			}
 			localOpts := options
 			if dest == "/run" {
-				localOpts = append(localOpts, "noexec")
+				localOpts = append(localOpts, "noexec", "size=65536k")
 			}
 			baseMounts[dest] = spec.Mount{
 				Destination: dest,

--- a/pkg/util/mountOpts.go
+++ b/pkg/util/mountOpts.go
@@ -92,9 +92,6 @@ func ProcessTmpfsOptions(options []string) ([]string, error) {
 	if !foundWrite {
 		baseOpts = append(baseOpts, "rw")
 	}
-	if !foundSize {
-		baseOpts = append(baseOpts, "size=65536k")
-	}
 	if !foundProp {
 		baseOpts = append(baseOpts, "rprivate")
 	}


### PR DESCRIPTION
Docker has unlimited tmpfs size where Podman had it set to 64mb. Should be standard between the two.

Closes #3780

Signed-off-by: Ashley Cui <ashleycui16@gmail.com>