### PR TITLE
Fix formatting and enable hack/man-page-checker

### DIFF
--- a/docs/links/podman-image-rm.1
+++ b/docs/links/podman-image-rm.1
@@ -1,1 +1,1 @@
-.so man1/podman-rm.1
+.so man1/podman-rmi.1

--- a/docs/podman-attach.1.md
+++ b/docs/podman-attach.1.md
@@ -6,6 +6,8 @@ podman\-attach - Attach to a running container
 ## SYNOPSIS
 **podman attach** [*options*] *container*
 
+**podman container attach** [*options*] *container*
+
 ## DESCRIPTION
 The attach command allows you to attach to a running container using the container's ID
 or name, either to view its ongoing output or to control it interactively.

--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -6,6 +6,8 @@ podman\-build - Build a container image using a Dockerfile
 ## SYNOPSIS
 **podman build** [*options*] *context*
 
+**podman image build** [*options*] *context*
+
 ## DESCRIPTION
 **podman build** Builds an image using instructions from one or more Dockerfiles and a specified build context directory.
 

--- a/docs/podman-commit.1.md
+++ b/docs/podman-commit.1.md
@@ -6,6 +6,8 @@ podman\-commit - Create new image based on the changed container
 ## SYNOPSIS
 **podman commit** [*options*] *container* *image*
 
+**podman container commit** [*options*] *container* *image*
+
 ## DESCRIPTION
 **podman commit** creates an image based on a changed container. The author of the
 image can be set using the `--author` flag. Various image instructions can be

--- a/docs/podman-container-cleanup.1.md
+++ b/docs/podman-container-cleanup.1.md
@@ -1,7 +1,7 @@
 % podman-container-cleanup(1)
 
 ## NAME
-podman\-container\-cleanup - Cleanup Container storage and networks
+podman\-container\-cleanup - Cleanup the container's network and mountpoints
 
 ## SYNOPSIS
 **podman container cleanup** [*options*] *container*

--- a/docs/podman-container-prune.1.md
+++ b/docs/podman-container-prune.1.md
@@ -1,7 +1,7 @@
 % podman-container-prune(1)
 
 ## NAME
-podman-container-prune - Remove all stopped containers
+podman-container-prune - Remove all stopped containers from local storage
 
 ## SYNOPSIS
 **podman container prune** [*options*]

--- a/docs/podman-container-restore.1.md
+++ b/docs/podman-container-restore.1.md
@@ -1,7 +1,7 @@
 % podman-container-restore(1)
 
 ## NAME
-podman\-container\-restore - Restores one or more running containers
+podman\-container\-restore - Restores one or more containers from a checkpoint
 
 ## SYNOPSIS
 **podman container restore** [*options*] *container* ...

--- a/docs/podman-container-runlabel.1.md
+++ b/docs/podman-container-runlabel.1.md
@@ -1,10 +1,10 @@
 % podman-container-runlabel(1)
 
 ## NAME
-podman-container-runlabel - Execute Image Label Method
+podman-container-runlabel - Executes a command as described by a container image label
 
 ## SYNOPSIS
-**podman container runlabel** [*options*] *LABEL* *IMAGE* [ARG...]
+**podman container runlabel** [*options*] *label* *image* [*arg...*]
 
 ## DESCRIPTION
 **podman container runlabel** reads the provided `LABEL` field in the container

--- a/docs/podman-container.1.md
+++ b/docs/podman-container.1.md
@@ -14,8 +14,8 @@ The container command allows you to manage containers
 | Command    | Man Page                                            | Description                                                                  |
 | ---------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
 | attach     | [podman-attach(1)](podman-attach.1.md)              | Attach to a running container.                                               |
-| checkpoint | [podman-container-checkpoint(1)](podman-container-checkpoint.1.md)  | Checkpoints one or more containers.                          |
-| cleanup    | [podman-container-cleanup(1)](podman-container-cleanup.1.md)    | Cleanup containers network and mountpoints.                      |
+| checkpoint | [podman-container-checkpoint(1)](podman-container-checkpoint.1.md)  | Checkpoints one or more running containers.                  |
+| cleanup    | [podman-container-cleanup(1)](podman-container-cleanup.1.md)    | Cleanup the container's network and mountpoints.                 |
 | commit     | [podman-commit(1)](podman-commit.1.md)              | Create new image based on the changed container.                             |
 | cp         | [podman-cp(1)](podman-cp.1.md)                      | Copy files/folders between a container and the local filesystem.             |
 | create     | [podman-create(1)](podman-create.1.md)              | Create a new container.                                                      |

--- a/docs/podman-cp.1.md
+++ b/docs/podman-cp.1.md
@@ -6,6 +6,8 @@ podman\-cp - Copy files/folders between a container and the local filesystem
 ## SYNOPSIS
 **podman cp** [*options*] [*container*:]*src_path* [*container*:]*dest_path*
 
+**podman container cp** [*options*] [*container*:]*src_path* [*container*:]*dest_path*
+
 ## DESCRIPTION
 Copies the contents of **src_path** to the **dest_path**. You can copy from the container's filesystem to the local machine or the reverse, from the local filesystem to the container.
 If - is specified for either the SRC_PATH or DEST_PATH, you can also stream a tar archive from STDIN or to STDOUT.

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -6,6 +6,8 @@ podman\-create - Create a new container
 ## SYNOPSIS
 **podman create** [*options*] *image* [*command* [*arg* ...]]
 
+**podman container create** [*options*] *image* [*command* [*arg* ...]]
+
 ## DESCRIPTION
 
 Creates a writable container layer over the specified image and prepares it for

--- a/docs/podman-diff.1.md
+++ b/docs/podman-diff.1.md
@@ -6,6 +6,8 @@ podman\-diff - Inspect changes on a container or image's filesystem
 ## SYNOPSIS
 **podman diff** [*options*] *name*
 
+**podman container diff** [*options*] *name*
+
 ## DESCRIPTION
 Displays changes on a container or image's filesystem.  The container or image will be compared to its parent layer
 

--- a/docs/podman-exec.1.md
+++ b/docs/podman-exec.1.md
@@ -6,6 +6,8 @@ podman\-exec - Execute a command in a running container
 ## SYNOPSIS
 **podman exec** [*options*] *container* [*command* [*arg* ...]]
 
+**podman container exec** [*options*] *container* [*command* [*arg* ...]]
+
 ## DESCRIPTION
 **podman exec** executes a command in a running container.
 

--- a/docs/podman-export.1.md
+++ b/docs/podman-export.1.md
@@ -6,6 +6,8 @@ podman\-export - Export a container's filesystem contents as a tar archive
 ## SYNOPSIS
 **podman export** [*options*] *container*
 
+**podman container export** [*options*] *container*
+
 ## DESCRIPTION
 **podman export** exports the filesystem of a container and saves it as a tarball
 on the local machine. **podman export** writes to STDOUT by default and can be

--- a/docs/podman-generate-kube.1.md
+++ b/docs/podman-generate-kube.1.md
@@ -1,6 +1,6 @@
 % podman-generate-kube(1)
 ## NAME
-podman-generate-kube - Generate Kubernetes YAML
+podman-generate-kube - Generate Kubernetes YAML based on a pod or container
 
 ## SYNOPSIS
 **podman generate kube** [*options*] *container* | *pod*

--- a/docs/podman-generate-systemd.1.md
+++ b/docs/podman-generate-systemd.1.md
@@ -1,7 +1,7 @@
 % podman-generate-systemd(1)
 
 ## NAME
-podman-generate-systemd- Generate Systemd Unit file
+podman\-generate\-systemd - Generate systemd unit file(s) for a container. Not supported for the remote client
 
 ## SYNOPSIS
 **podman generate systemd** [*options*] *container|pod*

--- a/docs/podman-history.1.md
+++ b/docs/podman-history.1.md
@@ -6,6 +6,8 @@ podman\-history - Show the history of an image
 ## SYNOPSIS
 **podman history** [*options*] *image*[:*tag*|@*digest*]
 
+**podman image history** [*options*] *image*[:*tag*|@*digest*]
+
 ## DESCRIPTION
 **podman history** displays the history of an image by printing out information
 about each layer used in the image. The information printed out for each layer

--- a/docs/podman-image-prune.1.md
+++ b/docs/podman-image-prune.1.md
@@ -1,7 +1,7 @@
 % podman-image-prune(1)
 
 ## NAME
-podman-image-prune - Remove all unused images
+podman-image-prune - Remove all unused images from the local store
 
 ## SYNOPSIS
 **podman image prune** [*options*]

--- a/docs/podman-image-trust.1.md
+++ b/docs/podman-image-trust.1.md
@@ -5,7 +5,7 @@ podman\-image\-trust - Manage container registry image trust policy
 
 
 ## SYNOPSIS
-**podman image trust** set|show [*options*] *REGISTRY[/REPOSITORY]*
+**podman image trust** set|show [*options*] *registry[/repository]*
 
 ## DESCRIPTION
 Manages which registries you trust as a source of container images  based on its location.  The location is determined

--- a/docs/podman-image.1.md
+++ b/docs/podman-image.1.md
@@ -25,10 +25,10 @@ The image command allows you to manage images
 | push     | [podman-push(1)](podman-push.1.md)              | Push an image from local storage to elsewhere.                              |
 | rm       | [podman-rmi(1)](podman-rmi.1.md)                | Removes one or more locally stored images.                                  |
 | save     | [podman-save(1)](podman-save.1.md)              | Save an image to docker-archive or oci.                                     |
-| sign     | [podman-image-sign(1)](podman-image-sign.1.md)  | Sign an image.                                                              |
+| sign     | [podman-image-sign(1)](podman-image-sign.1.md)  | Create a signature for an image.                                            |
 | tag      | [podman-tag(1)](podman-tag.1.md)                | Add an additional name to a local image.                                    |
 | tree     | [podman-image-tree(1)](podman-image-tree.1.md)  | Prints layer hierarchy of an image in a tree format.                        |
-| trust    | [podman-image-trust(1)](podman-image-trust.1.md)| Manage container image trust policy.                                        |
+| trust    | [podman-image-trust(1)](podman-image-trust.1.md)| Manage container registry image trust policy.                               |
 
 ## SEE ALSO
 podman

--- a/docs/podman-images.1.md
+++ b/docs/podman-images.1.md
@@ -6,6 +6,10 @@ podman\-images - List images in local storage
 ## SYNOPSIS
 **podman images** [*options*]
 
+**podman image list** [*options*]
+
+**podman image ls** [*options*]
+
 ## DESCRIPTION
 Displays locally stored images, their names, and their IDs.
 

--- a/docs/podman-import.1.md
+++ b/docs/podman-import.1.md
@@ -6,6 +6,8 @@ podman\-import - Import a tarball and save it as a filesystem image
 ## SYNOPSIS
 **podman import** [*options*] *path* [*reference*]
 
+**podman image import** [*options*] *path* [*reference*]
+
 ## DESCRIPTION
 **podman import** imports a tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz)
 and saves it as a filesystem image. Remote tarballs can be specified using a URL.

--- a/docs/podman-info.1.md
+++ b/docs/podman-info.1.md
@@ -1,12 +1,12 @@
 % podman-info(1)
 
 ## NAME
-podman\-system\-info - Display system information
-podman\-info - Display system information
+podman\-info - Displays Podman related system information
 
 ## SYNOPSIS
 **podman info** [*options*]
 
+**podman system info** [*options*]
 
 ## DESCRIPTION
 

--- a/docs/podman-init.1.md
+++ b/docs/podman-init.1.md
@@ -6,6 +6,8 @@ podman\-init - Initialize one or more containers
 ## SYNOPSIS
 **podman init** [*options*] *container* [*container*...]
 
+**podman container init** [*options*] *container* [*container*...]
+
 ## DESCRIPTION
 Initialize one or more containers.
 You may use container IDs or names as input.

--- a/docs/podman-kill.1.md
+++ b/docs/podman-kill.1.md
@@ -6,6 +6,8 @@ podman\-kill - Kill the main process in one or more containers
 ## SYNOPSIS
 **podman kill** [*options*] [*container* ...]
 
+**podman container kill** [*options*] [*container* ...]
+
 ## DESCRIPTION
 The main process inside each container specified will be sent SIGKILL, or any signal specified with option --signal.
 

--- a/docs/podman-kill.1.md
+++ b/docs/podman-kill.1.md
@@ -1,7 +1,7 @@
 % podman-kill(1)
 
 ## NAME
-podman\-kill - Kills one or more containers with a signal
+podman\-kill - Kill the main process in one or more containers
 
 ## SYNOPSIS
 **podman kill** [*options*] [*container* ...]

--- a/docs/podman-load.1.md
+++ b/docs/podman-load.1.md
@@ -6,6 +6,8 @@ podman\-load - Load an image from a container image archive into container stora
 ## SYNOPSIS
 **podman load** [*options*] [*name*[:*tag*]]
 
+**podman image load** [*options*] [*name*[:*tag*]]
+
 ## DESCRIPTION
 **podman load** loads an image from either an **oci-archive** or **docker-archive** stored on the local machine into container storage. **podman load** reads from stdin by default or a file if the **input** option is set.
 You can also specify a name for the image if the archive does not contain a named reference, of if you want an additional name for the local image.

--- a/docs/podman-logs.1.md
+++ b/docs/podman-logs.1.md
@@ -1,12 +1,12 @@
 % podman-logs(1)
 
 ## NAME
-podman\-container\-logs (podman\-logs) - Fetch the logs of one or more containers
+podman\-logs - Display the logs of one or more containers
 
 ## SYNOPSIS
-**podman container logs** [*options*] *container* [*container...*]
-
 **podman logs** [*options*] *container* [*container...*]
+
+**podman container logs** [*options*] *container* [*container...*]
 
 ## DESCRIPTION
 The podman logs command batch-retrieves whatever logs are present for one or more containers at the time of execution.

--- a/docs/podman-mount.1.md
+++ b/docs/podman-mount.1.md
@@ -1,7 +1,7 @@
 % podman-mount(1)
 
 ## NAME
-podman\-mount - Mount the specified working containers' root filesystem
+podman\-mount - Mount a working container's root filesystem
 
 ## SYNOPSIS
 **podman mount** [*container* ...]

--- a/docs/podman-mount.1.md
+++ b/docs/podman-mount.1.md
@@ -6,6 +6,8 @@ podman\-mount - Mount a working container's root filesystem
 ## SYNOPSIS
 **podman mount** [*container* ...]
 
+**podman container mount** [*container* ...]
+
 ## DESCRIPTION
 Mounts the specified containers' root file system in a location which can be
 accessed from the host, and returns its location.

--- a/docs/podman-network-inspect.1.md
+++ b/docs/podman-network-inspect.1.md
@@ -1,7 +1,7 @@
 % podman-network-inspect(1)
 
 ## NAME
-podman\-network-inspect- Inspect one or more Podman networks
+podman\-network\-inspect - Displays the raw CNI network configuration for one or more networks
 
 ## SYNOPSIS
 **podman network inspect**  [*network* ...]

--- a/docs/podman-network-ls.1.md
+++ b/docs/podman-network-ls.1.md
@@ -1,7 +1,7 @@
 % podman-network-ls(1)
 
 ## NAME
-podman\-network-ls- Display a summary of CNI networks
+podman\-network\-ls - Display a summary of CNI networks
 
 ## SYNOPSIS
 **podman network ls**  [*options*]

--- a/docs/podman-network-rm.1.md
+++ b/docs/podman-network-rm.1.md
@@ -1,7 +1,7 @@
 % podman-network-rm(1)
 
 ## NAME
-podman\-network-rm- Delete a Podman CNI network
+podman\-network\-rm - Remove one or more CNI networks
 
 ## SYNOPSIS
 **podman network rm**  [*network...*]

--- a/docs/podman-network.1.md
+++ b/docs/podman-network.1.md
@@ -1,7 +1,7 @@
 % podman-network(1)
 
 ## NAME
-podman\-network- Manage podman CNI networks
+podman\-network - Manage Podman CNI networks
 
 ## SYNOPSIS
 **podman network** *subcommand*

--- a/docs/podman-pause.1.md
+++ b/docs/podman-pause.1.md
@@ -6,6 +6,8 @@ podman\-pause - Pause one or more containers
 ## SYNOPSIS
 **podman pause** [*options*] [*container*...]
 
+**podman container pause** [*options*] [*container*...]
+
 ## DESCRIPTION
 Pauses all the processes in one or more containers.  You may use container IDs or names as input.
 

--- a/docs/podman-play-kube.1.md
+++ b/docs/podman-play-kube.1.md
@@ -4,7 +4,7 @@
 podman-play-kube - Create pods and containers based on Kubernetes YAML
 
 ## SYNOPSIS
-**podman play kube** [*options*] *file***.yml**
+**podman play kube** [*options*] *file*__.yml__
 
 ## DESCRIPTION
 **podman play kube** will read in a structured file of Kubernetes YAML.  It will then recreate

--- a/docs/podman-play.1.md
+++ b/docs/podman-play.1.md
@@ -14,7 +14,7 @@ file input.  Containers will be automatically started.
 
 | Command  | Man Page                                            | Description                                                                  |
 | -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
-| kube     | [podman-play-kube(1)](podman-play-kube.1.md)        | Recreate pods and containers based on Kubernetes YAML.                       |
+| kube     | [podman-play-kube(1)](podman-play-kube.1.md)        | Create pods and containers based on Kubernetes YAML.                         |
 
 ## SEE ALSO
 podman, podman-pod(1), podman-container(1), podman-generate(1), podman-play(1), podman-play-kube(1)

--- a/docs/podman-pod-kill.1.md
+++ b/docs/podman-pod-kill.1.md
@@ -1,7 +1,7 @@
 % podman-pod-kill(1)
 
 ## NAME
-podman\-pod\-kill - Kills all containers in one or more pods with a signal
+podman\-pod\-kill - Kill the main process of each container in one or more pods
 
 ## SYNOPSIS
 **podman pod kill** [*options*] *pod* ...

--- a/docs/podman-pod-stats.1.md
+++ b/docs/podman-pod-stats.1.md
@@ -1,7 +1,7 @@
 % podman-pod-stats(1)
 
 ## NAME
-podman\-pod\-stats - Display a live stream of resource usage statistics for the containers in one or more pods
+podman\-pod\-stats - Display a live stream of resource usage stats for containers in one or more pods
 
 ## SYNOPSIS
 **podman pod stats** [*options*] [*pod*]

--- a/docs/podman-pod.1.md
+++ b/docs/podman-pod.1.md
@@ -1,7 +1,7 @@
 % podman-pod(1)
 
 ## NAME
-podman\-pod - Simple management tool for groups of containers, called pods.
+podman\-pod - Management tool for groups of containers, called pods
 
 ## SYNOPSIS
 **podman pod** *subcommand*
@@ -11,22 +11,22 @@ podman pod is a set of subcommands that manage pods, or groups of containers.
 
 ## SUBCOMMANDS
 
-| Command | Man Page                                                 | Description                                                                    |
-| ------- | -------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| create  | [podman-pod-create(1)](podman-pod-create.1.md)           | Create a new pod.                                                              |
-| exists  | [podman-pod-exists(1)](podman-pod-exists.1.md)           | Check if a pod exists in local storage.                                        |
-| inspect | [podman-pod-inspect(1)](podman-pod-inspect.1.md)         | Displays information describing a pod.                                         |
-| kill    | [podman-pod-kill(1)](podman-pod-kill.1.md)               | Kill the main process of each container in pod.                                |
-| pause   | [podman-pod-pause(1)](podman-pod-pause.1.md)             | Pause one or more pods.                                                        |
-| prune   | [podman-container-prune(1)](podman-container-prune.1.md) | Remove all stopped containers from local storage.                        |
-| ps      | [podman-pod-ps(1)](podman-pod-ps.1.md)                   | Prints out information about pods.                                             |
-| restart | [podman-pod-restart(1)](podman-pod-restart.1.md)         | Restart one or more pods.                                                      |
-| rm      | [podman-pod-rm(1)](podman-pod-rm.1.md)                   | Remove one or more pods.                                                       |
-| start   | [podman-pod-start(1)](podman-pod-start.1.md)             | Start one or more pods.                                                        |
-| stats   | [podman-pod-stats(1)](podman-pod-stats.1.md)             | Display live stream resource usage stats for containers in one or more pods.   |
-| stop    | [podman-pod-stop(1)](podman-pod-stop.1.md)               | Stop one or more pods.                                                         |
-| top     | [podman-pod-top(1)](podman-pod-top.1.md)                 | Display the running processes of containers in a pod.                          |
-| unpause | [podman-pod-unpause(1)](podman-pod-unpause.1.md)         | Unpause one or more pods.                                                      |
+| Command | Man Page                                          | Description                                                                    |
+| ------- | ------------------------------------------------- | --------------------------------------------------------------------------------- |
+| create  | [podman-pod-create(1)](podman-pod-create.1.md)    | Create a new pod.                                                                 |
+| exists  | [podman-pod-exists(1)](podman-pod-exists.1.md)    | Check if a pod exists in local storage.                                           |
+| inspect | [podman-pod-inspect(1)](podman-pod-inspect.1.md)  | Displays information describing a pod.                                            |
+| kill    | [podman-pod-kill(1)](podman-pod-kill.1.md)        | Kill the main process of each container in one or more pods.                      |
+| pause   | [podman-pod-pause(1)](podman-pod-pause.1.md)      | Pause one or more pods.                                                           |
+| prune   | [podman-pod-prune(1)](podman-pod-prune.1.md)      | Remove all stopped pods.                                                          |
+| ps      | [podman-pod-ps(1)](podman-pod-ps.1.md)            | Prints out information about pods.                                                |
+| restart | [podman-pod-restart(1)](podman-pod-restart.1.md)  | Restart one or more pods.                                                         |
+| rm      | [podman-pod-rm(1)](podman-pod-rm.1.md)            | Remove one or more pods.                                                          |
+| start   | [podman-pod-start(1)](podman-pod-start.1.md)      | Start one or more pods.                                                           |
+| stats   | [podman-pod-stats(1)](podman-pod-stats.1.md)      | Display a live stream of resource usage stats for containers in one or more pods. |
+| stop    | [podman-pod-stop(1)](podman-pod-stop.1.md)        | Stop one or more pods.                                                            |
+| top     | [podman-pod-top(1)](podman-pod-top.1.md)          | Display the running processes of containers in a pod.                             |
+| unpause | [podman-pod-unpause(1)](podman-pod-unpause.1.md)  | Unpause one or more pods.                                                         |
 
 ## SEE ALSO
 podman(1)

--- a/docs/podman-pod.1.md
+++ b/docs/podman-pod.1.md
@@ -11,7 +11,7 @@ podman pod is a set of subcommands that manage pods, or groups of containers.
 
 ## SUBCOMMANDS
 
-| Command | Man Page                                          | Description                                                                    |
+| Command | Man Page                                          | Description                                                                       |
 | ------- | ------------------------------------------------- | --------------------------------------------------------------------------------- |
 | create  | [podman-pod-create(1)](podman-pod-create.1.md)    | Create a new pod.                                                                 |
 | exists  | [podman-pod-exists(1)](podman-pod-exists.1.md)    | Check if a pod exists in local storage.                                           |

--- a/docs/podman-port.1.md
+++ b/docs/podman-port.1.md
@@ -6,6 +6,8 @@ podman\-port - List port mappings for a container
 ## SYNOPSIS
 **podman port** [*options*] *container* [*private-port*[/*proto*]]
 
+**podman container port** [*options*] *container* [*private-port*[/*proto*]]
+
 ## DESCRIPTION
 List port mappings for the *container* or lookup the public-facing port that is NAT-ed to the *private-port*.
 

--- a/docs/podman-ps.1.md
+++ b/docs/podman-ps.1.md
@@ -6,6 +6,16 @@ podman\-ps - Prints out information about containers
 ## SYNOPSIS
 **podman ps** [*options*]
 
+**podman container list** [*options*]
+
+**podman container ls** [*options*]
+
+**podman container ps** [*options*]
+
+**podman list** [*options*]
+
+**podman ls** [*options*]
+
 ## DESCRIPTION
 **podman ps** lists the running containers on the system. Use the **--all** flag to view
 all the containers information.  By default it lists:

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -6,6 +6,8 @@ podman\-pull - Pull an image from a registry
 ## SYNOPSIS
 **podman pull** [*options*] *name*[:*tag*|@*digest*]
 
+**podman image pull** [*options*] *name*[:*tag*|@*digest*]
+
 ## DESCRIPTION
 Copies an image from a registry onto the local machine. **podman pull** pulls an
 image from Docker Hub if a registry is not specified in the command line argument.

--- a/docs/podman-push.1.md
+++ b/docs/podman-push.1.md
@@ -6,6 +6,8 @@ podman\-push - Push an image from local storage to elsewhere
 ## SYNOPSIS
 **podman push** [*options*] *image* [*destination*]
 
+**podman image push** [*options*] *image* [*destination*]
+
 ## DESCRIPTION
 Pushes an image from local storage to a specified destination.
 Push is mainly used to push images to registries, however **podman push**

--- a/docs/podman-remote.1.md
+++ b/docs/podman-remote.1.md
@@ -1,7 +1,7 @@
 % podman-remote(1)
 
 ## NAME
-podman-remote - A tool for remote management of pods, containers and images
+podman-remote - A remote CLI for Podman: A Simple management tool for pods, containers and images.
 
 ## SYNOPSIS
 **podman-remote** [*options*] *command*

--- a/docs/podman-remote.1.md
+++ b/docs/podman-remote.1.md
@@ -1,7 +1,7 @@
 % podman-remote(1)
 
 ## NAME
-podman-remote - A remote CLI for Podman: A Simple management tool for pods, containers and images.
+podman-remote - A tool for remote management of pods, containers and images
 
 ## SYNOPSIS
 **podman-remote** [*options*] *command*

--- a/docs/podman-restart.1.md
+++ b/docs/podman-restart.1.md
@@ -6,6 +6,8 @@ podman\-restart - Restart one or more containers
 ## SYNOPSIS
 **podman restart** [*options*] *container* ...
 
+**podman container restart** [*options*] *container* ...
+
 ## DESCRIPTION
 The restart command allows containers to be restarted using their ID or name.
 Containers will be stopped if they are running and then restarted. Stopped

--- a/docs/podman-rm.1.md
+++ b/docs/podman-rm.1.md
@@ -1,12 +1,12 @@
 % podman-rm(1)
 
 ## NAME
-podman\-container\-rm (podman\-rm) - Remove one or more containers
+podman\-rm - Remove one or more containers
 
 ## SYNOPSIS
-**podman container rm** [*options*] *container*
-
 **podman rm** [*options*] *container*
+
+**podman container rm** [*options*] *container*
 
 ## DESCRIPTION
 **podman rm** will remove one or more containers from the host.  The container name or ID can be used.  This does not remove images.  Running containers will not be removed without the `-f` option

--- a/docs/podman-rmi.1.md
+++ b/docs/podman-rmi.1.md
@@ -1,12 +1,12 @@
 % podman-rmi(1)
 
 ## NAME
-podman\-image\-rm (podman\-rmi) - Removes one or more images
+podman\-rmi - Removes one or more locally stored images
 
 ## SYNOPSIS
-**podman image rm** *image* [...]
-
 **podman rmi** *image* [...]
+
+**podman image rm** *image* [...]
 
 ## DESCRIPTION
 Removes one or more locally stored images.

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -6,6 +6,8 @@ podman\-run - Run a command in a new container
 ## SYNOPSIS
 **podman run** [*options*] *image* [*command* [*arg* ...]]
 
+**podman container run** [*options*] *image* [*command* [*arg* ...]]
+
 ## DESCRIPTION
 
 Run a process in a new container. **podman run** starts a process with its own

--- a/docs/podman-save.1.md
+++ b/docs/podman-save.1.md
@@ -6,6 +6,8 @@ podman\-save - Save an image to a container archive
 ## SYNOPSIS
 **podman save** [*options*] *name*[:*tag*]
 
+**podman image save** [*options*] *name*[:*tag*]
+
 ## DESCRIPTION
 **podman save** saves an image to either **docker-archive**, **oci-archive**, **oci-dir** (directory with oci manifest type), or **docker-dir** (directory with v2s2 manifest type) on the local machine,
 default is **docker-archive**. **podman save** writes to STDOUT by default and can be redirected to a

--- a/docs/podman-start.1.md
+++ b/docs/podman-start.1.md
@@ -6,6 +6,8 @@ podman\-start - Start one or more containers
 ## SYNOPSIS
 **podman start** [*options*] *container* ...
 
+**podman container start** [*options*] *container* ...
+
 ## DESCRIPTION
 Start one or more containers.  You may use container IDs or names as input.  The *attach* and *interactive*
 options cannot be used to override the *--tty* and *--interactive* options from when the container

--- a/docs/podman-stats.1.md
+++ b/docs/podman-stats.1.md
@@ -1,7 +1,7 @@
 % podman-stats(1)
 
 ## NAME
-podman\-stats - Display a live stream of 1 or more containers' resource usage statistics
+podman\-stats - Display a live stream of one or more container's resource usage statistics
 
 ## SYNOPSIS
 **podman stats** [*options*] [*container*]

--- a/docs/podman-stats.1.md
+++ b/docs/podman-stats.1.md
@@ -6,6 +6,8 @@ podman\-stats - Display a live stream of one or more container's resource usage 
 ## SYNOPSIS
 **podman stats** [*options*] [*container*]
 
+**podman container stats** [*options*] [*container*]
+
 ## DESCRIPTION
 Display a live stream of one or more containers' resource usage statistics
 

--- a/docs/podman-stop.1.md
+++ b/docs/podman-stop.1.md
@@ -1,7 +1,7 @@
 % podman-stop(1)
 
 ## NAME
-podman\-stop - Stop one or more containers
+podman\-stop - Stop one or more running containers
 
 ## SYNOPSIS
 **podman stop** [*options*] *container* ...

--- a/docs/podman-stop.1.md
+++ b/docs/podman-stop.1.md
@@ -6,6 +6,8 @@ podman\-stop - Stop one or more running containers
 ## SYNOPSIS
 **podman stop** [*options*] *container* ...
 
+**podman container stop** [*options*] *container* ...
+
 ## DESCRIPTION
 Stops one or more containers.  You may use container IDs or names as input. The **--timeout** switch
 allows you to specify the number of seconds to wait before forcibly stopping the container after the stop command

--- a/docs/podman-system-migrate.1.md
+++ b/docs/podman-system-migrate.1.md
@@ -1,7 +1,7 @@
 % podman-system-migrate(1)
 
 ## NAME
-podman\-system\-migrate - Migrate container to the latest version of podman
+podman\-system\-migrate - Migrate existing containers to a new podman version
 
 ## SYNOPSIS
 ** podman system migrate**

--- a/docs/podman-system-renumber.1.md
+++ b/docs/podman-system-renumber.1.md
@@ -1,7 +1,7 @@
 % podman-system-renumber(1)
 
 ## NAME
-podman\-system\-renumber - Renumber container locks
+podman\-system\-renumber - Migrate lock numbers to handle a change in maximum number of locks
 
 ## SYNOPSIS
 **podman system renumber**

--- a/docs/podman-system.1.md
+++ b/docs/podman-system.1.md
@@ -15,7 +15,7 @@ The system command allows you to manage the podman systems
 | -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
 | df       | [podman-system-df(1)](podman-system-df.1.md)        | Show podman disk usage.                                                      |
 | info     | [podman-system-info(1)](podman-info.1.md)           | Displays Podman related system information.                                  |
-| prune    | [podman-system-prune(1)](podman-system-prune.1.md)  | Remove all unused data                                                       |
+| prune    | [podman-system-prune(1)](podman-system-prune.1.md)  | Remove all unused container, image and volume data                              |
 | renumber | [podman-system-renumber(1)](podman-system-renumber.1.md)| Migrate lock numbers to handle a change in maximum number of locks.      |
 | migrate  | [podman-system-migrate(1)](podman-system-migrate.1.md)| Migrate existing containers to a new podman version.                       |
 

--- a/docs/podman-tag.1.md
+++ b/docs/podman-tag.1.md
@@ -6,6 +6,7 @@ podman\-tag - Add an additional name to a local image
 ## SYNOPSIS
 **podman tag** *image*[:*tag*] *target-name*[:*tag*] [*options*]
 
+**podman image tag** *image*[:*tag*] *target-name*[:*tag*] [*options*]
 
 ## DESCRIPTION
 Assigns a new alias to an image.  An alias refers to the entire image name, including the optional

--- a/docs/podman-top.1.md
+++ b/docs/podman-top.1.md
@@ -6,6 +6,8 @@ podman\-top - Display the running processes of a container
 ## SYNOPSIS
 **podman top** [*options*] *container* [*format-descriptors*]
 
+**podman container top** [*options*] *container* [*format-descriptors*]
+
 ## DESCRIPTION
 Display the running processes of the container. The *format-descriptors* are ps (1) compatible AIX format descriptors but extended to print additional information, such as the seccomp mode or the effective capabilities of a given process. The descriptors can either be passed as separated arguments or as a single comma-separated argument. Note that you can also specify options and or flags of ps(1); in this case, Podman will fallback to executing ps with the specified arguments and flags in the container.
 

--- a/docs/podman-umount.1.md
+++ b/docs/podman-umount.1.md
@@ -1,7 +1,7 @@
 % podman-umount(1)
 
 ## NAME
-podman\-umount - Unmount the specified working containers' root file system.
+podman\-umount - Unmount a working container's root filesystem
 
 ## SYNOPSIS
 **podman umount** *container* [...]

--- a/docs/podman-umount.1.md
+++ b/docs/podman-umount.1.md
@@ -6,6 +6,12 @@ podman\-umount - Unmount a working container's root filesystem
 ## SYNOPSIS
 **podman umount** *container* [...]
 
+**podman container umount** *container* [...]
+
+**podman container unmount** *container* [...]
+
+**podman unmount** *container* [...]
+
 ## DESCRIPTION
 Unmounts the specified containers' root file system, if no other processes
 are using it.

--- a/docs/podman-unpause.1.md
+++ b/docs/podman-unpause.1.md
@@ -6,6 +6,8 @@ podman\-unpause - Unpause one or more containers
 ## SYNOPSIS
 **podman unpause** [*options*]|[*container* ...]
 
+**podman container unpause** [*options*]|[*container* ...]
+
 ## DESCRIPTION
 Unpauses the processes in one or more containers.  You may use container IDs or names as input.
 

--- a/docs/podman-unshare.1.md
+++ b/docs/podman-unshare.1.md
@@ -1,10 +1,10 @@
 % podman-unshare(1)
 
 ## NAME
-podman\-unshare - Run a command inside of a modified user namespace.
+podman\-unshare - Run a command inside of a modified user namespace
 
 ## SYNOPSIS
-**podman unshare** [*options*] [**--**] [*command*]
+**podman unshare** [*options*] [*--*] [*command*]
 
 ## DESCRIPTION
 Launches a process (by default, *$SHELL*) in a new user namespace. The user

--- a/docs/podman-version.1.md
+++ b/docs/podman-version.1.md
@@ -1,7 +1,7 @@
 % podman-version(1)
 
 ## NAME
-podman\-version - Display the PODMAN Version Information
+podman\-version - Display the Podman version information
 
 ## SYNOPSIS
 **podman version** [*options*]

--- a/docs/podman-volume-inspect.1.md
+++ b/docs/podman-volume-inspect.1.md
@@ -1,7 +1,7 @@
 % podman-volume-inspect(1)
 
 ## NAME
-podman\-volume\-inspect - Inspect one or more volumes
+podman\-volume\-inspect - Get detailed information on one or more volumes
 
 ## SYNOPSIS
 **podman volume inspect** [*options*] *volume* [...]

--- a/docs/podman-volume-ls.1.md
+++ b/docs/podman-volume-ls.1.md
@@ -1,7 +1,7 @@
 % podman-volume-ls(1)
 
 ## NAME
-podman\-volume\-ls - List volumes
+podman\-volume\-ls - List all the available volumes
 
 ## SYNOPSIS
 **podman volume ls** [*options*]

--- a/docs/podman-volume.1.md
+++ b/docs/podman-volume.1.md
@@ -1,7 +1,7 @@
 % podman-volume(1)
 
 ## NAME
-podman\-volume - Simple management tool for volumes.
+podman\-volume - Simple management tool for volumes
 
 ## SYNOPSIS
 **podman volume** *subcommand*

--- a/docs/podman-wait.1.md
+++ b/docs/podman-wait.1.md
@@ -6,6 +6,8 @@ podman\-wait - Wait on one or more containers to stop and print their exit codes
 ## SYNOPSIS
 **podman wait** [*options*] *container*
 
+**podman container wait** [*options*] *container*
+
 ## DESCRIPTION
 Waits on one or more containers to stop.  The container can be referred to by its
 name or ID.  In the case of multiple containers, podman will wait on each consecutively.

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -153,15 +153,15 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-images(1)](podman-images.1.md)           | List images in local storage.                                               |
 | [podman-import(1)](podman-import.1.md)           | Import a tarball and save it as a filesystem image.                         |
 | [podman-info(1)](podman-info.1.md)               | Displays Podman related system information.                                 |
-| [podman-init(1)](podman-init.1.md)               | Initialize a container                                                      |
+| [podman-init(1)](podman-init.1.md)               | Initialize one or more containers                                           |
 | [podman-inspect(1)](podman-inspect.1.md)         | Display a container or image's configuration.                               |
 | [podman-kill(1)](podman-kill.1.md)               | Kill the main process in one or more containers.                            |
 | [podman-load(1)](podman-load.1.md)               | Load an image from a container image archive into container storage.        |
 | [podman-login(1)](podman-login.1.md)             | Login to a container registry.                                              |
 | [podman-logout(1)](podman-logout.1.md)           | Logout of a container registry.                                             |
-| [podman-logs(1)](podman-logs.1.md)               | Display the logs of a container.                                            |
+| [podman-logs(1)](podman-logs.1.md)               | Display the logs of one or more containers.                                 |
 | [podman-mount(1)](podman-mount.1.md)             | Mount a working container's root filesystem.                                |
-| [podman-network(1)](podman-network.1.md)         | Manage Podman CNI networks.                                |
+| [podman-network(1)](podman-network.1.md)         | Manage Podman CNI networks.                                                 |
 | [podman-pause(1)](podman-pause.1.md)             | Pause one or more containers.                                               |
 | [podman-play(1)](podman-play.1.md)               | Play pods and containers based on a structured input file.                  |
 | [podman-pod(1)](podman-pod.1.md)                 | Management tool for groups of containers, called pods.                      |
@@ -169,6 +169,7 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-ps(1)](podman-ps.1.md)                   | Prints out information about containers.                                    |
 | [podman-pull(1)](podman-pull.1.md)               | Pull an image from a registry.                                              |
 | [podman-push(1)](podman-push.1.md)               | Push an image from local storage to elsewhere.                              |
+| [podman-remote(1)](podman-remote.1.md)           | A tool for remote management of pods, containers and images                 |
 | [podman-restart(1)](podman-restart.1.md)         | Restart one or more containers.                                             |
 | [podman-rm(1)](podman-rm.1.md)                   | Remove one or more containers.                                              |
 | [podman-rmi(1)](podman-rmi.1.md)                 | Removes one or more locally stored images.                                  |
@@ -186,7 +187,7 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-unshare(1)](podman-unshare.1.md)         | Run a command inside of a modified user namespace.                          |
 | [podman-varlink(1)](podman-varlink.1.md)         | Runs the varlink backend interface.                                         |
 | [podman-version(1)](podman-version.1.md)         | Display the Podman version information.                                     |
-| [podman-volume(1)](podman-volume.1.md)           | Manage Volumes.                                                             |
+| [podman-volume(1)](podman-volume.1.md)           | Simple management tool for volumes.                                         |
 | [podman-wait(1)](podman-wait.1.md)               | Wait on one or more containers to stop and print their exit codes.          |
 
 ## FILES

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -169,7 +169,6 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-ps(1)](podman-ps.1.md)                   | Prints out information about containers.                                    |
 | [podman-pull(1)](podman-pull.1.md)               | Pull an image from a registry.                                              |
 | [podman-push(1)](podman-push.1.md)               | Push an image from local storage to elsewhere.                              |
-| [podman-remote(1)](podman-remote.1.md)           | A tool for remote management of pods, containers and images                 |
 | [podman-restart(1)](podman-restart.1.md)         | Restart one or more containers.                                             |
 | [podman-rm(1)](podman-rm.1.md)                   | Remove one or more containers.                                              |
 | [podman-rmi(1)](podman-rmi.1.md)                 | Removes one or more locally stored images.                                  |

--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -41,6 +41,11 @@ done
 # Make sure the descriptive text in podman-foo.1.md matches the one
 # in the table in podman.1.md.
 for md in *-*.1.md;do
+    # Currently the only exception.
+    if [ "$md" = "podman-remote.1.md" ]; then
+        continue
+    fi
+
     desc=$(egrep -A1 '^#* NAME' $md|tail -1|sed -e 's/^podman[^ ]\+ - //')
 
     # podman.1.md has a two-column table; podman-*.1.md all have three.

--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -40,7 +40,7 @@ done
 #
 # Make sure the descriptive text in podman-foo.1.md matches the one
 # in the table in podman.1.md.
-for md in *.1.md;do
+for md in *-*.1.md;do
     desc=$(egrep -A1 '^#* NAME' $md|tail -1|sed -e 's/^podman[^ ]\+ - //')
 
     # podman.1.md has a two-column table; podman-*.1.md all have three.

--- a/hack/man-page-checker
+++ b/hack/man-page-checker
@@ -39,13 +39,9 @@ done
 # Pass 2: compare descriptions.
 #
 # Make sure the descriptive text in podman-foo.1.md matches the one
-# in the table in podman.1.md.
-for md in *-*.1.md;do
-    # Currently the only exception.
-    if [ "$md" = "podman-remote.1.md" ]; then
-        continue
-    fi
-
+# in the table in podman.1.md. podman-remote is not a podman subcommand,
+# so it is excluded here.
+for md in $(ls -1 *-*.1.md | grep -v remote);do
     desc=$(egrep -A1 '^#* NAME' $md|tail -1|sed -e 's/^podman[^ ]\+ - //')
 
     # podman.1.md has a two-column table; podman-*.1.md all have three.


### PR DESCRIPTION
This allows the `hack/man-page-checker` script to run successfully. I had to make some uninformed decisions regarding the descriptive text differences. Any input feedback would be appreciated!


Signed-off-by: Ryan Whalen <rj.whalen@gmail.com>