### PR TITLE
dont panic when using varlink commit and uppercase image names

### DIFF
--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -563,7 +563,6 @@ func (i *LibpodAPI) Commit(call iopodman.VarlinkCall, name, imageName string, ch
 	}
 
 	c := make(chan error)
-	defer close(c)
 
 	go func() {
 		newImage, err = ctr.Commit(getContext(), imageName, options)
@@ -571,6 +570,7 @@ func (i *LibpodAPI) Commit(call iopodman.VarlinkCall, name, imageName string, ch
 			c <- err
 		}
 		c <- nil
+		close(c)
 	}()
 
 	// reply is the func being sent to the output forwarder.  in this case it is replying

--- a/test/endpoint/commit.go
+++ b/test/endpoint/commit.go
@@ -1,0 +1,47 @@
+package endpoint
+
+import (
+	"encoding/json"
+	"os"
+
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman commit", func() {
+	var (
+		tempdir      string
+		err          error
+		endpointTest *EndpointTestIntegration
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		endpointTest = Setup(tempdir)
+		endpointTest.StartVarlinkWithCache()
+	})
+
+	AfterEach(func() {
+		endpointTest.Cleanup()
+
+	})
+
+	It("ensure commit with uppercase image name does not panic", func() {
+		body := make(map[string]string)
+		body["image_name"] = "FOO"
+		body["format"] = "oci"
+		body["name"] = "top"
+		b, err := json.Marshal(body)
+		Expect(err).To(BeNil())
+		// run the container to be committed
+		_ = endpointTest.startTopContainer("top")
+		result := endpointTest.Varlink("Commit", string(b), false)
+		// This indicates an error occured
+		Expect(len(result.StdErrToString())).To(BeNumerically(">", 0))
+	})
+
+})

--- a/test/endpoint/endpoint.go
+++ b/test/endpoint/endpoint.go
@@ -189,6 +189,11 @@ func (p *EndpointTestIntegration) Varlink(endpoint, message string, more bool) *
 	return &EndpointSession{session}
 }
 
+func (s *EndpointSession) StdErrToString() string {
+	fields := strings.Fields(fmt.Sprintf("%s", s.Err.Contents()))
+	return strings.Join(fields, " ")
+}
+
 func (s *EndpointSession) OutputToString() string {
 	fields := strings.Fields(fmt.Sprintf("%s", s.Out.Contents()))
 	return strings.Join(fields, " ")

--- a/test/endpoint/exists_test.go
+++ b/test/endpoint/exists_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Podman pull", func() {
+var _ = Describe("Podman exists", func() {
 	var (
 		tempdir      string
 		err          error


### PR DESCRIPTION
when using an upper case image name for container commit, we observed
panics due to a channel closing early.

Fixes: #3897

Signed-off-by: baude <bbaude@redhat.com>