### PR TITLE
Volume lookup needs to include state to unmarshal into

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -1749,6 +1749,7 @@ func (s *BoltState) LookupVolume(name string) (*Volume, error) {
 
 	volume := new(Volume)
 	volume.config = new(VolumeConfig)
+	volume.state = new(VolumeState)
 
 	db, err := s.getDBCon()
 	if err != nil {


### PR DESCRIPTION
Lookup was written before volume states merged, but merged after, and CI didn't catch the obvious failure here. Without a valid state, we try to unmarshall into a null pointer, and 'volume rm' is completely broken because of it.