### PR TITLE
Correct use of reexec.Init()

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -149,6 +149,8 @@ func main() {
 	//cpuProfile := false
 
 	if reexec.Init() {
+		// We were invoked with a different argv[0] indicating that we
+		// had a specific job to do as a subprocess, and it's done.
 		return
 	}
 	// Hard code TMPDIR functions to use /var/tmp, if user did not override

--- a/contrib/perftest/main.go
+++ b/contrib/perftest/main.go
@@ -36,6 +36,9 @@ var helpMessage = `
 `
 
 func main() {
+	if reexec.Init() {
+		return
+	}
 
 	ctx := context.Background()
 	imageName := ""
@@ -50,10 +53,6 @@ func main() {
 	}
 
 	flag.Parse()
-
-	if reexec.Init() {
-		return
-	}
 
 	switch strings.ToLower(*logLevel) {
 	case "error":

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -29,7 +29,6 @@ import (
 	"github.com/containers/libpod/pkg/registries"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/storage"
-	"github.com/containers/storage/pkg/reexec"
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -85,9 +84,6 @@ func NewImageRuntimeFromStore(store storage.Store) *Runtime {
 // NewImageRuntimeFromOptions creates an Image Runtime including the store given
 // store options
 func NewImageRuntimeFromOptions(options storage.StoreOptions) (*Runtime, error) {
-	if reexec.Init() {
-		return nil, errors.Errorf("unable to reexec")
-	}
 	store, err := setStore(options)
 	if err != nil {
 		return nil, err

--- a/libpod/image/image_test.go
+++ b/libpod/image/image_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/libpod/libpod/events"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/reexec"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 )
@@ -68,6 +69,13 @@ func makeLocalMatrix(b, bg *Image) ([]localImageTest, error) {
 	l = append(l, busybox, busyboxGlibc)
 	return l, nil
 
+}
+
+func TestMain(m *testing.M) {
+	if reexec.Init() {
+		return
+	}
+	os.Exit(m.Run())
 }
 
 // TestImage_NewFromLocal tests finding the image locally by various names,

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -78,11 +78,15 @@ func (a testResultsSorted) Less(i, j int) bool { return a[i].length < a[j].lengt
 
 var testResults []testResult
 
+func TestMain(m *testing.M) {
+	if reexec.Init() {
+		return
+	}
+	os.Exit(m.Run())
+}
+
 // TestLibpod ginkgo master function
 func TestLibpod(t *testing.T) {
-	if reexec.Init() {
-		os.Exit(1)
-	}
 	if os.Getenv("NOCACHE") == "1" {
 		CACHE_IMAGES = []string{}
 		RESTORE_IMAGES = []string{}


### PR DESCRIPTION
A true result from `reexec.Init()` isn't an error, but it indicates that `main()` should exit with a success exit status.