### PR TITLE
Add `ContainerManager` annotation to created containers

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -21,7 +21,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containers/buildah/pkg/secrets"
 	"github.com/containers/libpod/libpod/define"
-	crioAnnotations "github.com/containers/libpod/pkg/annotations"
+	"github.com/containers/libpod/pkg/annotations"
 	"github.com/containers/libpod/pkg/apparmor"
 	"github.com/containers/libpod/pkg/cgroups"
 	"github.com/containers/libpod/pkg/criu"
@@ -347,8 +347,12 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 	}
 
 	g.SetRootPath(c.state.Mountpoint)
-	g.AddAnnotation(crioAnnotations.Created, c.config.CreatedTime.Format(time.RFC3339Nano))
+	g.AddAnnotation(annotations.Created, c.config.CreatedTime.Format(time.RFC3339Nano))
 	g.AddAnnotation("org.opencontainers.image.stopSignal", fmt.Sprintf("%d", c.config.StopSignal))
+
+	if _, exists := g.Config.Annotations[annotations.ContainerManager]; !exists {
+		g.AddAnnotation(annotations.ContainerManager, annotations.ContainerManagerLibpod)
+	}
 
 	for _, i := range c.config.Spec.Linux.Namespaces {
 		if i.Type == spec.UTSNamespace {

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -102,6 +102,10 @@ const (
 
 	// CNIResult is the JSON string representation of the Result from CNI
 	CNIResult = "io.kubernetes.cri-o.CNIResult"
+
+	// ContainerManager is the annotation key for indicating the creator and
+	// manager of the container
+	ContainerManager = "io.container.manager"
 )
 
 // ContainerType values
@@ -112,3 +116,7 @@ const (
 	// ContainerTypeContainer represents a container running within a pod
 	ContainerTypeContainer = "container"
 )
+
+// ContainerManagerLibpod indicates that libpod created and manages the
+// container
+const ContainerManagerLibpod = "libpod"

--- a/test/e2e/container_inspect_test.go
+++ b/test/e2e/container_inspect_test.go
@@ -1,0 +1,45 @@
+package integration
+
+import (
+	"os"
+
+	"github.com/containers/libpod/pkg/annotations"
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman container inspect", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest *PodmanTestIntegration
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanTestCreate(tempdir)
+		podmanTest.Setup()
+		podmanTest.SeedImages()
+	})
+
+	AfterEach(func() {
+		podmanTest.CleanupPod()
+		f := CurrentGinkgoTestDescription()
+		processTestResult(f)
+	})
+
+	It("podman inspect a container for the container manager annotation", func() {
+		const testContainer = "container-inspect-test-1"
+		setup := podmanTest.RunTopContainer(testContainer)
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+
+		data := podmanTest.InspectContainer(testContainer)
+		Expect(data[0].Config.Annotations[annotations.ContainerManager]).
+			To(Equal(annotations.ContainerManagerLibpod))
+	})
+})


### PR DESCRIPTION
Hey :wave:, I had this idea to improve the distinction between container
runtimes to avoid issues with removed containers like in https://github.com/cri-o/cri-o/pull/2761.

This change adds the following annotation to every container created by
podman:

```json
"Annotations": {
    "io.containers.manager": "libpod"
}
```

Target of this annotaions is to indicate which project in the containers
ecosystem is the major manager of a container when applications share
the same storage paths. This way projects can decide if they want to
manipulate the container or not. For example, since CRI-O and podman are
not using the same container library (libpod), CRI-O can skip podman
containers and provide the end user more useful information.

~~Related projects like buildah and CRI-O could use the pre-defined
`ContainerManagerCRIO` and `ContainerManagerBuildah` types, whereas
podman would now be able to tell the end user which tool created the
container as well.~~

A corresponding end-to-end test has been adapted as well.

Relates to: https://github.com/cri-o/cri-o/pull/2761