### PR TITLE
runtime: fix logic to disable SDNotify

### DIFF
--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -171,7 +171,7 @@ func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber, migra
 		options = append(options, libpod.WithDefaultInfraCommand(infraCommand))
 	}
 
-	if withFDS {
+	if !withFDS {
 		options = append(options, libpod.WithEnableSDNotify())
 	}
 	if c.Flags().Changed("config") {


### PR DESCRIPTION
Fix the logic when getting the runtime for varlink to actually disable
SDNotify support.

Fixes: #4005
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>