### PR TITLE
rootless: bind mount devices instead of creating them

### DIFF
--- a/pkg/spec/config_linux.go
+++ b/pkg/spec/config_linux.go
@@ -173,15 +173,16 @@ func (c *CreateConfig) addPrivilegedDevices(g *generate.Generator) error {
 			newMounts = append(newMounts, devMnt)
 		}
 		g.Config.Mounts = append(newMounts, g.Config.Mounts...)
+		g.Config.Linux.Resources.Devices = nil
 	} else {
 		for _, d := range hostDevices {
 			g.AddDevice(Device(d))
 		}
+		// Add resources device - need to clear the existing one first.
+		g.Config.Linux.Resources.Devices = nil
+		g.AddLinuxResourcesDevice(true, "", nil, nil, "rwm")
 	}
 
-	// Add resources device - need to clear the existing one first.
-	g.Config.Linux.Resources.Devices = nil
-	g.AddLinuxResourcesDevice(true, "", nil, nil, "rwm")
 	return nil
 }
 

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -35,44 +35,40 @@ var _ = Describe("Podman run device", func() {
 	})
 
 	It("podman run bad device test", func() {
-		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/baddevice", ALPINE, "ls", "/dev/kmsg"})
+		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/baddevice", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
 
 	It("podman run device test", func() {
-		SkipIfRootless()
-		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/kmsg", ALPINE, "ls", "--color=never", "/dev/kmsg"})
+		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg", ALPINE, "ls", "--color=never", "/dev/kmsg"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Equal("/dev/kmsg"))
 	})
 
 	It("podman run device rename test", func() {
-		SkipIfRootless()
-		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/kmsg:/dev/kmsg1", ALPINE, "ls", "--color=never", "/dev/kmsg1"})
+		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg:/dev/kmsg1", ALPINE, "ls", "--color=never", "/dev/kmsg1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Equal("/dev/kmsg1"))
 	})
 
 	It("podman run device permission test", func() {
-		SkipIfRootless()
-		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/kmsg:r", ALPINE, "ls", "--color=never", "/dev/kmsg"})
+		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg:r", ALPINE, "ls", "--color=never", "/dev/kmsg"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Equal("/dev/kmsg"))
 	})
 
 	It("podman run device rename and permission test", func() {
-		SkipIfRootless()
-		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/kmsg:/dev/kmsg1:r", ALPINE, "ls", "--color=never", "/dev/kmsg1"})
+		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg:/dev/kmsg1:r", ALPINE, "ls", "--color=never", "/dev/kmsg1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Equal("/dev/kmsg1"))
 	})
 	It("podman run device rename and bad permission test", func() {
-		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/kmsg:/dev/kmsg1:rd", ALPINE, "ls", "--color=never", "/dev/kmsg1"})
+		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg:/dev/kmsg1:rd", ALPINE, "ls", "--color=never", "/dev/kmsg1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})


### PR DESCRIPTION
when running in rootless mode, --device creates a bind mount from the
host instead of specifying the device in the OCI configuration.  This
is required as an unprivileged user cannot use mknod, even when root
in a user namespace.

Closes: https://github.com/containers/libpod/issues/3905

Signed-off-by: Giuseppe Scrivano <giuseppe@scrivano.org>