### PR TITLE
Return a better error for volume name conflicts

### DIFF
--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -48,6 +48,15 @@ func (r *Runtime) newVolume(ctx context.Context, options ...VolumeCreateOption) 
 	}
 	volume.config.CreatedTime = time.Now()
 
+	// Check if volume with given name exists.
+	exists, err := r.state.HasVolume(volume.config.Name)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error checking if volume with name %s exists", volume.config.Name)
+	}
+	if exists {
+		return nil, errors.Wrapf(define.ErrVolumeExists, "volume with name %s already exists", volume.config.Name)
+	}
+
 	if volume.config.Driver == define.VolumeDriverLocal {
 		logrus.Debugf("Validating options for local driver")
 		// Validate options


### PR DESCRIPTION
When you try and create a new volume with the name of a volume that already exists, you presently get a thoroughly unhelpful error from `mkdir` as the volume attempts to create the directory it will be mounted at. An EEXIST out of mkdir is not particularly helpful to Podman users - it doesn't explain that the name is already taken by another volume.

The solution here is potentially racy as the runtime is not locked, so someone else could take the name while we're still getting things set up, but that's a narrow timing window, and we will still return an error - just an error that's not as good as this one.