### PR TITLE
libpod, rootless: create cgroup for conmon

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1220,14 +1220,6 @@ func (r *ConmonOCIRuntime) moveConmonToCgroupAndSignal(ctr *Container, cmd *exec
 		mustCreateCgroup = false
 	}
 
-	if rootless.IsRootless() {
-		ownsCgroup, err := cgroups.UserOwnsCurrentSystemdCgroup()
-		if err != nil {
-			return err
-		}
-		mustCreateCgroup = !ownsCgroup
-	}
-
 	if mustCreateCgroup {
 		cgroupParent := ctr.CgroupParent()
 		if r.cgroupManager == SystemdCgroupsManager {


### PR DESCRIPTION
always create a new cgroup for conmon also when running as rootless.
We were previously creating one only when necessary, but that behaves
differently than root containers.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>