### PR TITLE
podman-remote image trust is broken

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -518,6 +518,10 @@ type SearchValues struct {
 	TlsVerify bool
 }
 
+type TrustValues struct {
+	PodmanCommand
+}
+
 type SignValues struct {
 	PodmanCommand
 	Directory string

--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -33,6 +33,7 @@ func getMainCommands() []*cobra.Command {
 func getImageSubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		_signCommand,
+		_trustCommand,
 	}
 }
 

--- a/cmd/podman/trust.go
+++ b/cmd/podman/trust.go
@@ -6,22 +6,20 @@ import (
 )
 
 var (
+	trustCommand     cliconfig.TrustValues
 	trustDescription = `Manages which registries you trust as a source of container images based on its location.
-
   The location is determined by the transport and the registry host of the image.  Using this container image docker://docker.io/library/busybox as an example, docker is the transport and docker.io is the registry host.`
-	trustCommand = cliconfig.PodmanCommand{
-		Command: &cobra.Command{
-			Use:   "trust",
-			Short: "Manage container image trust policy",
-			Long:  trustDescription,
-			RunE:  commandRunE(),
-		},
+	_trustCommand = &cobra.Command{
+		Use:   "trust",
+		Short: "Manage container image trust policy",
+		Long:  trustDescription,
+		RunE:  commandRunE(),
 	}
 )
 
 func init() {
+	trustCommand.Command = _trustCommand
 	trustCommand.SetHelpTemplate(HelpTemplate())
 	trustCommand.SetUsageTemplate(UsageTemplate())
 	trustCommand.AddCommand(getTrustSubCommands()...)
-	imageCommand.AddCommand(trustCommand.Command)
 }

--- a/docs/podman-image-trust.1.md
+++ b/docs/podman-image-trust.1.md
@@ -8,7 +8,9 @@ podman\-image\-trust - Manage container registry image trust policy
 **podman image trust** set|show [*options*] *registry[/repository]*
 
 ## DESCRIPTION
-Manages which registries you trust as a source of container images  based on its location.  The location is determined
+Manages which registries you trust as a source of container images  based on its location. (Not available for remote commands)
+
+The location is determined
 by the transport and the registry host of the image.  Using this container image `docker://docker.io/library/busybox`
 as an example, `docker` is the transport and `docker.io` is the registry host.
 


### PR DESCRIPTION
We should not be making it available, it does nothing.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>