### PR TITLE
systemd: accept also /sbin/init

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -668,7 +668,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot parse bool %s", c.String("systemd"))
 		}
-		if x && (command[0] == "/usr/sbin/init" || (filepath.Base(command[0]) == "systemd")) {
+		if x && (command[0] == "/usr/sbin/init" || command[0] == "/sbin/init" || (filepath.Base(command[0]) == "systemd")) {
 			systemd = true
 		}
 	}

--- a/docs/podman-create.1.md
+++ b/docs/podman-create.1.md
@@ -716,12 +716,11 @@ Run container in systemd mode. The default is *true*.
 
 The value *always* enforces the systemd mode is enforced without
 looking at the executable name.  Otherwise, if set to true and the
-command you are running inside the container is systemd or
-/usr/sbin/init.
+command you are running inside the container is systemd, /usr/sbin/init
+or /sbin/init.
 
-If the command you are running inside of the container is systemd or
-/usr/sbin/init, Podman will setup tmpfs mount points in the following
-directories:
+If the command you are running inside of the container is systemd,
+Podman will setup tmpfs mount points in the following directories:
 
 /run, /run/lock, /tmp, /sys/fs/cgroup/systemd, /var/lib/journal
 

--- a/docs/podman-run.1.md
+++ b/docs/podman-run.1.md
@@ -753,12 +753,11 @@ Run container in systemd mode. The default is *true*.
 
 The value *always* enforces the systemd mode is enforced without
 looking at the executable name.  Otherwise, if set to true and the
-command you are running inside the container is systemd or
-/usr/sbin/init.
+command you are running inside the container is systemd, /usr/sbin/init
+or /sbin/init.
 
-If the command you are running inside of the container is systemd or
-/usr/sbin/init, Podman will setup tmpfs mount points in the following
-directories:
+If the command you are running inside of the container is systemd
+Podman will setup tmpfs mount points in the following directories:
 
 /run, /run/lock, /tmp, /sys/fs/cgroup/systemd, /var/lib/journal
 


### PR DESCRIPTION
it is a regression caused by
3ba3e1c7510d1780b6527a4aa52e40ac2c5b576a.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1761514

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>