### PR TITLE
system tests: info: deal with hyphen in username

### DIFF
--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -33,7 +33,7 @@ RunRoot:
     run_podman info --format=json
 
     expr_nvr="[a-z0-9-]\\\+-[a-z0-9.]\\\+-[a-z0-9]\\\+\."
-    expr_path="/[a-z0-9\\\-\\\/.]\\\+\\\$"
+    expr_path="/[a-z0-9\\\/.-]\\\+\\\$"
 
     tests="
 host.BuildahVersion       | [0-9.]


### PR DESCRIPTION
...e.g. cloud-user. 9822f54ac was intended to fix this,
but it doesn't. Simple and standard solution is to
move the dash to the end of the character class.

Signed-off-by: Ed Santiago <santiago@redhat.com>