### PR TITLE
Set TMPDIR to /var/tmp by default

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -145,6 +145,10 @@ func main() {
 	if reexec.Init() {
 		return
 	}
+	// Hard code TMPDIR functions to use /var/tmp, if user did not override
+	if _, ok := os.LookupEnv("TMPDIR"); !ok {
+		os.Setenv("TMPDIR", "/var/tmp")
+	}
 	if err := rootCmd.Execute(); err != nil {
 		outputError(err)
 	} else {


### PR DESCRIPTION
We have had some issues with users squashing large images or pulling large
content from github, that could trigger crashes based on the size of /tmp.

Docker had an issue with this back in 2016. https://github.com/golang/go/issues/14021

The discussion there was to change the default to /var/tmp.

This change will only effect systems that do not set the TMPDIR environment variable.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>