### PR TITLE
Refactor tests when checking for error exit codes

### DIFF
--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -67,13 +67,13 @@ var _ = Describe("Podman checkpoint", func() {
 	It("podman checkpoint bogus container", func() {
 		session := podmanTest.Podman([]string{"container", "checkpoint", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman restore bogus container", func() {
 		session := podmanTest.Podman([]string{"container", "restore", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman checkpoint a running container by id", func() {

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Podman cp", func() {
 
 		session = podmanTest.Podman([]string{"cp", srcPath, name + ":foo/"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"cp", srcPath, name + ":foo"})
 		session.WaitWithDefaultTimeout()
@@ -205,7 +205,7 @@ var _ = Describe("Podman cp", func() {
 
 		session = podmanTest.Podman([]string{"cp", "--pause=false", srcPath, name + ":/test1/"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 	})
 	It("podman cp volume", func() {

--- a/test/e2e/create_staticip_test.go
+++ b/test/e2e/create_staticip_test.go
@@ -40,13 +40,13 @@ var _ = Describe("Podman create with --ip flag", func() {
 	It("Podman create --ip with garbage address", func() {
 		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", "114232346", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 	})
 
 	It("Podman create --ip with v6 address", func() {
 		result := podmanTest.Podman([]string{"create", "--name", "test", "--ip", "2001:db8:bad:beef::1", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 	})
 
 	It("Podman create --ip with non-allocatable IP", func() {
@@ -56,7 +56,7 @@ var _ = Describe("Podman create with --ip flag", func() {
 
 		result = podmanTest.Podman([]string{"start", "test"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 	})
 
 	It("Podman create with specified static IP has correct IP", func() {
@@ -88,6 +88,6 @@ var _ = Describe("Podman create with --ip flag", func() {
 		Expect(result.ExitCode()).To(Equal(0))
 		result = podmanTest.Podman([]string{"start", "test2"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 	})
 })

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Podman create", func() {
 	It("podman create --pull", func() {
 		session := podmanTest.PodmanNoCache([]string{"create", "--pull", "never", "--name=foo", "nginx"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.PodmanNoCache([]string{"create", "--pull", "always", "--name=foo", "nginx"})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -203,11 +203,11 @@ var _ = Describe("Podman exec", func() {
 
 		session := podmanTest.Podman([]string{"exec", "--workdir", "/missing", "test1", "pwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"exec", "-w", "/missing", "test1", "pwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman exec cannot be invoked", func() {

--- a/test/e2e/export_test.go
+++ b/test/e2e/export_test.go
@@ -72,6 +72,6 @@ var _ = Describe("Podman export", func() {
 		outfile := filepath.Join(podmanTest.TempDir, "container:with:colon.tar")
 		result := podmanTest.Podman([]string{"export", "-o", outfile, cid})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Not(Equal(0)))
+		Expect(result).To(ExitWithError())
 	})
 })

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -40,13 +40,13 @@ var _ = Describe("Podman generate kube", func() {
 	It("podman generate pod kube on bogus object", func() {
 		session := podmanTest.Podman([]string{"generate", "kube", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman generate service kube on bogus object", func() {
 		session := podmanTest.Podman([]string{"generate", "kube", "-s", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman generate kube on container", func() {

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -37,19 +37,19 @@ var _ = Describe("Podman generate systemd", func() {
 	It("podman generate systemd on bogus container/pod", func() {
 		session := podmanTest.Podman([]string{"generate", "systemd", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman generate systemd bad restart policy", func() {
 		session := podmanTest.Podman([]string{"generate", "systemd", "--restart-policy", "never", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman generate systemd bad timeout value", func() {
 		session := podmanTest.Podman([]string{"generate", "systemd", "--timeout", "-1", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman generate systemd good timeout value", func() {

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	It("podman healthcheck run bogus container", func() {
 		session := podmanTest.Podman([]string{"healthcheck", "run", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman healthcheck on valid container", func() {

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Podman inspect", func() {
 		SkipIfRemote()
 		session := podmanTest.Podman([]string{"inspect", "foobar4321"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman inspect with GO format", func() {

--- a/test/e2e/kill_test.go
+++ b/test/e2e/kill_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Podman kill", func() {
 	It("podman kill bogus container", func() {
 		session := podmanTest.Podman([]string{"kill", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman container kill a running container by id", func() {

--- a/test/e2e/load_test.go
+++ b/test/e2e/load_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Podman load", func() {
 	It("podman load bogus file", func() {
 		save := podmanTest.PodmanNoCache([]string{"load", "-i", "foobar.tar"})
 		save.WaitWithDefaultTimeout()
-		Expect(save.ExitCode()).ToNot(Equal(0))
+		Expect(save).To(ExitWithError())
 	})
 
 	It("podman load multiple tags", func() {

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{"push", ALPINE, testImg})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman login and logout with flag --authfile", func() {
@@ -198,7 +198,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{"push", ALPINE, "localhost:9001/test-alpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"login", "--username", "podmantest", "--password", "test", "localhost:9001"})
 		session.WaitWithDefaultTimeout()
@@ -218,7 +218,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{"push", ALPINE, testImg})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"push", ALPINE, "localhost:9001/test-alpine"})
 		session.WaitWithDefaultTimeout()
@@ -234,10 +234,10 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{"push", ALPINE, testImg})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"push", ALPINE, "localhost:9001/test-alpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 })

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Podman logs", func() {
 	It("podman logs latest and container name should fail", func() {
 		results := podmanTest.Podman([]string{"logs", "-l", "foobar"})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).ToNot(Equal(0))
+		Expect(results).To(ExitWithError())
 	})
 
 	It("podman logs two containers and should display short container IDs", func() {

--- a/test/e2e/negative_test.go
+++ b/test/e2e/negative_test.go
@@ -33,6 +33,6 @@ var _ = Describe("Podman negative command-line", func() {
 	It("podman snuffleupagus exits non-zero", func() {
 		session := podmanTest.Podman([]string{"snuffleupagus"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 })

--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -182,19 +182,19 @@ var _ = Describe("Podman network create", func() {
 	It("podman network create with invalid subnet", func() {
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/17000", "fail"})
 		nc.WaitWithDefaultTimeout()
-		Expect(nc.ExitCode()).ToNot(BeZero())
+		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create with invalid IP", func() {
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.0/17000", "fail"})
 		nc.WaitWithDefaultTimeout()
-		Expect(nc.ExitCode()).ToNot(BeZero())
+		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create with invalid gateway for subnet", func() {
 		nc := podmanTest.Podman([]string{"network", "create", "--subnet", "10.11.12.0/24", "--gateway", "192.168.1.1", "fail"})
 		nc.WaitWithDefaultTimeout()
-		Expect(nc.ExitCode()).ToNot(BeZero())
+		Expect(nc).To(ExitWithError())
 	})
 
 	It("podman network create two networks with same name should fail", func() {
@@ -205,13 +205,13 @@ var _ = Describe("Podman network create", func() {
 
 		ncFail := podmanTest.Podman([]string{"network", "create", "samename"})
 		ncFail.WaitWithDefaultTimeout()
-		Expect(ncFail.ExitCode()).ToNot(BeZero())
+		Expect(ncFail).To(ExitWithError())
 	})
 
 	It("podman network create with invalid network name", func() {
 		nc := podmanTest.Podman([]string{"network", "create", "foo "})
 		nc.WaitWithDefaultTimeout()
-		Expect(nc.ExitCode()).ToNot(BeZero())
+		Expect(nc).To(ExitWithError())
 	})
 
 })

--- a/test/e2e/pause_test.go
+++ b/test/e2e/pause_test.go
@@ -52,13 +52,13 @@ var _ = Describe("Podman pause", func() {
 	It("podman pause bogus container", func() {
 		session := podmanTest.Podman([]string{"pause", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman unpause bogus container", func() {
 		session := podmanTest.Podman([]string{"unpause", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman pause a created container by id", func() {
@@ -70,7 +70,7 @@ var _ = Describe("Podman pause", func() {
 		result := podmanTest.Podman([]string{"pause", cid})
 		result.WaitWithDefaultTimeout()
 
-		Expect(result.ExitCode()).To(Not(Equal(0)))
+		Expect(result).To(ExitWithError())
 		Expect(podmanTest.NumberOfContainersRunning()).To(Equal(0))
 		Expect(podmanTest.GetContainerStatus()).To(ContainSubstring(createdState))
 	})

--- a/test/e2e/pod_infra_container_test.go
+++ b/test/e2e/pod_infra_container_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Podman pod create", func() {
 
 		session = podmanTest.Podman([]string{"run", fedoraMinimal, "curl", "localhost"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman pod correctly sets up IPCNS", func() {
@@ -218,7 +218,7 @@ var _ = Describe("Podman pod create", func() {
 
 		session = podmanTest.Podman([]string{"run", "--pod", podID, "--network", "bridge", nginx, "curl", "localhost"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman pod container can override pod pid NS", func() {
@@ -309,7 +309,7 @@ var _ = Describe("Podman pod create", func() {
 
 		session = podmanTest.Podman([]string{"rm", infraID})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"pod", "rm", podID})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/pod_inspect_test.go
+++ b/test/e2e/pod_inspect_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Podman pod inspect", func() {
 	It("podman inspect bogus pod", func() {
 		session := podmanTest.Podman([]string{"pod", "inspect", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).Should(ExitWithError())
 	})
 
 	It("podman inspect a pod", func() {

--- a/test/e2e/pod_kill_test.go
+++ b/test/e2e/pod_kill_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Podman pod kill", func() {
 	It("podman pod kill bogus", func() {
 		session := podmanTest.Podman([]string{"pod", "kill", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman pod kill a pod by id", func() {

--- a/test/e2e/pod_pause_test.go
+++ b/test/e2e/pod_pause_test.go
@@ -38,13 +38,13 @@ var _ = Describe("Podman pod pause", func() {
 	It("podman pod pause bogus pod", func() {
 		session := podmanTest.Podman([]string{"pod", "pause", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman unpause bogus pod", func() {
 		session := podmanTest.Podman([]string{"pod", "unpause", "foobar"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman pod pause a created pod by id", func() {

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Podman ps", func() {
 	It("podman pod ps mutually exclusive flags", func() {
 		session := podmanTest.Podman([]string{"pod", "ps", "-q", "--format", "{{.ID}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 	})
 

--- a/test/e2e/pod_rm_test.go
+++ b/test/e2e/pod_rm_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Podman pod rm", func() {
 		fmt.Printf("Removing all empty pods\n")
 		result := podmanTest.Podman([]string{"pod", "rm", "-a"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Not(Equal(0)))
+		Expect(result).To(ExitWithError())
 		foundExpectedError, _ := result.ErrorGrepString("contains containers and cannot be removed")
 		Expect(foundExpectedError).To(Equal(true))
 

--- a/test/e2e/pod_stats_test.go
+++ b/test/e2e/pod_stats_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		stats := podmanTest.Podman([]string{"pod", "stats", "-a", "--no-reset", "--no-stream", "--format", "\"table {{.ID}} \""})
 		stats.WaitWithDefaultTimeout()
-		Expect(stats.ExitCode()).ToNot(Equal(0))
+		Expect(stats).To(ExitWithError())
 	})
 
 })

--- a/test/e2e/port_test.go
+++ b/test/e2e/port_test.go
@@ -39,13 +39,13 @@ var _ = Describe("Podman port", func() {
 	It("podman port all and latest", func() {
 		result := podmanTest.Podman([]string{"port", "-a", "-l"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 	})
 
 	It("podman port all and extra", func() {
 		result := podmanTest.Podman([]string{"port", "-a", "foobar"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 	})
 
 	It("podman port -l nginx", func() {

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -230,11 +230,11 @@ var _ = Describe("Podman ps", func() {
 	It("podman ps mutually exclusive flags", func() {
 		session := podmanTest.Podman([]string{"ps", "-aqs"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"ps", "-a", "--ns", "-s"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman --sort by size", func() {

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Podman pull", func() {
 	It("podman pull from docker a not existing image", func() {
 		session := podmanTest.PodmanNoCache([]string{"pull", "ibetthisdoesntexistthere:foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman pull from docker with tag", func() {
@@ -96,7 +96,7 @@ var _ = Describe("Podman pull", func() {
 	It("podman pull bogus image", func() {
 		session := podmanTest.PodmanNoCache([]string{"pull", "umohnani/get-started"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman pull from docker-archive", func() {

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Podman push", func() {
 
 		push := podmanTest.PodmanNoCache([]string{"push", "--creds=podmantest:test", ALPINE, "localhost:5000/tlstest"})
 		push.WaitWithDefaultTimeout()
-		Expect(push.ExitCode()).To(Not(Equal(0)))
+		Expect(push).To(ExitWithError())
 
 		push = podmanTest.PodmanNoCache([]string{"push", "--creds=podmantest:test", "--tls-verify=false", ALPINE, "localhost:5000/tlstest"})
 		push.WaitWithDefaultTimeout()
@@ -151,11 +151,11 @@ var _ = Describe("Podman push", func() {
 
 		push = podmanTest.PodmanNoCache([]string{"push", "--creds=podmantest:wrongpasswd", ALPINE, "localhost:5000/credstest"})
 		push.WaitWithDefaultTimeout()
-		Expect(push.ExitCode()).To(Not(Equal(0)))
+		Expect(push).To(ExitWithError())
 
 		push = podmanTest.PodmanNoCache([]string{"push", "--creds=podmantest:test", "--cert-dir=fakedir", ALPINE, "localhost:5000/certdirtest"})
 		push.WaitWithDefaultTimeout()
-		Expect(push.ExitCode()).To(Not(Equal(0)))
+		Expect(push).To(ExitWithError())
 
 		push = podmanTest.PodmanNoCache([]string{"push", "--creds=podmantest:test", ALPINE, "localhost:5000/defaultflags"})
 		push.WaitWithDefaultTimeout()

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Podman rmi", func() {
 		// Trying without --force should fail
 		result := podmanTest.PodmanNoCache([]string{"rmi", alpineId})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 
 		// With --force it should work
 		resultForce := podmanTest.PodmanNoCache([]string{"rmi", "-f", alpineId})

--- a/test/e2e/run_cpu_test.go
+++ b/test/e2e/run_cpu_test.go
@@ -164,12 +164,12 @@ var _ = Describe("Podman run cpu", func() {
 	It("podman run cpus and cpu-period", func() {
 		result := podmanTest.Podman([]string{"run", "--rm", "--cpu-period=5000", "--cpus=0.5", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Not(Equal(0)))
+		Expect(result).To(ExitWithError())
 	})
 
 	It("podman run cpus and cpu-quota", func() {
 		result := podmanTest.Podman([]string{"run", "--rm", "--cpu-quota=5000", "--cpus=0.5", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Not(Equal(0)))
+		Expect(result).To(ExitWithError())
 	})
 })

--- a/test/e2e/run_device_test.go
+++ b/test/e2e/run_device_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Podman run device", func() {
 	It("podman run bad device test", func() {
 		session := podmanTest.Podman([]string{"run", "-q", "--device", "/dev/baddevice", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman run device test", func() {
@@ -70,7 +70,7 @@ var _ = Describe("Podman run device", func() {
 	It("podman run device rename and bad permission test", func() {
 		session := podmanTest.Podman([]string{"run", "-q", "--security-opt", "label=disable", "--device", "/dev/kmsg:/dev/kmsg1:rd", ALPINE, "ls", "--color=never", "/dev/kmsg1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman run device host device and container device parameter are directories", func() {

--- a/test/e2e/run_dns_test.go
+++ b/test/e2e/run_dns_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Podman run dns", func() {
 	It("podman run add bad dns server", func() {
 		session := podmanTest.Podman([]string{"run", "--dns=foobar", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman run add dns server", func() {
@@ -71,7 +71,7 @@ var _ = Describe("Podman run dns", func() {
 	It("podman run add bad host", func() {
 		session := podmanTest.Podman([]string{"run", "--add-host=foo:1.2", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman run add host", func() {
@@ -105,15 +105,15 @@ var _ = Describe("Podman run dns", func() {
 	It("podman run mutually excludes --dns* and --network", func() {
 		session := podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "container:ALPINE", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"run", "--dns-opt=1.2.3.4", "--network", "container:ALPINE", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"run", "--dns-search=foobar.com", "--network", "none", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"run", "--dns=1.2.3.4", "--network", "host", ALPINE})
 		session.WaitWithDefaultTimeout()

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Podman run networking", func() {
 		Expect(results.OutputToString()).To(ContainSubstring("8000"))
 
 		ncBusy := SystemExec("nc", []string{"-l", "-p", "80"})
-		Expect(ncBusy.ExitCode()).ToNot(Equal(0))
+		Expect(ncBusy).To(ExitWithError())
 	})
 
 	It("podman run network expose ports in image metadata", func() {
@@ -229,7 +229,7 @@ var _ = Describe("Podman run networking", func() {
 	It("podman run network in bogus user created network namespace", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--net", "ns:/run/netns/xxy", ALPINE, "wget", "www.podman.io"})
 		session.Wait(90)
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("stat /run/netns/xxy: no such file or directory"))
 	})
 })

--- a/test/e2e/run_ns_test.go
+++ b/test/e2e/run_ns_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Podman run ns", func() {
 
 		session = podmanTest.Podman([]string{"run", "--pid=badpid", fedoraMinimal, "bash", "-c", "echo $$"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman run --cgroup private test", func() {
@@ -102,6 +102,6 @@ var _ = Describe("Podman run ns", func() {
 	It("podman run bad ipc pid test", func() {
 		session := podmanTest.Podman([]string{"run", "--ipc=badpid", fedoraMinimal, "bash", "-c", "echo $$"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session).To(ExitWithError())
 	})
 })

--- a/test/e2e/run_staticip_test.go
+++ b/test/e2e/run_staticip_test.go
@@ -40,19 +40,19 @@ var _ = Describe("Podman run with --ip flag", func() {
 	It("Podman run --ip with garbage address", func() {
 		result := podmanTest.Podman([]string{"run", "-ti", "--ip", "114232346", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 	})
 
 	It("Podman run --ip with v6 address", func() {
 		result := podmanTest.Podman([]string{"run", "-ti", "--ip", "2001:db8:bad:beef::1", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 	})
 
 	It("Podman run --ip with non-allocatable IP", func() {
 		result := podmanTest.Podman([]string{"run", "-ti", "--ip", "203.0.113.124", ALPINE, "ls"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 	})
 
 	It("Podman run with specified static IP has correct IP", func() {
@@ -70,6 +70,6 @@ var _ = Describe("Podman run with --ip flag", func() {
 		Expect(result.ExitCode()).To(Equal(0))
 		result = podmanTest.Podman([]string{"run", "-ti", "--ip", ip, ALPINE, "ip", "addr"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 	})
 })

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Podman run", func() {
 
 		session := podmanTest.Podman([]string{"run", "-it", "--security-opt", strings.Join([]string{"seccomp=", jsonFile}, ""), ALPINE, "pwd"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 		match, _ := session.GrepString("Operation not permitted")
 		Expect(match).Should(BeTrue())
 	})
@@ -730,11 +730,11 @@ USER mail`
 
 		session := podmanTest.Podman([]string{"run", "--volume", ":/myvol1:z", ALPINE, "touch", "/myvol2/foo.txt"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("directory cannot be empty"))
 		session = podmanTest.Podman([]string{"run", "--volume", vol1 + ":", ALPINE, "touch", "/myvol2/foo.txt"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("directory cannot be empty"))
 	})
 
@@ -815,7 +815,7 @@ USER mail`
 	It("podman run --rm failed container should delete itself", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		numContainers := podmanTest.NumberOfContainers()
 		Expect(numContainers).To(Equal(0))
@@ -824,7 +824,7 @@ USER mail`
 	It("podman run failed container should NOT delete itself", func() {
 		session := podmanTest.Podman([]string{"run", ALPINE, "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		numContainers := podmanTest.NumberOfContainers()
 		Expect(numContainers).To(Equal(1))
@@ -840,28 +840,28 @@ USER mail`
 	It("podman run with bad healthcheck retries", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "[\"foo\"]", "--health-retries", "0", ALPINE, "top"})
 		session.Wait()
-		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("healthcheck-retries must be greater than 0"))
 	})
 
 	It("podman run with bad healthcheck timeout", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "[\"foo\"]", "--health-timeout", "0s", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("healthcheck-timeout must be at least 1 second"))
 	})
 
 	It("podman run with bad healthcheck start-period", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "[\"foo\"]", "--health-start-period", "-1s", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("healthcheck-start-period must be 0 seconds or greater"))
 	})
 
 	It("podman run with --add-host and --no-hosts fails", func() {
 		session := podmanTest.Podman([]string{"run", "-dt", "--add-host", "test1:127.0.0.1", "--no-hosts", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).ToNot(Equal(0))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman run --http-proxy test", func() {
@@ -990,6 +990,6 @@ USER mail`
 	It("podman run with cgroups=garbage errors", func() {
 		session := podmanTest.Podman([]string{"run", "-d", "--cgroups=garbage", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 })

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Podman run with volumes", func() {
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", fmt.Sprintf("type=bind,src=%s,target=/run/test,ro=true,rw=false", mountPath), ALPINE, "grep", "/run/test", "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman run with volume flag and multiple named volumes", func() {
@@ -191,7 +191,7 @@ var _ = Describe("Podman run with volumes", func() {
 	It("podman run with noexec can't exec", func() {
 		session := podmanTest.Podman([]string{"run", "--rm", "-v", "/bin:/hostbin:noexec", ALPINE, "/hostbin/ls", "/"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 
 	It("podman run with tmpfs named volume mounts and unmounts", func() {

--- a/test/e2e/runlabel_test.go
+++ b/test/e2e/runlabel_test.go
@@ -75,12 +75,12 @@ var _ = Describe("podman container runlabel", func() {
 	It("podman container runlabel bogus label should result in non-zero exit code", func() {
 		result := podmanTest.Podman([]string{"container", "runlabel", "RUN", ALPINE})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 	})
 	It("podman container runlabel bogus label in remote image should result in non-zero exit", func() {
 		result := podmanTest.Podman([]string{"container", "runlabel", "RUN", "docker.io/library/ubuntu:latest"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).ToNot(Equal(0))
+		Expect(result).To(ExitWithError())
 
 	})
 

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Podman save", func() {
 
 		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, "FOOBAR"})
 		save.WaitWithDefaultTimeout()
-		Expect(save.ExitCode()).To(Not(Equal(0)))
+		Expect(save).To(ExitWithError())
 	})
 
 	It("podman save to directory with oci format", func() {
@@ -113,7 +113,7 @@ var _ = Describe("Podman save", func() {
 
 		save := podmanTest.PodmanNoCache([]string{"save", "--compress", "--format", "docker-dir", "-o", outdir, ALPINE})
 		save.WaitWithDefaultTimeout()
-		Expect(save.ExitCode()).To(Not(Equal(0)))
+		Expect(save).To(ExitWithError())
 	})
 
 })

--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Podman start", func() {
 
 		start := podmanTest.Podman([]string{"start", "-l"})
 		start.WaitWithDefaultTimeout()
-		Expect(start.ExitCode()).Should(BeNumerically(">", 0))
+		Expect(start).To(ExitWithError())
 
 		Eventually(podmanTest.NumberOfContainers(), defaultWaitTimeout, 3.0).Should(BeZero())
 	})
@@ -120,7 +120,7 @@ var _ = Describe("Podman start", func() {
 
 		start := podmanTest.Podman([]string{"start", "-l"})
 		start.WaitWithDefaultTimeout()
-		Expect(start.ExitCode()).Should(BeNumerically(">", 0))
+		Expect(start).To(ExitWithError())
 
 		Eventually(podmanTest.NumberOfContainers(), defaultWaitTimeout, 3.0).Should(Equal(1))
 	})

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -61,6 +61,6 @@ var _ = Describe("Podman volume create", func() {
 	It("podman create volume with bad volume option", func() {
 		session := podmanTest.Podman([]string{"volume", "create", "--opt", "badOpt=bad"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 	})
 })

--- a/test/e2e/volume_rm_test.go
+++ b/test/e2e/volume_rm_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Podman volume rm", func() {
 
 		session = podmanTest.Podman([]string{"volume", "rm", "myvol"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring(cid))
 
 		session = podmanTest.Podman([]string{"volume", "rm", "-f", "myvol"})
@@ -116,7 +116,7 @@ var _ = Describe("Podman volume rm", func() {
 
 		session = podmanTest.Podman([]string{"volume", "rm", "myv"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Not(Equal(0)))
+		Expect(session).To(ExitWithError())
 
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()

--- a/test/utils/matchers.go
+++ b/test/utils/matchers.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/gexec"
+)
+
+// ExitWithError matches when assertion is > argument.  Default 0
+// Modeled after the gomega Exit() matcher
+func ExitWithError(optionalExitCode ...int) *exitMatcher {
+	exitCode := 0
+	if len(optionalExitCode) > 0 {
+		exitCode = optionalExitCode[0]
+	}
+	return &exitMatcher{exitCode: exitCode}
+}
+
+type exitMatcher struct {
+	exitCode       int
+	actualExitCode int
+}
+
+func (m *exitMatcher) Match(actual interface{}) (success bool, err error) {
+	exiter, ok := actual.(gexec.Exiter)
+	if !ok {
+		return false, fmt.Errorf("ExitWithError must be passed a gexec.Exiter (Missing method ExitCode() int) Got:\n#{format.Object(actual, 1)}")
+	}
+
+	m.actualExitCode = exiter.ExitCode()
+	if m.actualExitCode == -1 {
+		return false, nil
+	}
+	return m.actualExitCode > m.exitCode, nil
+}
+
+func (m *exitMatcher) FailureMessage(actual interface{}) (message string) {
+	if m.actualExitCode == -1 {
+		return "Expected process to exit.  It did not."
+	}
+	return format.Message(m.actualExitCode, "to be greater than exit code:", m.exitCode)
+}
+
+func (m *exitMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	if m.actualExitCode == -1 {
+		return "you really shouldn't be able to see this!"
+	} else {
+		if m.exitCode == -1 {
+			return "Expected process not to exit.  It did."
+		}
+		return format.Message(m.actualExitCode, "is less than or equal to exit code:", m.exitCode)
+	}
+}
+func (m *exitMatcher) MatchMayChangeInTheFuture(actual interface{}) bool {
+	session, ok := actual.(*gexec.Session)
+	if ok {
+		return session.ExitCode() == -1
+	}
+	return true
+}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -268,7 +268,7 @@ func (s *PodmanSession) ErrorGrepString(term string) (bool, []string) {
 	return matches, greps
 }
 
-//LineInOutputStartsWith returns true if a line in a
+// LineInOutputStartsWith returns true if a line in a
 // session output starts with the supplied string
 func (s *PodmanSession) LineInOuputStartsWith(term string) bool {
 	for _, i := range s.OutputToStringArray() {
@@ -279,7 +279,7 @@ func (s *PodmanSession) LineInOuputStartsWith(term string) bool {
 	return false
 }
 
-//LineInOutputContains returns true if a line in a
+// LineInOutputContains returns true if a line in a
 // session output contains the supplied string
 func (s *PodmanSession) LineInOutputContains(term string) bool {
 	for _, i := range s.OutputToStringArray() {
@@ -290,7 +290,7 @@ func (s *PodmanSession) LineInOutputContains(term string) bool {
 	return false
 }
 
-//LineInOutputContainsTag returns true if a line in the
+// LineInOutputContainsTag returns true if a line in the
 // session's output contains the repo-tag pair as returned
 // by podman-images(1).
 func (s *PodmanSession) LineInOutputContainsTag(repo, tag string) bool {
@@ -348,7 +348,7 @@ func StringInSlice(s string, sl []string) bool {
 	return false
 }
 
-//tagOutPutToMap parses each string in imagesOutput and returns
+// tagOutPutToMap parses each string in imagesOutput and returns
 // a map of repo:tag pairs.  Notice, the first array item will
 // be skipped as it's considered to be the header.
 func tagOutputToMap(imagesOutput []string) map[string]string {
@@ -371,7 +371,7 @@ func tagOutputToMap(imagesOutput []string) map[string]string {
 	return m
 }
 
-//GetHostDistributionInfo returns a struct with its distribution name and version
+// GetHostDistributionInfo returns a struct with its distribution name and version
 func GetHostDistributionInfo() HostOS {
 	f, err := os.Open(OSReleasePath)
 	defer f.Close()
@@ -415,7 +415,7 @@ func IsKernelNewerThan(version string) (bool, error) {
 
 }
 
-//IsCommandAvaible check if command exist
+// IsCommandAvaible check if command exist
 func IsCommandAvailable(command string) bool {
 	check := exec.Command("bash", "-c", strings.Join([]string{"command -v", command}, " "))
 	err := check.Run()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -346,12 +346,12 @@ github.com/onsi/ginkgo/internal/specrunner
 # github.com/onsi/gomega v1.7.0
 github.com/onsi/gomega
 github.com/onsi/gomega/gexec
+github.com/onsi/gomega/format
 github.com/onsi/gomega/internal/assertion
 github.com/onsi/gomega/internal/asyncassertion
 github.com/onsi/gomega/internal/testingtsupport
 github.com/onsi/gomega/matchers
 github.com/onsi/gomega/types
-github.com/onsi/gomega/format
 github.com/onsi/gomega/gbytes
 github.com/onsi/gomega/internal/oraclematcher
 github.com/onsi/gomega/matchers/support/goraph/bipartitegraph


### PR DESCRIPTION
Rather than checking for non-zero, we need to check for >0 to
distinguish between timeouts and error exit codes.

Signed-off-by: Jhon Honce <jhonce@redhat.com>