### PR TITLE
Cirrus: Update e-mail -> IRC Nick table

### DIFF
--- a/contrib/cirrus/git_authors_to_irc_nicks.csv
+++ b/contrib/cirrus/git_authors_to_irc_nicks.csv
@@ -3,6 +3,10 @@
 # Sorting is done at runtime - first-found e-mail match wins.
 # Comments (like this) and blank lines are ignored.
 
+bbaude@redhat.com,baude
+matthew.heon@pm.me,mheon
+matthew.heon@gmail.com,mheon
+emilien@redhat.com,EmilienM
 rothberg@redhat.com,vrothberg
 santiago@redhat.com,edsantiago
 gscrivan@redhat.com,giuseppe

--- a/contrib/cirrus/success.sh
+++ b/contrib/cirrus/success.sh
@@ -4,12 +4,14 @@ set -e
 
 source $(dirname $0)/lib.sh
 
-req_env_var CIRRUS_BRANCH CIRRUS_BUILD_ID CIRRUS_REPO_FULL_NAME
+req_env_var CIRRUS_BRANCH CIRRUS_BUILD_ID CIRRUS_REPO_FULL_NAME CIRRUS_BASE_SHA CIRRUS_CHANGE_IN_REPO
 
 cd $CIRRUS_WORKING_DIR
 
 if [[ "$CIRRUS_BRANCH" =~ "pull" ]]
 then
+    echo "Retrieving latest HEADS and tags"
+    git fetch --all --tags
     echo "Finding commit authors for PR $CIRRUS_PR"
     unset NICKS
     if [[ -r "$AUTHOR_NICKS_FILEPATH" ]]
@@ -20,7 +22,8 @@ then
         # Depending on branch-state, it's possible SHARANGE could be _WAY_ too big
         MAX_NICKS=10
         # newline separated
-        COMMIT_AUTHORS=$(git log --format='%ae' $SHARANGE | \
+        GITLOG="git log --format='%ae'"
+        COMMIT_AUTHORS=$($GITLOGt $SHARANGE || $GITLOG -1 HEAD | \
                          sort -u | \
                          egrep -v "$EXCLUDE_RE" | \
                          tail -$MAX_NICKS)


### PR DESCRIPTION
Also add fixes to help prevent 'fatal: Invalid revision range' error.
Should obtaining all authors from the range still fail, only grab the
HEAD commit author as a fallback.

Signed-off-by: Chris Evich <cevich@redhat.com>