### PR TITLE
performance fix for podman events with large journalds

### DIFF
--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -73,6 +73,11 @@ func (e EventJournalD) Read(options ReadOptions) error {
 		if err := j.SeekTail(); err != nil {
 			return errors.Wrap(err, "failed to seek end of journal")
 		}
+	} else {
+		podmanJournal := sdjournal.Match{Field: "SYSLOG_IDENTIFIER", Value: "podman"} //nolint
+		if err := j.AddMatch(podmanJournal.String()); err != nil {
+			return errors.Wrap(err, "failed to add filter for event log")
+		}
 	}
 	// the api requires a next|prev before getting a cursor
 	if _, err := j.Next(); err != nil {


### PR DESCRIPTION
in the case where the host has a large journald, iterating the journal
without using a Match is very poor performance.  this might be a
temporary fix while we figure out why the systemd library does not seem to
behave properly.

Signed-off-by: baude <bbaude@redhat.com>