### PR TITLE
Log warn instead of error for removing nonexistant container

### DIFF
--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -438,7 +438,11 @@ func (r *LocalRuntime) Run(ctx context.Context, c *cliconfig.RunValues, exitCode
 
 	if c.IsSet("rm") {
 		if err := r.Runtime.RemoveContainer(ctx, ctr, false, true); err != nil {
-			logrus.Errorf("Error removing container %s: %v", ctr.ID(), err)
+			if errors.Cause(err) == define.ErrNoSuchCtr {
+				logrus.Warnf("Container %s does not exist: %v", ctr.ID(), err)
+			} else {
+				logrus.Errorf("Error removing container %s: %v", ctr.ID(), err)
+			}
 		}
 	}
 


### PR DESCRIPTION
In event of a container removal that is no longer in database, log a
warning instead of an error, as there is not any problem continuing
execution.

Resolves #4314 

Signed-off-by: Tyler Ramer <tyaramer@gmail.com>

---
Unfortunately, I can't reproduce the race condition causing the error on my build VM, but this should be the solution.