### PR TITLE
tests: enable ps --size tests for rootless

### DIFF
--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -80,8 +80,6 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman ps size flag", func() {
-		SkipIfRootless()
-
 		_, ec, _ := podmanTest.RunLsContainer("")
 		Expect(ec).To(Equal(0))
 
@@ -233,8 +231,6 @@ var _ = Describe("Podman ps", func() {
 	})
 
 	It("podman --sort by size", func() {
-		SkipIfRootless()
-
 		session := podmanTest.Podman([]string{"create", "busybox", "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))


### PR DESCRIPTION
rootless podman is usin a single user namespace for all the containers
so it can safely access the storage for all of them.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>