### PR TITLE
rootless: set DBUS_SESSION_BUS_ADDRESS if it is not set

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -387,6 +387,13 @@ func SetXdgDirs() error {
 		return errors.Wrapf(err, "cannot set XDG_RUNTIME_DIR")
 	}
 
+	if rootless.IsRootless() && os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
+		sessionAddr := filepath.Join(runtimeDir, "bus")
+		if _, err := os.Stat(sessionAddr); err == nil {
+			os.Setenv("DBUS_SESSION_BUS_ADDRESS", fmt.Sprintf("unix:path=%s", sessionAddr))
+		}
+	}
+
 	// Setup XDG_CONFIG_HOME
 	if cfgHomeDir := os.Getenv("XDG_CONFIG_HOME"); cfgHomeDir == "" {
 		if cfgHomeDir, err = util.GetRootlessConfigHomeDir(); err != nil {


### PR DESCRIPTION
if the variable is not set, make sure it has a sane value so that
go-dbus won't try to connect to the wrong user session.

Closes: https://github.com/containers/libpod/issues/4162
Closes: https://github.com/containers/libpod/issues/4164

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>