### PR TITLE
Validate contextdir on build

### DIFF
--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -238,6 +238,9 @@ func buildCmd(c *cliconfig.BuildValues) error {
 	if contextDir == "" {
 		return errors.Errorf("no context directory specified, and no containerfile specified")
 	}
+	if !fileIsDir(contextDir) {
+		return errors.Errorf("context must be a directory: %v", contextDir)
+	}
 	if len(containerfiles) == 0 {
 		if checkIfFileExists(filepath.Join(contextDir, "Containerfile")) {
 			containerfiles = append(containerfiles, filepath.Join(contextDir, "Containerfile"))

--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -74,3 +74,13 @@ func checkIfFileExists(name string) bool {
 	}
 	return !file.IsDir()
 }
+
+// Check if a file is or is not a directory
+func fileIsDir(name string) bool {
+	file, err := os.Stat(name)
+	// All errors return file == nil
+	if err != nil {
+		return false
+	}
+	return file.IsDir()
+}


### PR DESCRIPTION
We never verified that the context directory passed into the build
command was a valid directory.  When we then slapped a default Containerfile
name onto it, things went south fast if the user had passed us a file and
not a directory.

Fixes: #4383

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>