### PR TITLE
rootless v2 cannot collect network stats

### DIFF
--- a/docs/podman-stats.1.md
+++ b/docs/podman-stats.1.md
@@ -15,6 +15,9 @@ Note:  Podman stats will not work in rootless environments that use CGroups V1.
 Podman stats relies on CGroup information for statistics, and CGroup v1 is not
 supported for rootless use cases.
 
+Note: Rootless environments that use CGroups V2 are not able to report statistics
+about their networking usage.
+
 ## OPTIONS
 
 **--all**, **-a**

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -462,6 +462,12 @@ func getContainerNetNS(ctr *Container) (string, error) {
 
 func getContainerNetIO(ctr *Container) (*netlink.LinkStatistics, error) {
 	var netStats *netlink.LinkStatistics
+	// rootless v2 cannot seem to resolve its network connection to
+	// collect statistics.  For now, we allow stats to at least run
+	// by returning nil
+	if rootless.IsRootless() {
+		return netStats, nil
+	}
 	netNSPath, netPathErr := getContainerNetNS(ctr)
 	if netPathErr != nil {
 		return nil, netPathErr


### PR DESCRIPTION
network statistics cannot be collected for rootless network devices with
the current implementation.  for now, we return nil so that stats will
at least for users.

Fixes:#4268

Signed-off-by: baude <bbaude@redhat.com>