### PR TITLE
Fix output message for "podman start" command.

### DIFF
--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -663,7 +663,7 @@ func (r *LocalRuntime) Start(ctx context.Context, c *cliconfig.StartValues, sigP
 			lastError = errors.Wrapf(err, "unable to start container %q", container)
 			continue
 		}
-		fmt.Println(container)
+		fmt.Println(ctr.ID())
 	}
 	return exitCode, lastError
 }


### PR DESCRIPTION
Fix output message for "podman start" command: it prints short container ID instead of full one.

Signed-off-by: Boris Klimenko <2@borisklimenko.ru>