### PR TITLE
io.podman.socket: drop Also=multi-user.target

### DIFF
--- a/contrib/varlink/io.podman.socket
+++ b/contrib/varlink/io.podman.socket
@@ -8,4 +8,3 @@ SocketMode=0600
 
 [Install]
 WantedBy=sockets.target
-Also=multi-user.target


### PR DESCRIPTION
Using `Also=` means that the target unit will also be
installed/uninstalled together with our unit. Doing
`Also=multi-user.target` essentially says: disable `multi-user.target`
if `io.podman.socket` is disabled, which sounds... not at all like
what we want.

In practice, systemd thankfully ignores this (likely because it's the
default target). I think having `Also=io.podman.socket` in the
`io.podman.service` already does what we want here: it gets installed
under `sockets.target` whenever the service is. (And the fact that
systemd ignored this means that it wasn't actually playing a role in
resolving #3998.)

This was causing `systemctl preset-all` to dump core in Fedora CoreOS:
https://github.com/coreos/fedora-coreos-tracker/issues/290

(Likely there's a systemd bug around here too.)