### PR TITLE
Add support for mounting volumes with local driver and options

### DIFF
--- a/docs/podman-volume-create.1.md
+++ b/docs/podman-volume-create.1.md
@@ -39,6 +39,8 @@ $ podman volume create myvol
 $ podman volume create
 
 $ podman volume create --label foo=bar myvol
+
+$ podman volume create --opt device=tmpfs --opt type=tmpfs --opt o=nodev,noexec myvol
 ```
 
 ## SEE ALSO

--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -1403,11 +1403,10 @@ func (s *BoltState) AddVolume(volume *Volume) error {
 	// Volume state is allowed to not exist
 	var volStateJSON []byte
 	if volume.state != nil {
-		stateJSON, err := json.Marshal(volume.state)
+		volStateJSON, err = json.Marshal(volume.state)
 		if err != nil {
 			return errors.Wrapf(err, "error marshalling volume %s state to JSON", volume.Name())
 		}
-		volStateJSON = stateJSON
 	}
 
 	db, err := s.getDBCon()

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -449,7 +449,7 @@ func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bu
 		return errors.Wrapf(err, "error unmarshalling volume %s config from DB", string(name))
 	}
 
-	// Volume state is allowed to be nil for legacy compatability
+	// Volume state is allowed to be nil for legacy compatibility
 	volStateBytes := volDB.Get(stateKey)
 	if volStateBytes != nil {
 		if err := json.Unmarshal(volStateBytes, volume.state); err != nil {

--- a/libpod/boltdb_state_internal.go
+++ b/libpod/boltdb_state_internal.go
@@ -449,6 +449,14 @@ func (s *BoltState) getVolumeFromDB(name []byte, volume *Volume, volBkt *bolt.Bu
 		return errors.Wrapf(err, "error unmarshalling volume %s config from DB", string(name))
 	}
 
+	// Volume state is allowed to be nil for legacy compatability
+	volStateBytes := volDB.Get(stateKey)
+	if volStateBytes != nil {
+		if err := json.Unmarshal(volStateBytes, volume.state); err != nil {
+			return errors.Wrapf(err, "error unmarshalling volume %s state from DB", string(name))
+		}
+	}
+
 	// Get the lock
 	lock, err := s.runtime.lockManager.RetrieveLock(volume.config.LockID)
 	if err != nil {

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -49,12 +49,12 @@ func (c *Container) mountSHM(shmOptions string) error {
 }
 
 func (c *Container) unmountSHM(mount string) error {
-	if err := unix.Unmount(mount, unix.MNT_DETACH); err != nil {
+	if err := unix.Unmount(mount, 0); err != nil {
 		if err != syscall.EINVAL {
-			logrus.Warnf("container %s failed to unmount %s : %v", c.ID(), mount, err)
-		} else {
-			logrus.Debugf("container %s failed to unmount %s : %v", c.ID(), mount, err)
+			return errors.Wrapf(err, "error unmounting container %s SHM mount %s", c.ID(), mount)
 		}
+		// If it's just an EINVAL, debug logs only
+		logrus.Debugf("container %s failed to unmount %s : %v", c.ID(), mount, err)
 	}
 	return nil
 }

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -61,7 +61,7 @@ func (c *Container) unmountSHM(mount string) error {
 
 // prepare mounts the container and sets up other required resources like net
 // namespaces
-func (c *Container) prepare() (err error) {
+func (c *Container) prepare() (Err error) {
 	var (
 		wg                              sync.WaitGroup
 		netNS                           ns.NetNS
@@ -108,31 +108,42 @@ func (c *Container) prepare() (err error) {
 		logrus.Debugf("Created root filesystem for container %s at %s", c.ID(), c.state.Mountpoint)
 	}()
 
-	defer func() {
-		if err != nil {
-			if err2 := c.cleanupNetwork(); err2 != nil {
-				logrus.Errorf("Error cleaning up container %s network: %v", c.ID(), err2)
-			}
-			if err2 := c.cleanupStorage(); err2 != nil {
-				logrus.Errorf("Error cleaning up container %s storage: %v", c.ID(), err2)
-			}
-		}
-	}()
-
 	wg.Wait()
 
+	var createErr error
 	if createNetNSErr != nil {
-		if mountStorageErr != nil {
-			logrus.Error(createNetNSErr)
-			return mountStorageErr
-		}
-		return createNetNSErr
+		createErr = createNetNSErr
 	}
 	if mountStorageErr != nil {
-		return mountStorageErr
+		logrus.Errorf("Error preparing container %s: %v", c.ID(), createErr)
+		createErr = mountStorageErr
 	}
 
-	// Save the container
+	// Only trigger storage cleanup if mountStorage was successful.
+	// Otherwise, we may mess up mount counters.
+	if createNetNSErr != nil && mountStorageErr == nil {
+		if err := c.cleanupStorage(); err != nil {
+			// createErr is guaranteed non-nil, so print
+			// unconditionally
+			logrus.Errorf("Error preparing container %s: %v", c.ID(), createErr)
+			createErr = errors.Wrapf(err, "error unmounting storage for container %s after network create failure", c.ID())
+		}
+	}
+
+	// It's OK to unconditionally trigger network cleanup. If the network
+	// isn't ready it will do nothing.
+	if createErr != nil {
+		if err := c.cleanupNetwork(); err != nil {
+			logrus.Errorf("Error preparing container %s: %v", c.ID(), createErr)
+			createErr = errors.Wrapf(err, "error cleaning up container %s network after setup failure", c.ID())
+		}
+	}
+
+	if createErr != nil {
+		return createErr
+	}
+
+	// Save changes to container state
 	return c.save()
 }
 

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -18,3 +18,7 @@ type InfoData struct {
 	Type string
 	Data map[string]interface{}
 }
+
+// VolumeDriverLocal is the "local" volume driver. It is managed by libpod
+// itself.
+const VolumeDriverLocal = "local"

--- a/libpod/in_memory_state.go
+++ b/libpod/in_memory_state.go
@@ -507,6 +507,36 @@ func (s *InMemoryState) RemoveVolume(volume *Volume) error {
 	return nil
 }
 
+// UpdateVolume updates a volume from the database.
+// For the in-memory state, this is a no-op.
+func (s *InMemoryState) UpdateVolume(volume *Volume) error {
+	if !volume.valid {
+		return define.ErrVolumeRemoved
+	}
+
+	if _, ok := s.volumes[volume.Name()]; !ok {
+		volume.valid = false
+		return errors.Wrapf(define.ErrNoSuchVolume, "volume with name %q not found in state", volume.Name())
+	}
+
+	return nil
+}
+
+// SaveVolume saves a volume's state to the database.
+// For the in-memory state, this is a no-op.
+func (s *InMemoryState) SaveVolume(volume *Volume) error {
+	if !volume.valid {
+		return define.ErrVolumeRemoved
+	}
+
+	if _, ok := s.volumes[volume.Name()]; !ok {
+		volume.valid = false
+		return errors.Wrapf(define.ErrNoSuchVolume, "volume with name %q not found in state", volume.Name())
+	}
+
+	return nil
+}
+
 // VolumeInUse checks if the given volume is being used by at least one container
 func (s *InMemoryState) VolumeInUse(volume *Volume) ([]string, error) {
 	if !volume.valid {

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -48,6 +48,19 @@ func (r *Runtime) newVolume(ctx context.Context, options ...VolumeCreateOption) 
 	}
 	volume.config.CreatedTime = time.Now()
 
+	if volume.config.Driver == "local" {
+		logrus.Debugf("Validating options for local driver")
+		// Validate options
+		for key := range volume.config.Options {
+			switch key {
+			case "device", "o", "type":
+				// Do nothing, valid keys
+			default:
+				return nil, errors.Wrapf(define.ErrInvalidArg, "invalid mount option %s for driver 'local'", key)
+			}
+		}
+	}
+
 	// Create the mountpoint of this volume
 	volPathRoot := filepath.Join(r.config.VolumePath, volume.config.Name)
 	if err := os.MkdirAll(volPathRoot, 0700); err != nil {
@@ -102,6 +115,11 @@ func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool) error
 		return define.ErrVolumeRemoved
 	}
 
+	// Update volume status to pick up a potential removal from state
+	if err := v.update(); err != nil {
+		return err
+	}
+
 	deps, err := r.state.VolumeInUse(v)
 	if err != nil {
 		return err
@@ -135,6 +153,11 @@ func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool) error
 				return errors.Wrapf(err, "error removing container %s that depends on volume %s", ctr.ID(), v.Name())
 			}
 		}
+	}
+
+	// If the volume is still mounted - force unmount it
+	if err := v.unmount(true); err != nil {
+		return errors.Wrapf(err, "error unmounting volume %s", v.Name())
 	}
 
 	// Set volume as invalid so it can no longer be used

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -44,11 +44,11 @@ func (r *Runtime) newVolume(ctx context.Context, options ...VolumeCreateOption) 
 		volume.config.Name = stringid.GenerateNonCryptoID()
 	}
 	if volume.config.Driver == "" {
-		volume.config.Driver = "local"
+		volume.config.Driver = define.VolumeDriverLocal
 	}
 	volume.config.CreatedTime = time.Now()
 
-	if volume.config.Driver == "local" {
+	if volume.config.Driver == define.VolumeDriverLocal {
 		logrus.Debugf("Validating options for local driver")
 		// Validate options
 		for key := range volume.config.Options {

--- a/libpod/state.go
+++ b/libpod/state.go
@@ -203,6 +203,10 @@ type State interface {
 	// RemoveVolume removes the specified volume.
 	// Only volumes that have no container dependencies can be removed
 	RemoveVolume(volume *Volume) error
+	// UpdateVolume updates the volume's state from the database.
+	UpdateVolume(volume *Volume) error
+	// SaveVolume saves a volume's state to the database.
+	SaveVolume(volume *Volume) error
 	// AllVolumes returns all the volumes available in the state
 	AllVolumes() ([]*Volume, error)
 }

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -26,7 +26,7 @@ type VolumeConfig struct {
 	Labels map[string]string `json:"labels"`
 	// The volume driver. Empty string or local does not activate a volume
 	// driver, all other volumes will.
-	Driver string `json:"driver"`
+	Driver string `json:"volumeDriver"`
 	// The location the volume is mounted at.
 	MountPoint string `json:"mountPoint"`
 	// Time the volume was created.
@@ -34,7 +34,7 @@ type VolumeConfig struct {
 	// Options to pass to the volume driver. For the local driver, this is
 	// a list of mount options. For other drivers, they are passed to the
 	// volume driver handling the volume.
-	Options map[string]string `json:"options"`
+	Options map[string]string `json:"volumeOptions"`
 	// Whether this volume was created for a specific container and will be
 	// removed with it.
 	IsCtrSpecific bool `json:"ctrSpecific"`

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -38,14 +38,6 @@ type VolumeConfig struct {
 	// a list of mount options. For other drivers, they are passed to the
 	// volume driver handling the volume.
 	Options map[string]string `json:"volumeOptions,omitempty"`
-	// Type is the type of the volume. This is only used with the local
-	// driver. It the the filesystem that we will attempt to mount - nfs,
-	// tmpfs, etc.
-	Type string `json:"type,omitempty"`
-	// Device is the device of the volume. This is only used with the local
-	// driver, and only with some filesystem types (e.g., not required by
-	// tmpfs). It is the device to mount.
-	Device string `json:"device,omitempty"`
 	// Whether this volume was created for a specific container and will be
 	// removed with it.
 	IsCtrSpecific bool `json:"ctrSpecific"`
@@ -101,10 +93,9 @@ func (v *Volume) MountPoint() string {
 // Options return the volume's options
 func (v *Volume) Options() map[string]string {
 	options := make(map[string]string)
-	for key, value := range v.config.Options {
-		options[key] = value
+	for k, v := range v.config.Options {
+		options[k] = v
 	}
-
 	return options
 }
 

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -26,7 +26,7 @@ func (v *Volume) teardownStorage() error {
 // Volumes with options set, or a filesystem type, or a device to mount need to
 // be mounted and unmounted.
 func (v *Volume) needsMount() bool {
-	return len(v.config.Options) > 0 && v.config.Driver == "local"
+	return len(v.config.Options) > 0 && v.config.Driver == define.VolumeDriverLocal
 }
 
 // update() updates the volume state from the DB.

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -3,6 +3,8 @@ package libpod
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/containers/libpod/libpod/define"
 )
 
 // Creates a new volume
@@ -19,4 +21,26 @@ func newVolume(runtime *Runtime) (*Volume, error) {
 // teardownStorage deletes the volume from volumePath
 func (v *Volume) teardownStorage() error {
 	return os.RemoveAll(filepath.Join(v.runtime.config.VolumePath, v.Name()))
+}
+
+// Volumes with options set, or a filesystem type, or a device to mount need to
+// be mounted and unmounted.
+func (v *Volume) needsMount() bool {
+	return len(v.config.Options) > 0 && v.config.Driver == "local"
+}
+
+// update() updates the volume state from the DB.
+func (v *Volume) update() error {
+	if err := v.runtime.state.UpdateVolume(v); err != nil {
+		return err
+	}
+	if !v.valid {
+		return define.ErrVolumeRemoved
+	}
+	return nil
+}
+
+// save() saves the volume state to the DB
+func (v *Volume) save() error {
+	return v.runtime.state.SaveVolume(v)
 }

--- a/libpod/volume_internal_linux.go
+++ b/libpod/volume_internal_linux.go
@@ -67,7 +67,7 @@ func (v *Volume) mount() error {
 
 	errPipe, err := mountCmd.StderrPipe()
 	if err != nil {
-		return errors.Wrapf(err, "getting stderr pipe")
+		return errors.Wrapf(err, "error getting stderr pipe for mount")
 	}
 	if err := mountCmd.Start(); err != nil {
 		out, err2 := ioutil.ReadAll(errPipe)

--- a/libpod/volume_internal_linux.go
+++ b/libpod/volume_internal_linux.go
@@ -1,0 +1,128 @@
+// +build linux
+
+package libpod
+
+import (
+	"io/ioutil"
+	"os/exec"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// mount mounts the volume if necessary.
+// A mount is necessary if a volume has any options set.
+// If a mount is necessary, v.state.MountCount will be incremented.
+// If it was 0 when the increment occurred, the volume will be mounted on the
+// host. Otherwise, we assume it is already mounted.
+// Must be done while the volume is locked.
+// Is a no-op on volumes that do not require a mount (as defined by
+// volumeNeedsMount())
+func (v *Volume) mount() error {
+	if !v.needsMount() {
+		return nil
+	}
+
+	// Update the volume from the DB to get an accurate mount counter.
+	if err := v.update(); err != nil {
+		return err
+	}
+
+	// If the count is non-zero, the volume is already mounted.
+	// Nothing to do.
+	if v.state.MountCount > 0 {
+		v.state.MountCount = v.state.MountCount + 1
+		logrus.Debugf("Volume %s mount count now at %d", v.Name(), v.state.MountCount)
+		return v.save()
+	}
+
+	volDevice := v.config.Options["device"]
+	volType := v.config.Options["type"]
+	volOptions := v.config.Options["o"]
+
+	// Some filesystems (tmpfs) don't have a device, but we still need to
+	// give the kernel something.
+	if volDevice == "" && volType != "" {
+		volDevice = volType
+	}
+
+	// We need to use the actual mount command.
+	// Convincing unix.Mount to use the same semantics as the mount command
+	// itself seems prohibitively difficult.
+	// TODO: might want to cache this path in the runtime?
+	mountPath, err := exec.LookPath("mount")
+	if err != nil {
+		return errors.Wrapf(err, "error locating 'mount' binary")
+	}
+	mountArgs := []string{}
+	if volOptions != "" {
+		mountArgs = append(mountArgs, "-o", volOptions)
+	}
+	if volType != "" {
+		mountArgs = append(mountArgs, "-t", volType)
+	}
+	mountArgs = append(mountArgs, volDevice, v.config.MountPoint)
+	mountCmd := exec.Command(mountPath, mountArgs...)
+
+	errPipe, err := mountCmd.StderrPipe()
+	if err != nil {
+		return errors.Wrapf(err, "getting stderr pipe")
+	}
+	if err := mountCmd.Start(); err != nil {
+		out, err2 := ioutil.ReadAll(errPipe)
+		if err2 != nil {
+			return errors.Wrapf(err2, "error reading mount STDERR")
+		}
+		return errors.Wrapf(errors.New(string(out)), "error mounting volume %s", v.Name())
+	}
+
+	logrus.Debugf("Mounted volume %s", v.Name())
+
+	// Increment the mount counter
+	v.state.MountCount = v.state.MountCount + 1
+	logrus.Debugf("Volume %s mount count now at %d", v.Name(), v.state.MountCount)
+	return v.save()
+}
+
+// unmount unmounts the volume if necessary.
+// Unmounting a volume that is not mounted is a no-op.
+// Unmounting a volume that does not require a mount is a no-op.
+// The volume must be locked for this to occur.
+// The mount counter will be decremented if non-zero. If the counter reaches 0,
+// the volume will really be unmounted, as no further containers are using the
+// volume.
+// If force is set, the volume will be unmounted regardless of mount counter.
+func (v *Volume) unmount(force bool) error {
+	if !v.needsMount() {
+		return nil
+	}
+
+	// Update the volume from the DB to get an accurate mount counter.
+	if err := v.update(); err != nil {
+		return err
+	}
+
+	if v.state.MountCount == 0 {
+		logrus.Debugf("Volume %s already unmounted", v.Name())
+		return nil
+	}
+
+	if !force {
+		v.state.MountCount = v.state.MountCount - 1
+	} else {
+		v.state.MountCount = 0
+	}
+
+	logrus.Debugf("Volume %s mount count now at %d", v.Name(), v.state.MountCount)
+
+	if v.state.MountCount == 0 {
+		// Unmount the volume
+		if err := unix.Unmount(v.config.MountPoint, unix.MNT_DETACH); err != nil {
+			return errors.Wrapf(err, "error unmounting volume %s", v.Name())
+		}
+		logrus.Debugf("Unmounted volume %s", v.Name())
+	}
+
+	return v.save()
+}

--- a/libpod/volume_internal_unsupported.go
+++ b/libpod/volume_internal_unsupported.go
@@ -1,0 +1,15 @@
+// +build !linux
+
+package libpod
+
+import (
+	"github.com/containers/libpod/libpod/define"
+)
+
+func (v *Volume) mount() error {
+	return define.ErrNotImplemented
+}
+
+func (v *Volume) unmount(force bool) error {
+	return define.ErrNotImplemented
+}

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -185,7 +185,7 @@ func (r *LocalRuntime) CreateVolume(ctx context.Context, c *cliconfig.VolumeCrea
 		options = append(options, libpod.WithVolumeLabels(labels))
 	}
 
-	if len(options) != 0 {
+	if len(opts) != 0 {
 		options = append(options, libpod.WithVolumeOptions(opts))
 	}
 	newVolume, err := r.NewVolume(ctx, options...)

--- a/pkg/varlinkapi/volumes.go
+++ b/pkg/varlinkapi/volumes.go
@@ -67,8 +67,7 @@ func (i *LibpodAPI) GetVolumes(call iopodman.VarlinkCall, args []string, all boo
 			Labels:     v.Labels(),
 			MountPoint: v.MountPoint(),
 			Name:       v.Name(),
-			// TODO change types here to be correct
-			//Options:    v.Options(),
+			Options:    v.Options(),
 		}
 		volumes = append(volumes, newVol)
 	}

--- a/pkg/varlinkapi/volumes.go
+++ b/pkg/varlinkapi/volumes.go
@@ -67,7 +67,8 @@ func (i *LibpodAPI) GetVolumes(call iopodman.VarlinkCall, args []string, all boo
 			Labels:     v.Labels(),
 			MountPoint: v.MountPoint(),
 			Name:       v.Name(),
-			Options:    v.Options(),
+			// TODO change types here to be correct
+			//Options:    v.Options(),
 		}
 		volumes = append(volumes, newVol)
 	}

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -57,4 +57,10 @@ var _ = Describe("Podman volume create", func() {
 		Expect(match).To(BeTrue())
 		Expect(len(check.OutputToStringArray())).To(Equal(1))
 	})
+
+	It("podman create volume with bad volume option", func() {
+		session := podmanTest.Podman([]string{"volume", "create", "--opt", "badOpt=bad"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+	})
 })


### PR DESCRIPTION
Volumes with the `local` driver and mount options specified are mounted using the `mount` command, instead of being plain directories. The volumes are mounted as the first container using them is started, and unmounted when the last container using them exits.

Given the mount/unmount behavior, we need to add a mount counter to volumes to know when to mount/unmount. This requires adding a mutable state to volumes, with associated methods in the DB to update and save the state.

Missing tests right now, but I've tested locally with tmpfs and btrfs with positive results.