### PR TITLE
Running Podman with a nonexistent hooks dir is nonfatal

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -4,6 +4,7 @@ package hooks
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -56,7 +57,7 @@ func New(ctx context.Context, directories []string, extensionStages []string) (m
 
 	for _, dir := range directories {
 		err = ReadDir(dir, manager.extensionStages, manager.hooks)
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Even explicitly defined hooks directories may not exist under some circumstances. It's not worth a hard-fail if we hit an ENOENT in these cases.

Fixes a BZ reported against Rawhide - Podman 1.5.0 and above don't have a hard dependency on any OCI hook, so the hooks directory won't be created on a default install and Podman will fail.