### PR TITLE
image: remove unused Decompose method

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	types2 "github.com/containernetworking/cni/pkg/types"
 	cp "github.com/containers/image/copy"
 	"github.com/containers/image/directory"
 	dockerarchive "github.com/containers/image/docker/archive"
@@ -382,11 +381,6 @@ func (i *Image) Remove(ctx context.Context, force bool) error {
 		parent = nextParent
 	}
 	return nil
-}
-
-// Decompose an Image
-func (i *Image) Decompose() error {
-	return types2.NotImplementedError
 }
 
 // TODO: Rework this method to not require an assembly of the fq name with transport


### PR DESCRIPTION
Decompose() returns an error defined in CNI which has been removed
upstream because it had no in-tree (eg in CNI) users.

@mrunalp @baude @mheon 