### PR TITLE
mount sysfs in namespace

### DIFF
--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -138,6 +138,13 @@ func NewNS() (ns.NetNS, error) {
 		if err != nil {
 			err = fmt.Errorf("failed to bind mount ns at %s: %v", nsPath, err)
 		}
+
+		// mount sysfs so the process running in the container can see the
+		// correct /sys/class/net entries
+		err = unix.Mount("sysfs", "/sys", "sysfs", unix.MS_RDONLY, "")
+		if err != nil {
+			err = fmt.Errorf("failed to mount sysfs: %v", err)
+		}
 	})()
 	wg.Wait()
 


### PR DESCRIPTION
mount sysfs so the process running in the container
can see the correct /sys/class/net entries

Signed-off-by: Gabi Beyer <Gabrielle.n.beyer@intel.com>