### PR TITLE
Attach to container if it was created with --interactive

### DIFF
--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -612,7 +612,9 @@ func (r *LocalRuntime) Start(ctx context.Context, c *cliconfig.StartValues, sigP
 		if c.Attach {
 			inputStream := os.Stdin
 			if !c.Interactive {
-				inputStream = nil
+				if !ctr.Stdin() {
+					inputStream = nil
+				}
 			}
 
 			// attach to the container and also start it not already running


### PR DESCRIPTION
Check to see if the container's start config includes the interactive
flag when determining to attach or ignore stdin stream.

This is in line with behavior of Docker CLI and engine

Signed-off-by: Tyler Ramer <tyaramer@gmail.com>

---

Addresses https://github.com/containers/libpod/issues/4259