### PR TITLE
Switch to bufio Reader for exec streams

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"bufio"
 	"context"
 	"io"
 	"io/ioutil"
@@ -361,7 +362,7 @@ type AttachStreams struct {
 	// ErrorStream will be attached to container's STDERR
 	ErrorStream io.WriteCloser
 	// InputStream will be attached to container's STDIN
-	InputStream io.Reader
+	InputStream *bufio.Reader
 	// AttachOutput is whether to attach to STDOUT
 	// If false, stdout will not be attached
 	AttachOutput bool

--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -133,7 +133,9 @@ func (c *Container) runHealthCheck() (HealthCheckStatus, error) {
 	streams := new(AttachStreams)
 	streams.OutputStream = hcw
 	streams.ErrorStream = hcw
-	streams.InputStream = os.Stdin
+
+	streams.InputStream = bufio.NewReader(os.Stdin)
+
 	streams.AttachOutput = true
 	streams.AttachError = true
 	streams.AttachInput = true

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -891,7 +891,7 @@ func (r *LocalRuntime) execPS(c *libpod.Container, args []string) ([]string, err
 	streams := new(libpod.AttachStreams)
 	streams.OutputStream = wPipe
 	streams.ErrorStream = wPipe
-	streams.InputStream = os.Stdin
+	streams.InputStream = bufio.NewReader(os.Stdin)
 	streams.AttachOutput = true
 	streams.AttachError = true
 	streams.AttachInput = true
@@ -969,7 +969,7 @@ func (r *LocalRuntime) ExecContainer(ctx context.Context, cli *cliconfig.ExecVal
 	streams.OutputStream = os.Stdout
 	streams.ErrorStream = os.Stderr
 	if cli.Interactive {
-		streams.InputStream = os.Stdin
+		streams.InputStream = bufio.NewReader(os.Stdin)
 		streams.AttachInput = true
 	}
 	streams.AttachOutput = true

--- a/pkg/adapter/terminal_linux.go
+++ b/pkg/adapter/terminal_linux.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -61,7 +62,7 @@ func StartAttachCtr(ctx context.Context, ctr *libpod.Container, stdout, stderr, 
 	streams := new(libpod.AttachStreams)
 	streams.OutputStream = stdout
 	streams.ErrorStream = stderr
-	streams.InputStream = stdin
+	streams.InputStream = bufio.NewReader(stdin)
 	streams.AttachOutput = true
 	streams.AttachError = true
 	streams.AttachInput = true

--- a/pkg/varlinkapi/attach.go
+++ b/pkg/varlinkapi/attach.go
@@ -32,7 +32,7 @@ func setupStreams(call iopodman.VarlinkCall) (*bufio.Reader, *bufio.Writer, *io.
 
 	streams := libpod.AttachStreams{
 		OutputStream: stdoutWriter,
-		InputStream:  pr,
+		InputStream:  bufio.NewReader(pr),
 		// Runc eats the error stream
 		ErrorStream:  stdoutWriter,
 		AttachInput:  true,


### PR DESCRIPTION
There were many situations that made exec act funky with input. pipes didn't work as expected, as well as sending input before the shell opened.
Thinking about it, it seemed as though the issues were because of how os.Stdin buffers (it doesn't). Dropping this input had some weird consequences.
Instead, read from os.Stdin as bufio.Reader, allowing the input to buffer before passing it to the container.

Note: I think there are some missed edge cases that need hammering out, so I would say this is WIP until I know everything works as expected

fixes: https://github.com/containers/libpod/issues/4397
fixes: https://github.com/containers/libpod/issues/4326
fixes the open part of: https://github.com/containers/libpod/issues/3302

Signed-off-by: Peter Hunt <pehunt@redhat.com>