### PR TITLE
Add support for returning the exitcode in podman-remote run

### DIFF
--- a/cmd/podman/attach.go
+++ b/cmd/podman/attach.go
@@ -52,5 +52,6 @@ func attachCmd(c *cliconfig.AttachValues) error {
 		return errors.Wrapf(err, "error creating runtime")
 	}
 	defer runtime.DeferredShutdown(false)
-	return runtime.Attach(getContext(), c)
+	exitCode, err = runtime.Attach(getContext(), c, exitCode)
+	return err
 }

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -698,8 +698,8 @@ method PauseContainer(name: string) -> (container: string)
 method UnpauseContainer(name: string) -> (container: string)
 
 # Attach takes the name or ID of a container and sets up the ability to remotely attach to its console. The start
-# bool is whether you wish to start the container in question first.
-method Attach(name: string, detachKeys: string, start: bool) -> ()
+# bool is whether you wish to start the container in question first, exitCode is the default exitCode to return on error.
+method Attach(name: string, detachKeys: string, start: bool, exitCode: int) -> ()
 
 method AttachControl(name: string) -> ()
 


### PR DESCRIPTION
Currently we don't return the exit code of commands run through
podman-remote.

This patch allows the caller to specify the execcode when executing the varlink
command, the call then returns either success (0), the default exitcode passed in
by the caller or the actual exit code from the container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>