### PR TITLE
Docs: Update links, add links to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ popularized by Kubernetes.  Libpod also contains the Pod Manager tool `(Podman)`
 * [Continuous Integration:](contrib/cirrus/README.md) [![Build Status](https://api.cirrus-ci.com/github/containers/libpod.svg)](https://cirrus-ci.com/github/containers/libpod/master)
 * [GoDoc: ![GoDoc](https://godoc.org/github.com/containers/libpod/libpod?status.svg)](https://godoc.org/github.com/containers/libpod/libpod)
 * Automated continuous release downloads (including remote-client):
-  * Master Branch: [https://storage.cloud.google.com/libpod-master-releases/](https://storage.cloud.google.com/libpod-master-releases/)
-  * Pull-requests: [https://storage.cloud.google.com/libpod-pr-releases/](https://storage.cloud.google.com/libpod-pr-releases/)
+  * [Latest remote client for Windows](https://storage.googleapis.com/libpod-master-releases/podman-remote-latest-master-windows-amd64.msi)
+  * [Latest remote client for MacOS](https://storage.googleapis.com/libpod-master-releases/podman-remote-latest-master-darwin-amd64.zip)
+  * [Latest Snap package](https://snapcraft.io/podman)
 
 ## Overview and scope
 

--- a/contrib/upldrel/entrypoint.sh
+++ b/contrib/upldrel/entrypoint.sh
@@ -7,7 +7,7 @@ source /usr/local/bin/lib_entrypoint.sh
 req_env_var GCPJSON_FILEPATH GCPNAME GCPPROJECT BUCKET FROM_FILEPATH TO_FILENAME ALSO_FILENAME
 
 [[ -r "$FROM_FILEPATH" ]] || \
-    die 2 ERROR Cannot read release archive file: "$REL_ARC_FILEPATH"
+    die 2 ERROR Cannot read release archive file: "$FROM_FILEPATH"
 
 [[ -r "$GCPJSON_FILEPATH" ]] || \
     die 3 ERROR Cannot read GCP credentials file: "$GCPJSON_FILEPATH"
@@ -17,9 +17,11 @@ gcloud_init "$GCPJSON_FILEPATH"
 
 echo "Uploading archive as $TO_FILENAME"
 gsutil cp "$FROM_FILEPATH" "gs://$BUCKET/$TO_FILENAME"
-gsutil cp "$FROM_FILEPATH" "gs://$BUCKET/$ALSO_FILENAME"
+[[ -z "$ALSO_FILENAME" ]] || \
+    gsutil cp "$FROM_FILEPATH" "gs://$BUCKET/$ALSO_FILENAME"
 
 echo "."
 echo "Release now available for download at:"
-echo "    https://storage.cloud.google.com/$BUCKET/$TO_FILENAME"
-echo "    https://storage.cloud.google.com/$BUCKET/$ALSO_FILENAME"
+echo "    https://storage.googleapis.com/$BUCKET/$TO_FILENAME"
+[[ -z "$ALSO_FILENAME" ]] || \
+    echo "    https://storage.googleapis.com/$BUCKET/$ALSO_FILENAME"


### PR DESCRIPTION
These links do not require any login to google and can be used directly (e.g. with `curl`).

Also update the script in the upload container, to fix URIs & make `$ALSO_FILENAME` optional (for future use).