### PR TITLE
Image volumes should not be mounted noexec

### DIFF
--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -738,13 +738,13 @@ func (config *CreateConfig) getImageVolumes() (map[string]spec.Mount, map[string
 				Destination: cleanDest,
 				Source:      TypeTmpfs,
 				Type:        TypeTmpfs,
-				Options:     []string{"rprivate", "rw", "nodev"},
+				Options:     []string{"rprivate", "rw", "nodev", "exec"},
 			}
 			mounts[vol] = mount
 		} else {
 			// Anonymous volumes have no name.
 			namedVolume := new(libpod.ContainerNamedVolume)
-			namedVolume.Options = []string{"rprivate", "rw", "nodev"}
+			namedVolume.Options = []string{"rprivate", "rw", "nodev", "exec"}
 			namedVolume.Dest = cleanDest
 			volumes[vol] = namedVolume
 		}

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -357,4 +357,11 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(len(arr2)).To(Equal(1))
 		Expect(arr2[0]).To(Equal(volName))
 	})
+
+	It("podman run image volume is not noexec", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", redis, "grep", "/data", "/proc/self/mountinfo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Not(ContainSubstring("noexec")))
+	})
 })


### PR DESCRIPTION
This matches Docker more closely, but retains the more important protections of nosuid/nodev.

Fixes #4318