### PR TITLE
Cirrus: Remove hardcoded snap version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -706,10 +706,12 @@ test_building_snap_task:
         $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
 
     container:
-        image: yakshaveinc/snapcraft:core18
+        #image: yakshaveinc/snapcraft:core18
+        image: snapcore/snapcraft:stable
     env:
         - SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: true
     snapcraft_script:
+        - 'cat /etc/os-release'
         - 'apt-get -y update'
         - 'cd contrib/snapcraft && snapcraft'
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -696,6 +696,24 @@ special_testing_endpoint_task:
         <<: *standardlogs
 
 
+test_building_snap_task:
+
+    depends_on:
+        - "gating"
+
+    only_if: >-
+        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
+        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
+
+    container:
+        image: yakshaveinc/snapcraft:core18
+    env:
+        - SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: true
+    snapcraft_script:
+        - 'apt-get -y update'
+        - 'cd contrib/snapcraft && snapcraft'
+
+
 # Test building of new cache-images for future PR testing, in this PR.
 test_build_cache_images_task:
 
@@ -821,6 +839,7 @@ success_task:
         - "test_build_cache_images"
         - "verify_test_built_images"
         - "docs"
+        - "test_building_snap"
         # FIXME remove when all v2 tests pass
         - "integration_test_temporary"
 

--- a/contrib/snapcraft/snap/snapcraft.yaml
+++ b/contrib/snapcraft/snap/snapcraft.yaml
@@ -21,7 +21,6 @@ parts:
      # https://github.com/containers/libpod/blob/master/install.md#build-and-run-dependencies
      - btrfs-tools
      - git
-     #- golang-go
      - go-md2man
      - iptables
      - libassuan-dev

--- a/contrib/snapcraft/snap/snapcraft.yaml
+++ b/contrib/snapcraft/snap/snapcraft.yaml
@@ -15,11 +15,13 @@ parts:
   podman:
     plugin: make
     source: ../..
+    build-snaps:
+     - go/1.13/stable
     build-packages:
      # https://github.com/containers/libpod/blob/master/install.md#build-and-run-dependencies
      - btrfs-tools
      - git
-     - golang-go
+     #- golang-go
      - go-md2man
      - iptables
      - libassuan-dev

--- a/contrib/snapcraft/snap/snapcraft.yaml
+++ b/contrib/snapcraft/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: podman # you probably want to 'snapcraft register <name>'
-version: '0.11.1.1' # just for humans, typically '1.2+git' or '1.3.2'
+version: git
 summary: Manage pods, containers and container images
 description: |
   `podman` is a tool for managing Pods, Containers, and Container Images
@@ -14,7 +14,7 @@ base: core18
 parts:
   podman:
     plugin: go
-    source: https://github.com/containers/libpod/archive/v0.11.1.1.tar.gz
+    source: ../..
     go-importpath: github.com/containers/libpod
     build-packages:
      # https://github.com/containers/libpod/blob/master/install.md#build-and-run-dependencies

--- a/contrib/snapcraft/snap/snapcraft.yaml
+++ b/contrib/snapcraft/snap/snapcraft.yaml
@@ -18,28 +18,26 @@ parts:
     build-snaps:
      - go/1.13/stable
     build-packages:
-     # https://github.com/containers/libpod/blob/master/install.md#build-and-run-dependencies
+     # https://podman.io/getting-started/installation#building-from-scratch
      - btrfs-tools
      - git
      - go-md2man
      - iptables
      - libassuan-dev
+     - libc6-dev
      - libdevmapper-dev
      - libglib2.0-dev
-     - libc6-dev
-     - libgpgme11-dev
+     - libgpgme-dev
      - libgpg-error-dev
-     - libostree-dev
      - libprotobuf-dev
      - libprotobuf-c0-dev
      - libseccomp-dev
      - libselinux1-dev
      - pkg-config
-    stage-packages:
-     - libarchive13
-     - libassuan0
-     - libgpgme11
-     - libicu60
-     - libostree-1-1
-     - libsoup2.4-1
-     - libxml2
+       # stage-packages:
+       #- libarchive13
+       #     - libassuan0
+       #     - libgpgme11
+       #     - libicu60
+       #     - libsoup2.4-1
+       #     - libxml2

--- a/contrib/snapcraft/snap/snapcraft.yaml
+++ b/contrib/snapcraft/snap/snapcraft.yaml
@@ -13,9 +13,8 @@ base: core18
 
 parts:
   podman:
-    plugin: go
+    plugin: make
     source: ../..
-    go-importpath: github.com/containers/libpod
     build-packages:
      # https://github.com/containers/libpod/blob/master/install.md#build-and-run-dependencies
      - btrfs-tools


### PR DESCRIPTION
Should fix #4134.

`git` version semantics is described at https://snapcraft.io/docs/snapcraft-yaml-reference