### PR TITLE
Add squash-all, fix squash option in build

### DIFF
--- a/cmd/podman/cliconfig/create.go
+++ b/cmd/podman/cliconfig/create.go
@@ -12,13 +12,20 @@ type RunValues struct {
 	PodmanCommand
 }
 
+// PodmanBuildResults represents the results for Podman Build flags
+// that are unique to Podman.
+type PodmanBuildResults struct {
+	SquashAll bool
+}
+
 type BuildValues struct {
 	PodmanCommand
 	*buildahcli.BudResults
 	*buildahcli.UserNSResults
 	*buildahcli.FromAndBudResults
-	*buildahcli.NameSpaceResults
 	*buildahcli.LayerResults
+	*buildahcli.NameSpaceResults
+	*PodmanBuildResults
 }
 
 type CpValues struct {

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1246,6 +1246,7 @@ _podman_build() {
 	  -q
 	  --rm
 	  --squash
+	  --squash-all
 	  --tls-verify
   "
 

--- a/docs/podman-build.1.md
+++ b/docs/podman-build.1.md
@@ -405,6 +405,11 @@ If you omit the unit, the system uses bytes. If you omit the size entirely, the 
 
 **--squash**
 
+Squash all of the image's new layers into a single new layer; any preexisting layers
+are not squashed.
+
+**--squash-all**
+
 Squash all of the new image's layers (including those inherited from a base image) into a single new layer.
 
 **--tag**, **-t**=*imageName*


### PR DESCRIPTION
Translate the podman build --squash command to podman build --layers=false which
has the same functionality as docker build --squash. Add a new option --squash-all
which will squash all layers into one. This will be translated to buildah bud --squash
for the buildah bud api.

Also allow only one option, squash, layers or squash--all to be used per build command.

Fixes: https://github.com/containers/buildah/issues/1234

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>