### PR TITLE
Add ability to look up volumes by unambiguous partial name

### DIFF
--- a/API.md
+++ b/API.md
@@ -177,7 +177,7 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func VolumeCreate(options: VolumeCreateOpts) string](#VolumeCreate)
 
-[func VolumeRemove(options: VolumeRemoveOpts) []string](#VolumeRemove)
+[func VolumeRemove(options: VolumeRemoveOpts) []string, map[string]](#VolumeRemove)
 
 [func VolumesPrune() []string, []string](#VolumesPrune)
 
@@ -1151,7 +1151,7 @@ VolumeCreate creates a volume on a remote host
 ### <a name="VolumeRemove"></a>func VolumeRemove
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
-method VolumeRemove(options: [VolumeRemoveOpts](#VolumeRemoveOpts)) [[]string](#[]string)</div>
+method VolumeRemove(options: [VolumeRemoveOpts](#VolumeRemoveOpts)) [[]string](#[]string), [map[string]](#map[string])</div>
 VolumeRemove removes a volume on a remote host
 ### <a name="VolumesPrune"></a>func VolumesPrune
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">

--- a/cmd/podman/shared/volumes_shared.go
+++ b/cmd/podman/shared/volumes_shared.go
@@ -1,0 +1,47 @@
+package shared
+
+import (
+	"context"
+
+	"github.com/containers/libpod/libpod"
+)
+
+// Remove given set of volumes
+func SharedRemoveVolumes(ctx context.Context, runtime *libpod.Runtime, vols []string, all, force bool) ([]string, map[string]error, error) {
+	var (
+		toRemove []*libpod.Volume
+		success  []string
+		failed   map[string]error
+	)
+
+	failed = make(map[string]error)
+
+	if all {
+		vols, err := runtime.Volumes()
+		if err != nil {
+			return nil, nil, err
+		}
+		toRemove = vols
+	} else {
+		for _, v := range vols {
+			vol, err := runtime.LookupVolume(v)
+			if err != nil {
+				failed[v] = err
+				continue
+			}
+			toRemove = append(toRemove, vol)
+		}
+	}
+
+	// We could parallelize this, but I haven't heard anyone complain about
+	// performance here yet, so hold off.
+	for _, vol := range toRemove {
+		if err := runtime.RemoveVolume(ctx, vol, force); err != nil {
+			failed[vol.Name()] = err
+			continue
+		}
+		success = append(success, vol.Name())
+	}
+
+	return success, failed, nil
+}

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -1212,7 +1212,7 @@ method ReceiveFile(path: string, delete: bool) -> (len: int)
 method VolumeCreate(options: VolumeCreateOpts) -> (volumeName: string)
 
 # VolumeRemove removes a volume on a remote host
-method VolumeRemove(options: VolumeRemoveOpts) -> (volumeNames: []string)
+method VolumeRemove(options: VolumeRemoveOpts) -> (successes: []string, failures: [string]string)
 
 # GetVolumes gets slice of the volumes on a remote host
 method GetVolumes(args: []string, all: bool) -> (volumes: []Volume)

--- a/cmd/podman/volume_rm.go
+++ b/cmd/podman/volume_rm.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"
@@ -52,19 +50,9 @@ func volumeRmCmd(c *cliconfig.VolumeRmValues) error {
 		return errors.Wrapf(err, "error creating libpod runtime")
 	}
 	defer runtime.DeferredShutdown(false)
-	deletedVolumeNames, err := runtime.RemoveVolumes(getContext(), c)
+	deletedVolumeNames, deletedVolumeErrors, err := runtime.RemoveVolumes(getContext(), c)
 	if err != nil {
-		if len(deletedVolumeNames) > 0 {
-			printDeleteVolumes(deletedVolumeNames)
-			return err
-		}
+		return err
 	}
-	printDeleteVolumes(deletedVolumeNames)
-	return err
-}
-
-func printDeleteVolumes(volumes []string) {
-	for _, v := range volumes {
-		fmt.Println(v)
-	}
+	return printCmdResults(deletedVolumeNames, deletedVolumeErrors)
 }

--- a/docs/podman-volume-inspect.1.md
+++ b/docs/podman-volume-inspect.1.md
@@ -11,6 +11,7 @@ podman\-volume\-inspect - Get detailed information on one or more volumes
 Display detailed information on one or more volumes. The output can be formatted using
 the **--format** flag and a Go template. To get detailed information about all the
 existing volumes, use the **--all** flag.
+Volumes can be queried individually by providing their full name or a unique partial name.
 
 
 ## OPTIONS

--- a/docs/podman-volume-rm.1.md
+++ b/docs/podman-volume-rm.1.md
@@ -4,14 +4,14 @@
 podman\-volume\-rm - Remove one or more volumes
 
 ## SYNOPSIS
-**podman volume rm** [*options*]
+**podman volume rm** [*options*] *volume* [...]
 
 ## DESCRIPTION
 
-Removes one ore more volumes. Only volumes that are not being used will be removed.
+Removes one or more volumes. Only volumes that are not being used will be removed.
 If a volume is being used by a container, an error will be returned unless the **--force**
-flag is being used. To remove all the volumes, use the **--all** flag.
-
+flag is being used. To remove all volumes, use the **--all** flag.
+Volumes can be removed individually by providing their full name or a unique partial name.
 
 ## OPTIONS
 

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -190,6 +190,9 @@ type State interface {
 	// Volume accepts full name of volume
 	// If the volume doesn't exist, an error will be returned
 	Volume(volName string) (*Volume, error)
+	// LookupVolume accepts an unambiguous partial name or full name of a
+	// volume. Ambiguous names will result in an error.
+	LookupVolume(name string) (*Volume, error)
 	// HasVolume returns true if volName exists in the state,
 	// otherwise it returns false
 	HasVolume(volName string) (bool, error)

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -196,8 +196,8 @@ func (r *LocalRuntime) CreateVolume(ctx context.Context, c *cliconfig.VolumeCrea
 }
 
 // RemoveVolumes is a wrapper to remove volumes
-func (r *LocalRuntime) RemoveVolumes(ctx context.Context, c *cliconfig.VolumeRmValues) ([]string, error) {
-	return r.Runtime.RemoveVolumes(ctx, c.InputArgs, c.All, c.Force)
+func (r *LocalRuntime) RemoveVolumes(ctx context.Context, c *cliconfig.VolumeRmValues) ([]string, map[string]error, error) {
+	return shared.SharedRemoveVolumes(ctx, r.Runtime, c.InputArgs, c.All, c.Force)
 }
 
 // Push is a wrapper to push an image to a registry
@@ -220,7 +220,7 @@ func (r *LocalRuntime) InspectVolumes(ctx context.Context, c *cliconfig.VolumeIn
 		volumes, err = r.GetAllVolumes()
 	} else {
 		for _, v := range c.InputArgs {
-			vol, err := r.GetVolume(v)
+			vol, err := r.LookupVolume(v)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -622,13 +622,18 @@ func (r *LocalRuntime) CreateVolume(ctx context.Context, c *cliconfig.VolumeCrea
 }
 
 // RemoveVolumes removes volumes over a varlink connection for the remote client
-func (r *LocalRuntime) RemoveVolumes(ctx context.Context, c *cliconfig.VolumeRmValues) ([]string, error) {
+func (r *LocalRuntime) RemoveVolumes(ctx context.Context, c *cliconfig.VolumeRmValues) ([]string, map[string]error, error) {
 	rmOpts := iopodman.VolumeRemoveOpts{
 		All:     c.All,
 		Force:   c.Force,
 		Volumes: c.InputArgs,
 	}
-	return iopodman.VolumeRemove().Call(r.Conn, rmOpts)
+	success, failures, err := iopodman.VolumeRemove().Call(r.Conn, rmOpts)
+	stringsToErrors := make(map[string]error)
+	for k, v := range failures {
+		stringsToErrors[k] = errors.New(v)
+	}
+	return success, stringsToErrors, err
 }
 
 func (r *LocalRuntime) Push(ctx context.Context, srcName, destination, manifestMIMEType, authfile, digestfile, signaturePolicyPath string, writer io.Writer, forceCompress bool, signingOptions image.SigningOptions, dockerRegistryOptions *image.DockerRegistryOptions, additionalDockerArchiveTags []reference.NamedTagged) error {

--- a/pkg/varlinkapi/volumes.go
+++ b/pkg/varlinkapi/volumes.go
@@ -3,6 +3,7 @@
 package varlinkapi
 
 import (
+	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
 )
@@ -32,11 +33,16 @@ func (i *LibpodAPI) VolumeCreate(call iopodman.VarlinkCall, options iopodman.Vol
 
 // VolumeRemove removes volumes by options.All or options.Volumes
 func (i *LibpodAPI) VolumeRemove(call iopodman.VarlinkCall, options iopodman.VolumeRemoveOpts) error {
-	deletedVolumes, err := i.Runtime.RemoveVolumes(getContext(), options.Volumes, options.All, options.Force)
+	success, failed, err := shared.SharedRemoveVolumes(getContext(), i.Runtime, options.Volumes, options.All, options.Force)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
-	return call.ReplyVolumeRemove(deletedVolumes)
+	// Convert map[string]string to map[string]error
+	errStrings := make(map[string]string)
+	for k, v := range failed {
+		errStrings[k] = v.Error()
+	}
+	return call.ReplyVolumeRemove(success, errStrings)
 }
 
 // GetVolumes returns all the volumes known to the remote system

--- a/test/e2e/volume_rm_test.go
+++ b/test/e2e/volume_rm_test.go
@@ -89,4 +89,38 @@ var _ = Describe("Podman volume rm", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(0))
 	})
+
+	It("podman volume rm by partial name", func() {
+		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "rm", "myv"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(0))
+	})
+
+	It("podman volume rm by nonunique partial name", func() {
+		session := podmanTest.Podman([]string{"volume", "create", "myvol1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "create", "myvol2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "rm", "myv"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray()) >= 2).To(BeTrue())
+	})
 })


### PR DESCRIPTION
Fixes #3891

Add the ability to look up volumes based on partial names, so long as the name given is not ambiguous. This is piped into `volume remove` and `volume inspect` so we can use those with short names. It is not piped into `--volume` and `--mount` for `podman run` - a full name will still be required there, as we create volumes that don't exist (IE, changing the behavior would break Docker compatibility).