### PR TITLE
exec: run with user specified on container start

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -274,6 +274,11 @@ func (c *Container) Exec(tty, privileged bool, env, cmd []string, user, workDir 
 		}
 	}()
 
+	// if the user is empty, we should inherit the user that the container is currently running with
+	if user == "" {
+		user = c.config.User
+	}
+
 	pid, attachChan, err := c.ociRuntime.execContainer(c, cmd, capList, env, tty, workDir, user, sessionID, streams, preserveFDs, resize, detachKeys)
 	if err != nil {
 		ec := define.ExecErrorCodeGeneric

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -146,6 +146,25 @@ var _ = Describe("Podman exec", func() {
 		Expect(session2.OutputToString()).To(Equal(testUser))
 	})
 
+	It("podman exec with user from run", func() {
+		testUser := "guest"
+		setup := podmanTest.Podman([]string{"run", "--user", testUser, "-d", ALPINE, "top"})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+		ctrID := setup.OutputToString()
+
+		session := podmanTest.Podman([]string{"exec", ctrID, "whoami"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(testUser))
+
+		overrideUser := "root"
+		session = podmanTest.Podman([]string{"exec", "--user", overrideUser, ctrID, "whoami"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(overrideUser))
+	})
+
 	It("podman exec simple working directory test", func() {
 		setup := podmanTest.RunTopContainer("test1")
 		setup.WaitWithDefaultTimeout()


### PR DESCRIPTION
Before, if the container was run with a specified user that wasn't root, exec would fail because it always set to root unless respecified by user.
instead, inherit the user from the container start.

fixes: https://github.com/containers/libpod/issues/3838

Signed-off-by: Peter Hunt <pehunt@redhat.com>