### PR TITLE
check existing bridge names when creating networks

### DIFF
--- a/pkg/network/devices.go
+++ b/pkg/network/devices.go
@@ -24,19 +24,26 @@ func GetFreeDeviceName() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	bridgeNames, err := GetBridgeNamesFromFileSystem()
+	if err != nil {
+		return "", err
+	}
 	for {
 		deviceName = fmt.Sprintf("%s%d", CNIDeviceName, deviceNum)
-		logrus.Debugf("checking if device name %s exists in other cni networks", deviceName)
+		logrus.Debugf("checking if device name %q exists in other cni networks", deviceName)
 		if util.StringInSlice(deviceName, networkNames) {
 			deviceNum++
 			continue
 		}
-		logrus.Debugf("checking if device name %s exists in live networks", deviceName)
-		if !util.StringInSlice(deviceName, liveNetworksNames) {
+		logrus.Debugf("checking if device name %q exists in live networks", deviceName)
+		if util.StringInSlice(deviceName, liveNetworksNames) {
+			deviceNum++
+			continue
+		}
+		logrus.Debugf("checking if device name %q already exists as a bridge name ", deviceName)
+		if !util.StringInSlice(deviceName, bridgeNames) {
 			break
 		}
-		// TODO Still need to check the bridge names for a conflict but I dont know
-		// how to get them yet!
 		deviceNum++
 	}
 	return deviceName, nil

--- a/pkg/network/files.go
+++ b/pkg/network/files.go
@@ -129,3 +129,29 @@ func GetInterfaceNameFromConfig(path string) (string, error) {
 	}
 	return name, nil
 }
+
+// GetBridgeNamesFromFileSystem is a convenience function to get all the bridge
+// names from the configured networks
+func GetBridgeNamesFromFileSystem() ([]string, error) {
+	var bridgeNames []string
+	networks, err := LoadCNIConfsFromDir(CNIConfigDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, n := range networks {
+		var name string
+		// iterate network conflists
+		for _, cniplugin := range n.Plugins {
+			// iterate plugins
+			if cniplugin.Network.Type == "bridge" {
+				plugin := make(map[string]interface{})
+				if err := json.Unmarshal(cniplugin.Bytes, &plugin); err != nil {
+					continue
+				}
+				name = plugin["bridge"].(string)
+			}
+		}
+		bridgeNames = append(bridgeNames, name)
+	}
+	return bridgeNames, nil
+}


### PR DESCRIPTION
when creating a new networking, we should check existing networks for
their bridge names and make sure the proposed new name is not part of
this. reported by QE.

Signed-off-by: baude <bbaude@redhat.com>