### PR TITLE
Stop glob'ing on podman cp

### DIFF
--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -223,7 +223,7 @@ var _ = Describe("Podman cp", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"cp", "testctr:testfile", "testfile1"})
+		session = podmanTest.Podman([]string{"cp", "--pause=false", "testctr:testfile", "testfile1"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -233,7 +233,7 @@ var _ = Describe("Podman cp", func() {
 		Expect(err).To(BeNil())
 		Expect(strings.Contains(string(cmdRet), "testuser")).To(BeFalse())
 
-		session = podmanTest.Podman([]string{"cp", "testfile1", "testctr:testfile2"})
+		session = podmanTest.Podman([]string{"cp", "--pause=false", "testfile1", "testctr:testfile2"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -27,13 +27,8 @@ load helpers
                "echo $rand_content1 >/tmp/$rand_filename1;
                 echo $rand_content2 >/tmp/$rand_filename2"
 
-    run_podman cp 'cpcontainer:/tmp/*' $dstdir
-
-    test -e $dstdir/$rand_filename1 || die "file 1 not copied from container"
-    test -e $dstdir/$rand_filename2 || die "file 2 not copied from container"
-
-    is "$(<$dstdir/$rand_filename1)" "$rand_content1" "content of file 1"
-    is "$(<$dstdir/$rand_filename2)" "$rand_content2" "content of file 2"
+    # cp no longer supports wildcarding
+    run_podman 125 cp 'cpcontainer:/tmp/*' $dstdir
 
     run_podman rm cpcontainer
 }
@@ -150,13 +145,13 @@ load helpers
 
     # Copy file from host into container, into a file named 'x'
     # Note that the second has a trailing slash; this will trigger mkdir
-    run_podman cp $srcdir/$rand_filename1 cpcontainer:/tmp/d1/x
+    run_podman cp --pause=false $srcdir/$rand_filename1 cpcontainer:/tmp/d1/x
     is "$output" "" "output from podman cp 1"
 
-    run_podman cp $srcdir/$rand_filename2 cpcontainer:/tmp/d2/x/
+    run_podman cp --pause=false $srcdir/$rand_filename2 cpcontainer:/tmp/d2/x/
     is "$output" "" "output from podman cp 3"
 
-    run_podman cp $srcdir/$rand_filename3 cpcontainer:/tmp/d3/x
+    run_podman cp --pause=false $srcdir/$rand_filename3 cpcontainer:/tmp/d3/x
     is "$output" "" "output from podman cp 3"
 
     # Read back.
@@ -205,7 +200,7 @@ load helpers
                "mkdir -p $graphroot; trap 'exit 0' 15;while :;do sleep 0.5;done"
 
     # Copy from host into container.
-    run_podman cp $srcdir/$rand_filename cpcontainer:$graphroot/$rand_filename
+    run_podman cp --pause=false $srcdir/$rand_filename cpcontainer:$graphroot/$rand_filename
 
     # ls, and confirm it's there.
     run_podman exec cpcontainer ls -l $graphroot/$rand_filename


### PR DESCRIPTION
* Do not support wildcards
* Restore pause=true to avoid race conditions.  User can still do --pause=false to avoid container pause.

Signed-off-by: Jhon Honce <jhonce@redhat.com>