### PR TITLE
do not activate sd_notify support when varlink

### DIFF
--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -15,25 +15,30 @@ import (
 
 // GetRuntimeMigrate gets a libpod runtime that will perform a migration of existing containers
 func GetRuntimeMigrate(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(ctx, c, false, true, false)
+	return getRuntime(ctx, c, false, true, false, true)
+}
+
+// GetRuntimeDisableFDs gets a libpod runtime that will disable sd notify
+func GetRuntimeDisableFDs(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
+	return getRuntime(ctx, c, false, false, false, false)
 }
 
 // GetRuntimeRenumber gets a libpod runtime that will perform a lock renumber
 func GetRuntimeRenumber(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(ctx, c, true, false, false)
+	return getRuntime(ctx, c, true, false, false, true)
 }
 
 // GetRuntime generates a new libpod runtime configured by command line options
 func GetRuntime(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(ctx, c, false, false, false)
+	return getRuntime(ctx, c, false, false, false, true)
 }
 
 // GetRuntimeNoStore generates a new libpod runtime configured by command line options
 func GetRuntimeNoStore(ctx context.Context, c *cliconfig.PodmanCommand) (*libpod.Runtime, error) {
-	return getRuntime(ctx, c, false, false, true)
+	return getRuntime(ctx, c, false, false, true, true)
 }
 
-func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber, migrate, noStore bool) (*libpod.Runtime, error) {
+func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber, migrate, noStore, withFDS bool) (*libpod.Runtime, error) {
 	options := []libpod.RuntimeOption{}
 	storageOpts := storage.StoreOptions{}
 	storageSet := false
@@ -164,6 +169,10 @@ func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber, migra
 	if infraCommandFlag != nil && infraImageFlag.Changed {
 		infraCommand, _ := c.Flags().GetString("infra-command")
 		options = append(options, libpod.WithDefaultInfraCommand(infraCommand))
+	}
+
+	if withFDS {
+		options = append(options, libpod.WithEnableSDNotify())
 	}
 	if c.Flags().Changed("config") {
 		return libpod.NewRuntimeFromConfig(ctx, c.GlobalFlags.Config, options...)

--- a/cmd/podman/varlink.go
+++ b/cmd/podman/varlink.go
@@ -79,7 +79,7 @@ func varlinkCmd(c *cliconfig.VarlinkValues) error {
 	timeout := time.Duration(c.Timeout) * time.Millisecond
 
 	// Create a single runtime for varlink
-	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)
+	runtime, err := libpodruntime.GetRuntimeDisableFDs(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -60,6 +60,7 @@ type OCIRuntime struct {
 	noPivot       bool
 	reservePorts  bool
 	supportsJSON  bool
+	sdNotify      bool
 }
 
 // ociError is used to parse the OCI runtime JSON log.  It is not part of the
@@ -87,6 +88,7 @@ func newOCIRuntime(name string, paths []string, conmonPath string, runtimeCfg *R
 	runtime.logSizeMax = runtimeCfg.MaxLogSize
 	runtime.noPivot = runtimeCfg.NoPivotRoot
 	runtime.reservePorts = runtimeCfg.EnablePortReservation
+	runtime.sdNotify = runtimeCfg.SDNotify
 
 	// TODO: probe OCI runtime for feature and enable automatically if
 	// available.

--- a/libpod/oci_internal_linux.go
+++ b/libpod/oci_internal_linux.go
@@ -247,10 +247,14 @@ func (r *OCIRuntime) configureConmonEnv(runtimeDir string) ([]string, []*os.File
 	if notify, ok := os.LookupEnv("NOTIFY_SOCKET"); ok {
 		env = append(env, fmt.Sprintf("NOTIFY_SOCKET=%s", notify))
 	}
-	if listenfds, ok := os.LookupEnv("LISTEN_FDS"); ok {
-		env = append(env, fmt.Sprintf("LISTEN_FDS=%s", listenfds), "LISTEN_PID=1")
-		fds := activation.Files(false)
-		extraFiles = append(extraFiles, fds...)
+	if !r.sdNotify {
+		if listenfds, ok := os.LookupEnv("LISTEN_FDS"); ok {
+			env = append(env, fmt.Sprintf("LISTEN_FDS=%s", listenfds), "LISTEN_PID=1")
+			fds := activation.Files(false)
+			extraFiles = append(extraFiles, fds...)
+		}
+	} else {
+		logrus.Debug("disabling SD notify")
 	}
 	return env, extraFiles, nil
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -482,6 +482,15 @@ func WithEventsLogger(logger string) RuntimeOption {
 	}
 }
 
+// WithEnableSDNotify sets a runtime option so we know whether to disable socket/FD
+// listening
+func WithEnableSDNotify() RuntimeOption {
+	return func(rt *Runtime) error {
+		rt.config.SDNotify = true
+		return nil
+	}
+}
+
 // Container Creation Options
 
 // WithShmDir sets the directory that should be mounted on /dev/shm.

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -252,6 +252,10 @@ type RuntimeConfig struct {
 	EventsLogFilePath string `toml:"-events_logfile_path"`
 	//DetachKeys is the sequence of keys used to detach a container
 	DetachKeys string `toml:"detach_keys"`
+
+	// SDNotify tells Libpod to allow containers to notify the host
+	// systemd of readiness using the SD_NOTIFY mechanism
+	SDNotify bool
 }
 
 // runtimeConfiguredFrom is a struct used during early runtime init to help


### PR DESCRIPTION
add ability to not activate sd_notify when running under varlink as it
causes deadlocks and hangs.

Fixes: #3572

Signed-off-by: baude <bbaude@redhat.com>