### PR TITLE
rootless: allow cgroupfs manager on cgroups v2

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -387,6 +387,9 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 		if err != nil {
 			return nil, err
 		}
+		if !addedResources {
+			configSpec.Linux.Resources = &spec.LinuxResources{}
+		}
 		if addedResources && !cgroup2 {
 			return nil, errors.New("invalid configuration, cannot set resources with rootless containers not using cgroups v2 unified mode")
 		}


### PR DESCRIPTION
if there are no resources specified, make sure the OCI resources block
is empty so that the OCI runtime won't complain.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>