### PR TITLE
enable dnsplugin for network create

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -267,6 +267,7 @@ type MountValues struct {
 type NetworkCreateValues struct {
 	PodmanCommand
 	Driver     string
+	DisableDNS bool
 	Gateway    net.IP
 	Internal   bool
 	IPamDriver string

--- a/cmd/podman/network_create.go
+++ b/cmd/podman/network_create.go
@@ -46,7 +46,7 @@ func init() {
 	// TODO enable when IPv6 is working
 	//flags.BoolVar(&networkCreateCommand.IPV6, "IPv6", false, "enable IPv6 networking")
 	flags.IPNetVar(&networkCreateCommand.Network, "subnet", net.IPNet{}, "subnet in CIDR format")
-
+	flags.BoolVar(&networkCreateCommand.DisableDNS, "disable-dns", false, "disable dns plugin")
 }
 
 func networkcreateCmd(c *cliconfig.NetworkCreateValues) error {

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -982,6 +982,7 @@ _podman_network_create() {
     --subnet
      "
     local boolean_options="
+    --disable-dns
 	--help
 	-h
 	--internal

--- a/docs/podman-network-create.1.md
+++ b/docs/podman-network-create.1.md
@@ -15,6 +15,11 @@ If no options are provided, Podman will assign a free subnet and name for your n
 Upon completion of creating the network, Podman will display the path to the newly added network file.
 
 ## OPTIONS
+**--disable-dns**
+
+Disables the DNS plugin for this network which if enabled, can perform container to container name
+resolution.
+
 **-d**, , **--driver**
 
 Driver to manage the network (default "bridge").  Currently on `bridge` is supported.

--- a/pkg/network/config.go
+++ b/pkg/network/config.go
@@ -14,6 +14,9 @@ const (
 	// CNIDeviceName is the default network device name and in
 	// reality should have an int appended to it (cni-podman4)
 	CNIDeviceName = "cni-podman"
+	// DefaultPodmanDomainName is used for the dnsname plugin to define
+	// a localized domain name for a created network
+	DefaultPodmanDomainName = "dns.podman"
 )
 
 // GetDefaultPodmanNetwork outputs the default network for podman
@@ -96,4 +99,15 @@ type FirewallConfig struct {
 // Bytes outputs the configuration as []byte
 func (f FirewallConfig) Bytes() ([]byte, error) {
 	return json.MarshalIndent(f, "", "\t")
+}
+
+// DNSNameConfig describes the dns container name resolution plugin config
+type DNSNameConfig struct {
+	PluginType string `json:"type"`
+	DomainName string `json:"domainName"`
+}
+
+// Bytes outputs the configuration as []byte
+func (d DNSNameConfig) Bytes() ([]byte, error) {
+	return json.MarshalIndent(d, "", "\t")
 }

--- a/pkg/network/netconflist.go
+++ b/pkg/network/netconflist.go
@@ -2,6 +2,8 @@ package network
 
 import (
 	"net"
+	"os"
+	"path/filepath"
 )
 
 // NcList describes a generic map
@@ -110,4 +112,23 @@ func NewFirewallPlugin() FirewallConfig {
 		PluginType: "firewall",
 		Backend:    "iptables",
 	}
+}
+
+// NewDNSNamePlugin creates the dnsname config with a given
+// domainname
+func NewDNSNamePlugin(domainName string) DNSNameConfig {
+	return DNSNameConfig{
+		PluginType: "dnsname",
+		DomainName: domainName,
+	}
+}
+
+// HasDNSNamePlugin looks to see if the dnsname cni plugin is present
+func HasDNSNamePlugin(paths []string) bool {
+	for _, p := range paths {
+		if _, err := os.Stat(filepath.Join(p, "dnsname")); err == nil {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
when users create a new network and the dnsname plugin can be found by
podman, we will enable container name resolution on the new network.
there is an option to opt *out* as well.

tests cannot be added until we solve the packaging portion of the
dnsname plugin.

Signed-off-by: baude <bbaude@redhat.com>