### PR TITLE
Force a CNI Delete on refreshing containers

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -622,7 +622,7 @@ func (c *Container) refresh() error {
 		return err
 	}
 
-	return nil
+	return c.refreshCNI()
 }
 
 // Remove conmon attach socket and terminal resize FIFO

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1294,3 +1294,10 @@ func (c *Container) copyOwnerAndPerms(source, dest string) error {
 	}
 	return nil
 }
+
+// Teardown CNI config on refresh
+func (c *Container) refreshCNI() error {
+	// Let's try and delete any lingering network config...
+	podNetwork := c.runtime.getPodNetwork(c.ID(), c.config.Name, "", c.config.Networks, c.config.PortMappings, c.config.StaticIP)
+	return c.runtime.netPlugin.TearDownPod(podNetwork)
+}

--- a/libpod/container_internal_unsupported.go
+++ b/libpod/container_internal_unsupported.go
@@ -40,3 +40,7 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 func (c *Container) copyOwnerAndPerms(source, dest string) error {
 	return nil
 }
+
+func (c *Container) refreshCNI() error {
+	return define.ErrNotImplemented
+}


### PR DESCRIPTION
CNI expects that a DELETE be run before re-creating container networks. If a reboot occurs quickly enough that containers can't stop and clean up, that DELETE never happens, and Podman currently wipes the old network info and thinks the state has been entirely cleared. Unfortunately, that may not be the case on the CNI side. Some things - like IP address reservations - may not have been cleared.

To solve this, manually re-run CNI Delete on refresh. If the container has already been deleted this seems harmless. If not, it should clear lingering state.

Fixes: #3759