### PR TITLE
Fix selinux test for exec

### DIFF
--- a/test/e2e/run_selinux_test.go
+++ b/test/e2e/run_selinux_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Podman run", func() {
 		setup.WaitWithDefaultTimeout()
 		Expect(setup.ExitCode()).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"exec", "test1", "cat", "/proc/self/attr/current"})
+		session := podmanTest.Podman([]string{"exec", "test1", "cat", "/proc/1/attr/current"})
 		session.WaitWithDefaultTimeout()
 		session1 := podmanTest.Podman([]string{"exec", "test1", "cat", "/proc/self/attr/current"})
 		session1.WaitWithDefaultTimeout()


### PR DESCRIPTION
We want to make sure that the process label of pid 1 is the same as the process label of a process execed into the container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>