### PR TITLE
Handle conflict between volumes and --read-only-tmpfs

### DIFF
--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -168,6 +168,9 @@ func (config *CreateConfig) parseVolumes(runtime *libpod.Runtime) ([]spec.Mount,
 			if _, ok := baseMounts[dest]; ok {
 				continue
 			}
+			if _, ok := baseVolumes[dest]; ok {
+				continue
+			}
 			localOpts := options
 			if dest == "/run" {
 				localOpts = append(localOpts, "noexec", "size=65536k")

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -270,4 +270,14 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(separateVolumeSession.ExitCode()).To(Equal(0))
 		Expect(separateVolumeSession.OutputToString()).To(Equal(baselineOutput))
 	})
+
+	It("podman read-only tmpfs conflict with volume", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", "-t", "-i", "--read-only", "-v", "tmp_volume:/run", ALPINE, "touch", "/run/a"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session2 := podmanTest.Podman([]string{"run", "--rm", "-t", "-i", "--read-only", "--tmpfs", "/run", ALPINE, "touch", "/run/a"})
+		session2.WaitWithDefaultTimeout()
+		Expect(session2.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
When a named volume is mounted on any of the tmpfs filesystems created by read-only tmpfs, it caused a conflict that was not resolved prior to this.

Fixes BZ1755119