### PR TITLE
podman-remote: cp crashes

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -11,6 +11,7 @@ const remoteclient = false
 // Commands that the local client implements
 func getMainCommands() []*cobra.Command {
 	rootCommands := []*cobra.Command{
+		_cpCommand,
 		_playCommand,
 		_loginCommand,
 		_logoutCommand,
@@ -39,6 +40,7 @@ func getImageSubCommands() []*cobra.Command {
 func getContainerSubCommands() []*cobra.Command {
 
 	return []*cobra.Command{
+		_cpCommand,
 		_cleanupCommand,
 		_mountCommand,
 		_refreshCommand,

--- a/cmd/podman/container.go
+++ b/cmd/podman/container.go
@@ -55,7 +55,6 @@ var (
 		_commitCommand,
 		_containerExistsCommand,
 		_contInspectSubCommand,
-		_cpCommand,
 		_diffCommand,
 		_execCommand,
 		_exportCommand,

--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -55,7 +55,6 @@ func init() {
 	flags.BoolVar(&cpCommand.Pause, "pause", false, "Pause the container while copying")
 	cpCommand.SetHelpTemplate(HelpTemplate())
 	cpCommand.SetUsageTemplate(UsageTemplate())
-	rootCmd.AddCommand(cpCommand.Command)
 }
 
 func cpCmd(c *cliconfig.CpValues) error {

--- a/cmd/podman/shared/intermediate.go
+++ b/cmd/podman/shared/intermediate.go
@@ -114,7 +114,7 @@ func (f GenericCLIResults) findResult(flag string) GenericCLIResult {
 	if ok {
 		return val
 	}
-	logrus.Errorf("unable to find flag %s", flag)
+	logrus.Debugf("unable to find flag %s", flag)
 	return nil
 }
 
@@ -366,12 +366,10 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIRes
 	m["add-host"] = newCRStringSlice(c, "add-host")
 	m["annotation"] = newCRStringSlice(c, "annotation")
 	m["attach"] = newCRStringSlice(c, "attach")
-	m["authfile"] = newCRString(c, "authfile")
 	m["blkio-weight"] = newCRString(c, "blkio-weight")
 	m["blkio-weight-device"] = newCRStringSlice(c, "blkio-weight-device")
 	m["cap-add"] = newCRStringSlice(c, "cap-add")
 	m["cap-drop"] = newCRStringSlice(c, "cap-drop")
-	m["cgroupns"] = newCRString(c, "cgroupns")
 	m["cgroup-parent"] = newCRString(c, "cgroup-parent")
 	m["cidfile"] = newCRString(c, "cidfile")
 	m["conmon-pidfile"] = newCRString(c, "conmon-pidfile")
@@ -395,7 +393,6 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIRes
 	m["dns-search"] = newCRStringSlice(c, "dns-search")
 	m["entrypoint"] = newCRString(c, "entrypoint")
 	m["env"] = newCRStringArray(c, "env")
-	m["env-host"] = newCRBool(c, "env-host")
 	m["env-file"] = newCRStringSlice(c, "env-file")
 	m["expose"] = newCRStringSlice(c, "expose")
 	m["gidmap"] = newCRStringSlice(c, "gidmap")
@@ -407,7 +404,6 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIRes
 	m["healthcheck-start-period"] = newCRString(c, "health-start-period")
 	m["healthcheck-timeout"] = newCRString(c, "health-timeout")
 	m["hostname"] = newCRString(c, "hostname")
-	m["http-proxy"] = newCRBool(c, "http-proxy")
 	m["image-volume"] = newCRString(c, "image-volume")
 	m["init"] = newCRBool(c, "init")
 	m["init-path"] = newCRString(c, "init-path")
@@ -465,6 +461,10 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIRes
 	m["workdir"] = newCRString(c, "workdir")
 	// global flag
 	if !remote {
+		m["authfile"] = newCRString(c, "authfile")
+		m["cgroupns"] = newCRString(c, "cgroupns")
+		m["env-host"] = newCRBool(c, "env-host")
+		m["http-proxy"] = newCRBool(c, "http-proxy")
 		m["trace"] = newCRBool(c, "trace")
 		m["syslog"] = newCRBool(c, "syslog")
 	}


### PR DESCRIPTION
prune unwanted messages when running a container remotely.  also, cp is
not remote-enabled yet and as such should not be available on the remote
client.

Fixes: #3861

Signed-off-by: baude <bbaude@redhat.com>