### PR TITLE
Set log-level immediately, before rootless setup

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -107,15 +107,6 @@ func before(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	if err := setupRootless(cmd, args); err != nil {
-		return err
-	}
-
-	// check that global opts input is valid
-	if err := checkInput(); err != nil {
-		return err
-	}
-
 	//	Set log level; if not log-level is provided, default to error
 	logLevel := MainGlobalOpts.LogLevel
 	if logLevel == "" {
@@ -127,6 +118,15 @@ func before(cmd *cobra.Command, args []string) error {
 	}
 	logrus.SetLevel(level)
 	if err := setSyslog(); err != nil {
+		return err
+	}
+
+	if err := setupRootless(cmd, args); err != nil {
+		return err
+	}
+
+	// check that global opts input is valid
+	if err := checkInput(); err != nil {
 		return err
 	}
 

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -365,7 +365,7 @@ func GetConfiguredMappings() ([]idtools.IDMap, []idtools.IDMap, error) {
 	}
 	mappings, err := idtools.NewIDMappings(username, username)
 	if err != nil {
-		logrus.Warnf("cannot find mappings for user %s: %v", username, err)
+		logrus.Errorf("cannot find mappings for user %s: %v", username, err)
 	} else {
 		uids = mappings.UIDs()
 		gids = mappings.GIDs()


### PR DESCRIPTION
If we don't do this, we print WARN level messages that we should not be printing by default.

Up one WARN message to ERROR so it still shows up by default.

Fixes: #4115
Fixes: #4012
