### PR TITLE
removMergeDir from inspect result if not mounted

### DIFF
--- a/libpod/driver/driver.go
+++ b/libpod/driver/driver.go
@@ -38,6 +38,10 @@ func GetDriverData(store cstorage.Store, layerID string) (*Data, error) {
 	if err != nil {
 		return nil, err
 	}
+	if mountTimes, err := store.Mounted(layerID); mountTimes == 0 || err != nil {
+		delete(metaData, "MergedDir")
+	}
+
 	return &Data{
 		Name: name,
 		Data: metaData,


### PR DESCRIPTION
Close #3798 
Remove GraphDriver.Data.MergedDir from the result of podman inspect if the container not mounte. Because the /var/lib/containers/.../merged directory is no longer created by default; it only exists during the scope of podman mount.

Signed-off-by: Qi Wang <qiwan@redhat.com>