### PR TITLE
Podman-remote run should wait for exit code

### DIFF
--- a/cmd/podman/containers_prune.go
+++ b/cmd/podman/containers_prune.go
@@ -53,7 +53,7 @@ func pruneContainersCmd(c *cliconfig.PruneContainersValues) error {
 	if err != nil {
 		if errors.Cause(err) == define.ErrNoSuchCtr {
 			if len(c.InputArgs) > 1 {
-				exitCode = 125
+				exitCode = define.ExecErrorCodeGeneric
 			} else {
 				exitCode = 1
 			}
@@ -61,7 +61,7 @@ func pruneContainersCmd(c *cliconfig.PruneContainersValues) error {
 		return err
 	}
 	if len(failures) > 0 {
-		exitCode = 125
+		exitCode = define.ExecErrorCodeGeneric
 	}
 	return printCmdResults(ok, failures)
 }

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	_ "github.com/containers/libpod/pkg/hooks/0.1.0"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/version"
@@ -20,7 +21,7 @@ import (
 // This is populated by the Makefile from the VERSION file
 // in the repository
 var (
-	exitCode = 125
+	exitCode = define.ExecErrorCodeGeneric
 	Ctx      context.Context
 	span     opentracing.Span
 	closer   io.Closer
@@ -152,11 +153,12 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		outputError(err)
 	} else {
-		// The exitCode modified from 125, indicates an application
+		// The exitCode modified from define.ExecErrorCodeGeneric,
+		// indicates an application
 		// running inside of a container failed, as opposed to the
 		// podman command failed.  Must exit with that exit code
 		// otherwise command exited correctly.
-		if exitCode == 125 {
+		if exitCode == define.ExecErrorCodeGeneric {
 			exitCode = 0
 		}
 

--- a/cmd/podman/pause.go
+++ b/cmd/podman/pause.go
@@ -56,7 +56,7 @@ func pauseCmd(c *cliconfig.PauseValues) error {
 	if err != nil {
 		if errors.Cause(err) == define.ErrNoSuchCtr {
 			if len(c.InputArgs) > 1 {
-				exitCode = 125
+				exitCode = define.ExecErrorCodeGeneric
 			} else {
 				exitCode = 1
 			}
@@ -64,7 +64,7 @@ func pauseCmd(c *cliconfig.PauseValues) error {
 		return err
 	}
 	if len(failures) > 0 {
-		exitCode = 125
+		exitCode = define.ExecErrorCodeGeneric
 	}
 	return printCmdResults(ok, failures)
 }

--- a/cmd/podman/restart.go
+++ b/cmd/podman/restart.go
@@ -61,7 +61,7 @@ func restartCmd(c *cliconfig.RestartValues) error {
 	if err != nil {
 		if errors.Cause(err) == define.ErrNoSuchCtr {
 			if len(c.InputArgs) > 1 {
-				exitCode = 125
+				exitCode = define.ExecErrorCodeGeneric
 			} else {
 				exitCode = 1
 			}
@@ -69,7 +69,7 @@ func restartCmd(c *cliconfig.RestartValues) error {
 		return err
 	}
 	if len(failures) > 0 {
-		exitCode = 125
+		exitCode = define.ExecErrorCodeGeneric
 	}
 	return printCmdResults(ok, failures)
 }

--- a/cmd/podman/unpause.go
+++ b/cmd/podman/unpause.go
@@ -55,7 +55,7 @@ func unpauseCmd(c *cliconfig.UnpauseValues) error {
 	if err != nil {
 		if errors.Cause(err) == define.ErrNoSuchCtr {
 			if len(c.InputArgs) > 1 {
-				exitCode = 125
+				exitCode = define.ExecErrorCodeGeneric
 			} else {
 				exitCode = 1
 			}
@@ -63,7 +63,7 @@ func unpauseCmd(c *cliconfig.UnpauseValues) error {
 		return err
 	}
 	if len(failures) > 0 {
-		exitCode = 125
+		exitCode = define.ExecErrorCodeGeneric
 	}
 	return printCmdResults(ok, failures)
 }

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -216,8 +216,8 @@ func (c *Container) Kill(signal uint) error {
 }
 
 // Exec starts a new process inside the container
-// Returns an exit code and an error. If Exec was not able to exec in the container before a failure, an exit code of 126 is returned.
-// If another generic error happens, an exit code of 125 is returned.
+// Returns an exit code and an error. If Exec was not able to exec in the container before a failure, an exit code of define.ExecErrorCodeCannotInvoke is returned.
+// If another generic error happens, an exit code of define.ExecErrorCodeGeneric is returned.
 // Sometimes, the $RUNTIME exec call errors, and if that is the case, the exit code is the exit code of the call.
 // Otherwise, the exit code will be the exit code of the executed call inside of the container.
 // TODO investigate allowing exec without attaching

--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -821,3 +821,12 @@ func (c *Container) Restore(ctx context.Context, options ContainerCheckpointOpti
 	defer c.newContainerEvent(events.Restore)
 	return c.restore(ctx, options)
 }
+
+// AutoRemove indicates whether the container will be removed after it is executed
+func (c *Container) AutoRemove() bool {
+	spec := c.config.Spec
+	if spec.Annotations == nil {
+		return false
+	}
+	return c.Spec().Annotations[InspectAnnotationAutoremove] == InspectResponseTrue
+}

--- a/libpod/define/exec_codes.go
+++ b/libpod/define/exec_codes.go
@@ -1,6 +1,8 @@
 package define
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 )
 
@@ -27,4 +29,20 @@ func TranslateExecErrorToExitCode(originalEC int, err error) int {
 		return ExecErrorCodeNotFound
 	}
 	return originalEC
+}
+
+// ExitCode reads the error message when failing to executing container process
+// and then returns 0 if no error, ExecErrorCodeNotFound if command does not exist, or ExecErrorCodeCannotInvoke for
+// all other errors
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	e := strings.ToLower(err.Error())
+	if strings.Contains(e, "file not found") ||
+		strings.Contains(e, "no such file or directory") {
+		return ExecErrorCodeNotFound
+	}
+
+	return ExecErrorCodeCannotInvoke
 }

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -396,14 +396,7 @@ func (r *LocalRuntime) Run(ctx context.Context, c *cliconfig.RunValues, exitCode
 		// Do not perform cleanup, or wait for container exit code
 		// Just exit immediately
 		if errors.Cause(err) == define.ErrDetach {
-			exitCode = 0
-			return exitCode, nil
-		}
-		// This means the command did not exist
-		exitCode = 127
-		e := strings.ToLower(err.Error())
-		if strings.Contains(e, "permission denied") || strings.Contains(e, "operation not permitted") {
-			exitCode = 126
+			return 0, nil
 		}
 		if c.IsSet("rm") {
 			if deleteError := r.Runtime.RemoveContainer(ctx, ctr, true, false); deleteError != nil {

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -669,7 +669,7 @@ func (r *LocalRuntime) Restore(ctx context.Context, c *cliconfig.RestoreValues) 
 func (r *LocalRuntime) Start(ctx context.Context, c *cliconfig.StartValues, sigProxy bool) (int, error) {
 	var (
 		finalErr error
-		exitCode = 125
+		exitCode = define.ExecErrorCodeGeneric
 	)
 	// TODO Figure out how to deal with exit codes
 	inputStream := os.Stdin

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -377,3 +377,19 @@ func ValidatePullType(pullType string) (PullType, error) {
 		return PullImageMissing, errors.Errorf("invalid pull type %q", pullType)
 	}
 }
+
+// ExitCode reads the error message when failing to executing container process
+// and then returns 0 if no error, 126 if command does not exist, or 127 for
+// all other errors
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	e := strings.ToLower(err.Error())
+	if strings.Contains(e, "file not found") ||
+		strings.Contains(e, "no such file or directory") {
+		return 127
+	}
+
+	return 126
+}

--- a/test/e2e/run_exit_test.go
+++ b/test/e2e/run_exit_test.go
@@ -1,5 +1,3 @@
-// +build !remoteclient
-
 package integration
 
 import (

--- a/test/e2e/run_exit_test.go
+++ b/test/e2e/run_exit_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"os"
 
+	"github.com/containers/libpod/libpod/define"
 	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,22 +35,22 @@ var _ = Describe("Podman run exit", func() {
 
 	})
 
-	It("podman run exit 125", func() {
+	It("podman run exit define.ExecErrorCodeGeneric", func() {
 		result := podmanTest.Podman([]string{"run", "--foobar", ALPINE, "ls", "$tmp"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(125))
+		Expect(result.ExitCode()).To(Equal(define.ExecErrorCodeGeneric))
 	})
 
-	It("podman run exit 126", func() {
+	It("podman run exit ExecErrorCodeCannotInvoke", func() {
 		result := podmanTest.Podman([]string{"run", ALPINE, "/etc"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(126))
+		Expect(result.ExitCode()).To(Equal(define.ExecErrorCodeCannotInvoke))
 	})
 
-	It("podman run exit 127", func() {
+	It("podman run exit ExecErrorCodeNotFound", func() {
 		result := podmanTest.Podman([]string{"run", ALPINE, "foobar"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(127))
+		Expect(result.ExitCode()).To(Equal(define.ExecErrorCodeNotFound))
 	})
 
 	It("podman run exit 0", func() {

--- a/test/e2e/run_selinux_test.go
+++ b/test/e2e/run_selinux_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Podman run", func() {
 
 		session = podmanTest.Podman([]string{"run", "-it", "--security-opt", "label=type:spc_t", "--security-opt", "label=filetype:foobar", fedoraMinimal, "ls", "-Z", "/dev"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(127))
+		Expect(session.ExitCode()).To(Equal(126))
 	})
 
 })

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -60,7 +60,6 @@ echo $rand        |   0 | $rand
 # 'run --rm' goes through different code paths and may lose exit status.
 # See https://github.com/containers/libpod/issues/3795
 @test "podman run --rm" {
-    skip_if_remote "podman-remote does not handle exit codes"
 
     run_podman 0 run --rm $IMAGE /bin/true
     run_podman 1 run --rm $IMAGE /bin/false


### PR DESCRIPTION
This change matches what is happening on the podman local side
and should eliminate a race condition.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>