### PR TITLE
Fix play kube command in pod yaml

### DIFF
--- a/pkg/adapter/pods.go
+++ b/pkg/adapter/pods.go
@@ -707,6 +707,8 @@ func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container
 		return nil, errors.Errorf("No command specified in container YAML or as CMD or ENTRYPOINT in this image for %s", containerConfig.Name)
 	}
 
+	containerConfig.UserCommand = containerConfig.Command
+
 	containerConfig.StopSignal = 15
 
 	// If the user does not pass in ID mappings, just set to basics


### PR DESCRIPTION
This PR fixes the play kube can't recognize `command` setting in pod yaml file.

The initial issue was fixed in: https://github.com/containers/libpod/pull/3588

But it was introduced again in: https://github.com/containers/libpod/pull/3744

/assign @haircommander @mheon