### PR TITLE
Update installation - Ubuntu. [skip ci]

### DIFF
--- a/install.md
+++ b/install.md
@@ -72,6 +72,8 @@ sudo apt-get install -qq -y software-properties-common uidmap
 sudo add-apt-repository -y ppa:projectatomic/ppa
 sudo apt-get update -qq
 sudo apt-get -qq -y install podman
+sudo mkdir -p /etc/containers
+echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | sudo tee /etc/containers/registries.conf
 ```
 
 #### Fedora


### PR DESCRIPTION
This PR is related to https://github.com/containers/libpod/issues/3679 .

Current podman deb package does not install /etc/containers/registries.conf .
So, we need to update the document.

The added line just 1 line is for compatibility of use cases with docker.
Seeing the current installation document, I thought it would be better to add just 1 line rather than showing the Travis CI specific cases with the syntax. Maybe Travis users can manage it by themselves seeing the Travis CI manual. And the syntax is beyond the podman's responsibility.

Here is the modified `install.md` on my forked repository and the branch.
https://github.com/junaruga/libpod/blob/feature/install-ubuntu/install.md#ubuntu

Here is the tested Travis CI and the result.
https://github.com/junaruga/podman-experiment/blob/master/.travis.yml#L23
https://travis-ci.org/junaruga/podman-experiment/builds/607226114

`[skip ci]` in the commit message is to skip Cirrus CI.
See https://cirrus-ci.org/guide/writing-tasks/ - Skip CI Completely
