### PR TITLE
Fixed issue #4391; podman info --format '{{ json . }}'

### DIFF
--- a/cmd/podman/info.go
+++ b/cmd/podman/info.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	rt "runtime"
+	"strings"
 
 	"github.com/containers/buildah/pkg/formats"
 	"github.com/containers/libpod/cmd/podman/cliconfig"
@@ -88,6 +89,9 @@ func infoCmd(c *cliconfig.InfoValues) error {
 
 	var out formats.Writer
 	infoOutputFormat := c.Format
+	if strings.Join(strings.Fields(infoOutputFormat), "") == "{{json.}}" {
+		infoOutputFormat = formats.JSONString
+	}
 	switch infoOutputFormat {
 	case formats.JSONString:
 		out = formats.JSONStruct{Output: info}

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -45,4 +45,10 @@ var _ = Describe("Podman Info", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 
 	})
+	It("podman info --format GO template", func() {
+		session := podmanTest.Podman([]string{"info", "--format", "{{ json .}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.IsJSONOutputValid()).To(BeTrue())
+	})
 })


### PR DESCRIPTION
JSON Go template format now recognized through the info action.
Fixes issue #4391 