### PR TITLE
Processes execed into container should match container label

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1023,8 +1023,8 @@ func prepareProcessExec(c *Container, cmd, env []string, tty bool, cwd, user, se
 	if err != nil {
 		return nil, err
 	}
-
 	pspec := c.config.Spec.Process
+	pspec.SelinuxLabel = c.config.ProcessLabel
 	pspec.Args = cmd
 	// We need to default this to false else it will inherit terminal as true
 	// from the container.

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -243,4 +243,5 @@ var _ = Describe("Podman exec", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
+
 })

--- a/test/e2e/run_selinux_test.go
+++ b/test/e2e/run_selinux_test.go
@@ -165,4 +165,16 @@ var _ = Describe("Podman run", func() {
 		Expect(session.ExitCode()).To(Equal(126))
 	})
 
+	It("podman exec selinux check", func() {
+		setup := podmanTest.RunTopContainer("test1")
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"exec", "test1", "cat", "/proc/self/attr/current"})
+		session.WaitWithDefaultTimeout()
+		session1 := podmanTest.Podman([]string{"exec", "test1", "cat", "/proc/self/attr/current"})
+		session1.WaitWithDefaultTimeout()
+		Expect(session.OutputToString()).To(Equal(session1.OutputToString()))
+	})
+
 })


### PR DESCRIPTION
Processes execed into a container were not being run with the correct label.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>