### PR TITLE
fix bug checkIfFileExists

### DIFF
--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -241,7 +241,8 @@ func buildCmd(c *cliconfig.BuildValues) error {
 	if len(containerfiles) == 0 {
 		if checkIfFileExists(filepath.Join(contextDir, "Containerfile")) {
 			containerfiles = append(containerfiles, filepath.Join(contextDir, "Containerfile"))
-		} else {
+		}
+		if checkIfFileExists(filepath.Join(contextDir, "Dockerfile")) {
 			containerfiles = append(containerfiles, filepath.Join(contextDir, "Dockerfile"))
 		}
 	}

--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -68,7 +68,7 @@ func aliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 // Check if a file exists and is not a directory
 func checkIfFileExists(name string) bool {
 	file, err := os.Stat(name)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
 	return !file.IsDir()


### PR DESCRIPTION
close #4383 
fix checkIfFileExists returns true only if stats path success and path is not a directory.
replace os.IsNotExist(err) with err != nil check because if name is a file , stat name/Containerfile or name/Dockerfile will retunr not a directory error. os.IsNotExist(err) can not catch this error.

Signed-off-by: Qi Wang <qiwan@redhat.com>