### PR TITLE
cirrus: Add bash-completion support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ###
-    _BUILT_IMAGE_SUFFIX: "libpod-5664838702858240"
+    _BUILT_IMAGE_SUFFIX: # FIXME
     FEDORA_CACHE_IMAGE_NAME: "fedora-30-${_BUILT_IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-29-${_BUILT_IMAGE_SUFFIX}"
     SPECIAL_FEDORA_CACHE_IMAGE_NAME: "xfedora-30-${_BUILT_IMAGE_SUFFIX}"
@@ -622,9 +622,7 @@ verify_test_built_images_task:
     integration_test_script: >-
         [[ "$PACKER_BUILDER_NAME" == "xfedora-30" ]] || \
             $SCRIPT_BASE/integration_test.sh |& ${TIMESTAMP}
-    build_release_script: >-
-        [[ "$PACKER_BUILDER_NAME" == "xfedora-30" ]] || \
-            $SCRIPT_BASE/build_release.sh |& ${TIMESTAMP}
+    build_release_script: '$SCRIPT_BASE/build_release.sh |& ${TIMESTAMP}'
     system_test_script: >-
         [[ "$PACKER_BUILDER_NAME" == "xfedora-30" ]] || \
             $SCRIPT_BASE/system_test.sh |& ${TIMESTAMP}

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ###
-    _BUILT_IMAGE_SUFFIX: # FIXME
+    _BUILT_IMAGE_SUFFIX: "libpod-5816955207942144"
     FEDORA_CACHE_IMAGE_NAME: "fedora-30-${_BUILT_IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-29-${_BUILT_IMAGE_SUFFIX}"
     SPECIAL_FEDORA_CACHE_IMAGE_NAME: "xfedora-30-${_BUILT_IMAGE_SUFFIX}"

--- a/contrib/cirrus/check_image.sh
+++ b/contrib/cirrus/check_image.sh
@@ -56,6 +56,11 @@ then
     item_test "On ubuntu /usr/bin/runc is /usr/lib/cri-o-runc/sbin/runc" "$SAMESAME" -eq "0" || let "NFAILS+=1"
 fi
 
+if [[ "$OS_RELEASE_ID" == "ubuntu" ]]
+then
+    item_test "On ubuntu, no periodic apt crap is enabled" -z "$(egrep $PERIODIC_APT_RE /etc/apt/apt.conf.d/*)"
+fi
+
 echo "Checking items specific to ${PACKER_BUILDER_NAME}${BUILT_IMAGE_SUFFIX}"
 case "$PACKER_BUILDER_NAME" in
     xfedora*)

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -73,6 +73,8 @@ UPLDREL_IMAGE="quay.io/libpod/upldrel:latest"
 export DEBIAN_FRONTEND="noninteractive"
 SUDOAPTGET="ooe.sh sudo -E apt-get -qq --yes"
 SUDOAPTADD="ooe.sh sudo -E add-apt-repository --yes"
+# Regex that finds enabled periodic apt configuration items
+PERIODIC_APT_RE='^(APT::Periodic::.+")1"\;'
 # Short-cuts for retrying/timeout calls
 LILTO="timeout_attempt_delay_command 24s 5 30s"
 BIGTO="timeout_attempt_delay_command 300s 5 30s"

--- a/contrib/cirrus/packer/fedora_setup.sh
+++ b/contrib/cirrus/packer/fedora_setup.sh
@@ -26,6 +26,7 @@ ooe.sh sudo dnf install -y \
     atomic-registries \
     autoconf \
     automake \
+    bash-completion \
     bats \
     bridge-utils \
     btrfs-progs-devel \

--- a/contrib/cirrus/packer/ubuntu_setup.sh
+++ b/contrib/cirrus/packer/ubuntu_setup.sh
@@ -41,6 +41,7 @@ $BIGTO $SUDOAPTGET install \
     aufs-tools \
     autoconf \
     automake \
+    bash-completion \
     bats \
     bison \
     btrfs-tools \

--- a/contrib/cirrus/packer/ubuntu_setup.sh
+++ b/contrib/cirrus/packer/ubuntu_setup.sh
@@ -18,8 +18,16 @@ trap "sudo rm -rf $GOPATH" EXIT
 # Ensure there are no disruptive periodic services enabled by default in image
 systemd_banish
 
+# Stop disruption upon boot ASAP after booting
+echo "Disabling all packaging activity on boot"
+# Don't let sed process sed's temporary files
+_FILEPATHS=$(sudo ls -1 /etc/apt/apt.conf.d)
+for filename in $_FILEPATHS; do \
+    echo "Checking/Patching $filename"
+    sudo sed -i -r -e "s/$PERIODIC_APT_RE/"'\10"\;/' "/etc/apt/apt.conf.d/$filename"; done
+
 echo "Updating/configuring package repositories."
-$LILTO $SUDOAPTGET update
+$BIGTO $SUDOAPTGET update
 
 echo "Upgrading all packages"
 $BIGTO $SUDOAPTGET upgrade


### PR DESCRIPTION
Fixes #3447 

This is fairly standard thing to have on a user's workstation, supported
by podman.  When installed in a VM image, then it's useful for debugging
with `hack/get_ci_vm.sh` at the cost of a minor increase in disk-space.

***Depends on #4054***

Signed-off-by: Chris Evich <cevich@redhat.com>