### PR TITLE
Ensure volumes can be removed when they fail to unmount

### DIFF
--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -65,6 +65,10 @@ var (
 	// CGroup.
 	ErrNoCgroups = errors.New("this container does not have a cgroup")
 
+	// ErrRootless indicates that the given command cannot but run without
+	// root.
+	ErrRootless = errors.New("operation requires root privileges")
+
 	// ErrRuntimeStopped indicates that the runtime has already been shut
 	// down and no further operations can be performed on it
 	ErrRuntimeStopped = errors.New("runtime has already been stopped")

--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -157,7 +157,14 @@ func (r *Runtime) removeVolume(ctx context.Context, v *Volume, force bool) error
 
 	// If the volume is still mounted - force unmount it
 	if err := v.unmount(true); err != nil {
-		return errors.Wrapf(err, "error unmounting volume %s", v.Name())
+		if force {
+			// If force is set, evict the volume, even if errors
+			// occur. Otherwise we'll never be able to get rid of
+			// them.
+			logrus.Errorf("Error unmounting volume %s: %v", v.Name(), err)
+		} else {
+			return errors.Wrapf(err, "error unmounting volume %s", v.Name())
+		}
 	}
 
 	// Set volume as invalid so it can no longer be used


### PR DESCRIPTION
Also, ensure that we don't try to mount them without root - it appears that it can somehow not error and report that mount was successful when it clearly did not succeed, which can induce this case.

We reuse the `--force` flag to indicate that a volume should be removed even after unmount errors. It seems fairly natural to expect that --force will remove a volume that is otherwise presenting problems.

Finally, ignore EINVAL on unmount - if the mount point no longer exists our job is done.

Fixes: #4247
Fixes: #4248