### PR TITLE
Enable hack/man-page-checker in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -111,6 +111,7 @@ gating_task:
     build_script:
         - '/usr/local/bin/entrypoint.sh podman |& ${TIMESTAMP}'
         - 'cd $GOSRC && ./hack/podman-commands.sh |& ${TIMESTAMP}'
+        - 'cd $GOSRC && ./hack/man-page-checker |& ${TIMESTAMP}'
         # N/B: need 'clean' so some commited files are re-generated.
         - '/usr/local/bin/entrypoint.sh clean podman-remote |& ${TIMESTAMP}'
         - '/usr/local/bin/entrypoint.sh clean podman BUILDTAGS="exclude_graphdriver_devicemapper selinux seccomp" |& ${TIMESTAMP}'


### PR DESCRIPTION
With huge thanks to @rwha for #3915. All man pages are clean
and consistent now - let's keep them that way.

Signed-off-by: Ed Santiago <santiago@redhat.com>