### PR TITLE
stale action: add exempt-issue-label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,4 +22,5 @@ jobs:
         stale-pr-label: 'stale-pr'
         days-before-stale: 30
         days-before-close: 7
+        exempt-issue-label: 'do-not-close'
         exempt-pr-label: 'do-not-close'


### PR DESCRIPTION
Without the label, issues would be closed regardless of the
"do-not-close" label.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>