### PR TITLE
Make links relative in Tutorial README

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -4,18 +4,18 @@
 
 ## Links to a number of useful tutorials for the Podman utility.
 
-**[Introduction Tutorial](https://github.com/containers/libpod/tree/master/docs/tutorials/podman_tutorial.md)**
+**[Introduction Tutorial](podman_tutorial.md)**
 
 Learn how to setup Podman and perform some basic commands with the utility.
 
-**[Basic Setup and Use of Podman in a Rootless environment.](https://github.com/containers/libpod/blob/master/docs/tutorials/rootless_tutorial.md).**
+**[Basic Setup and Use of Podman in a Rootless environment](rootless_tutorial.md)**
 
 The steps required to setup rootless Podman are enumerated.
 
-**[Setup on OS X](https://github.com/containers/libpod/blob/master/doc/tutorials/mac_client.md)**
+**[Setup on OS X](mac_client.md)**
 
-Special setup for running the Podman remote client on a Mac and connecting to Podman running on a Linux VM are documented
+Special setup for running the Podman remote client on a Mac and connecting to Podman running on a Linux VM are documented.
 
-**[Remote Client](https://github.com/containers/libpod/blob/master/doc/tutorials/remote_client.md)**
+**[Remote Client](remote_client.md)**
 
 A brief how-to on using the Podman remote-client.


### PR DESCRIPTION
Remove the longer html link in favor or relative links
which are shorter and less error prone.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>