### PR TITLE
rootless: detect no system session with --cgroup-manager=systemd

### DIFF
--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -174,14 +174,13 @@ func setupRootless(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-
+		conf, err := runtime.GetConfig()
+		if err != nil {
+			return err
+		}
 		if !ownsCgroup {
 			unitName := fmt.Sprintf("podman-%d.scope", os.Getpid())
 			if err := utils.RunUnderSystemdScope(os.Getpid(), "user.slice", unitName); err != nil {
-				conf, err2 := runtime.GetConfig()
-				if err2 != nil {
-					return err2
-				}
 				if conf.CgroupManager == libpod.SystemdCgroupsManager {
 					logrus.Warnf("Failed to add podman to systemd sandbox cgroup: %v", err)
 				} else {


### PR DESCRIPTION
if the cgroup manager is set to systemd, detect if dbus is available,
otherwise raise an error.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>