### PR TITLE
add lint and manpage check to make validate

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -104,14 +104,12 @@ gating_task:
         # N/B: entrypoint.sh resets $GOSRC (same as make clean)
         - '/usr/local/bin/entrypoint.sh install.tools |& ${TIMESTAMP}'
         - '/usr/local/bin/entrypoint.sh validate |& ${TIMESTAMP}'
-        - '/usr/local/bin/entrypoint.sh golangci-lint |& ${TIMESTAMP}'
 
     # This task builds Podman with different buildtags to ensure the build does
     # not break.  It also verifies all sub-commands have man pages.
     build_script:
         - '/usr/local/bin/entrypoint.sh podman |& ${TIMESTAMP}'
         - 'cd $GOSRC && ./hack/podman-commands.sh |& ${TIMESTAMP}'
-        - 'cd $GOSRC && ./hack/man-page-checker |& ${TIMESTAMP}'
         # N/B: need 'clean' so some commited files are re-generated.
         - '/usr/local/bin/entrypoint.sh clean podman-remote |& ${TIMESTAMP}'
         - '/usr/local/bin/entrypoint.sh clean podman BUILDTAGS="exclude_graphdriver_devicemapper selinux seccomp" |& ${TIMESTAMP}'

--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,9 @@ docs: $(MANPAGES) ## Generate documentation
 install-podman-remote-docs: docs
 	@(cd docs; ./podman-remote.sh ./remote)
 
+man-page-check:
+	./hack/man-page-checker
+
 # When publishing releases include critical build-time details
 .PHONY: release.txt
 release.txt:
@@ -505,7 +508,7 @@ validate.completions: completions/bash/podman
 	. completions/bash/podman
 	if [ -x /bin/zsh ]; then /bin/zsh completions/zsh/_podman; fi
 
-validate: gofmt .gitvalidation validate.completions
+validate: gofmt .gitvalidation validate.completions golangci-lint man-page-check
 
 build-all-new-commits:
 	# Validate that all the commits build on top of $(GIT_BASE_BRANCH)


### PR DESCRIPTION
make validate now runs golangci-lint and the man-page-checker to ensure
a PR is ready for our CI.

Signed-off-by: baude <bbaude@redhat.com>