### PR TITLE
Add a missing escape in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ clean: ## Clean artifacts
 	rm -rf \
 		.gopathok \
 		_output \
-		release.txt
+		release.txt \
 		$(wildcard podman-remote*.zip) \
 		$(wildcard podman*.tar.gz) \
 		bin \


### PR DESCRIPTION
There's a missing `\` at the end of a line in the `clean` target.