### PR TITLE
Set SELinux labels based on the security context in the kube.yaml

### DIFF
--- a/libpod/util.go
+++ b/libpod/util.go
@@ -187,6 +187,9 @@ func programVersion(mountProgram string) (string, error) {
 	return strings.TrimSuffix(output, "\n"), nil
 }
 
+// DefaultSeccompPath returns the path to the default seccomp.json file
+// if it exists, first it checks OverrideSeccomp and then default.
+// If neither exist function returns ""
 func DefaultSeccompPath() (string, error) {
 	_, err := os.Stat(config.SeccompOverridePath)
 	if err == nil {

--- a/pkg/adapter/pods.go
+++ b/pkg/adapter/pods.go
@@ -704,6 +704,24 @@ func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container
 			}
 
 		}
+		if seopt := containerYAML.SecurityContext.SELinuxOptions; seopt != nil {
+			if seopt.User != "" {
+				containerConfig.SecurityOpts = append(containerConfig.SecurityOpts, fmt.Sprintf("label=user:%s", seopt.User))
+				containerConfig.LabelOpts = append(containerConfig.LabelOpts, fmt.Sprintf("user:%s", seopt.User))
+			}
+			if seopt.Role != "" {
+				containerConfig.SecurityOpts = append(containerConfig.SecurityOpts, fmt.Sprintf("label=role:%s", seopt.Role))
+				containerConfig.LabelOpts = append(containerConfig.LabelOpts, fmt.Sprintf("role:%s", seopt.Role))
+			}
+			if seopt.Type != "" {
+				containerConfig.SecurityOpts = append(containerConfig.SecurityOpts, fmt.Sprintf("label=type:%s", seopt.Type))
+				containerConfig.LabelOpts = append(containerConfig.LabelOpts, fmt.Sprintf("type:%s", seopt.Type))
+			}
+			if seopt.Level != "" {
+				containerConfig.SecurityOpts = append(containerConfig.SecurityOpts, fmt.Sprintf("label=level:%s", seopt.Level))
+				containerConfig.LabelOpts = append(containerConfig.LabelOpts, fmt.Sprintf("level:%s", seopt.Level))
+			}
+		}
 		if caps := containerYAML.SecurityContext.Capabilities; caps != nil {
 			for _, capability := range caps.Add {
 				containerConfig.CapAdd = append(containerConfig.CapAdd, string(capability))

--- a/test/e2e/test.yaml
+++ b/test/e2e/test.yaml
@@ -1,0 +1,34 @@
+# Save the output of this file and use kubectl create -f to import
+# it into Kubernetes.
+#
+# Created with podman-1.6.2
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: test
+  name: test
+spec:
+  containers:
+  - command:
+    - sleep
+    - "100"
+    env:
+    - name: PATH
+      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    - name: TERM
+      value: xterm
+    - name: container
+      value: podman
+    image: docker.io/library/fedora:latest
+    name: test
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities: {}
+      privileged: false
+      seLinuxOptions:
+	  level: "s0:c1,c2"
+      readOnlyRootFilesystem: false
+    workingDir: /
+status: {}


### PR DESCRIPTION
If the kube.yaml specifieds the SELinux type or Level, we need the container
to be launched with the correct label.


Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>