### PR TITLE
Report errors when trying to pause rootless containers

### DIFF
--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -319,12 +319,14 @@ func (i *LibpodAPI) ExportContainer(call iopodman.VarlinkCall, name, outPath str
 
 // GetContainerStats ...
 func (i *LibpodAPI) GetContainerStats(call iopodman.VarlinkCall, name string) error {
-	cgroupv2, err := cgroups.IsCgroup2UnifiedMode()
-	if err != nil {
-		return call.ReplyErrorOccurred(err.Error())
-	}
-	if rootless.IsRootless() && !cgroupv2 {
-		return call.ReplyErrRequiresCgroupsV2ForRootless("rootless containers cannot report container stats")
+	if rootless.IsRootless() {
+		cgroupv2, err := cgroups.IsCgroup2UnifiedMode()
+		if err != nil {
+			return call.ReplyErrorOccurred(err.Error())
+		}
+		if !cgroupv2 {
+			return call.ReplyErrRequiresCgroupsV2ForRootless("rootless containers cannot report container stats")
+		}
 	}
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {

--- a/pkg/varlinkapi/pods.go
+++ b/pkg/varlinkapi/pods.go
@@ -5,12 +5,12 @@ package varlinkapi
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/containers/libpod/pkg/adapter/shortcuts"
 	"syscall"
 
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/pkg/adapter/shortcuts"
 )
 
 // CreatePod ...


### PR DESCRIPTION
If you are running a rootless container on cgroupV1
you can not pause the container.  We need to report the proper error
if this happens.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>