### PR TITLE
cli-flags: use a consistent format for <size><unit>

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -22,7 +22,8 @@ var (
 )
 
 const (
-	idTruncLength = 12
+	idTruncLength      = 12
+	sizeWithUnitFormat = "(format: `<number>[<unit>]`, where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))"
 )
 
 func splitCamelCase(src string) string {
@@ -302,7 +303,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.String(
 		"kernel-memory", "",
-		"Kernel memory limit (format: `<number>[<unit>]`, where unit = b, k, m or g)",
+		"Kernel memory limit "+sizeWithUnitFormat,
 	)
 	createFlags.StringArrayP(
 		"label", "l", []string{},
@@ -326,11 +327,11 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.StringP(
 		"memory", "m", "",
-		"Memory limit (format: <number>[<unit>], where unit = b, k, m or g)",
+		"Memory limit "+sizeWithUnitFormat,
 	)
 	createFlags.String(
 		"memory-reservation", "",
-		"Memory soft limit (format: <number>[<unit>], where unit = b, k, m or g)",
+		"Memory soft limit "+sizeWithUnitFormat,
 	)
 	createFlags.String(
 		"memory-swap", "",
@@ -422,7 +423,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.String(
 		"shm-size", cliconfig.DefaultShmSize,
-		"Size of `/dev/shm`. The format is `<number><unit>`",
+		"Size of /dev/shm "+sizeWithUnitFormat,
 	)
 	createFlags.String(
 		"stop-signal", "",

--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -281,7 +281,7 @@ with 3 being roughly equivalent to using the global *--debug* option, and
 values below 0 omitting even error messages which accompany fatal errors.
 
 **--memory**, **-m**=*LIMIT*
-Memory limit (format: <number>[<unit>], where unit = b, k, m or g)
+Memory limit (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 Allows you to constrain the memory available to a container. If the host
 supports swap memory, then the **-m** memory setting can be larger than physical

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -379,7 +379,7 @@ Default is to create a private IPC namespace (POSIX SysV IPC) for the container
 
 **--kernel-memory**=*number[unit]*
 
-Kernel memory limit (format: `<number>[<unit>]`, where unit = b, k, m or g)
+Kernel memory limit (format: `<number>[<unit>]`, where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 Constrains the kernel memory available to a container. If a limit of 0
 is specified (not using `--kernel-memory`), the container's kernel memory
@@ -421,7 +421,7 @@ Not currently supported
 
 **--memory**, **-m**=*limit*
 
-Memory limit (format: <number>[<unit>], where unit = b, k, m or g)
+Memory limit (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 Allows you to constrain the memory available to a container. If the host
 supports swap memory, then the **-m** memory setting can be larger than physical
@@ -431,7 +431,7 @@ system's page size (the value would be very large, that's millions of trillions)
 
 **--memory-reservation**=*limit*
 
-Memory soft limit (format: <number>[<unit>], where unit = b, k, m or g)
+Memory soft limit (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 After setting memory reservation, when the system detects memory contention
 or low memory, containers are forced to restrict their consumption to their
@@ -661,9 +661,9 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 **--shm-size**=*size*
 
-Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater than `0`.
-Unit is optional and can be `b` (bytes), `k` (kilobytes), `m`(megabytes), or `g` (gigabytes).
+Size of `/dev/shm` (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
+When size is `0`, there is no limit on the amount of memory used for IPC by the container.
 
 **--stop-signal**=*SIGTERM*
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -390,7 +390,7 @@ Default is to create a private IPC namespace (POSIX SysV IPC) for the container
 
 **--kernel-memory**=*number[unit]*
 
-Kernel memory limit (format: `<number>[<unit>]`, where unit = b, k, m or g)
+Kernel memory limit (format: `<number>[<unit>]`, where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 Constrains the kernel memory available to a container. If a limit of 0
 is specified (not using `--kernel-memory`), the container's kernel memory
@@ -432,7 +432,7 @@ Not currently supported
 
 **--memory**, **-m**=*limit*
 
-Memory limit (format: <number>[<unit>], where unit = b, k, m or g)
+Memory limit (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 Allows you to constrain the memory available to a container. If the host
 supports swap memory, then the **-m** memory setting can be larger than physical
@@ -442,7 +442,7 @@ system's page size (the value would be very large, that's millions of trillions)
 
 **--memory-reservation**=*limit*
 
-Memory soft limit (format: <number>[<unit>], where unit = b, k, m or g)
+Memory soft limit (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 After setting memory reservation, when the system detects memory contention
 or low memory, containers are forced to restrict their consumption to their
@@ -683,9 +683,9 @@ Note: Labeling can be disabled for all containers by setting label=false in the 
 
 **--shm-size**=*size*
 
-Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater than `0`.
-Unit is optional and can be `b` (bytes), `k` (kilobytes), `m`(megabytes), or `g` (gigabytes).
+Size of `/dev/shm` (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
+When size is `0`, there is no limit on the amount of memory used for IPC by the container.
 
 **--sig-proxy**=*true|false*
 


### PR DESCRIPTION
Use a consistent format for description of the <size><unit> flags.
Also, avoid backticks for /dev/shm, as that's interpreted as the format
by the flag parsing lib.

Signed-off-by: Marco Vedovati <mvedovati@suse.com>

------------------------

Before / after:
```
$ podman run --help | grep unit
      --kernel-memory <number>[<unit>]           Kernel memory limit (format: <number>[<unit>], where unit = b, k, m or g)
  -m, --memory string                            Memory limit (format: <number>[<unit>], where unit = b, k, m or g)
      --memory-reservation string                Memory soft limit (format: <number>[<unit>], where unit = b, k, m or g)
      --shm-size /dev/shm                        Size of /dev/shm. The format is `<number><unit>` (default "65536k")

$ ./bin/podman run --help | grep unit
      --kernel-memory <number>[<unit>]           Kernel memory limit (format: <number>[<unit>], where unit = b, k, m or g)
  -m, --memory <number>[<unit>]                  Memory limit (format: <number>[<unit>], where unit = b, k, m or g)
      --memory-reservation <number>[<unit>]      Memory soft limit (format: <number>[<unit>], where unit = b, k, m or g)
      --shm-size <number>[<unit>]                Size of /dev/shm (format: <number>[<unit>], where unit = b, k, m or g) (default "65536k")

```