### PR TITLE
Add .travis.yml to test podman deb package on Ubuntu with Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,64 @@
+dist: xenial
+os: linux
+language: bash
+# Installing Dependencies
+# https://docs.travis-ci.com/user/installing-dependencies/
+addons:
+  apt:
+    update: true
+    sources:
+      # To install podman.
+      # https://github.com/containers/libpod/blob/master/install.md
+      - sourceline: "ppa:projectatomic/ppa"
+    packages:
+      - podman
+before_install:
+  # Show version and info.
+  - podman --version
+  - podman version
+  - podman info --debug
+  # Show deb package info.
+  - apt-cache show podman
+  - dpkg-query -L podman
+  - apt-cache show containers-common
+  - dpkg-query -L containers-common
+
+  # Create a configuration file /etc/containers/registries.conf,
+  # as it does not exist.
+  # Incompatibilities of podman from docker on Travis CI
+  # https://github.com/containers/libpod/issues/3679
+  - mkdir -p /etc/containers
+  - echo -e "[registries.search]\nregistries = ['docker.io']" | sudo tee /etc/containers/registries.conf
+matrix:
+  include:
+    - name: "xenial rootless podman run"
+      script:
+        - podman run --rm -t fedora uname -m
+    - name: "xenial rootless podman build"
+      install:
+        - podman build --rm -t my-fedora -f Dockerfile.simple .
+      script:
+        - podman run --rm -t my-fedora uname -m
+    - name: "xenial root podman run"
+      script:
+        - sudo podman run --rm -t fedora uname -m
+    - name: "xenial root podman build"
+      install:
+        - sudo podman build --rm -t my-fedora -f Dockerfile.simple .
+      script:
+        - sudo podman run --rm -t my-fedora uname -m
+    - name: "bionic rootless podman build"
+      dist: bionic
+      install:
+        - podman build --rm -t my-fedora -f Dockerfile.simple .
+      script:
+        - podman run --rm -t my-fedora uname -m
+    - name: "bionic root podman build"
+      dist: bionic
+      install:
+        - sudo podman build --rm -t my-fedora -f Dockerfile.simple .
+      script:
+        - sudo podman run --rm -t my-fedora uname -m
+  allow_failures:
+    - name: "bionic root podman build"
+  fast_finish: true

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -1,0 +1,3 @@
+ARG BASE_IMAGE=fedora:30
+FROM ${BASE_IMAGE}
+RUN uname -m

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Libpod provides a library for applications looking to use the Container Pod conc
 popularized by Kubernetes.  Libpod also contains the Pod Manager tool `(Podman)`. Podman manages pods, containers, container images, and container volumes.
 
 * [Latest Version: 1.5.1](https://github.com/containers/libpod/releases/latest)
-* [Continuous Integration:](contrib/cirrus/README.md) [![Build Status](https://api.cirrus-ci.com/github/containers/libpod.svg)](https://cirrus-ci.com/github/containers/libpod/master)
+* [Continuous Integration:](contrib/cirrus/README.md) [![Build Status](https://api.cirrus-ci.com/github/containers/libpod.svg)](https://cirrus-ci.com/github/containers/libpod/master), [![Build Status](https://travis-ci.org/containers/libpod.svg?branch=master)](https://travis-ci.org/containers/libpod)
 * [GoDoc: ![GoDoc](https://godoc.org/github.com/containers/libpod/libpod?status.svg)](https://godoc.org/github.com/containers/libpod/libpod)
 * Automated continuous release downloads (including remote-client):
   * Master Branch: [https://storage.cloud.google.com/libpod-master-releases/](https://storage.cloud.google.com/libpod-master-releases/)


### PR DESCRIPTION
Add `.travis.yml` to test Ubuntu deb package.
It's related to https://github.com/containers/libpod/issues/3679#issuecomment-536993796 .

I found bionic is available on Travis CI.
https://docs.travis-ci.com/user/reference/bionic/
https://github.com/travis-ci/docs-travis-ci-com/tree/master/user/reference

So, this `.travis.yml` has total 6 cases (4 cases for xenial, and 2 cases for bionic).
Here is the result on my forked repository.
https://travis-ci.org/junaruga/libpod/builds/592091305

As I got below error for bionic root case, I added it as allow failures. That's why this `.travis.yml` exists. :)
https://travis-ci.org/junaruga/libpod/jobs/592091311#L543

```
$ sudo podman run --rm -t my-fedora uname -m
ERRO[0000] Error adding network: failed to find plugin "loopback" in path [/usr/libexec/cni /usr/lib/cni /usr/local/lib/cni /opt/cni/bin] 
ERRO[0000] Error while adding to cni lo network: failed to find plugin "loopback" in path [/usr/libexec/cni /usr/lib/cni /usr/local/lib/cni /opt/cni/bin] 
```

I added Travis badge image to `README.md` that is useful to see the build status easily.
Here is the modified `README.md`.
https://github.com/junaruga/libpod/blob/feature/add-travis-ci/README.md

I did not add qemu cases that exist in the example https://github.com/containers/libpod/issues/3679#issuecomment-536295147 to simply the cases.

Travis "addon" syntax used for this PR might not be reliable to install deb packages.
For example ruby project is using own commands to control a retry logic of the commands.
https://github.com/ruby/ruby/blob/master/.travis.yml#L71-L89

```
- |-
  tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install \
    gcc-8 \
```

Could you review this PR?

The actual documentation to run podman on Travis CI will be later by another PR after this PR will be merged.

Thanks.