### PR TITLE
Add --digestfile option to push

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -423,6 +423,7 @@ type PushValues struct {
 	CertDir          string
 	Compress         bool
 	Creds            string
+	Digestfile       string
 	Format           string
 	Quiet            bool
 	RemoveSignatures bool

--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -51,6 +51,7 @@ func init() {
 	pushCommand.SetUsageTemplate(UsageTemplate())
 	flags := pushCommand.Flags()
 	flags.StringVar(&pushCommand.Creds, "creds", "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
+	flags.StringVar(&pushCommand.Digestfile, "digestfile", "", "After copying the image, write the digest of the resulting image to the file")
 	flags.StringVarP(&pushCommand.Format, "format", "f", "", "Manifest type (oci, v2s1, or v2s2) to use when pushing an image using the 'dir:' transport (default is manifest type of source)")
 	flags.BoolVarP(&pushCommand.Quiet, "quiet", "q", false, "Don't output progress information when pushing images")
 	flags.BoolVar(&pushCommand.RemoveSignatures, "remove-signatures", false, "Discard any pre-existing signatures in the image")
@@ -143,5 +144,5 @@ func pushCmd(c *cliconfig.PushValues) error {
 		SignBy:           signBy,
 	}
 
-	return runtime.Push(getContext(), srcName, destName, manifestType, c.Authfile, c.SignaturePolicy, writer, c.Compress, so, &dockerRegistryOptions, nil)
+	return runtime.Push(getContext(), srcName, destName, manifestType, c.Authfile, c.String("digestfile"), c.SignaturePolicy, writer, c.Compress, so, &dockerRegistryOptions, nil)
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1758,6 +1758,7 @@ _podman_mount() {
 _podman_push() {
     local boolean_options="
 	--compress
+	--digestflag
 	--help
 	-h
 	--quiet

--- a/docs/podman-push.1.md
+++ b/docs/podman-push.1.md
@@ -61,12 +61,16 @@ value can be entered.  The password is entered without echo.
 **--cert-dir**=*path*
 
 Use certificates at *path* (\*.crt, \*.cert, \*.key) to connect to the registry.
-Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands) (Not available for remote commands)
+Default certificates directory is _/etc/containers/certs.d_. (Not available for remote commands)
 
 **--compress**
 
 Compress tarball image layers when pushing to a directory using the 'dir' transport. (default is same compression type, compressed or uncompressed, as source)
 Note: This flag can only be set when using the **dir** transport
+
+**--digestfile** *Digestfile*
+
+After copying the image, write the digest of the resulting image to the file.  (Not available for remote commands)
 
 **--format**, **-f**=*format*
 
@@ -93,19 +97,23 @@ TLS verification will be used unless the target registry is listed as an insecur
 
 ## EXAMPLE
 
-This example extracts the imageID image to a local directory in docker format.
+This example pushes the image specified by the imageID to a local directory in docker format.
 
  `# podman push imageID dir:/path/to/image`
 
-This example extracts the imageID image to a local directory in oci format.
+This example pushes the image specified by the imageID to a local directory in oci format.
 
  `# podman push imageID oci-archive:/path/to/layout:image:tag`
 
-This example extracts the imageID image to a container registry named registry.example.com
+This example pushes the image specified by the imageID to a container registry named registry.example.com
 
  `# podman push imageID docker://registry.example.com/repository:tag`
 
-This example extracts the imageID image and puts into the local docker container store
+This example pushes the image specified by the imageID to a container registry named registry.example.com and saves the digest in the specified digestfile.
+
+ `# podman push --digestfile=/tmp/mydigest imageID docker://registry.example.com/repository:tag`
+
+This example pushes the image specified by the imageID and puts it into the local docker container store
 
  `# podman push imageID docker-daemon:image:tag`
 

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -201,12 +201,12 @@ func (r *LocalRuntime) RemoveVolumes(ctx context.Context, c *cliconfig.VolumeRmV
 }
 
 // Push is a wrapper to push an image to a registry
-func (r *LocalRuntime) Push(ctx context.Context, srcName, destination, manifestMIMEType, authfile, signaturePolicyPath string, writer io.Writer, forceCompress bool, signingOptions image.SigningOptions, dockerRegistryOptions *image.DockerRegistryOptions, additionalDockerArchiveTags []reference.NamedTagged) error {
+func (r *LocalRuntime) Push(ctx context.Context, srcName, destination, manifestMIMEType, authfile, digestfile, signaturePolicyPath string, writer io.Writer, forceCompress bool, signingOptions image.SigningOptions, dockerRegistryOptions *image.DockerRegistryOptions, additionalDockerArchiveTags []reference.NamedTagged) error {
 	newImage, err := r.ImageRuntime().NewFromLocal(srcName)
 	if err != nil {
 		return err
 	}
-	return newImage.PushImageToHeuristicDestination(ctx, destination, manifestMIMEType, authfile, signaturePolicyPath, writer, forceCompress, signingOptions, dockerRegistryOptions, nil)
+	return newImage.PushImageToHeuristicDestination(ctx, destination, manifestMIMEType, authfile, digestfile, signaturePolicyPath, writer, forceCompress, signingOptions, dockerRegistryOptions, nil)
 }
 
 // InspectVolumes returns a slice of volumes based on an arg list or --all

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -619,7 +619,7 @@ func (r *LocalRuntime) RemoveVolumes(ctx context.Context, c *cliconfig.VolumeRmV
 	return iopodman.VolumeRemove().Call(r.Conn, rmOpts)
 }
 
-func (r *LocalRuntime) Push(ctx context.Context, srcName, destination, manifestMIMEType, authfile, signaturePolicyPath string, writer io.Writer, forceCompress bool, signingOptions image.SigningOptions, dockerRegistryOptions *image.DockerRegistryOptions, additionalDockerArchiveTags []reference.NamedTagged) error {
+func (r *LocalRuntime) Push(ctx context.Context, srcName, destination, manifestMIMEType, authfile, digestfile, signaturePolicyPath string, writer io.Writer, forceCompress bool, signingOptions image.SigningOptions, dockerRegistryOptions *image.DockerRegistryOptions, additionalDockerArchiveTags []reference.NamedTagged) error {
 
 	reply, err := iopodman.PushImage().Send(r.Conn, varlink.More, srcName, destination, forceCompress, manifestMIMEType, signingOptions.RemoveSignatures, signingOptions.SignBy)
 	if err != nil {

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -353,7 +353,7 @@ func (i *LibpodAPI) PushImage(call iopodman.VarlinkCall, name, tag string, compr
 	output := bytes.NewBuffer([]byte{})
 	c := make(chan error)
 	go func() {
-		err := newImage.PushImageToHeuristicDestination(getContext(), destname, manifestType, "", "", output, compress, so, &dockerRegistryOptions, nil)
+		err := newImage.PushImageToHeuristicDestination(getContext(), destname, manifestType, "", "", "", output, compress, so, &dockerRegistryOptions, nil)
 		c <- err
 		close(c)
 	}()
@@ -615,7 +615,7 @@ func (i *LibpodAPI) ExportImage(call iopodman.VarlinkCall, name, destination str
 		return err
 	}
 
-	if err := newImage.PushImageToHeuristicDestination(getContext(), destination, "", "", "", nil, compress, image.SigningOptions{}, &image.DockerRegistryOptions{}, additionalTags); err != nil {
+	if err := newImage.PushImageToHeuristicDestination(getContext(), destination, "", "", "", "", nil, compress, image.SigningOptions{}, &image.DockerRegistryOptions{}, additionalTags); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
 	return call.ReplyExportImage(newImage.ID())

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -76,6 +76,14 @@ var _ = Describe("Podman push", func() {
 		push := podmanTest.PodmanNoCache([]string{"push", "--tls-verify=false", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
 		push.WaitWithDefaultTimeout()
 		Expect(push.ExitCode()).To(Equal(0))
+
+		// Test --digestfile option
+		push2 := podmanTest.PodmanNoCache([]string{"push", "--tls-verify=false", "--digestfile=/tmp/digestfile.txt", "--remove-signatures", ALPINE, "localhost:5000/my-alpine"})
+		push2.WaitWithDefaultTimeout()
+		fi, err := os.Lstat("/tmp/digestfile.txt")
+		Expect(err).To(BeNil())
+		Expect(fi.Name()).To(Equal("digestfile.txt"))
+		Expect(push2.ExitCode()).To(Equal(0))
 	})
 
 	It("podman push to local registry with authorization", func() {


### PR DESCRIPTION
Add the digestfile option to the push command so the digest can
be stored away in a file when requested by the user.  Also have added
a debug statement to show the completion of the push.

Emulates Buildah's https://github.com/containers/buildah/pull/1799/files

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>