### PR TITLE
System tests: make sure exec pid hash w/o leaking

### DIFF
--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -29,4 +29,24 @@ load helpers
     run_podman rm $cid
 }
 
+@test "podman exec - leak check" {
+    skip_if_remote
+
+    # Start a container in the background then run exec command
+    # three times and make sure no any exec pid hash file leak
+    run_podman run -td $IMAGE /bin/sh
+    cid="$output"
+
+    is "$(check_exec_pid)" "" "exec pid hash file indeed doesn't exist"
+
+    for i in {1..3}; do
+        run_podman exec $cid /bin/true
+    done
+
+    is "$(check_exec_pid)" "" "there isn't any exec pid hash file leak"
+
+    run_podman stop --time 1 $cid
+    run_podman rm -f $cid
+}
+
 # vim: filetype=sh

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -373,5 +373,19 @@ function random_string() {
     head /dev/urandom | tr -dc a-zA-Z0-9 | head -c$length
 }
 
+
+#########################
+#  find_exec_pid_files  #  Returns nothing or exec_pid hash files
+#########################
+#
+# Return exec_pid hash files if exists, otherwise, return nothing
+#
+function find_exec_pid_files() {
+    run_podman info --format '{{.store.RunRoot}}'
+    local storage_path="$output"
+    if [ -d $storage_path ]; then
+        find $storage_path -type f -iname 'exec_pid_*'
+    fi
+}
 # END   miscellaneous tools
 ###############################################################################


### PR DESCRIPTION
this test case is used for covering rhbz#1731117.

bats -f "podman exec - leak check" test/system/075-exec.bats                                                      
 ✓ podman exec - leak check

1 test, 0 failures

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>