### PR TITLE
Unmounting a container that is already unmounted is OK

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1368,7 +1368,7 @@ func (c *Container) cleanupStorage() error {
 		// error
 		// We still want to be able to kick the container out of the
 		// state
-		if errors.Cause(err) == storage.ErrNotAContainer || errors.Cause(err) == storage.ErrContainerUnknown {
+		if errors.Cause(err) == storage.ErrNotAContainer || errors.Cause(err) == storage.ErrContainerUnknown || errors.Cause(err) == storage.ErrLayerNotMounted {
 			logrus.Errorf("Storage for container %s has been removed", c.ID())
 		} else {
 			if cleanupErr != nil {


### PR DESCRIPTION
We should not be throwing errors because the operation we wanted to perform is already done. Now, it is definitely strange that a container is actually unmounted, but shows as mounted in the DB - if this reoccurs in a way where we can investigate, it's worth tearing into.

Fixes #4033