### PR TITLE
add pip requirements file for rtd

### DIFF
--- a/docs/rtd/requirements.txt
+++ b/docs/rtd/requirements.txt
@@ -1,0 +1,4 @@
+# requirements file for readthedocs pip installs
+
+# use md instead of rst
+recommonmark


### PR DESCRIPTION
read the docs requires a pip requirements file to build markdown files
instead of the rst format.

Signed-off-by: baude <bbaude@redhat.com>