### PR TITLE
Add further fields to StorageContainer

### DIFF
--- a/libpod/runtime_cstorage.go
+++ b/libpod/runtime_cstorage.go
@@ -1,6 +1,8 @@
 package libpod
 
 import (
+	"time"
+
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
@@ -12,6 +14,8 @@ import (
 type StorageContainer struct {
 	ID              string
 	Names           []string
+	Image           string
+	CreateTime      time.Time
 	PresentInLibpod bool
 }
 
@@ -31,6 +35,8 @@ func (r *Runtime) ListStorageContainers() ([]*StorageContainer, error) {
 		storageCtr := new(StorageContainer)
 		storageCtr.ID = ctr.ID
 		storageCtr.Names = ctr.Names
+		storageCtr.Image = ctr.ImageID
+		storageCtr.CreateTime = ctr.Created
 
 		// Look up if container is in state
 		hasCtr, err := r.state.HasContainer(ctr.ID)


### PR DESCRIPTION
This will be used when we allow 'podman ps' to display info on storage containers instead of Libpod containers.