### PR TITLE
Skip spec_test for rootless envs without cgroup v2.

### DIFF
--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -36,13 +36,15 @@ func doCommonSkipChecks(t *testing.T) {
 		t.Skip("seccomp, which is enabled by default, is only supported on Linux")
 	}
 
-	isUnified, err := cgroups.IsCgroup2UnifiedMode()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	if rootless.IsRootless() {
+		isCgroupV2, err := cgroups.IsCgroup2UnifiedMode()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 
-	if rootless.IsRootless() && !isUnified {
-		t.Skip("cgroups v1 cannot be used when rootless")
+		if !isCgroupV2 {
+			t.Skip("cgroups v1 cannot be used when rootless")
+		}
 	}
 }
 

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -4,6 +4,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/containers/libpod/pkg/cgroups"
+	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/sysinfo"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
@@ -26,14 +28,28 @@ func makeTestCreateConfig() *CreateConfig {
 	return cc
 }
 
-// TestPIDsLimit verifies the given pid-limit is correctly defined in the spec
-func TestPIDsLimit(t *testing.T) {
+func doCommonSkipChecks(t *testing.T) {
 	// The default configuration of podman enables seccomp, which is not available on non-Linux systems.
 	// Thus, any tests that use the default seccomp setting would fail.
 	// Skip the tests on non-Linux platforms rather than explicitly disable seccomp in the test and possibly affect the test result.
 	if runtime.GOOS != "linux" {
 		t.Skip("seccomp, which is enabled by default, is only supported on Linux")
 	}
+
+	isUnified, err := cgroups.IsCgroup2UnifiedMode()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if rootless.IsRootless() && !isUnified {
+		t.Skip("cgroups v1 cannot be used when rootless")
+	}
+}
+
+// TestPIDsLimit verifies the given pid-limit is correctly defined in the spec
+func TestPIDsLimit(t *testing.T) {
+	doCommonSkipChecks(t)
+
 	if !sysInfo.PidsLimit {
 		t.Skip("running test not supported by the host system")
 	}
@@ -50,12 +66,8 @@ func TestPIDsLimit(t *testing.T) {
 // TestBLKIOWeightDevice verifies the given blkio weight is correctly set in the
 // spec.
 func TestBLKIOWeightDevice(t *testing.T) {
-	// The default configuration of podman enables seccomp, which is not available on non-Linux systems.
-	// Thus, any tests that use the default seccomp setting would fail.
-	// Skip the tests on non-Linux platforms rather than explicitly disable seccomp in the test and possibly affect the test result.
-	if runtime.GOOS != "linux" {
-		t.Skip("seccomp, which is enabled by default, is only supported on Linux")
-	}
+	doCommonSkipChecks(t)
+
 	if !sysInfo.BlkioWeightDevice {
 		t.Skip("running test not supported by the host system")
 	}
@@ -75,12 +87,8 @@ func TestBLKIOWeightDevice(t *testing.T) {
 // TestMemorySwap verifies that the given swap memory limit is correctly set in
 // the spec.
 func TestMemorySwap(t *testing.T) {
-	// The default configuration of podman enables seccomp, which is not available on non-Linux systems.
-	// Thus, any tests that use the default seccomp setting would fail.
-	// Skip the tests on non-Linux platforms rather than explicitly disable seccomp in the test and possibly affect the test result.
-	if runtime.GOOS != "linux" {
-		t.Skip("seccomp, which is enabled by default, is only supported on Linux")
-	}
+	doCommonSkipChecks(t)
+
 	if !sysInfo.SwapLimit {
 		t.Skip("running test not supported by the host system")
 	}


### PR DESCRIPTION
When running rootless on systems with cgroups v1, local unit tests fail (tried on: Arch, Fedora 30):

```
=== RUN   TestPIDsLimit
--- FAIL: TestPIDsLimit (0.00s)
    spec_test.go:61: 
            Error Trace:    spec_test.go:61
            Error:          Received unexpected error:
                            invalid configuration, cannot set resources with rootless containers not using cgroups v2 unified mode
                            github.com/containers/libpod/pkg/spec.(*CreateConfig).createConfigToOCISpec
```

This PR makes the specific unit tests skippable in such environments.