### PR TITLE
system tests: reenable skipped tests

### DIFF
--- a/test/system/055-rm.bats
+++ b/test/system/055-rm.bats
@@ -32,8 +32,6 @@ load helpers
 #
 # See https://github.com/containers/libpod/issues/3795
 @test "podman rm -f" {
-    skip_if_remote "podman-remote does not handle exit codes"
-
     rand=$(random_string 30)
     ( sleep 3; run_podman rm -f $rand ) &
     run_podman 137 run --name $rand $IMAGE sleep 30

--- a/test/system/065-cp.bats
+++ b/test/system/065-cp.bats
@@ -38,7 +38,6 @@ load helpers
 # into host-only space. Try to podman-cp that symlink. It should fail.
 @test "podman cp - will not recognize symlink pointing into host space" {
     skip_if_remote "podman-remote does not yet handle cp"
-    skip "BROKEN: PLEASE ENABLE ONCE #3829 GETS FIXED"
 
     srcdir=$PODMAN_TMPDIR/cp-test-in
     dstdir=$PODMAN_TMPDIR/cp-test-out
@@ -69,7 +68,6 @@ load helpers
 # this invalid double symlink. It must fail.
 @test "podman cp - will not expand globs in host space (#3829)" {
     skip_if_remote "podman-remote does not yet handle cp"
-    skip "BROKEN: PLEASE ENABLE ONCE #3829 GETS FIXED"
 
     srcdir=$PODMAN_TMPDIR/cp-test-in
     dstdir=$PODMAN_TMPDIR/cp-test-out


### PR DESCRIPTION
Issue #3829 (cp symlinks) has been fixed: enable tests for it

And, it looks like podman-remote is now handling exit status
of a force-rm'ed container. Enable that test too.

Signed-off-by: Ed Santiago <santiago@redhat.com>