### PR TITLE
Fix default path for auth.json

### DIFF
--- a/cmd/podman/shared/funcs.go
+++ b/cmd/podman/shared/funcs.go
@@ -21,7 +21,7 @@ func GetAuthFile(authfile string) string {
 	}
 
 	if runtimeDir, err := util.GetRuntimeDir(); err == nil {
-		return filepath.Join(runtimeDir, "auth.json")
+		return filepath.Join(runtimeDir, "containers/auth.json")
 	}
 	return ""
 }


### PR DESCRIPTION
Default path should be ${XDG_RUNTIME_DIR}/containers/auth.json according
to the docs.

This regressed to ${XDG_RUNTIME_DIR}/auth.json in #3760.

Fixes: #4227

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>