### PR TITLE
podman import syntax fix

### DIFF
--- a/cmd/podman/import.go
+++ b/cmd/podman/import.go
@@ -39,7 +39,7 @@ func init() {
 	importCommand.SetHelpTemplate(HelpTemplate())
 	importCommand.SetUsageTemplate(UsageTemplate())
 	flags := importCommand.Flags()
-	flags.StringSliceVarP(&importCommand.Change, "change", "c", []string{}, "Apply the following possible instructions to the created image (default []): CMD | ENTRYPOINT | ENV | EXPOSE | LABEL | STOPSIGNAL | USER | VOLUME | WORKDIR")
+	flags.StringArrayVarP(&importCommand.Change, "change", "c", []string{}, "Apply the following possible instructions to the created image (default []): CMD | ENTRYPOINT | ENV | EXPOSE | LABEL | STOPSIGNAL | USER | VOLUME | WORKDIR")
 	flags.StringVarP(&importCommand.Message, "message", "m", "", "Set commit message for imported image")
 	flags.BoolVarP(&importCommand.Quiet, "quiet", "q", false, "Suppress output")
 
@@ -56,7 +56,6 @@ func importCmd(c *cliconfig.ImportValues) error {
 		source    string
 		reference string
 	)
-
 	args := c.InputArgs
 	switch len(args) {
 	case 0:
@@ -81,7 +80,7 @@ func importCmd(c *cliconfig.ImportValues) error {
 	if runtime.Remote {
 		quiet = false
 	}
-	iid, err := runtime.Import(getContext(), source, reference, c.StringSlice("change"), c.String("message"), quiet)
+	iid, err := runtime.Import(getContext(), source, reference, importCommand.Change, c.String("message"), quiet)
 	if err == nil {
 		fmt.Println(iid)
 	}

--- a/docs/podman-import.1.md
+++ b/docs/podman-import.1.md
@@ -55,6 +55,26 @@ db65d991f3bbf7f31ed1064db9a6ced7652e3f8166c4736aa9133dadd3c7acb3
 ```
 
 ```
+$ podman import --change "ENTRYPOINT ["/bin/sh","-c","test-image"]"  --change LABEL=blue=image test-image.tar image-imported
+Getting image source signatures
+Copying blob e3b0c44298fc skipped: already exists
+Copying config 1105523502 done
+Writing manifest to image destination
+Storing signatures
+110552350206337183ceadc0bdd646dc356e06514c548b69a8917b4182414b
+```
+```
+$ podman import --change "CMD /bin/sh"  --change LABEL=blue=image test-image.tar image-imported
+Getting image source signatures
+Copying blob e3b0c44298fc skipped: already exists
+Copying config ae9a27e249 done
+Writing manifest to image destination
+Storing signatures
+ae9a27e249f801aff11a4ba54a81751ea9fbc9db45a6df3f1bfd63fc2437bb9c
+```
+
+
+```
 $ cat ctr.tar | podman -q import --message "importing the ctr.tar tarball" - image-imported
 db65d991f3bbf7f31ed1064db9a6ced7652e3f8166c4736aa9133dadd3c7acb3
 ```

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -1,8 +1,9 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -16,4 +17,72 @@ func TestStringInSlice(t *testing.T) {
 	assert.False(t, StringInSlice("five", sliceData))
 	// string is not in empty slice
 	assert.False(t, StringInSlice("one", []string{}))
+}
+
+func TestParseChanges(t *testing.T) {
+	// CMD=/bin/sh
+	_, vals, err := ParseChanges("CMD=/bin/sh")
+	assert.EqualValues(t, []string{"/bin/sh"}, vals)
+	assert.NoError(t, err)
+
+	// CMD [/bin/sh]
+	_, vals, err = ParseChanges("CMD [/bin/sh]")
+	assert.EqualValues(t, []string{"/bin/sh"}, vals)
+	assert.NoError(t, err)
+
+	// CMD ["/bin/sh"]
+	_, vals, err = ParseChanges(`CMD ["/bin/sh"]`)
+	assert.EqualValues(t, []string{`"/bin/sh"`}, vals)
+	assert.NoError(t, err)
+
+	// CMD ["/bin/sh","-c","ls"]
+	_, vals, err = ParseChanges(`CMD ["/bin/sh","c","ls"]`)
+	assert.EqualValues(t, []string{`"/bin/sh"`, `"c"`, `"ls"`}, vals)
+	assert.NoError(t, err)
+
+	// CMD ["/bin/sh","arg-with,comma"]
+	_, vals, err = ParseChanges(`CMD ["/bin/sh","arg-with,comma"]`)
+	assert.EqualValues(t, []string{`"/bin/sh"`, `"arg-with`, `comma"`}, vals)
+	assert.NoError(t, err)
+
+	// CMD "/bin/sh"]
+	_, _, err = ParseChanges(`CMD "/bin/sh"]`)
+	assert.Error(t, err)
+	assert.Equal(t, `invalid value "/bin/sh"]`, err.Error())
+
+	// CMD [bin/sh
+	_, _, err = ParseChanges(`CMD "/bin/sh"]`)
+	assert.Error(t, err)
+	assert.Equal(t, `invalid value "/bin/sh"]`, err.Error())
+
+	// CMD ["/bin /sh"]
+	_, _, err = ParseChanges(`CMD ["/bin /sh"]`)
+	assert.Error(t, err)
+	assert.Equal(t, `invalid value "/bin /sh"`, err.Error())
+
+	// CMD ["/bin/sh", "-c","ls"] whitespace between values
+	_, vals, err = ParseChanges(`CMD ["/bin/sh", "c","ls"]`)
+	assert.Error(t, err)
+	assert.Equal(t, `invalid value  "c"`, err.Error())
+
+	// CMD?
+	_, _, err = ParseChanges(`CMD?`)
+	assert.Error(t, err)
+	assert.Equal(t, `invalid format CMD?`, err.Error())
+
+	// empty values for CMD
+	_, _, err = ParseChanges(`CMD `)
+	assert.Error(t, err)
+	assert.Equal(t, `invalid value `, err.Error())
+
+	// LABEL=blue=image
+	_, vals, err = ParseChanges(`LABEL=blue=image`)
+	assert.EqualValues(t, []string{"blue", "image"}, vals)
+	assert.NoError(t, err)
+
+	// LABEL = blue=image
+	_, vals, err = ParseChanges(`LABEL = blue=image`)
+	assert.Error(t, err)
+	assert.Equal(t, `invalid value = blue=image`, err.Error())
+
 }

--- a/test/e2e/import_test.go
+++ b/test/e2e/import_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Podman import", func() {
 		Expect(results.LineInOuputStartsWith("importing container test message")).To(BeTrue())
 	})
 
-	It("podman import with change flag", func() {
+	It("podman import with change flag CMD=<path>", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "container.tar")
 		_, ec, cid := podmanTest.RunLsContainer("")
 		Expect(ec).To(Equal(0))
@@ -98,6 +98,46 @@ var _ = Describe("Podman import", func() {
 		Expect(export.ExitCode()).To(Equal(0))
 
 		importImage := podmanTest.Podman([]string{"import", "--change", "CMD=/bin/bash", outfile, "imported-image"})
+		importImage.WaitWithDefaultTimeout()
+		Expect(importImage.ExitCode()).To(Equal(0))
+
+		results := podmanTest.Podman([]string{"inspect", "imported-image"})
+		results.WaitWithDefaultTimeout()
+		Expect(results.ExitCode()).To(Equal(0))
+		imageData := results.InspectImageJSON()
+		Expect(imageData[0].Config.Cmd[0]).To(Equal("/bin/bash"))
+	})
+
+	It("podman import with change flag CMD <path>", func() {
+		outfile := filepath.Join(podmanTest.TempDir, "container.tar")
+		_, ec, cid := podmanTest.RunLsContainer("")
+		Expect(ec).To(Equal(0))
+
+		export := podmanTest.Podman([]string{"export", "-o", outfile, cid})
+		export.WaitWithDefaultTimeout()
+		Expect(export.ExitCode()).To(Equal(0))
+
+		importImage := podmanTest.Podman([]string{"import", "--change", "CMD /bin/sh", outfile, "imported-image"})
+		importImage.WaitWithDefaultTimeout()
+		Expect(importImage.ExitCode()).To(Equal(0))
+
+		results := podmanTest.Podman([]string{"inspect", "imported-image"})
+		results.WaitWithDefaultTimeout()
+		Expect(results.ExitCode()).To(Equal(0))
+		imageData := results.InspectImageJSON()
+		Expect(imageData[0].Config.Cmd[0]).To(Equal("/bin/sh"))
+	})
+
+	It("podman import with change flag CMD [\"path\",\"path'\"", func() {
+		outfile := filepath.Join(podmanTest.TempDir, "container.tar")
+		_, ec, cid := podmanTest.RunLsContainer("")
+		Expect(ec).To(Equal(0))
+
+		export := podmanTest.Podman([]string{"export", "-o", outfile, cid})
+		export.WaitWithDefaultTimeout()
+		Expect(export.ExitCode()).To(Equal(0))
+
+		importImage := podmanTest.Podman([]string{"import", "--change", "CMD [/bin/bash]", outfile, "imported-image"})
 		importImage.WaitWithDefaultTimeout()
 		Expect(importImage.ExitCode()).To(Equal(0))
 


### PR DESCRIPTION
syntax updated for podman import --change
    
currently, podman import change do not support syntax like
- KEY val
- KEY ["val"]
This adds support for both of these syntax along with KEY=val
Fixes #4000     

Signed-off-by: Kunal Kushwaha <kunal.kushwaha@gmail.com>
