### PR TITLE
Add api link to tutorials

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -19,3 +19,7 @@ Special setup for running the Podman remote client on a Mac and connecting to Po
 **[Remote Client](remote_client.md)**
 
 A brief how-to on using the Podman remote-client.
+
+**[How to use libpod for custom/derivative projects](podman-derivative-api.md)**
+
+How the libpod API can be used within your own project.

--- a/docs/tutorials/podman-derivative-api.md
+++ b/docs/tutorials/podman-derivative-api.md
@@ -1,3 +1,5 @@
+![PODMAN logo](../../logo/podman-logo-source.svg)
+
 # How to use libpod for custom/derivative projects
 
 libpod today is a Golang library and a CLI.  The choice of interface you make has advantages and disadvantages.


### PR DESCRIPTION
We recently moved the "How to use libpod for custom/derivative projects" page to
the docs/tutorials directory.  This adds a link to the README.md there so it can
be more easily found and adds a logo to the tutorial itself.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>