### PR TITLE
Create tests for attaching network from rootless container

### DIFF
--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -21,6 +21,12 @@ func SkipIfRootless() {
 	}
 }
 
+func SkipIfRoot() {
+	if os.Geteuid() == 0 {
+		ginkgo.Skip("This function is not enabled for root podman")
+	}
+}
+
 // Podman is the exec call to podman on the filesystem
 func (p *PodmanTestIntegration) Podman(args []string) *PodmanSessionIntegration {
 	podmanSession := p.PodmanBase(args, false, false)


### PR DESCRIPTION
Related to #4333 and issue #4332 
Check that rootless containers can't attach network, fail and give an appropriate message
Need #4333 to be merged