### PR TITLE
slirp4netns: fix timeout

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -295,7 +295,7 @@ func (r *Runtime) setupRootlessNetNS(ctr *Container) (err error) {
 		defer close(chWait)
 
 		// wait that API socket file appears before trying to use it.
-		if _, err := WaitForFile(apiSocket, chWait, pidWaitTimeout*time.Millisecond); err != nil {
+		if _, err := WaitForFile(apiSocket, chWait, pidWaitTimeout); err != nil {
 			return errors.Wrapf(err, "waiting for slirp4nets to create the api socket file %s", apiSocket)
 		}
 


### PR DESCRIPTION
the pidWaitTimeout is already a Duration so do not multiply it again
by time.Millisecond.

Closes: https://github.com/containers/libpod/issues/4344

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>