### PR TITLE
execuser: look at the source for /etc/{passwd,group} overrides

### DIFF
--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -200,6 +200,12 @@ var _ = Describe("Podman run", func() {
 		match, _ := session.GrepString("/root")
 		Expect(match).Should(BeTrue())
 
+		session = podmanTest.Podman([]string{"run", "--rm", "--user", "2", ALPINE, "printenv", "HOME"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ = session.GrepString("/sbin")
+		Expect(match).Should(BeTrue())
+
 		session = podmanTest.Podman([]string{"run", "--rm", "--env", "HOME=/foo", ALPINE, "printenv", "HOME"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))


### PR DESCRIPTION
look if there are bind mounts that can shadow the /etc/passwd and
/etc/group files.  In that case, look at the bind mount source.

Closes: https://github.com/containers/libpod/pull/4068#issuecomment-533782941

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>