### PR TITLE
support non-standard ssh port for remote-client

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -41,6 +41,7 @@ type MainFlags struct {
 	VarlinkAddress       string
 	ConnectionName       string
 	RemoteConfigFilePath string
+	Port                 int
 }
 
 type AttachValues struct {

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -111,6 +111,11 @@ func before(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// check that global opts input is valid
+	if err := checkInput(); err != nil {
+		return err
+	}
+
 	//	Set log level; if not log-level is provided, default to error
 	logLevel := MainGlobalOpts.LogLevel
 	if logLevel == "" {

--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -267,3 +267,8 @@ func setUMask() {
 	// Be sure we can create directories with 0755 mode.
 	syscall.Umask(0022)
 }
+
+// checkInput can be used to verify any of the globalopt values
+func checkInput() error {
+	return nil
+}

--- a/cmd/podman/main_remote.go
+++ b/cmd/podman/main_remote.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"github.com/pkg/errors"
 	"os/user"
 
 	"github.com/spf13/cobra"
@@ -18,6 +19,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.ConnectionName, "connection", "", "remote connection name")
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.RemoteConfigFilePath, "remote-config-path", "", "alternate path for configuration file")
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.RemoteUserName, "username", username, "username on the remote host")
+	rootCmd.PersistentFlags().IntVar(&MainGlobalOpts.Port, "port", 22, "port on remote host")
 	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.RemoteHost, "remote-host", "", "remote host")
 	// TODO maybe we allow the altering of this for bridge connections?
 	// rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.VarlinkAddress, "varlink-address", adapter.DefaultAddress, "address of the varlink socket")
@@ -42,3 +44,11 @@ func setRLimits() error {
 }
 
 func setUMask() {}
+
+// checkInput can be used to verify any of the globalopt values
+func checkInput() error {
+	if MainGlobalOpts.Port < 0 || MainGlobalOpts.Port > 65536 {
+		return errors.Errorf("remote port must be between 0 and 65536")
+	}
+	return nil
+}

--- a/cmd/podman/remoteclientconfig/config.go
+++ b/cmd/podman/remoteclientconfig/config.go
@@ -12,6 +12,7 @@ type RemoteConnection struct {
 	Destination string `toml:"destination"`
 	Username    string `toml:"username"`
 	IsDefault   bool   `toml:"default"`
+	Port        int    `toml:"port"`
 }
 
 // GetConfigFilePath is a simple helper to export the configuration file's

--- a/cmd/podman/remoteclientconfig/configfile_test.go
+++ b/cmd/podman/remoteclientconfig/configfile_test.go
@@ -13,11 +13,13 @@ var goodConfig = `
 [connections.homer]
 destination = "192.168.1.1"
 username = "myuser"
+port = 22
 default = true
 
 [connections.bart]
 destination = "foobar.com"
 username = "root"
+port = 22
 `
 var noDest = `
 [connections]
@@ -26,9 +28,11 @@ var noDest = `
 destination = "192.168.1.1"
 username = "myuser"
 default = true
+port = 22
 
 [connections.bart]
 username = "root"
+port = 22
 `
 
 var noUser = `
@@ -36,6 +40,7 @@ var noUser = `
 
 [connections.homer]
 destination = "192.168.1.1"
+port = 22
 `
 
 func makeGoodResult() *RemoteConfig {
@@ -44,10 +49,12 @@ func makeGoodResult() *RemoteConfig {
 		Destination: "192.168.1.1",
 		Username:    "myuser",
 		IsDefault:   true,
+		Port:        22,
 	}
 	goodConnections["bart"] = RemoteConnection{
 		Destination: "foobar.com",
 		Username:    "root",
+		Port:        22,
 	}
 	var goodResult = RemoteConfig{
 		Connections: goodConnections,
@@ -59,6 +66,7 @@ func makeNoUserResult() *RemoteConfig {
 	var goodConnections = make(map[string]RemoteConnection)
 	goodConnections["homer"] = RemoteConnection{
 		Destination: "192.168.1.1",
+		Port:        22,
 	}
 	var goodResult = RemoteConfig{
 		Connections: goodConnections,
@@ -135,7 +143,7 @@ func TestRemoteConfig_GetDefault(t *testing.T) {
 		wantErr bool
 	}{
 		// A good toml should return the connection that is marked isDefault
-		{"good", fields{Connections: makeGoodResult().Connections}, &RemoteConnection{"192.168.1.1", "myuser", true}, false},
+		{"good", fields{Connections: makeGoodResult().Connections}, &RemoteConnection{"192.168.1.1", "myuser", true, 22}, false},
 		// If nothing is marked as isDefault and there is more than one connection, error should occur
 		{"nodefault", fields{Connections: noDefault}, nil, true},
 		// if nothing is marked as isDefault but there is only one connection, the one connection is considered the default
@@ -175,9 +183,9 @@ func TestRemoteConfig_GetRemoteConnection(t *testing.T) {
 		wantErr bool
 	}{
 		// Good connection
-		{"goodhomer", fields{Connections: makeGoodResult().Connections}, args{name: "homer"}, &RemoteConnection{"192.168.1.1", "myuser", true}, false},
+		{"goodhomer", fields{Connections: makeGoodResult().Connections}, args{name: "homer"}, &RemoteConnection{"192.168.1.1", "myuser", true, 22}, false},
 		// Good connection
-		{"goodbart", fields{Connections: makeGoodResult().Connections}, args{name: "bart"}, &RemoteConnection{"foobar.com", "root", false}, false},
+		{"goodbart", fields{Connections: makeGoodResult().Connections}, args{name: "bart"}, &RemoteConnection{"foobar.com", "root", false, 22}, false},
 		// Getting an unknown connection should result in error
 		{"noexist", fields{Connections: makeGoodResult().Connections}, args{name: "foobar"}, nil, true},
 		// Getting a connection when there are none should result in an error

--- a/docs/podman-remote.1.md
+++ b/docs/podman-remote.1.md
@@ -35,6 +35,10 @@ Print usage statement
 
 Log messages above specified level: debug, info, warn, error (default), fatal or panic
 
+**--port**=*integer*
+
+Use an alternative port for the ssh connections.  The default port is 22
+
 **--remote-config-path**=*path*
 
 Alternate path for configuration file

--- a/docs/podman-remote.conf.5.md
+++ b/docs/podman-remote.conf.5.md
@@ -22,6 +22,9 @@ of the user's remote connections.
   Denotes whether the connection is the default connection for the user.  The default connection
   is used when the user does not specify a destination or connection name to `podman`.
 
+**port** = int
+  Use an alternative port for the ssh connections.  The default port is 22.
+
 
 ## EXAMPLE
 
@@ -37,6 +40,7 @@ is designated as the default connection.
     [connections.host2]
     destination = "192.168.122.133"
     username = "fedora"
+    port = 2222
 ```
 
 ## FILES

--- a/pkg/adapter/client.go
+++ b/pkg/adapter/client.go
@@ -35,7 +35,7 @@ func (r RemoteRuntime) RemoteEndpoint() (remoteEndpoint *Endpoint, err error) {
 		if len(r.cmd.RemoteUserName) < 1 {
 			return nil, errors.New("you must provide a username when providing a remote host name")
 		}
-		rc := remoteclientconfig.RemoteConnection{r.cmd.RemoteHost, r.cmd.RemoteUserName, false}
+		rc := remoteclientconfig.RemoteConnection{r.cmd.RemoteHost, r.cmd.RemoteUserName, false, r.cmd.Port}
 		remoteEndpoint, err = newBridgeConnection("", &rc, r.cmd.LogLevel)
 		//  if the user has a config file with connections in it
 	} else if len(remoteConfigConnections.Connections) > 0 {

--- a/pkg/adapter/client_unix.go
+++ b/pkg/adapter/client_unix.go
@@ -10,7 +10,11 @@ import (
 )
 
 func formatDefaultBridge(remoteConn *remoteclientconfig.RemoteConnection, logLevel string) string {
+	port := remoteConn.Port
+	if port == 0 {
+		port = 22
+	}
 	return fmt.Sprintf(
-		`ssh -T %s@%s -- /usr/bin/varlink -A \'/usr/bin/podman --log-level=%s varlink \\\$VARLINK_ADDRESS\' bridge`,
-		remoteConn.Username, remoteConn.Destination, logLevel)
+		`ssh -p %d -T %s@%s -- /usr/bin/varlink -A \'/usr/bin/podman --log-level=%s varlink \\\$VARLINK_ADDRESS\' bridge`,
+		port, remoteConn.Username, remoteConn.Destination, logLevel)
 }


### PR DESCRIPTION
when using the remote client, users may need to specify a non-standard
port for ssh connections.  we can do so on the command line and within
the remote-client configuration file.

Fixes: #3987

Signed-off-by: baude <bbaude@redhat.com>