### PR TITLE
fix cp none exists dest path ends with '/'

### DIFF
--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -290,7 +290,7 @@ func copy(src, destPath, dest string, idMappingOpts storage.IDMappingOptions, ch
 	}
 
 	destdir := destPath
-	if !srcfi.IsDir() && !strings.HasSuffix(dest, string(os.PathSeparator)) {
+	if !srcfi.IsDir() {
 		destdir = filepath.Dir(destPath)
 	}
 	_, err = os.Stat(destdir)
@@ -329,7 +329,7 @@ func copy(src, destPath, dest string, idMappingOpts storage.IDMappingOptions, ch
 
 	destfi, err := os.Stat(destPath)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !os.IsNotExist(err) || strings.HasSuffix(dest, string(os.PathSeparator)) {
 			return errors.Wrapf(err, "failed to get stat of dest path %s", destPath)
 		}
 	}

--- a/docs/podman-cp.1.md
+++ b/docs/podman-cp.1.md
@@ -29,7 +29,7 @@ Assuming a path separator of /, a first argument of **src_path** and second argu
   - **dest_path** does not exist
 	- the file is saved to a file created at **dest_path**
   - **dest_path** does not exist and ends with /
-	- **dest_path** is created as a directory and the file is copied into this directory using the basename from **src_path**
+	- Error condition: the destination directory must exist.
   - **dest_path** exists and is a file
 	- the destination is overwritten with the source file's contents
   - **dest_path** exists and is a directory


### PR DESCRIPTION
close #3894
This patch will let podman cp return 'no such file or directory' error if DEST_PATH does not exist and ends with / when copying file.

```
$ podman run -d --name cpc alpine sh -c 'sleep 999'
$ podman exec cpc sh -c 'mkdir /tmp/d1;ln -s /tmp/nonesuch1 /tmp/d1/x'
$ podman exec cpc sh -c 'mkdir /tmp/d2;ln -s /tmp/nonesuch2 /tmp/d2/x'
$ podman exec cpc sh -c 'mkdir /tmp/d3'
$ podman exec cpc ls -lR /tmp
/tmp:
total 12
drwxr-xr-x    2 root     root          4096 Sep 24 14:45 d1
drwxr-xr-x    2 root     root          4096 Sep 24 14:45 d2
drwxr-xr-x    2 root     root          4096 Sep 24 14:45 d3

/tmp/d1:
total 0
lrwxrwxrwx    1 root     root            14 Sep 24 14:45 x -> /tmp/nonesuch1

/tmp/d2:
total 0
lrwxrwxrwx    1 root     root            14 Sep 24 14:45 x -> /tmp/nonesuch2

/tmp/d3:
total 0

$ podman cp /tmp/myfile cpc:/tmp/d1/x
$ podman cp /tmp/myfile cpc:/tmp/d2/x/
Error: failed to get stat of dest path /home/qiwan/.local/share/containers/storage/overlay/82311cd5e4e276073e44ad65eaeec65a048a3141d447d4b46393b1c3fac64168/merged/tmp/nonesuch2: stat /home/qiwan/.local/share/containers/storage/overlay/82311cd5e4e276073e44ad65eaeec65a048a3141d447d4b46393b1c3fac64168/merged/tmp/nonesuch2: no such file or directory
$ podman cp /tmp/myfile cpc:/tmp/d3/x
$ podman exec cpc ls -lR /tmp
/tmp:
total 16
drwxr-xr-x    2 root     root          4096 Sep 24 14:45 d1
drwxr-xr-x    2 root     root          4096 Sep 24 14:45 d2
drwxr-xr-x    2 root     root          4096 Sep 24 14:46 d3
-rw-rw-r--    1 root     root             3 Sep 24 14:07 nonesuch1

/tmp/d1:
total 0
lrwxrwxrwx    1 root     root            14 Sep 24 14:45 x -> /tmp/nonesuch1

/tmp/d2:
total 0
lrwxrwxrwx    1 root     root            14 Sep 24 14:45 x -> /tmp/nonesuch2

/tmp/d3:
total 4
-rw-rw-r--    1 root     root             3 Sep 24 14:07 x
```

Signed-off-by: Qi Wang <qiwan@redhat.com>