### PR TITLE
Fix default to pause in podman cp

### DIFF
--- a/docs/podman-cp.1.md
+++ b/docs/podman-cp.1.md
@@ -65,7 +65,7 @@ Extract the tar file into the destination directory. If the destination director
 
 **--pause**
 
-Pause the container while copying into it to avoid potential security issues around symlinks. Defaults to *false*.
+Pause the container while copying into it to avoid potential security issues around symlinks. Defaults to *true*. On rootless containers with cgroups V1, defaults to false.
 
 ## ALTERNATIVES
 


### PR DESCRIPTION
We want to default to secure when running containers as root,
in rootless, we need to change the default if the system does not
support cgroup v1.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>