### PR TITLE
Cirrus: Push snap continuously

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -639,7 +639,7 @@ upload_snap_task:
         image: yakshaveinc/snapcraft:core18
 
     env:
-        SNAPCRAFT_LOGIN: ENCRYPTED[...FILLME...]
+        SNAPCRAFT_LOGIN: ENCRYPTED[d8e82eb31c6372fec07f405f413d57806026b1a9f8400033531ebcd54d6750a5e4a8b1f68e3ec65c98c65e0d9b2a6a75]
     snapcraft_login_file:
         path: /root/.snapcraft/login.cfg
         variable_name: SNAPCRAFT_LOGIN

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -629,6 +629,9 @@ verify_test_built_images_task:
 
 upload_snap_task:
 
+    # Only when PR or branch is merged into master
+    only_if: $CIRRUS_BRANCH == $DEST_BRANCH
+
     depends_on:
         - "test_building_snap"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -627,6 +627,25 @@ verify_test_built_images_task:
         <<: *standardlogs
 
 
+upload_snap_task:
+
+    depends_on:
+        - "test_building_snap"
+
+    container:
+        image: yakshaveinc/snapcraft:core18
+
+    env:
+        SNAPCRAFT_LOGIN: ENCRYPTED[...FILLME...]
+    snapcraft_login_file:
+        path: /root/.snapcraft/login.cfg
+        variable_name: SNAPCRAFT_LOGIN
+    snapcraft_script:
+        - 'apt-get -y update'
+        - 'snapcraft login --with "/root/.snapcraft/login.cfg"'
+        - 'cd contrib/snapcraft && snapcraft && snapcraft push *.snap --release edge'
+
+
 # Post message to IRC if everything passed PR testing
 success_task:
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -674,6 +674,7 @@ success_task:
         - "special_testing_endpoint"
         - "test_build_cache_images"
         - "test_building_snap"
+        - "upload_snap"
         - "verify_test_built_images"
 
     env:


### PR DESCRIPTION
A continuation of #3889.

This needs a login file generated with `snapcraft export-login` and then pasted into `SNAPCRAFT_LOGIN` [encrypted variable](https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables).