### PR TITLE
rootless: automatically recreate the pause.pid file

### DIFF
--- a/libpod/boltdb_state.go
+++ b/libpod/boltdb_state.go
@@ -2,6 +2,7 @@ package libpod
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"sync"
 
@@ -658,9 +659,13 @@ func (s *BoltState) UpdateContainer(ctr *Container) error {
 		return err
 	}
 
-	// Handle network namespace
-	if err := replaceNetNS(netNSPath, ctr, newState); err != nil {
-		return err
+	// Handle network namespace.
+	if os.Geteuid() == 0 {
+		// Do it only when root, either on the host or as root in the
+		// user namespace.
+		if err := replaceNetNS(netNSPath, ctr, newState); err != nil {
+			return err
+		}
 	}
 
 	// New state compiled successfully, swap it into the current state

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -1,0 +1,45 @@
+package rootless
+
+import (
+	"os"
+
+	"github.com/containers/storage"
+	"github.com/pkg/errors"
+)
+
+func TryJoinPauseProcess(pausePidPath string) (bool, int, error) {
+	if _, err := os.Stat(pausePidPath); err != nil {
+		return false, -1, nil
+	}
+
+	became, ret, err := TryJoinFromFilePaths("", false, []string{pausePidPath})
+	if err == nil {
+		return became, ret, err
+	}
+
+	// It could not join the pause process, let's lock the file before trying to delete it.
+	pidFileLock, err := storage.GetLockfile(pausePidPath)
+	if err != nil {
+		// The file was deleted by another process.
+		if os.IsNotExist(err) {
+			return false, -1, nil
+		}
+		return false, -1, errors.Wrapf(err, "error acquiring lock on %s", pausePidPath)
+	}
+
+	pidFileLock.Lock()
+	defer func() {
+		if pidFileLock.Locked() {
+			pidFileLock.Unlock()
+		}
+	}()
+
+	// Now the pause PID file is locked.  Try to join once again in case it changed while it was not locked.
+	became, ret, err = TryJoinFromFilePaths("", false, []string{pausePidPath})
+	if err != nil {
+		// It is still failing.  We can safely remove it.
+		os.Remove(pausePidPath)
+		return false, -1, nil
+	}
+	return became, ret, err
+}

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -566,10 +566,10 @@ func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []st
 
 			r, w := os.NewFile(uintptr(fds[0]), "read file"), os.NewFile(uintptr(fds[1]), "write file")
 
-			defer errorhandling.CloseQuiet(w)
 			defer errorhandling.CloseQuiet(r)
 
 			if _, _, err := becomeRootInUserNS("", path, w); err != nil {
+				w.Close()
 				lastErr = err
 				continue
 			}
@@ -578,7 +578,6 @@ func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []st
 				return false, 0, err
 			}
 			defer func() {
-				errorhandling.CloseQuiet(r)
 				C.reexec_in_user_namespace_wait(-1, 0)
 			}()
 


### PR DESCRIPTION
if the pause process cannot be joined, remove the pause.pid while keeping a lock on it, and try to recreate it.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
