### PR TITLE
Show volume options in 'volume inspect'

### DIFF
--- a/API.md
+++ b/API.md
@@ -107,6 +107,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func InspectPod(name: string) string](#InspectPod)
 
+[func InspectVolume(name: string) string](#InspectVolume)
+
 [func KillContainer(name: string, signal: int) string](#KillContainer)
 
 [func KillPod(name: string, signal: int) string](#KillPod)
@@ -804,6 +806,12 @@ method InspectPod(name: [string](https://godoc.org/builtin#string)) [string](htt
 InspectPod takes the name or ID of an image and returns a string representation of data associated with the
 pod.  You must serialize the string into JSON to use it further.  A [PodNotFound](#PodNotFound) error will
 be returned if the pod cannot be found.
+### <a name="InspectVolume"></a>func InspectVolume
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method InspectVolume(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+InspectVolume inspects a single volume. Returns inspect JSON in the form of a
+string.
 ### <a name="KillContainer"></a>func KillContainer
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -1268,6 +1268,10 @@ method VolumeRemove(options: VolumeRemoveOpts) -> (successes: []string, failures
 # GetVolumes gets slice of the volumes on a remote host
 method GetVolumes(args: []string, all: bool) -> (volumes: []Volume)
 
+# InspectVolume inspects a single volume. Returns inspect JSON in the form of a
+# string.
+method InspectVolume(name: string) -> (volume: string)
+
 # VolumesPrune removes unused volumes on the host
 method VolumesPrune() -> (prunedNames: []string, prunedErrors: []string)
 

--- a/libpod/volume_inspect.go
+++ b/libpod/volume_inspect.go
@@ -62,6 +62,9 @@ func (v *Volume) Inspect() (*InspectVolumeData, error) {
 	}
 	data.Scope = v.Scope()
 	data.Options = make(map[string]string)
+	for k, v := range v.config.Options {
+		data.Options[k] = v
+	}
 	data.UID = v.config.UID
 	data.GID = v.config.GID
 	data.ContainerSpecific = v.config.IsCtrSpecific

--- a/pkg/varlinkapi/volumes.go
+++ b/pkg/varlinkapi/volumes.go
@@ -3,6 +3,8 @@
 package varlinkapi
 
 import (
+	"encoding/json"
+
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/cmd/podman/varlink"
 	"github.com/containers/libpod/libpod"
@@ -78,6 +80,23 @@ func (i *LibpodAPI) GetVolumes(call iopodman.VarlinkCall, args []string, all boo
 		volumes = append(volumes, newVol)
 	}
 	return call.ReplyGetVolumes(volumes)
+}
+
+// InspectVolume inspects a single volume, returning its JSON as a string.
+func (i *LibpodAPI) InspectVolume(call iopodman.VarlinkCall, name string) error {
+	vol, err := i.Runtime.LookupVolume(name)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	inspectOut, err := vol.Inspect()
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	inspectJSON, err := json.Marshal(inspectOut)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	return call.ReplyInspectVolume(string(inspectJSON))
 }
 
 // VolumesPrune removes unused images via a varlink call

--- a/test/e2e/volume_inspect_test.go
+++ b/test/e2e/volume_inspect_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"os"
+	"strings"
 
 	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
@@ -73,5 +74,17 @@ var _ = Describe("Podman volume inspect", func() {
 		Expect(len(session.OutputToStringArray())).To(Equal(2))
 		Expect(session.OutputToStringArray()[0]).To(Equal(volName1))
 		Expect(session.OutputToStringArray()[1]).To(Equal(volName2))
+	})
+
+	It("inspect volume finds options", func() {
+		volName := "testvol"
+		session := podmanTest.Podman([]string{"volume", "create", "--opt", "type=tmpfs", volName})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"volume", "inspect", volName})
+		inspect.WaitWithDefaultTimeout()
+		Expect(inspect.ExitCode()).To(Equal(0))
+		Expect(strings.Contains(inspect.OutputToString(), "tmpfs")).To(BeTrue())
 	})
 })


### PR DESCRIPTION
We initialized the map to show them, but didn't actually copy them in, so they weren't being displayed.