### PR TITLE
Revert "catch runc v2 error" [v1.6]

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -947,13 +947,6 @@ func (c *Container) init(ctx context.Context, retainRetries bool) error {
 
 	// With the spec complete, do an OCI create
 	if err := c.ociRuntime.CreateContainer(c, nil); err != nil {
-		// Fedora 31 is carrying a patch to display improved error
-		// messages to better handle the V2 transition. This is NOT
-		// upstream in any OCI runtime.
-		// TODO: Remove once runc supports cgroupsv2
-		if strings.Contains(err.Error(), "this version of runc doesn't work on cgroups v2") {
-			logrus.Errorf("oci runtime %q does not support CGroups V2: use system migrate to mitigate", c.ociRuntime.Name())
-		}
 		return err
 	}
 


### PR DESCRIPTION
This reverts commit c35d71e3da7a84eae94769e005407cf99d1ccb49.

This is a Fedora-specific patch we do not want in upstream releases.