### PR TITLE
Unwrap errors before comparing them

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -533,7 +533,7 @@ func (c *Container) teardownStorage() error {
 		// error - we wanted it gone, it is already gone.
 		// Potentially another tool using containers/storage already
 		// removed it?
-		if err == storage.ErrNotAContainer || err == storage.ErrContainerUnknown {
+		if errors.Cause(err) == storage.ErrNotAContainer || errors.Cause(err) == storage.ErrContainerUnknown {
 			logrus.Warnf("Storage for container %s already removed", c.ID())
 			return nil
 		}

--- a/libpod/runtime_cstorage.go
+++ b/libpod/runtime_cstorage.go
@@ -68,7 +68,7 @@ func (r *Runtime) RemoveStorageContainer(idOrName string, force bool) error {
 func (r *Runtime) removeStorageContainer(idOrName string, force bool) error {
 	targetID, err := r.store.Lookup(idOrName)
 	if err != nil {
-		if err == storage.ErrLayerUnknown {
+		if errors.Cause(err) == storage.ErrLayerUnknown {
 			return errors.Wrapf(define.ErrNoSuchCtr, "no container with ID or name %q found", idOrName)
 		}
 		return errors.Wrapf(err, "error looking up container %q", idOrName)
@@ -78,7 +78,7 @@ func (r *Runtime) removeStorageContainer(idOrName string, force bool) error {
 	// So we can still error here.
 	ctr, err := r.store.Container(targetID)
 	if err != nil {
-		if err == storage.ErrContainerUnknown {
+		if errors.Cause(err) == storage.ErrContainerUnknown {
 			return errors.Wrapf(define.ErrNoSuchCtr, "%q does not refer to a container", idOrName)
 		}
 		return errors.Wrapf(err, "error retrieving container %q", idOrName)
@@ -96,7 +96,7 @@ func (r *Runtime) removeStorageContainer(idOrName string, force bool) error {
 	if !force {
 		timesMounted, err := r.store.Mounted(ctr.ID)
 		if err != nil {
-			if err == storage.ErrContainerUnknown {
+			if errors.Cause(err) == storage.ErrContainerUnknown {
 				// Container was removed from under us.
 				// It's gone, so don't bother erroring.
 				logrus.Warnf("Storage for container %s already removed", ctr.ID)
@@ -109,7 +109,7 @@ func (r *Runtime) removeStorageContainer(idOrName string, force bool) error {
 		}
 	} else {
 		if _, err := r.store.Unmount(ctr.ID, true); err != nil {
-			if err == storage.ErrContainerUnknown {
+			if errors.Cause(err) == storage.ErrContainerUnknown {
 				// Container again gone, no error
 				logrus.Warnf("Storage for container %s already removed", ctr.ID)
 				return nil
@@ -119,7 +119,7 @@ func (r *Runtime) removeStorageContainer(idOrName string, force bool) error {
 	}
 
 	if err := r.store.DeleteContainer(ctr.ID); err != nil {
-		if err == storage.ErrContainerUnknown {
+		if errors.Cause(err) == storage.ErrContainerUnknown {
 			// Container again gone, no error
 			logrus.Warnf("Storage for container %s already removed", ctr.ID)
 			return nil

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -69,7 +69,7 @@ func (r *Runtime) RemoveImage(ctx context.Context, img *image.Image, force bool)
 		// the image. we figure out which repotag the user is trying to refer
 		// to and untag it.
 		repoName, err := img.MatchRepoTag(img.InputName)
-		if hasChildren && err == image.ErrRepoTagNotFound {
+		if hasChildren && errors.Cause(err) == image.ErrRepoTagNotFound {
 			return "", errors.Errorf("unable to delete %q (cannot be forced) - image has dependent child images", img.ID())
 		}
 		if err != nil {


### PR DESCRIPTION
Unwrap errors before directly comparing them with errors defined by the storage and image libraries, as those comparisons will fail if the libraries we're calling start providing more context with those errors.