### PR TITLE
rootless: write storage overrides to the conf file

### DIFF
--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -528,6 +528,17 @@ func newRuntimeFromConfig(ctx context.Context, userConfigPath string, options ..
 		return nil, err
 	}
 
+	// storage.conf
+	storageConfFile, err := storage.DefaultConfigFile(rootless.IsRootless())
+	if err != nil {
+		return nil, err
+	}
+
+	createStorageConfFile := false
+	if _, err := os.Stat(storageConfFile); os.IsNotExist(err) {
+		createStorageConfFile = true
+	}
+
 	defRunConf, err := defaultRuntimeConfig()
 	if err != nil {
 		return nil, err
@@ -702,27 +713,21 @@ func newRuntimeFromConfig(ctx context.Context, userConfigPath string, options ..
 	}
 
 	if rootless.IsRootless() && configPath == "" {
-		configPath, err := getRootlessConfigPath()
-		if err != nil {
-			return nil, err
-		}
-
-		// storage.conf
-		storageConfFile, err := storage.DefaultConfigFile(rootless.IsRootless())
-		if err != nil {
-			return nil, err
-		}
-		if _, err := os.Stat(storageConfFile); os.IsNotExist(err) {
+		if createStorageConfFile {
 			if err := util.WriteStorageConfigFile(&runtime.config.StorageConfig, storageConfFile); err != nil {
 				return nil, errors.Wrapf(err, "cannot write config file %s", storageConfFile)
 			}
 		}
 
+		configPath, err := getRootlessConfigPath()
+		if err != nil {
+			return nil, err
+		}
 		if configPath != "" {
-			if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(configPath), 0711); err != nil {
 				return nil, err
 			}
-			file, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+			file, err := os.OpenFile(configPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
 			if err != nil && !os.IsExist(err) {
 				return nil, errors.Wrapf(err, "cannot open file %s", configPath)
 			}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -318,7 +318,7 @@ func WriteStorageConfigFile(storageOpts *storage.StoreOptions, storageConf strin
 	if err := os.MkdirAll(filepath.Dir(storageConf), 0755); err != nil {
 		return err
 	}
-	storageFile, err := os.OpenFile(storageConf, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
+	storageFile, err := os.OpenFile(storageConf, os.O_RDWR|os.O_TRUNC, 0600)
 	if err != nil {
 		return errors.Wrapf(err, "cannot open %s", storageConf)
 	}


### PR DESCRIPTION
make sure the user overrides are stored in the configuration file when
first created.

Closes: https://github.com/containers/libpod/issues/2659

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>