### PR TITLE
namespaces: by default create cgroupns on cgroups v2

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -132,7 +132,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"Drop capabilities from the container",
 	)
 	createFlags.String(
-		"cgroupns", "host",
+		"cgroupns", "",
 		"cgroup namespace to use",
 	)
 	createFlags.String(

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -67,11 +67,13 @@ Drop Linux capabilities
 
 **--cgroupns**=*mode*
 
-Set the cgroup namespace mode for the container, by default **host** is used.
+Set the cgroup namespace mode for the container.
     **host**: use the host's cgroup namespace inside the container.
     **container:<NAME|ID>**: join the namespace of the specified container.
     **private**: create a new cgroup namespace.
     **ns:<PATH>**: join the namespace at the specified path.
+
+If the host uses cgroups v1, the default is set to **host**.  On cgroups v2 the default is **private**.
 
 **--cgroups**=*mode*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -81,11 +81,13 @@ Drop Linux capabilities
 
 **--cgroupns**=*mode*
 
-Set the cgroup namespace mode for the container, by default **host** is used.
+Set the cgroup namespace mode for the container.
     **host**: use the host's cgroup namespace inside the container.
     **container:<NAME|ID>**: join the namespace of the specified container.
     **private**: create a new cgroup namespace.
     **ns:<PATH>**: join the namespace at the specified path.
+
+If the host uses cgroups v1, the default is set to **host**.  On cgroups v2 the default is **private**.
 
 **--cgroups**=*mode*
 

--- a/pkg/namespaces/namespaces.go
+++ b/pkg/namespaces/namespaces.go
@@ -25,6 +25,11 @@ func (n CgroupMode) IsHost() bool {
 	return n == hostType
 }
 
+// IsDefaultValue indicates whether the cgroup namespace has the default value.
+func (n CgroupMode) IsDefaultValue() bool {
+	return n == ""
+}
+
 // IsNS indicates a cgroup namespace passed in by path (ns:<path>)
 func (n CgroupMode) IsNS() bool {
 	return strings.HasPrefix(string(n), nsType)

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -631,6 +631,19 @@ func addIpcNS(config *CreateConfig, g *generate.Generator) error {
 
 func addCgroupNS(config *CreateConfig, g *generate.Generator) error {
 	cgroupMode := config.CgroupMode
+
+	if cgroupMode.IsDefaultValue() {
+		// If the value is not specified, default to "private" on cgroups v2 and "host" on cgroups v1.
+		unified, err := cgroups.IsCgroup2UnifiedMode()
+		if err != nil {
+			return err
+		}
+		if unified {
+			cgroupMode = "private"
+		} else {
+			cgroupMode = "host"
+		}
+	}
 	if cgroupMode.IsNS() {
 		return g.AddOrReplaceLinuxNamespace(string(spec.CgroupNamespace), NS(string(cgroupMode)))
 	}

--- a/test/e2e/run_cgroup_parent_test.go
+++ b/test/e2e/run_cgroup_parent_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 			Skip("Must be containerized to run this test.")
 		}
 		cgroup := "/zzz"
-		run := podmanTest.Podman([]string{"run", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/self/cgroup"})
+		run := podmanTest.Podman([]string{"run", "--cgroupns=host", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/self/cgroup"})
 		run.WaitWithDefaultTimeout()
 		Expect(run.ExitCode()).To(Equal(0))
 		ok, _ := run.GrepString(cgroup)
@@ -52,7 +52,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 		if !Containerized() && podmanTest.CgroupManager != "cgroupfs" {
 			cgroup = "/machine.slice"
 		}
-		run := podmanTest.Podman([]string{"run", fedoraMinimal, "cat", "/proc/self/cgroup"})
+		run := podmanTest.Podman([]string{"run", "--cgroupns=host", fedoraMinimal, "cat", "/proc/self/cgroup"})
 		run.WaitWithDefaultTimeout()
 		Expect(run.ExitCode()).To(Equal(0))
 		ok, _ := run.GrepString(cgroup)
@@ -64,7 +64,7 @@ var _ = Describe("Podman run with --cgroup-parent", func() {
 			Skip("Requires Systemd cgroup manager support")
 		}
 		cgroup := "aaaa.slice"
-		run := podmanTest.Podman([]string{"run", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/1/cgroup"})
+		run := podmanTest.Podman([]string{"run", "--cgroupns=host", "--cgroup-parent", cgroup, fedoraMinimal, "cat", "/proc/1/cgroup"})
 		run.WaitWithDefaultTimeout()
 		Expect(run.ExitCode()).To(Equal(0))
 		ok, _ := run.GrepString(cgroup)


### PR DESCRIPTION
change the default on cgroups v2 and create a new cgroup namespace.

When a cgroup namespace is used, processes inside the namespace are
only able to see cgroup paths relative to the cgroup namespace root
and not have full visibility on all the cgroups present on the
system.

The previous behaviour is maintained on a cgroups v1 host, where a
cgroup namespace is not created by default.

Closes: https://github.com/containers/libpod/issues/4363

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>