### PR TITLE
build: pass down the cgroup manager to buildah

### DIFF
--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/buildah/imagebuildah"
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/docker/go-units"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -224,6 +225,14 @@ func buildCmd(c *cliconfig.BuildValues) error {
 	runtimeFlags := []string{}
 	for _, arg := range c.RuntimeFlags {
 		runtimeFlags = append(runtimeFlags, "--"+arg)
+	}
+
+	conf, err := runtime.GetConfig()
+	if err != nil {
+		return err
+	}
+	if conf != nil && conf.CgroupManager == libpod.SystemdCgroupsManager {
+		runtimeFlags = append(runtimeFlags, "--systemd-cgroup")
 	}
 	// end from buildah
 

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -113,6 +113,18 @@ func (r RemoteRuntime) DeferredShutdown(force bool) {
 	}
 }
 
+// RuntimeConfig is a bogus wrapper for compat with the libpod runtime
+type RuntimeConfig struct {
+	// CGroupManager is the CGroup Manager to use
+	// Valid values are "cgroupfs" and "systemd"
+	CgroupManager string
+}
+
+// Shutdown is a bogus wrapper for compat with the libpod runtime
+func (r *RemoteRuntime) GetConfig() (*RuntimeConfig, error) {
+	return nil, nil
+}
+
 // Shutdown is a bogus wrapper for compat with the libpod runtime
 func (r RemoteRuntime) Shutdown(force bool) error {
 	return nil


### PR DESCRIPTION
Pass down the cgroup manager to use to buildah.

Closes: https://github.com/containers/libpod/issues/3938

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>