### PR TITLE
docs: Update "podman container rm -v" description

### DIFF
--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -43,7 +43,7 @@ func init() {
 	flags.BoolVarP(&rmCommand.Force, "force", "f", false, "Force removal of a running or unusable container.  The default is false")
 	flags.BoolVarP(&rmCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&rmCommand.Storage, "storage", false, "Remove container from storage library")
-	flags.BoolVarP(&rmCommand.Volumes, "volumes", "v", false, "Remove the volumes associated with the container")
+	flags.BoolVarP(&rmCommand.Volumes, "volumes", "v", false, "Remove anonymous volumes associated with the container")
 	markFlagHiddenForRemoteClient("storage", flags)
 	markFlagHiddenForRemoteClient("latest", flags)
 }

--- a/docs/source/markdown/podman-rm.1.md
+++ b/docs/source/markdown/podman-rm.1.md
@@ -42,7 +42,8 @@ The storage option conflicts with the **--all**, **--latest**, and **--volumes**
 
 **--volumes**, **-v**
 
-Remove the volumes associated with the container.
+Remove anonymous volumes associated with the container. This does not include named volumes
+created with `podman volume create`, or the `--volume` option of `podman run` and `podman create`.
 
 ## EXAMPLE
 Remove a container by its name *mywebserver*


### PR DESCRIPTION
In commit 52df1fa was implemented the `--volume` option for podman remove. However, its behaviour changed after 83db80c (Only remove image volumes when removing containers).

This commit updates the description of this option to reflect the new behaviour.