### PR TITLE
Need to include command name in error message

### DIFF
--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -140,7 +140,7 @@ func setupRootless(cmd *cobra.Command, args []string) error {
 		became, ret, err := rootless.TryJoinFromFilePaths("", false, []string{pausePidPath})
 		if err != nil {
 			logrus.Errorf("cannot join pause process.  You may need to remove %s and stop all containers", pausePidPath)
-			logrus.Errorf("you can use `system migrate` to recreate the pause process")
+			logrus.Errorf("you can use `%s system migrate` to recreate the pause process", os.Args[0])
 			logrus.Errorf(err.Error())
 			os.Exit(1)
 		}


### PR DESCRIPTION
I hit this error and it told be to system migrate`
as opposed to `podman system migrate`

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>