### PR TITLE
Update build man page with latest Buildah changes

### DIFF
--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"runtime/debug"
 
@@ -62,4 +63,13 @@ func aliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "health-timeout"
 	}
 	return pflag.NormalizedName(name)
+}
+
+// Check if a file exists and is not a directory
+func checkIfFileExists(name string) bool {
+	file, err := os.Stat(name)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !file.IsDir()
 }

--- a/docs/podman.1.md
+++ b/docs/podman.1.md
@@ -137,7 +137,7 @@ the exit codes follow the `chroot` standard, see below:
 | Command                                          | Description                                                                 |
 | ------------------------------------------------ | --------------------------------------------------------------------------- |
 | [podman-attach(1)](podman-attach.1.md)           | Attach to a running container.                                              |
-| [podman-build(1)](podman-build.1.md)             | Build a container image using a Dockerfile.                                 |
+| [podman-build(1)](podman-build.1.md)             | Build a container image using a Containerfile.                              |
 | [podman-commit(1)](podman-commit.1.md)           | Create new image based on the changed container.                            |
 | [podman-container(1)](podman-container.1.md)     | Manage containers.                                                          |
 | [podman-cp(1)](podman-cp.1.md)                   | Copy files/folders between a container and the local filesystem.            |


### PR DESCRIPTION
Changes include: Containerfile by default, add --device flags to bud, allow podman build to be called without arguments, and a couple of small typo corrections.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>