### PR TITLE
build: drop support for ostree

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@
 run:
   build-tags:
     - apparmor
-    - ostree
     - seccomp
     - selinux
   concurrency: 6

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get install -y \
     libfuse-dev \
     libnet-dev \
     libnl-3-dev \
-    libostree-dev \
     libprotobuf-dev \
     libprotobuf-c-dev \
     libseccomp2 \

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -22,7 +22,6 @@ RUN yum -y install btrfs-progs-devel \
               containers-common \
               runc \
               make \
-              ostree-devel \
               lsof \
               which\
               golang-github-cpuguy83-go-md2man \

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -22,7 +22,6 @@ RUN dnf -y install btrfs-progs-devel \
               containers-common \
               runc \
               make \
-              ostree-devel \
               lsof \
               which\
               golang-github-cpuguy83-go-md2man \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ BUILDTAGS ?= \
 	$(shell hack/apparmor_tag.sh) \
 	$(shell hack/btrfs_installed_tag.sh) \
 	$(shell hack/btrfs_tag.sh) \
-	$(shell hack/ostree_tag.sh) \
 	$(shell hack/selinux_tag.sh) \
 	$(shell hack/systemd_tag.sh) \
 	exclude_graphdriver_devicemapper \
@@ -46,7 +45,7 @@ $(warning \
 	Install libsystemd for journald support)
 endif
 
-BUILDTAGS_CROSS ?= containers_image_openpgp containers_image_ostree_stub exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay
+BUILDTAGS_CROSS ?= containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay
 ifneq (,$(findstring varlink,$(BUILDTAGS)))
 	PODMAN_VARLINK_DEPENDENCIES = cmd/podman/varlink/iopodman.go
 endif
@@ -156,7 +155,7 @@ gofmt: ## Verify the source code gofmt
 	git diff --exit-code
 
 test/checkseccomp/checkseccomp: .gopathok $(wildcard test/checkseccomp/*.go)
-	$(GO_BUILD) -ldflags '$(LDFLAGS)' -tags "$(BUILDTAGS) containers_image_ostree_stub" -o $@ $(PROJECT)/test/checkseccomp
+	$(GO_BUILD) -ldflags '$(LDFLAGS)' -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/checkseccomp
 
 test/goecho/goecho: .gopathok $(wildcard test/goecho/*.go)
 	$(GO_BUILD) -ldflags '$(LDFLAGS)' -o $@ $(PROJECT)/test/goecho
@@ -493,14 +492,6 @@ endef
 		   $(call go-get,github.com/cpuguy83/go-md2man); \
 	fi
 
-.install.ostree: .gopathok
-	if ! pkg-config ostree-1 2> /dev/null ; then \
-		git clone https://github.com/ostreedev/ostree $(FIRST_GOPATH)/src/github.com/ostreedev/ostree ; \
-		cd $(FIRST_GOPATH)src/github.com/ostreedev/ostree ; \
-		./autogen.sh --prefix=/usr/local; \
-		make all install; \
-	fi
-
 varlink_generate: .gopathok cmd/podman/varlink/iopodman.go ## Generate varlink
 varlink_api_generate: .gopathok API.md
 
@@ -528,7 +519,7 @@ build-all-new-commits:
 	git rebase $(GIT_BASE_BRANCH) -x make
 
 build-no-cgo:
-	env BUILDTAGS="containers_image_openpgp containers_image_ostree_stub exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_disk_quota" CGO_ENABLED=0 $(MAKE)
+	env BUILDTAGS="containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_disk_quota" CGO_ENABLED=0 $(MAKE)
 
 vendor:
 	export GO111MODULE=on \

--- a/contrib/build_rpm.sh
+++ b/contrib/build_rpm.sh
@@ -28,7 +28,6 @@ declare -a PKGS=(device-mapper-devel \
                 libseccomp-devel \
                 libselinux-devel \
                 make \
-                ostree-devel \
                 golang-github-cpuguy83-go-md2man \
                 rpm-build \
                 btrfs-progs-devel \

--- a/contrib/cirrus/container_test.sh
+++ b/contrib/cirrus/container_test.sh
@@ -89,7 +89,7 @@ if [ "${CONTAINER_RUNTIME}" == "none" ]; then
 fi
 
 
-export TAGS="seccomp $($GOSRC/hack/btrfs_tag.sh) $($GOSRC/hack/libdm_tag.sh) $($GOSRC/hack/btrfs_installed_tag.sh) $($GOSRC/hack/ostree_tag.sh) $($GOSRC/hack/selinux_tag.sh)"
+export TAGS="seccomp $($GOSRC/hack/btrfs_tag.sh) $($GOSRC/hack/libdm_tag.sh) $($GOSRC/hack/btrfs_installed_tag.sh) $($GOSRC/hack/selinux_tag.sh)"
 
 # Validate
 if [ $validate -eq 1 ]; then

--- a/contrib/cirrus/packer/fedora_setup.sh
+++ b/contrib/cirrus/packer/fedora_setup.sh
@@ -69,8 +69,6 @@ ooe.sh sudo dnf install -y \
     make \
     msitools \
     nmap-ncat \
-    ostree \
-    ostree-devel \
     pandoc \
     podman \
     procps-ng \

--- a/contrib/cirrus/packer/ubuntu_setup.sh
+++ b/contrib/cirrus/packer/ubuntu_setup.sh
@@ -83,7 +83,6 @@ $BIGTO $SUDOAPTGET install \
     libnet1 \
     libnet1-dev \
     libnl-3-dev \
-    libostree-dev \
     libvarlink \
     libprotobuf-c-dev \
     libprotobuf-dev \

--- a/contrib/gate/Dockerfile
+++ b/contrib/gate/Dockerfile
@@ -19,7 +19,6 @@ RUN dnf -y install \
       lsof \
       make \
       nmap-ncat \
-      ostree-devel \
       procps-ng \
       python \
       python3-dateutil \

--- a/contrib/podmanimage/upstream/Dockerfile
+++ b/contrib/podmanimage/upstream/Dockerfile
@@ -36,7 +36,6 @@ RUN dnf -y install --exclude container-selinux \
      libseccomp-devel \
      libselinux-devel \
      make \
-     ostree-devel \
      pkgconfig \
      runc \
      fuse-overlayfs \

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -63,7 +63,6 @@ BuildRequires: libassuan-devel
 BuildRequires: libgpg-error-devel
 BuildRequires: libseccomp-devel
 BuildRequires: libselinux-devel
-BuildRequires: ostree-devel
 BuildRequires: pkgconfig
 BuildRequires: make
 BuildRequires: systemd-devel
@@ -139,7 +138,6 @@ Provides: bundled(golang(github.com/opencontainers/runtime-spec)) = v1.0.0
 Provides: bundled(golang(github.com/opencontainers/runtime-tools)) = 625e2322645b151a7cbb93a8b42920933e72167f
 Provides: bundled(golang(github.com/opencontainers/selinux)) = b6fa367ed7f534f9ba25391cc2d467085dbb445a
 Provides: bundled(golang(github.com/openshift/imagebuilder)) = master
-Provides: bundled(golang(github.com/ostreedev/ostree-go)) = master
 Provides: bundled(golang(github.com/pkg/errors)) = v0.8.0
 Provides: bundled(golang(github.com/pmezard/go-difflib)) = 792786c7400a136282c1664665ae0a8db921c6c2
 Provides: bundled(golang(github.com/pquerna/ffjson)) = d49c2bc1aa135aad0c6f4fc2056623ec78f5d5ac
@@ -383,7 +381,7 @@ mkdir -p src/%{provider}.%{provider_tld}/{containers,opencontainers}
 ln -s $(dirs +1 -l) src/%{import_path_conmon}
 popd
 
-export BUILDTAGS="selinux seccomp $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh) containers_image_ostree_stub"
+export BUILDTAGS="selinux seccomp $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh)"
 BUILDTAGS=$BUILDTAGS make
 popd
 

--- a/docs/podman-pull.1.md
+++ b/docs/podman-pull.1.md
@@ -42,9 +42,6 @@ Image stored in local container/storage
   **oci-archive:**_path_**:**_tag_
   An image _tag_ in a directory compliant with "Open Container Image Layout Specification" at _path_.
 
-  **ostree:**_image_[**@**_/absolute/repo/path_]
-  An image in local OSTree repository.  _/absolute/repo/path_ defaults to _/ostree/repo_.
-
 ## OPTIONS
 
 **--all-tags**, **a**

--- a/docs/podman-push.1.md
+++ b/docs/podman-push.1.md
@@ -12,7 +12,7 @@ podman\-push - Push an image from local storage to elsewhere
 Pushes an image from local storage to a specified destination.
 Push is mainly used to push images to registries, however **podman push**
 can be used to save images to tarballs and directories using the following
-transports: **dir:**, **docker-archive:**, **docker-daemon:**, **oci-archive:**, and **ostree:**.
+transports: **dir:**, **docker-archive:**, **docker-daemon:** and **oci-archive:**.
 
 ## imageID
 Image stored in local container/storage
@@ -40,9 +40,6 @@ Image stored in local container/storage
 
   **oci-archive:**_path_**:**_tag_
   An image _tag_ in a directory compliant with "Open Container Image Layout Specification" at _path_.
-
-  **ostree:**_image_[**@**_/absolute/repo/path_]
-  An image in local OSTree repository.  _/absolute/repo/path_ defaults to _/ostree/repo_.
 
 ## OPTIONS
 

--- a/hack/ostree_tag.sh
+++ b/hack/ostree_tag.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-if ! pkg-config glib-2.0 gobject-2.0 ostree-1 libselinux 2> /dev/null ; then
-	echo containers_image_ostree_stub
-else
-	echo containers_image_ostree
-fi

--- a/install.md
+++ b/install.md
@@ -114,7 +114,6 @@ sudo yum install -y \
   libseccomp-devel \
   libselinux-devel \
   make \
-  ostree-devel \
   pkgconfig \
   runc \
   containers-common
@@ -136,7 +135,6 @@ sudo apt-get install \
   libglib2.0-dev \
   libgpgme-dev \
   libgpg-error-dev \
-  libostree-dev \
   libprotobuf-dev \
   libprotobuf-c0-dev \
   libseccomp-dev \
@@ -177,34 +175,6 @@ echo 'kernel.unprivileged_userns_clone=1' > /etc/sysctl.d/userns.conf
 
 If any dependencies cannot be installed or are not sufficiently current, they have to be built from source.
 This will mainly affect Debian, Ubuntu, and related distributions, or RHEL where no subscription is active (e.g. Cloud VMs).
-
-#### ostree
-
-A copy of the development libraries for `ostree` is necessary, either in the form of the `libostree-dev` package
-from the [flatpak](https://launchpad.net/~alexlarsson/+archive/ubuntu/flatpak) PPA,
-or built [from source](https://github.com/ostreedev/ostree/blob/master/docs/contributing-tutorial.md)
-(see also [here](https://ostree.readthedocs.io/en/latest/#building)). As of Ubuntu 18.04, `libostree-dev` is available in the main repositories,
-and the PPA is no longer required.
-
-To build, use the following (running `make` can take a while):
-```bash
-git clone https://github.com/ostreedev/ostree ~/ostree
-cd ~/ostree
-git submodule update --init
-
-# for Fedora, CentOS, RHEL
-sudo yum install -y automake bison e2fsprogs-devel fuse-devel gpgme-devel libseccomp-devel libtool systemd-devel xz-devel zlib-devel
-
-# for Debian, Ubuntu etc.
-sudo apt-get install -y automake bison e2fsprogs e2fslibs-dev fuse libfuse-dev libgpgme-dev liblzma-dev libseccomp-dev libsystemd-dev libtool zlib1g
-
-# for all distributions
-./autogen.sh --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc
-# remove --nonet option due to https:/github.com/ostreedev/ostree/issues/1374
-sed -i '/.*--nonet.*/d' ./Makefile-man.am
-make
-sudo make install
-```
 
 #### golang
 
@@ -324,8 +294,6 @@ make BUILDTAGS='seccomp apparmor'
 | exclude_graphdriver_btrfs        | exclude btrfs                      | libbtrfs             |
 | exclude_graphdriver_devicemapper | exclude device-mapper              | libdm                |
 | libdm_no_deferred_remove         | exclude deferred removal in libdm  | libdm                |
-| ostree                           | ostree support (requires selinux)  | ostree-1, libselinux |
-| containers_image_ostree_stub     | exclude ostree                     |                      |
 | seccomp                          | syscall filtering                  | libseccomp           |
 | selinux                          | selinux process and mount labeling |                      |
 | systemd                          | journald logging                   | libsystemd           |

--- a/test/e2e/push_test.go
+++ b/test/e2e/push_test.go
@@ -203,23 +203,6 @@ var _ = Describe("Podman push", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
-	It("podman push to local ostree", func() {
-		if !IsCommandAvailable("ostree") {
-			Skip("ostree is not installed")
-		}
-
-		ostreePath := filepath.Join(podmanTest.TempDir, "ostree/repo")
-		os.MkdirAll(ostreePath, os.ModePerm)
-
-		setup := SystemExec("ostree", []string{strings.Join([]string{"--repo=", ostreePath}, ""), "init"})
-		Expect(setup.ExitCode()).To(Equal(0))
-
-		session := podmanTest.PodmanNoCache([]string{"push", ALPINE, strings.Join([]string{"ostree:alp@", ostreePath}, "")})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-
-	})
-
 	It("podman push to docker-archive no reference", func() {
 		tarfn := filepath.Join(podmanTest.TempDir, "alp.tar")
 		session := podmanTest.PodmanNoCache([]string{"push", ALPINE,


### PR DESCRIPTION
it is going to be removed from containers/image as well, so no longer
depend on it.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>