### PR TITLE
podman network create: validate user input

### DIFF
--- a/cmd/podman/network_create.go
+++ b/cmd/podman/network_create.go
@@ -4,11 +4,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/containers/libpod/pkg/network"
 	"net"
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/adapter"
+	"github.com/containers/libpod/pkg/network"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -57,6 +58,9 @@ func networkcreateCmd(c *cliconfig.NetworkCreateValues) error {
 	}
 	if len(c.InputArgs) > 1 {
 		return errors.Errorf("only one network can be created at a time")
+	}
+	if len(c.InputArgs) > 0 && !libpod.NameRegex.MatchString(c.InputArgs[0]) {
+		return libpod.RegexError
 	}
 	runtime, err := adapter.GetRuntimeNoStore(getContext(), &c.PodmanCommand)
 	if err != nil {

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	nameRegex  = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
-	regexError = errors.Wrapf(define.ErrInvalidArg, "names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*")
+	NameRegex  = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+	RegexError = errors.Wrapf(define.ErrInvalidArg, "names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*")
 )
 
 // Runtime Creation Options
@@ -648,8 +648,8 @@ func WithName(name string) CtrCreateOption {
 		}
 
 		// Check the name against a regex
-		if !nameRegex.MatchString(name) {
-			return regexError
+		if !NameRegex.MatchString(name) {
+			return RegexError
 		}
 
 		ctr.config.Name = name
@@ -1426,8 +1426,8 @@ func WithVolumeName(name string) VolumeCreateOption {
 		}
 
 		// Check the name against a regex
-		if !nameRegex.MatchString(name) {
-			return regexError
+		if !NameRegex.MatchString(name) {
+			return RegexError
 		}
 		volume.config.Name = name
 
@@ -1532,8 +1532,8 @@ func WithPodName(name string) PodCreateOption {
 		}
 
 		// Check the name against a regex
-		if !nameRegex.MatchString(name) {
-			return regexError
+		if !NameRegex.MatchString(name) {
+			return RegexError
 		}
 
 		pod.config.Name = name
@@ -1550,8 +1550,8 @@ func WithPodHostname(hostname string) PodCreateOption {
 		}
 
 		// Check the hostname against a regex
-		if !nameRegex.MatchString(hostname) {
-			return regexError
+		if !NameRegex.MatchString(hostname) {
+			return RegexError
 		}
 
 		pod.config.Hostname = hostname

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -208,4 +208,10 @@ var _ = Describe("Podman network create", func() {
 		Expect(ncFail.ExitCode()).ToNot(BeZero())
 	})
 
+	It("podman network create with invalid network name", func() {
+		nc := podmanTest.Podman([]string{"network", "create", "foo "})
+		nc.WaitWithDefaultTimeout()
+		Expect(nc.ExitCode()).ToNot(BeZero())
+	})
+
 })


### PR DESCRIPTION
Disallow invalid/confusing names such as '../bar' or 'foo '
Closes #4184

Signed-off-by: Mrigank Krishan <mrigankkrishan@gmail.com>