### PR TITLE
Add Kata Containers runtimes to libpod.conf

### DIFF
--- a/libpod.conf
+++ b/libpod.conf
@@ -146,6 +146,29 @@ crun = [
 	    "/usr/local/bin/crun",
 ]
 
+# Kata Containers is an OCI runtime, where containers are run inside lightweight
+# Virtual Machines (VMs). Kata provides additional isolation towards the host,
+# minimizing the host attack surface and mitigating the consequences of
+# containers breakout.
+# Please notes that Kata does not support rootless podman yet, but we can leave
+# the paths below blank to let them be discovered by the $PATH environment
+# variable.
+
+# Kata Containers with the default configured VMM
+kata-runtime = [
+    "/usr/bin/kata-runtime",
+]
+
+# Kata Containers with the QEMU VMM
+kata-qemu = [
+    "/usr/bin/kata-qemu",
+]
+
+# Kata Containers with the Firecracker VMM
+kata-fc = [
+    "/usr/bin/kata-fc",
+]
+
 # The [runtimes] table MUST be the last thing in this file.
 # (Unless another table is added)
 # TOML does not provide a way to end a table other than a further table being


### PR DESCRIPTION
This adds the Kata Containers runtimes to the libpod.conf and adds
additional documentation to it.

Note: openSUSE Tumbleweed packages Kata where it works out of the box if the recommended packages got installed, too. If you want, then I could add instructions to the README how to setup podman together with Kata as a follow up, but I'm not sure which other distributions work as well. Maybe some of the Red Hat maintained ones?