### PR TITLE
change error wording when conmon fails without logs

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1359,7 +1359,7 @@ func readConmonPipeData(pipe *os.File, ociLog string) (int, error) {
 					}
 				}
 			}
-			return -1, errors.Wrapf(ss.err, "error reading container (probably exited) json message")
+			return -1, errors.Wrapf(ss.err, "container create failed (no logs from conmon)")
 		}
 		logrus.Debugf("Received: %d", ss.si.Data)
 		if ss.si.Data < 0 {


### PR DESCRIPTION
In some cases, conmon can fail without writing logs.  Change the wording
of the error message from

	"error reading container (probably exited) json message"
to
	"container create failed (no logs from conmon)"

to have more helpful error message that is more consistent with other
errors at the stage of execution.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>