### PR TITLE
When first mounting any named volume, copy up

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -115,7 +115,9 @@ func (c *Container) prepare() (Err error) {
 		createErr = createNetNSErr
 	}
 	if mountStorageErr != nil {
-		logrus.Errorf("Error preparing container %s: %v", c.ID(), createErr)
+		if createErr != nil {
+			logrus.Errorf("Error preparing container %s: %v", c.ID(), createErr)
+		}
 		createErr = mountStorageErr
 	}
 

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -275,10 +275,6 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (c *Contai
 			return nil, errors.Wrapf(err, "error creating named volume %q", vol.Name)
 		}
 
-		if err := ctr.copyWithTarFromImage(vol.Dest, newVol.MountPoint()); err != nil && !os.IsNotExist(err) {
-			return nil, errors.Wrapf(err, "Failed to copy content into new volume mount %q", vol.Name)
-		}
-
 		ctrNamedVolumes = append(ctrNamedVolumes, newVol)
 	}
 

--- a/libpod/volume.go
+++ b/libpod/volume.go
@@ -57,6 +57,13 @@ type VolumeState struct {
 	// On incrementing from 0, the volume will be mounted on the host.
 	// On decrementing to 0, the volume will be unmounted on the host.
 	MountCount uint `json:"mountCount"`
+	// NeedsCopyUp indicates that the next time the volume is mounted into
+	// a container, the container will "copy up" the contents of the
+	// mountpoint into the volume.
+	// This should only be done once. As such, this is set at container
+	// create time, then cleared after the copy up is done and never set
+	// again.
+	NeedsCopyUp bool `json:"notYetMounted,omitempty"`
 }
 
 // Name retrieves the volume's name

--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -11,9 +11,11 @@ import (
 func newVolume(runtime *Runtime) (*Volume, error) {
 	volume := new(Volume)
 	volume.config = new(VolumeConfig)
+	volume.state = new(VolumeState)
 	volume.runtime = runtime
 	volume.config.Labels = make(map[string]string)
 	volume.config.Options = make(map[string]string)
+	volume.state.NeedsCopyUp = true
 
 	return volume, nil
 }

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -249,4 +249,25 @@ var _ = Describe("Podman run with volumes", func() {
 		fmt.Printf("Output: %s", mountOut3)
 		Expect(strings.Contains(mountOut3, volName)).To(BeFalse())
 	})
+
+	It("podman named volume copyup", func() {
+		baselineSession := podmanTest.Podman([]string{"run", "--rm", "-t", "-i", ALPINE, "ls", "/etc/apk/"})
+		baselineSession.WaitWithDefaultTimeout()
+		Expect(baselineSession.ExitCode()).To(Equal(0))
+		baselineOutput := baselineSession.OutputToString()
+
+		inlineVolumeSession := podmanTest.Podman([]string{"run", "--rm", "-t", "-i", "-v", "testvol1:/etc/apk", ALPINE, "ls", "/etc/apk/"})
+		inlineVolumeSession.WaitWithDefaultTimeout()
+		Expect(inlineVolumeSession.ExitCode()).To(Equal(0))
+		Expect(inlineVolumeSession.OutputToString()).To(Equal(baselineOutput))
+
+		makeVolumeSession := podmanTest.Podman([]string{"volume", "create", "testvol2"})
+		makeVolumeSession.WaitWithDefaultTimeout()
+		Expect(makeVolumeSession.ExitCode()).To(Equal(0))
+
+		separateVolumeSession := podmanTest.Podman([]string{"run", "--rm", "-t", "-i", "-v", "testvol2:/etc/apk", ALPINE, "ls", "/etc/apk/"})
+		separateVolumeSession.WaitWithDefaultTimeout()
+		Expect(separateVolumeSession.ExitCode()).To(Equal(0))
+		Expect(separateVolumeSession.OutputToString()).To(Equal(baselineOutput))
+	})
 })


### PR DESCRIPTION
Previously, we only did this for volumes created at the same time as the container. However, this is not correct behavior - Docker does so for all named volumes, even those made with 'podman volume create' and mounted into a container later.

Fixes #3945