### PR TITLE
Personalize CI success messages to IRC

### DIFF
--- a/contrib/cirrus/git_authors_to_irc_nicks.csv
+++ b/contrib/cirrus/git_authors_to_irc_nicks.csv
@@ -1,0 +1,8 @@
+# Comma separated mapping of author e-mail, to Freenode IRC nick.
+# When no match is found here, the username portion of the e-mail is used.
+# Sorting is done at runtime - first-found e-mail match wins.
+# Comments (like this) and blank lines are ignored.
+
+rothberg@redhat.com,vrothberg
+santiago@redhat.com,edsantiago
+gscrivan@redhat.com,giuseppe

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -28,11 +28,12 @@ CIRRUS_WORKING_DIR="${CIRRUS_WORKING_DIR:-$GOPATH/src/github.com/containers/libp
 export GOSRC="${GOSRC:-$CIRRUS_WORKING_DIR}"
 export PATH="$HOME/bin:$GOPATH/bin:/usr/local/bin:$PATH"
 export LD_LIBRARY_PATH="/usr/local/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-TIMESTAMPS_FILEPATH="${TIMESTAMPS_FILEPATH:-/var/tmp/timestamps}"
-SETUP_MARKER_FILEPATH="${SETUP_MARKER_FILEPATH:-/var/tmp/.setup_environment_sh_complete}"
 # Saves typing / in case location ever moves
 SCRIPT_BASE=${SCRIPT_BASE:-./contrib/cirrus}
 PACKER_BASE=${PACKER_BASE:-./contrib/cirrus/packer}
+# Important filepaths
+SETUP_MARKER_FILEPATH="${SETUP_MARKER_FILEPATH:-/var/tmp/.setup_environment_sh_complete}"
+AUTHOR_NICKS_FILEPATH="${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/git_authors_to_irc_nicks.csv"
 
 cd $GOSRC
 if type -P git &> /dev/null

--- a/contrib/cirrus/success.sh
+++ b/contrib/cirrus/success.sh
@@ -4,14 +4,52 @@ set -e
 
 source $(dirname $0)/lib.sh
 
-req_env_var CIRRUS_BRANCH CIRRUS_BUILD_ID
+req_env_var CIRRUS_BRANCH CIRRUS_BUILD_ID CIRRUS_REPO_FULL_NAME
 
-REF=$(basename $CIRRUS_BRANCH)  # PR number or branch named
-URL="https://cirrus-ci.com/build/$CIRRUS_BUILD_ID"
+cd $CIRRUS_WORKING_DIR
 
 if [[ "$CIRRUS_BRANCH" =~ "pull" ]]
 then
-    ircmsg "Cirrus-CI testing successful for PR #$REF: $URL"
+    echo "Finding commit authors for PR $CIRRUS_PR"
+    unset NICKS
+    if [[ -r "$AUTHOR_NICKS_FILEPATH" ]]
+    then
+        SHARANGE="${CIRRUS_BASE_SHA}..${CIRRUS_CHANGE_IN_REPO}"
+        EXCLUDE_RE='merge-robot'
+        AUTHOR_NICKS=$(egrep -v '(^[[:space:]]*$)|(^[[:space:]]*#)' "$AUTHOR_NICKS_FILEPATH" | sort -u)
+        # Depending on branch-state, it's possible SHARANGE could be _WAY_ too big
+        MAX_NICKS=10
+        # newline separated
+        COMMIT_AUTHORS=$(git log --format='%ae' $SHARANGE | \
+                         sort -u | \
+                         egrep -v "$EXCLUDE_RE" | \
+                         tail -$MAX_NICKS)
+
+        for c_email in $COMMIT_AUTHORS
+        do
+            echo -e "\tExamining $c_email"
+            NICK=$(echo "$AUTHOR_NICKS" | grep -m 1 "$c_email" | \
+                   awk --field-separator ',' '{print $2}' | tr -d '[[:blank:]]')
+            if [[ -n "$NICK" ]]
+            then
+                echo -e "\t\tFound $c_email -> $NICK in $(basename $AUTHOR_NICKS_FILEPATH)"
+            else
+                echo -e "\t\tNot found in $(basename $AUTHOR_NICKS_FILEPATH), using e-mail username."
+                NICK=$(echo "$c_email" | cut -d '@' -f 1)
+            fi
+            echo -e "\tUsing nick $NICK"
+            NICKS="${NICKS:+$NICKS, }$NICK"
+        done
+    fi
+
+    unset MENTION_PREFIX
+    [[ -z "$NICKS" ]] || \
+        MENTION_PREFIX="$NICKS: "
+
+    URL="https://github.com/$CIRRUS_REPO_FULL_NAME/pull/$CIRRUS_PR"
+    PR_SUBJECT=$(echo "$CIRRUS_CHANGE_MESSAGE" | head -1)
+    ircmsg "${MENTION_PREFIX}Cirrus-CI testing successful for PR '$PR_SUBJECT': $URL"
 else
-    ircmsg "Cirrus-CI testing branch $REF successful: $URL"
+    URL="https://cirrus-ci.com/github/containers/libpod/$CIRRUS_BRANCH"
+    ircmsg "Cirrus-CI testing branch $(basename $CIRRUS_BRANCH) successful: $URL"
 fi


### PR DESCRIPTION
Rather than spamming the podman channel with impersonal success
messages referring to PR numbers, mention the author by nick name
and include the PR title and link.
    
Also avoid needless logging of all bot-script interactions with
IRC when there is no error detected.