### PR TITLE
stats: list all running containers unless specified otherwise

### DIFF
--- a/cmd/podman/stats.go
+++ b/cmd/podman/stats.go
@@ -35,7 +35,7 @@ var (
 
 	statsDescription = "Display percentage of CPU, memory, network I/O, block I/O and PIDs for one or more containers."
 	_statsCommand    = &cobra.Command{
-		Use:   "stats [flags] CONTAINER [CONTAINER...]",
+		Use:   "stats [flags] [CONTAINER...]",
 		Short: "Display a live stream of container resource usage statistics",
 		Long:  statsDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -43,9 +43,6 @@ var (
 			statsCommand.GlobalFlags = MainGlobalOpts
 			statsCommand.Remote = remoteclient
 			return statsCmd(&statsCommand)
-		},
-		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
 		},
 		Example: `podman stats --all --no-stream
   podman stats ctrID
@@ -92,8 +89,6 @@ func statsCmd(c *cliconfig.StatsValues) error {
 
 	if ctr > 1 {
 		return errors.Errorf("--all, --latest and containers cannot be used together")
-	} else if ctr == 0 {
-		return errors.Errorf("you must specify --all, --latest, or at least one container")
 	}
 
 	runtime, err := libpodruntime.GetRuntime(getContext(), &c.PodmanCommand)

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -11,6 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// TODO: we need to check the output. Currently, we only check the exit codes
+// which is not enough.
 var _ = Describe("Podman stats", func() {
 	var (
 		tempdir    string
@@ -57,6 +59,15 @@ var _ = Describe("Podman stats", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 		session = podmanTest.Podman([]string{"stats", "--no-stream", "-a"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
+
+	It("podman stats on all running containers", func() {
+		session := podmanTest.RunTopContainer("")
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"stats", "--no-stream"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -55,9 +55,11 @@ function check_help() {
 
         # If usage has required arguments, try running without them
         if expr "$usage" : '.*\[flags\] [A-Z]' >/dev/null; then
-            dprint "podman $@ $cmd (without required args)"
-            run_podman 125 "$@" $cmd
-            is "$output" "Error:"
+            if [ "$cmd" != "stats"]; then
+                dprint "podman $@ $cmd (without required args)"
+                run_podman 125 "$@" $cmd
+                is "$output" "Error:"
+            fi
         fi
 
         count=$(expr $count + 1)


### PR DESCRIPTION
Unless specified otherwise by --all, --latest or via arguments, list all
running containers.  This matches the behaviour of Docker and is also
illustrated in the man pages where containers and options are marked to
be optional.

Fixes: #4274
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>