### PR TITLE
Wait for `mount` command to finish when mounting volume

### DIFF
--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -364,4 +364,15 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(Not(ContainSubstring("noexec")))
 	})
+
+	It("podman mount with invalid option fails", func() {
+		volName := "testVol"
+		volCreate := podmanTest.Podman([]string{"volume", "create", "--opt", "type=tmpfs", "--opt", "device=tmpfs", "--opt", "o=invalid", volName})
+		volCreate.WaitWithDefaultTimeout()
+		Expect(volCreate.ExitCode()).To(Equal(0))
+
+		volMount := podmanTest.Podman([]string{"run", "--rm", "-v", fmt.Sprintf("%s:/tmp", volName), ALPINE, "ls"})
+		volMount.WaitWithDefaultTimeout()
+		Expect(volMount.ExitCode()).To(Not(Equal(0)))
+	})
 })


### PR DESCRIPTION
command.Start() just starts the command. That catches some errors, but the nasty ones - bad options and similar - happen when the command runs. Use CombinedOutput() instead - it waits for the command to exit, and thus catches non-0 exit of the `mount` command (invalid options, for  example).

STDERR from the `mount` command is directly used, which isn't necessarily the best, but we can't really get much more info on what went wrong.

Fixes #4303