### PR TITLE
conditionally send stdin on remote run

### DIFF
--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -473,7 +473,12 @@ func (r *LocalRuntime) Run(ctx context.Context, c *cliconfig.RunValues, exitCode
 		fmt.Println(cid)
 		return 0, nil
 	}
-	exitChan, errChan, err := r.attach(ctx, os.Stdin, os.Stdout, cid, true, c.String("detach-keys"))
+	inputStream := os.Stdin
+	// If -i is not set, clear stdin
+	if !c.Bool("interactive") {
+		inputStream = nil
+	}
+	exitChan, errChan, err := r.attach(ctx, inputStream, os.Stdout, cid, true, c.String("detach-keys"))
 	if err != nil {
 		return exitCode, err
 	}

--- a/pkg/varlinkapi/attach.go
+++ b/pkg/varlinkapi/attach.go
@@ -65,7 +65,9 @@ func (i *LibpodAPI) Attach(call iopodman.VarlinkCall, name string, detachKeys st
 	}
 
 	// ACK the client upgrade request
-	call.ReplyAttach()
+	if err := call.ReplyAttach(); err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
 
 	reader, writer, _, pw, streams := setupStreams(call)
 


### PR DESCRIPTION
when running a container remotely, we should only be sending stdin when
running with --interactive; otherwise use nil.

Fixes: #4095

Signed-off-by: baude <bbaude@redhat.com>