### PR TITLE
Cirrus: Minor, fix env. var. intention

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -295,7 +295,7 @@ meta_task:
 image_prune_task:
 
     # Do not run this frequently
-    only_if: $CIRRUS_BRANCH == 'master'
+    only_if: $CIRRUS_BRANCH == $DEST_BRANCH
 
     depends_on:
         - "meta"


### PR DESCRIPTION
Using env. var. on the RHS of an `only_if` was broken in Cirrus-CI (the service).  It's fixed now, so this PR is now only a very small/minor fix.