### PR TITLE
Turn off journald in podmanimages on quay.io

### DIFF
--- a/contrib/podmanimage/stable/Dockerfile
+++ b/contrib/podmanimage/stable/Dockerfile
@@ -18,7 +18,7 @@ RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var
 RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
 
 # Adjust libpod.conf to write logging to a file
-RUN sed -i 's/events_logger = "journald"/events_logger = "file"/g' /usr/share/containers/libpod.conf
+RUN sed -i 's/# events_logger = "journald"/events_logger = "file"/g' /usr/share/containers/libpod.conf
 
 # Set up environment variables to note that this is
 # not starting with usernamespace and default to

--- a/contrib/podmanimage/testing/Dockerfile
+++ b/contrib/podmanimage/testing/Dockerfile
@@ -20,7 +20,7 @@ RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var
 RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
 
 # Adjust libpod.conf to write logging to a file
-RUN sed -i 's/events_logger = "journald"/events_logger = "file"/g' /usr/share/containers/libpod.conf
+RUN sed -i 's/# events_logger = "journald"/events_logger = "file"/g' /usr/share/containers/libpod.conf
 
 # Set up environment variables to note that this is
 # not starting with usernamespace and default to

--- a/contrib/podmanimage/upstream/Dockerfile
+++ b/contrib/podmanimage/upstream/Dockerfile
@@ -62,7 +62,7 @@ RUN dnf -y install --exclude container-selinux \
      mkdir -p /usr/share/containers; \
      cp $GOPATH/src/github.com/containers/libpod/libpod.conf /usr/share/containers; \
      # Adjust libpod.conf to write logging to a file
-     sed -i 's/events_logger = "journald"/events_logger = "file"/g' /usr/share/containers/libpod.conf; \
+     sed -i 's/# events_logger = "journald"/events_logger = "file"/g' /usr/share/containers/libpod.conf; \
      rm -rf /root/podman/*; \
      dnf -y remove git golang go-md2man make; \
      dnf clean all;


### PR DESCRIPTION
In the Dockerfiles that are used to build the podman images on
quay.io, we were changing the events_logger from journald to
file in libpod.conf, but we weren't enabling it as we didn't
remove the comment.  This corrects that and addresses: #3464

May need a similar fix in Buildah.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>