### PR TITLE
systemd: mask /sys/fs/cgroup/systemd/release_agent

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -550,6 +550,7 @@ func (c *Container) setupSystemd(mounts []spec.Mount, g generate.Generator) erro
 			Options:     []string{"bind", "nodev", "noexec", "nosuid"},
 		}
 		g.AddMount(systemdMnt)
+		g.AddLinuxMaskedPaths("/sys/fs/cgroup/systemd/release_agent")
 	}
 
 	return nil


### PR DESCRIPTION
when running in systemd mode on cgroups v1, make sure the
/sys/fs/cgroup/systemd/release_agent is masked otherwise the container
is able to modify it and execute scripts on the host.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>