### PR TITLE
Setup a reasonable default for pids-limit 4096

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/libpod/pkg/sysinfo"
 	"github.com/fatih/camelcase"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -374,8 +375,8 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"PID namespace to use",
 	)
 	createFlags.Int64(
-		"pids-limit", 0,
-		"Tune container pids limit (set -1 for unlimited)",
+		"pids-limit", sysinfo.GetDefaultPidsLimit(),
+		"Tune container pids limit (set 0 for unlimited)",
 	)
 	createFlags.String(
 		"pod", "",

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -686,6 +686,11 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		logDriver = c.String("log-driver")
 	}
 
+	pidsLimit := c.Int64("pids-limit")
+	if c.String("cgroups") == "disabled" && !c.Changed("pids-limit") {
+		pidsLimit = 0
+	}
+
 	config := &cc.CreateConfig{
 		Annotations:       annotations,
 		BuiltinImgVolumes: ImageVolumes,
@@ -764,7 +769,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 			MemorySwappiness:  int(memorySwappiness),
 			KernelMemory:      memoryKernel,
 			OomScoreAdj:       c.Int("oom-score-adj"),
-			PidsLimit:         c.Int64("pids-limit"),
+			PidsLimit:         pidsLimit,
 			Ulimit:            c.StringSlice("ulimit"),
 		},
 		RestartPolicy: c.String("restart"),

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -552,7 +552,7 @@ Default is to create a private PID namespace for the container
 
 **--pids-limit**=*limit*
 
-Tune the container's pids limit. Set `-1` to have unlimited pids for the container.
+Tune the container's pids limit. Set `0` to have unlimited pids for the container. (default "4096" on systems that support PIDS cgroups).
 
 **--pod**=*name*
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -565,7 +565,7 @@ Default is to create a private PID namespace for the container
 
 **--pids-limit**=*limit*
 
-Tune the container's pids limit. Set `-1` to have unlimited pids for the container.
+Tune the container's pids limit. Set `0` to have unlimited pids for the container. (default "4096" on systems that support PIDS cgroups).
 
 **--pod**=*name*
 

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -142,3 +142,12 @@ func popcnt(x uint64) (n byte) {
 	x *= 0x0101010101010101
 	return byte(x >> 56)
 }
+
+// GetDefaultPidsLimit returns the default pids limit to run containers with
+func GetDefaultPidsLimit() int64 {
+	sysInfo := New(true)
+	if !sysInfo.PidsLimit {
+		return 0
+	}
+	return 4096
+}


### PR DESCRIPTION
CRI-O defaults to 1024 for the maximum pids in a container.  Podman
should have a similar limit. Once we have a containers.conf, we can
set the limit in this file, and have it easily customizable.

Currently the documentation says that -1 sets pids-limit=max, but -1 fails.
This patch allows -1, but also indicates that 0 also sets the max pids limit.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>