### PR TITLE
Add libbtrfs-dev for Debian build

### DIFF
--- a/install.md
+++ b/install.md
@@ -130,6 +130,7 @@ sudo apt-get install \
   go-md2man \
   iptables \
   libassuan-dev \
+  libbtrfs-dev \
   libc6-dev \
   libdevmapper-dev \
   libglib2.0-dev \


### PR DESCRIPTION
Despite installing btrfs-tools and btrfs-progs, I got 

fatal error: 'btrfs/ioctl.h' file not found
#include <btrfs/ioctl.h>

until I had installed libbtrfs-dev on Debian.