### PR TITLE
Fixup Makefile for BSD systems, e.g. macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,8 @@ help:
 .gopathok:
 ifeq ("$(wildcard $(GOPKGDIR))","")
 	mkdir -p "$(GOPKGBASEDIR)"
-	ln -sfnT "$(CURDIR)" "$(GOPKGDIR)"
-	ln -sfnT "$(CURDIR)/vendor/github.com/varlink" "$(FIRST_GOPATH)/src/github.com/varlink"
+	ln -sfn "$(CURDIR)" "$(GOPKGDIR)"
+	ln -sfn "$(CURDIR)/vendor/github.com/varlink" "$(FIRST_GOPATH)/src/github.com/varlink"
 endif
 	touch $@
 


### PR DESCRIPTION
The bsd variant of `ln` does not support the ``-T`` option.
Testing for existence using wildcard before creating new symlinks
should be sufficient here. Furthermore the target directory is
managed internally by this Makefile anyway.