### PR TITLE
Fix unit tests missing comparative for 'Expect'

### DIFF
--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -155,13 +155,13 @@ var _ = Describe("Podman images", func() {
 		retapline.WaitWithDefaultTimeout()
 		Expect(retapline.ExitCode()).To(Equal(0))
 		Expect(len(retapline.OutputToStringArray())).To(Equal(2))
-		Expect(retapline.LineInOutputContains("alpine"))
+		Expect(retapline.LineInOutputContains("alpine")).To(BeTrue())
 
 		retapline = podmanTest.PodmanNoCache([]string{"images", "-f", "reference=alpine"})
 		retapline.WaitWithDefaultTimeout()
 		Expect(retapline.ExitCode()).To(Equal(0))
 		Expect(len(retapline.OutputToStringArray())).To(Equal(2))
-		Expect(retapline.LineInOutputContains("alpine"))
+		Expect(retapline.LineInOutputContains("alpine")).To(BeTrue())
 
 		retnone := podmanTest.PodmanNoCache([]string{"images", "-q", "-f", "reference=bogus"})
 		retnone.WaitWithDefaultTimeout()

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Podman mount", func() {
 		j := podmanTest.Podman([]string{"mount", "--format=json"})
 		j.WaitWithDefaultTimeout()
 		Expect(j.ExitCode()).To(Equal(0))
-		Expect(j.IsJSONOutputValid())
+		Expect(j.IsJSONOutputValid()).To(BeTrue())
 
 		umount := podmanTest.Podman([]string{"umount", cid})
 		umount.WaitWithDefaultTimeout()

--- a/test/e2e/port_test.go
+++ b/test/e2e/port_test.go
@@ -135,12 +135,12 @@ var _ = Describe("Podman port", func() {
 		result1 := podmanTest.Podman([]string{"port", "-l", "5000"})
 		result1.WaitWithDefaultTimeout()
 		Expect(result1.ExitCode()).To(BeZero())
-		Expect(result1.LineInOuputStartsWith("0.0.0.0:5000"))
+		Expect(result1.LineInOuputStartsWith("0.0.0.0:5000")).To(BeTrue())
 
 		// Check that the second port was honored
 		result2 := podmanTest.Podman([]string{"port", "-l", "5001"})
 		result2.WaitWithDefaultTimeout()
 		Expect(result2.ExitCode()).To(BeZero())
-		Expect(result2.LineInOuputStartsWith("0.0.0.0:5001"))
+		Expect(result2.LineInOuputStartsWith("0.0.0.0:5001")).To(BeTrue())
 	})
 })

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -282,6 +282,7 @@ RUN find $LOCAL
 		session := podmanTest.PodmanNoCache([]string{"image", "rm"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(125))
-		Expect(session.LineInOutputContains("image name or ID must be specified"))
+		match, _ := session.ErrorGrepString("image name or ID must be specified")
+		Expect(match).To(BeTrue())
 	})
 })

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Podman run cpu", func() {
 		}
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
-		Expect(result.LineInOutputContains("5000"))
+		Expect(result.LineInOutputContains("5000")).To(BeTrue())
 	})
 
 	It("podman run cpu-quota", func() {
@@ -78,7 +78,7 @@ var _ = Describe("Podman run cpu", func() {
 		}
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
-		Expect(result.LineInOutputContains("5000"))
+		Expect(result.LineInOutputContains("5000")).To(BeTrue())
 	})
 
 	It("podman run cpus", func() {


### PR DESCRIPTION
Add '.To(BeTrue())' to 'Expect(' statements in unit tests that
are missing them. These tests weren't being compared to anything,
thus reporting false positives. Additionally remove a check on
the output of an execution returning 125, it is empty on nonzero.

Signed-off-by: gabi beyer <gabrielle.n.beyer@intel.com>