### PR TITLE
Respect --sig-proxy flag with podman start --attach

### DIFF
--- a/cmd/podman/start.go
+++ b/cmd/podman/start.go
@@ -60,6 +60,9 @@ func startCmd(c *cliconfig.StartValues) error {
 	}
 
 	sigProxy := c.SigProxy || attach
+	if c.Flag("sig-proxy").Changed {
+		sigProxy = c.SigProxy
+	}
 
 	if sigProxy && !attach {
 		return errors.Wrapf(define.ErrInvalidArg, "you cannot use sig-proxy without --attach")


### PR DESCRIPTION
If it's explicitly set, use it, instead of trying to set a sane default.