### PR TITLE
Cirrus: Fail early on CI script unit test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -117,6 +117,12 @@ gating_task:
         - '/usr/local/bin/entrypoint.sh podman-remote-darwin |& ${TIMESTAMP}'
         - '/usr/local/bin/entrypoint.sh podman-remote-windows |& ${TIMESTAMP}'
 
+    # Verify some aspects of ci/related scripts
+    ci_script:
+        - '${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/lib.sh.t |& ${TIMESTAMP}'
+        - '/usr/local/bin/entrypoint.sh -C ${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/packer test'
+        - '${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/cirrus_yaml_test.py |& ${TIMESTAMP}'
+
     # Verify expected bash environment (-o pipefail)
     pipefail_enabledscript: 'if /bin/false | /bin/true; then echo "pipefail fault" && exit 72; fi'
 

--- a/Makefile
+++ b/Makefile
@@ -245,9 +245,6 @@ localunit: test/goecho/goecho varlink_generate
 		--covermode atomic \
 		--tags "$(BUILDTAGS)" \
 		--succinct
-	$(MAKE) -C contrib/cirrus/packer test
-	./contrib/cirrus/lib.sh.t
-	./contrib/cirrus/cirrus_yaml_test.py
 
 ginkgo:
 	ginkgo -v -tags "$(BUILDTAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes 3 -debug test/e2e/.


### PR DESCRIPTION
Instead of running this basic checks for almost all tasks, just do them
once at the beginning.

Signed-off-by: Chris Evich <cevich@redhat.com>