### PR TITLE
Backport fixes for v1.4.2 branch

### DIFF
--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -43,7 +43,9 @@ func (e EventJournalD) Write(ee Event) error {
 		m["PODMAN_IMAGE"] = ee.Image
 		m["PODMAN_NAME"] = ee.Name
 		m["PODMAN_ID"] = ee.ID
-		m["PODMAN_EXIT_CODE"] = strconv.Itoa(ee.ContainerExitCode)
+		if ee.ContainerExitCode != 0 {
+			m["PODMAN_EXIT_CODE"] = strconv.Itoa(ee.ContainerExitCode)
+		}
 	case Volume:
 		m["PODMAN_NAME"] = ee.Name
 	}

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -70,6 +70,11 @@ func (e EventJournalD) Read(options ReadOptions) error {
 		if err := j.SeekTail(); err != nil {
 			return errors.Wrap(err, "failed to seek end of journal")
 		}
+	} else {
+		podmanJournal := sdjournal.Match{Field: "SYSLOG_IDENTIFIER", Value: "podman"} //nolint
+		if err := j.AddMatch(podmanJournal.String()); err != nil {
+			return errors.Wrap(err, "failed to add filter for event log")
+		}
 	}
 	// the api requires a next|prev before getting a cursor
 	if _, err := j.Next(); err != nil {

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -4,6 +4,7 @@ package events
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/coreos/go-systemd/journal"
@@ -42,6 +43,7 @@ func (e EventJournalD) Write(ee Event) error {
 		m["PODMAN_IMAGE"] = ee.Image
 		m["PODMAN_NAME"] = ee.Name
 		m["PODMAN_ID"] = ee.ID
+		m["PODMAN_EXIT_CODE"] = strconv.Itoa(ee.ContainerExitCode)
 	case Volume:
 		m["PODMAN_NAME"] = ee.Name
 	}
@@ -141,6 +143,14 @@ func newEventFromJournalEntry(entry *sdjournal.JournalEntry) (*Event, error) { /
 	case Container, Pod:
 		newEvent.ID = entry.Fields["PODMAN_ID"]
 		newEvent.Image = entry.Fields["PODMAN_IMAGE"]
+		if code, ok := entry.Fields["PODMAN_EXIT_CODE"]; ok {
+			intCode, err := strconv.Atoi(code)
+			if err != nil {
+				logrus.Errorf("Error parsing event exit code %s", code)
+			} else {
+				newEvent.ContainerExitCode = intCode
+			}
+		}
 	case Image:
 		newEvent.ID = entry.Fields["PODMAN_ID"]
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ package version
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-const Version = "1.4.2-stable1"
+const Version = "1.4.2-stable2"
 
 // RemoteAPIVersion is the version for the remote
 // client API.  It is used to determine compatibility


### PR DESCRIPTION
Specifically related to exit codes with 'podman run --rm' and the journald events backend.