### PR TITLE
Move noCache logic lower in stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /test/bin2img/bin2img
 /test/checkseccomp/checkseccomp
 /test/copyimg/copyimg
+/test/goecho/goecho
 /build/
 .nfs*
 .ropeproject

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -412,7 +412,7 @@ func (p *PodmanTestIntegration) BuildImage(dockerfile, imageName string, layers 
 
 // PodmanPID execs podman and returns its PID
 func (p *PodmanTestIntegration) PodmanPID(args []string) (*PodmanSessionIntegration, int) {
-	podmanOptions := p.MakeOptions(args, false)
+	podmanOptions := p.MakeOptions(args, false, false)
 	fmt.Printf("Running: %s %s\n", p.PodmanBinary, strings.Join(podmanOptions, " "))
 	command := exec.Command(p.PodmanBinary, podmanOptions...)
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)

--- a/test/e2e/libpod_suite_remoteclient_test.go
+++ b/test/e2e/libpod_suite_remoteclient_test.go
@@ -36,7 +36,7 @@ func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration 
 
 // PodmanNoCache calls podman with out adding the imagecache
 func (p *PodmanTestIntegration) PodmanNoCache(args []string) *PodmanSessionIntegration {
-	podmanSession := p.PodmanBase(args, true, false)
+	podmanSession := p.PodmanBase(args, false, true)
 	return &PodmanSessionIntegration{podmanSession}
 }
 
@@ -142,7 +142,7 @@ func (p *PodmanTestIntegration) StopVarlink() {
 }
 
 //MakeOptions assembles all the podman main options
-func (p *PodmanTestIntegration) makeOptions(args []string, noEvents bool) []string {
+func (p *PodmanTestIntegration) makeOptions(args []string, noEvents, noCache bool) []string {
 	return args
 }
 

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -29,7 +29,7 @@ func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration 
 
 // PodmanNoCache calls the podman command with no configured imagecache
 func (p *PodmanTestIntegration) PodmanNoCache(args []string) *PodmanSessionIntegration {
-	podmanSession := p.PodmanBase(args, true, false)
+	podmanSession := p.PodmanBase(args, false, true)
 	return &PodmanSessionIntegration{podmanSession}
 }
 
@@ -66,7 +66,7 @@ func PodmanTestCreate(tempDir string) *PodmanTestIntegration {
 }
 
 // MakeOptions assembles all the podman main options
-func (p *PodmanTestIntegration) makeOptions(args []string, noEvents bool) []string {
+func (p *PodmanTestIntegration) makeOptions(args []string, noEvents, noCache bool) []string {
 	var debug string
 	if _, ok := os.LookupEnv("DEBUG"); ok {
 		debug = "--log-level=debug --syslog=true "
@@ -84,6 +84,11 @@ func (p *PodmanTestIntegration) makeOptions(args []string, noEvents bool) []stri
 	}
 
 	podmanOptions = append(podmanOptions, strings.Split(p.StorageOptions, " ")...)
+	if !noCache {
+		cacheOptions := []string{"--storage-opt",
+			fmt.Sprintf("%s.imagestore=%s", p.PodmanTest.ImageCacheFS, p.PodmanTest.ImageCacheDir)}
+		podmanOptions = append(cacheOptions, podmanOptions...)
+	}
 	podmanOptions = append(podmanOptions, args...)
 	return podmanOptions
 }

--- a/test/utils/utils_suite_test.go
+++ b/test/utils/utils_suite_test.go
@@ -32,7 +32,7 @@ func FakePodmanTestCreate() *FakePodmanTest {
 	return p
 }
 
-func (p *FakePodmanTest) makeOptions(args []string, noEvents bool) []string {
+func (p *FakePodmanTest) makeOptions(args []string, noEvents, noCache bool) []string {
 	return FakeOutputs[strings.Join(args, " ")]
 }
 


### PR DESCRIPTION
Fixes #4111

One or more tests are not taking advantage of the local image cache.
This has been observed to cause a testing flake in at least one
`--sigproxy` test which uses `PodmanTestIntegration.PodmanPID()`.
It has a rather short timeout of 15-seconds, which isn't always
enough time to pull down a remote image.

Fix this by reloacing the `noCache` logic from
`PodmanTest.PodmanAsUserBase()` down the stack into
`PodmanTestIntegration.makeOptions()`.  This also eliminates the need to
also check if a remote-client is being used - since it uses a different
function.

Signed-off-by: Chris Evich <cevich@redhat.com>