### PR TITLE
clean up after remote build

### DIFF
--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -142,7 +142,14 @@ func (i *LibpodAPI) BuildImage(call iopodman.VarlinkCall, config iopodman.BuildI
 		return call.ReplyErrorOccurred(fmt.Sprintf("unable to untar context dir %s", contextDir))
 	}
 	logrus.Debugf("untar of %s successful", contextDir)
-
+	defer func() {
+		if err := os.Remove(contextDir); err != nil {
+			logrus.Errorf("unable to delete file '%s': %q", contextDir, err)
+		}
+		if err := os.RemoveAll(newContextDir); err != nil {
+			logrus.Errorf("unable to delete directory '%s': %q", newContextDir, err)
+		}
+	}()
 	// All output (stdout, stderr) is captured in output as well
 	var output bytes.Buffer
 


### PR DESCRIPTION
when performing an image build over a varlink connection, we should
clean up tmp files that are a result of sending the file to the host and
untarring it for the build.

Fixes: #3869

Signed-off-by: baude <bbaude@redhat.com>