### PR TITLE
inspect: rename ImageID go field to Image

### DIFF
--- a/cmd/podman/inspect.go
+++ b/cmd/podman/inspect.go
@@ -104,6 +104,9 @@ func inspectCmd(c *cliconfig.InspectValues) error {
 	if strings.Contains(outputFormat, ".Dst") {
 		outputFormat = strings.Replace(outputFormat, ".Dst", ".Destination", -1)
 	}
+	if strings.Contains(outputFormat, ".ImageID") {
+		outputFormat = strings.Replace(outputFormat, ".ImageID", ".Image", -1)
+	}
 	if latestContainer {
 		lc, err := runtime.GetLatestContainer()
 		if err != nil {

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -96,7 +96,7 @@ type InspectContainerData struct {
 	Path            string                      `json:"Path"`
 	Args            []string                    `json:"Args"`
 	State           *InspectContainerState      `json:"State"`
-	ImageID         string                      `json:"Image"`
+	Image           string                      `json:"Image"`
 	ImageName       string                      `json:"ImageName"`
 	Rootfs          string                      `json:"Rootfs"`
 	Pod             string                      `json:"Pod"`
@@ -718,7 +718,7 @@ func (c *Container) getContainerInspectData(size bool, driverData *driver.Data) 
 			StartedAt:  runtimeInfo.StartedTime,
 			FinishedAt: runtimeInfo.FinishedTime,
 		},
-		ImageID:         config.RootfsImageID,
+		Image:           config.RootfsImageID,
 		ImageName:       config.RootfsImageName,
 		ExitCommand:     config.ExitCommand,
 		Namespace:       config.Namespace,

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -100,6 +100,23 @@ var _ = Describe("Podman inspect", func() {
 		Expect(len(result.OutputToStringArray())).To(Equal(2))
 	})
 
+	It("podman inspect container and filter for Image{ID}", func() {
+		SkipIfRemote()
+		ls, ec, _ := podmanTest.RunLsContainer("")
+		Expect(ec).To(Equal(0))
+		cid := ls.OutputToString()
+
+		result := podmanTest.Podman([]string{"inspect", "--format={{.ImageID}}", cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(len(result.OutputToStringArray())).To(Equal(1))
+
+		result = podmanTest.Podman([]string{"inspect", "--format={{.Image}}", cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(len(result.OutputToStringArray())).To(Equal(1))
+	})
+
 	It("podman inspect -l with additional input should fail", func() {
 		SkipIfRemote()
 		result := podmanTest.Podman([]string{"inspect", "-l", "1234foobar"})


### PR DESCRIPTION
The json field is called `Image` while the go field is called `ImageID`,
tricking users into filtering for `Image` which ultimately results in an
error.  Hence, rename the field to `Image` to align json and go.

To prevent podman users from regressing, rename `Image` to `ImageID` in
the specified filters.  Add tests to prevent us from regressing.  Note
that consumers of the go API that are using `ImageID` are regressing;
ultimately we consider it to be a bug fix.

Fixes: #4193
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>