### PR TITLE
System-tests: Use bash explicitly

### DIFF
--- a/test/system/400-unprivileged-access.bats
+++ b/test/system/400-unprivileged-access.bats
@@ -22,7 +22,7 @@ load helpers
     # as a user, the parent directory must be world-readable.
     test_script=$PODMAN_TMPDIR/fail-if-writable
     cat >$test_script <<"EOF"
-#!/bin/sh
+#!/bin/bash
 
 path="$1"
 


### PR DESCRIPTION
On Ubuntu, /bin/sh != /bin/bash.  Update system-tests to only use
bash for testing consistency across platforms.

Signed-off-by: Chris Evich <cevich@redhat.com>