### PR TITLE
logs: support --tail 0

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -251,7 +251,7 @@ type LogsValues struct {
 	Details    bool
 	Follow     bool
 	Since      string
-	Tail       uint64
+	Tail       int64
 	Timestamps bool
 	Latest     bool
 }

--- a/cmd/podman/logs.go
+++ b/cmd/podman/logs.go
@@ -52,7 +52,7 @@ func init() {
 	flags.BoolVarP(&logsCommand.Follow, "follow", "f", false, "Follow log output.  The default is false")
 	flags.BoolVarP(&logsCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.StringVar(&logsCommand.Since, "since", "", "Show logs since TIMESTAMP")
-	flags.Uint64Var(&logsCommand.Tail, "tail", 0, "Output the specified number of LINES at the end of the logs.  Defaults to 0, which prints all lines")
+	flags.Int64Var(&logsCommand.Tail, "tail", -1, "Output the specified number of LINES at the end of the logs.  Defaults to -1, which prints all lines")
 	flags.BoolVarP(&logsCommand.Timestamps, "timestamps", "t", false, "Output the timestamps in the log")
 	markFlagHidden(flags, "details")
 	flags.SetInterspersed(false)

--- a/docs/source/markdown/podman-logs.1.md
+++ b/docs/source/markdown/podman-logs.1.md
@@ -39,7 +39,7 @@ and 2006-01-02.
 
 **--tail**=*LINES*
 
-Output the specified number of LINES at the end of the logs.  LINES must be a positive integer.  Defaults to 0,
+Output the specified number of LINES at the end of the logs.  LINES must be an integer.  Defaults to -1,
 which prints all lines
 
 **--timestamps**, **-t**

--- a/libpod/container_log_linux.go
+++ b/libpod/container_log_linux.go
@@ -6,6 +6,7 @@ package libpod
 import (
 	"fmt"
 	"io"
+	"math"
 	"strings"
 	"time"
 
@@ -30,7 +31,11 @@ const (
 
 func (c *Container) readFromJournal(options *logs.LogOptions, logChannel chan *logs.LogLine) error {
 	var config journal.JournalReaderConfig
-	config.NumFromTail = options.Tail
+	if options.Tail < 0 {
+		config.NumFromTail = math.MaxUint64
+	} else {
+		config.NumFromTail = uint64(options.Tail)
+	}
 	config.Formatter = journalFormatter
 	defaultTime := time.Time{}
 	if options.Since != defaultTime {
@@ -54,7 +59,7 @@ func (c *Container) readFromJournal(options *logs.LogOptions, logChannel chan *l
 	if r == nil {
 		return errors.Errorf("journal reader creation failed")
 	}
-	if options.Tail == 0 {
+	if options.Tail == math.MaxInt64 {
 		r.Rewind()
 	}
 

--- a/libpod/logs/log.go
+++ b/libpod/logs/log.go
@@ -31,7 +31,7 @@ type LogOptions struct {
 	Details    bool
 	Follow     bool
 	Since      time.Time
-	Tail       uint64
+	Tail       int64
 	Timestamps bool
 	Multi      bool
 	WaitGroup  *sync.WaitGroup
@@ -54,8 +54,10 @@ func GetLogFile(path string, options *LogOptions) (*tail.Tail, []*LogLine, error
 		logTail []*LogLine
 	)
 	// whence 0=origin, 2=end
-	if options.Tail > 0 {
+	if options.Tail >= 0 {
 		whence = 2
+	}
+	if options.Tail > 0 {
 		logTail, err = getTailLog(path, int(options.Tail))
 		if err != nil {
 			return nil, nil, err

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -307,7 +307,11 @@ func (r *LocalRuntime) Log(c *cliconfig.LogsValues, options *logs.LogOptions) er
 	if len(c.InputArgs) > 1 {
 		options.Multi = true
 	}
-	logChannel := make(chan *logs.LogLine, int(c.Tail)*len(c.InputArgs)+1)
+	tailLen := int(c.Tail)
+	if tailLen < 0 {
+		tailLen = 0
+	}
+	logChannel := make(chan *logs.LogLine, tailLen*len(c.InputArgs)+1)
 	containers, err := shortcuts.GetContainersByContext(false, c.Latest, c.InputArgs, r.Runtime)
 	if err != nil {
 		return err

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -739,7 +739,7 @@ func (i *LibpodAPI) GetContainersLogs(call iopodman.VarlinkCall, names []string,
 	options := logs.LogOptions{
 		Follow:     follow,
 		Since:      sinceTime,
-		Tail:       uint64(tail),
+		Tail:       tail,
 		Timestamps: timestamps,
 	}
 
@@ -747,7 +747,11 @@ func (i *LibpodAPI) GetContainersLogs(call iopodman.VarlinkCall, names []string,
 	if len(names) > 1 {
 		options.Multi = true
 	}
-	logChannel := make(chan *logs.LogLine, int(tail)*len(names)+1)
+	tailLen := int(tail)
+	if tailLen < 0 {
+		tailLen = 0
+	}
+	logChannel := make(chan *logs.LogLine, tailLen*len(names)+1)
 	containers, err := shortcuts.GetContainersByContext(false, latest, names, i.Runtime)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -57,6 +57,18 @@ var _ = Describe("Podman logs", func() {
 		Expect(len(results.OutputToStringArray())).To(Equal(2))
 	})
 
+	It("podman logs tail zero lines", func() {
+		logc := podmanTest.Podman([]string{"run", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
+		logc.WaitWithDefaultTimeout()
+		Expect(logc.ExitCode()).To(Equal(0))
+		cid := logc.OutputToString()
+
+		results := podmanTest.Podman([]string{"logs", "--tail", "0", cid})
+		results.WaitWithDefaultTimeout()
+		Expect(results.ExitCode()).To(Equal(0))
+		Expect(len(results.OutputToStringArray())).To(Equal(0))
+	})
+
 	It("podman logs tail 99 lines", func() {
 		logc := podmanTest.Podman([]string{"run", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()


### PR DESCRIPTION
change the default to -1, so that we can change the semantic of
"--tail 0" to not print any existing log line.

Closes: https://github.com/containers/libpod/issues/4396

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>