### PR TITLE
container start: fix regression when using name

### DIFF
--- a/test/e2e/start_test.go
+++ b/test/e2e/start_test.go
@@ -57,15 +57,32 @@ var _ = Describe("Podman start", func() {
 		session = podmanTest.Podman([]string{"container", "start", cid})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal(cid))
+	})
+
+	It("podman container start single container by short id", func() {
+		session := podmanTest.Podman([]string{"container", "create", "-d", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToString()
+		session = podmanTest.Podman([]string{"container", "start", cid[0:10]})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal(cid))
 	})
 
 	It("podman start single container by name", func() {
-		session := podmanTest.Podman([]string{"create", "-d", "--name", "foobar99", ALPINE, "ls"})
+		name := "foobar99"
+		session := podmanTest.Podman([]string{"create", "-d", "--name", name, ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"start", "foobar99"})
+		session = podmanTest.Podman([]string{"start", name})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		if podmanTest.RemoteTest {
+			Skip("Container-start name check doesn't work on remote client. It always returns the full ID.")
+		}
+		Expect(session.OutputToString()).To(Equal(name))
 	})
 
 	It("podman start multiple containers", func() {


### PR DESCRIPTION
When starting a container by using its name as a reference, we should
print the name instead of the ID.  We regressed on this behaviour
with commit b4124485ae7e which made it into Podman v1.6.2.

Kudos to openSUSE testing for catching it.  To prevent future
regressions, extend the e2e tests to check the printed container
name/ID.

Reported-by: @sysrich
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>