### PR TITLE
Add links to the Mac tutorial in the main tutorial

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -8,6 +8,10 @@
 
 Learn how to setup Podman and perform some basic commands with the utility.
 
-**[Basic Setup and Use of Podman in a Rootless environment.](https://github.com/containers/libpod/blob/master/docs/tutorials/rootless_tutorial.md).
+**[Basic Setup and Use of Podman in a Rootless environment.](https://github.com/containers/libpod/blob/master/docs/tutorials/rootless_tutorial.md).**
 
 The steps required to setup rootless Podman are enumerated.
+
+**[Setup on OS X](https://github.com/containers/libpod/blob/master/mac_client.md)**
+
+Special setup for running the Podman remote client on a Mac and connecting to Podman running on a Linux VM are documented

--- a/docs/tutorials/podman_tutorial.md
+++ b/docs/tutorials/podman_tutorial.md
@@ -5,6 +5,9 @@ Podman is a utility provided as part of the libpod library.  It can be used to c
 containers. The following tutorial will teach you how to set up Podman and perform some basic
 commands with Podman.
 
+If you are running on a Mac, you should instead follow the [Mac tutorial](https://github.com/containers/libpod/blob/master/mac_client.md)
+to set up the remote Podman client.
+
 **NOTE**: the code samples are intended to be run as a non-root user, and use `sudo` where
 root escalation is required.
 


### PR DESCRIPTION
As the title says. Should reduce confusion for people trying on OS X for the first time.