### PR TITLE
Fixup `util.GetRootlessConfigHomeDir` permission requirements

### DIFF
--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -83,7 +83,7 @@ func GetRootlessConfigHomeDir() (string, error) {
 				logrus.Errorf("unable to make temp dir %s", tmpDir)
 			}
 			st, err := os.Stat(tmpDir)
-			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && st.Mode().Perm() == 0755 {
+			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && st.Mode().Perm() >= 0700 {
 				cfgHomeDir = tmpDir
 			}
 		}


### PR DESCRIPTION
Do not require 0755 permissons for the ~/.config directory but require
at least 0700 which should be sufficient. The current implementation
internally creates this directory with 0755 if it does not exist, but if the
directory already exists with different perissions the current code returns
an empty string.

This is also a problem when using `podman-remote` because the log file
``podman.log`` will be created in **"cwd"**/containers/ instead of
``~/.config/containers/podman.log``.