### PR TITLE
Add ensureState helper for checking container state

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1185,3 +1185,12 @@ func (c *Container) HasHealthCheck() bool {
 func (c *Container) HealthCheckConfig() *manifest.Schema2HealthConfig {
 	return c.config.HealthCheckConfig
 }
+
+// AutoRemove indicates whether the container will be removed after it is executed
+func (c *Container) AutoRemove() bool {
+	spec := c.config.Spec
+	if spec.Annotations == nil {
+		return false
+	}
+	return c.Spec().Annotations[InspectAnnotationAutoremove] == InspectResponseTrue
+}


### PR DESCRIPTION
We have a lot of checks for container state scattered throughout libpod. Many of these need to ensure the container is in one of a given set of states so an operation may safely proceed.
Previously there was no set way of doing this, so we'd use unique boolean logic for each one. Introduce a helper to standardize state checks.

Note that this is only intended to replace checks for multiple states. A simple check for one state (ContainerStateRunning, for example) should remain a straight equality, and not use this new helper.