### PR TITLE
[1.4.2-stable] Stop glob-ing on podman cp

### DIFF
--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -51,7 +51,7 @@ func init() {
 	cpCommand.Command = _cpCommand
 	flags := cpCommand.Flags()
 	flags.BoolVar(&cpCommand.Extract, "extract", false, "Extract the tar file into the destination directory.")
-	flags.BoolVar(&cpCommand.Pause, "pause", false, "Pause the container while copying")
+	flags.BoolVar(&cpCommand.Pause, "pause", true, "Pause the container while copying")
 	cpCommand.SetHelpTemplate(HelpTemplate())
 	cpCommand.SetUsageTemplate(UsageTemplate())
 	rootCmd.AddCommand(cpCommand.Command)
@@ -143,7 +143,6 @@ func copyBetweenHostAndContainer(runtime *libpod.Runtime, src string, dest strin
 
 	hostOwner := idtools.IDPair{UID: int(hostUID), GID: int(hostGID)}
 
-	var glob []string
 	if isFromHostToCtr {
 		if isVol, volDestName, volName := isVolumeDestName(destPath, ctr); isVol {
 			path, err := pathWithVolumeMount(ctr, runtime, volDestName, volName, destPath)
@@ -204,13 +203,7 @@ func copyBetweenHostAndContainer(runtime *libpod.Runtime, src string, dest strin
 			srcPath = cleanedPath
 		}
 	}
-	glob, err = filepath.Glob(srcPath)
-	if err != nil {
-		return errors.Wrapf(err, "invalid glob %q", srcPath)
-	}
-	if len(glob) == 0 {
-		glob = append(glob, srcPath)
-	}
+
 	if !filepath.IsAbs(destPath) {
 		dir, err := os.Getwd()
 		if err != nil {
@@ -219,19 +212,11 @@ func copyBetweenHostAndContainer(runtime *libpod.Runtime, src string, dest strin
 		destPath = filepath.Join(dir, destPath)
 	}
 
-	var lastError error
-	for _, src := range glob {
-		if src == "-" {
-			src = os.Stdin.Name()
-			extract = true
-		}
-		err := copy(src, destPath, dest, idMappingOpts, &containerOwner, extract, isFromHostToCtr)
-		if lastError != nil {
-			logrus.Error(lastError)
-		}
-		lastError = err
+	if src == "-" {
+		srcPath = os.Stdin.Name()
+		extract = true
 	}
-	return lastError
+	return copy(srcPath, destPath, dest, idMappingOpts, &containerOwner, extract, isFromHostToCtr)
 }
 
 func getUser(mountPoint string, userspec string) (specs.User, error) {

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -205,4 +205,40 @@ var _ = Describe("Podman cp", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
+
+	It("podman cp from ctr chown ", func() {
+		setup := podmanTest.RunTopContainer("testctr")
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"exec", "testctr", "adduser", "-S", "testuser"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"exec", "-u", "testuser", "testctr", "touch", "testfile"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"cp", "--pause=false", "testctr:testfile", "testfile1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		// owner of the file copied to local machine is not testuser
+		cmd := exec.Command("ls", "-l", "testfile1")
+		cmdRet, err := cmd.Output()
+		Expect(err).To(BeNil())
+		Expect(strings.Contains(string(cmdRet), "testuser")).To(BeFalse())
+
+		session = podmanTest.Podman([]string{"cp", "--pause=false", "testfile1", "testctr:testfile2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		// owner of the file copied to a container is the root user
+		session = podmanTest.Podman([]string{"exec", "-it", "testctr", "ls", "-l", "testfile2"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("root"))
+
+		os.Remove("testfile1")
+	})
 })

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -205,40 +205,4 @@ var _ = Describe("Podman cp", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
-
-	It("podman cp from ctr chown ", func() {
-		setup := podmanTest.RunTopContainer("testctr")
-		setup.WaitWithDefaultTimeout()
-		Expect(setup.ExitCode()).To(Equal(0))
-
-		session := podmanTest.Podman([]string{"exec", "testctr", "adduser", "-S", "testuser"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-
-		session = podmanTest.Podman([]string{"exec", "-u", "testuser", "testctr", "touch", "testfile"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-
-		session = podmanTest.Podman([]string{"cp", "--pause=false", "testctr:testfile", "testfile1"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-
-		// owner of the file copied to local machine is not testuser
-		cmd := exec.Command("ls", "-l", "testfile1")
-		cmdRet, err := cmd.Output()
-		Expect(err).To(BeNil())
-		Expect(strings.Contains(string(cmdRet), "testuser")).To(BeFalse())
-
-		session = podmanTest.Podman([]string{"cp", "--pause=false", "testfile1", "testctr:testfile2"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-
-		// owner of the file copied to a container is the root user
-		session = podmanTest.Podman([]string{"exec", "-it", "testctr", "ls", "-l", "testfile2"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(ContainSubstring("root"))
-
-		os.Remove("testfile1")
-	})
 })


### PR DESCRIPTION
* Do not support wildcards on cp
* symlink processing and wildcarding led to unexpected files
  being copied

Signed-off-by: Jhon Honce <jhonce@redhat.com>

cherry-picked from https://github.com/containers/libpod/pull/3942