### PR TITLE
Podman cp does not work when stdin is a pipe

### DIFF
--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -257,8 +257,15 @@ func parsePath(runtime *libpod.Runtime, path string) (*libpod.Container, string)
 	return nil, path
 }
 
+func evalSymlinks(path string) (string, error) {
+	if path == os.Stdin.Name() {
+		return path, nil
+	}
+	return filepath.EvalSymlinks(path)
+}
+
 func getPathInfo(path string) (string, os.FileInfo, error) {
-	path, err := filepath.EvalSymlinks(path)
+	path, err := evalSymlinks(path)
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "error evaluating symlinks %q", path)
 	}
@@ -270,7 +277,7 @@ func getPathInfo(path string) (string, os.FileInfo, error) {
 }
 
 func copy(src, destPath, dest string, idMappingOpts storage.IDMappingOptions, chownOpts *idtools.IDPair, extract, isFromHostToCtr bool) error {
-	srcPath, err := filepath.EvalSymlinks(src)
+	srcPath, err := evalSymlinks(src)
 	if err != nil {
 		return errors.Wrapf(err, "error evaluating symlinks %q", srcPath)
 	}


### PR DESCRIPTION
In accordance with the Podman cp documentation

> If "-" is specified for either the SRC_PATH or DEST_PATH, you can also stream a tar archive from STDIN or to STDOUT.

Works great when the file is redirected directly

`podman cp - cnt:/tmp < archive.tar`

But ends with an error when the archive is redirected from the pipe

`cat archive.tar | podman cp - cnt:/tmp
Error: error evaluating symlinks "": lstat /proc/6771/fd/pipe:[11662070]: no such file or directory`

Copying from the pipe is useful when you have for example some long running process and you don’t want to save the archive locally, but stream it directly from the process to podman.

Fix if trivial. Because the error is not in reading from the pipe, but in resolving the symbolic link.