### PR TITLE
Cirrus: Only upload tagged releases

### DIFF
--- a/contrib/cirrus/upload_release_archive.sh
+++ b/contrib/cirrus/upload_release_archive.sh
@@ -17,8 +17,15 @@ then
     BUCKET="libpod-pr-releases"
 elif [[ -n "$CIRRUS_BRANCH" ]]
 then
-    PR_OR_BRANCH="$CIRRUS_BRANCH"
-    BUCKET="libpod-$CIRRUS_BRANCH-releases"
+    # Only release non-development tagged commit ranges
+    if is_release
+    then
+        PR_OR_BRANCH="$CIRRUS_BRANCH"
+        BUCKET="libpod-$CIRRUS_BRANCH-releases"
+    else
+        warn "" "Skipping release processing: Commit range|CIRRUS_TAG is development tagged."
+        exit 0
+    fi
 else
     die 1 "Expecting either \$CIRRUS_PR or \$CIRRUS_BRANCH to be non-empty."
 fi
@@ -63,6 +70,10 @@ do
     then
         echo "Warning: Not processing $filename (invalid extension '$EXT')"
         continue
+    fi
+    if [[ "$EXT" =~ "gz" ]]
+    then
+        EXT="tar.gz"
     fi
 
     [[ "$OS_RELEASE_ID" == "ubuntu" ]] || \


### PR DESCRIPTION
Prior to this commit, every push to master had it's builds packaged and
uploaded to google storage.  This is a waste, since potential users
are only ever concerned about tagged releases.

Unfortunately because the release process involves humans with
potentially multiple human and automation steps happening in parallel,
it's easy for automation to not detect a tagged release, or trigger on
development|pre-release tags.

Fix this in `upload_release_archive.sh` using a new unit-tested
function `is_release()`.  This acts as the definitive authority
on whether or not a specific commit rage or `$CIRRUS_TAG` value
constitutes something worthy of upload.

Also, when release files are uploaded for a branch, announce all
the URLs on IRC for monitoring purposes.

Signed-off-by: Chris Evich <cevich@redhat.com>