### PR TITLE
Remove containers when pod prune & pod rm.

### DIFF
--- a/cmd/podman/pod_rm.go
+++ b/cmd/podman/pod_rm.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	podRmCommand     cliconfig.PodRmValues
-	podRmDescription = fmt.Sprintf(`podman rm will remove one or more pods from the host.
+	podRmDescription = fmt.Sprintf(`podman rm will remove one or more stopped pods and their containers from the host.
 
   The pod name or ID can be used.  A pod with containers will not be removed without --force. If --force is specified, all containers will be stopped, then removed.`)
 	_podRmCommand = &cobra.Command{

--- a/cmd/podman/pods_prune.go
+++ b/cmd/podman/pods_prune.go
@@ -17,7 +17,7 @@ var (
 	_prunePodsCommand = &cobra.Command{
 		Use:   "prune",
 		Args:  noSubArgs,
-		Short: "Remove all stopped pods",
+		Short: "Remove all stopped pods and their containers",
 		Long:  podPruneDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			podPruneCommand.InputArgs = args
@@ -32,7 +32,7 @@ func init() {
 	podPruneCommand.SetHelpTemplate(HelpTemplate())
 	podPruneCommand.SetUsageTemplate(UsageTemplate())
 	flags := podPruneCommand.Flags()
-	flags.BoolVarP(&podPruneCommand.Force, "force", "f", false, "Force removal of a running pods.  The default is false")
+	flags.BoolVarP(&podPruneCommand.Force, "force", "f", false, "Force removal of all running pods.  The default is false")
 }
 
 func podPruneCmd(c *cliconfig.PodPruneValues) error {

--- a/cmd/podman/system_prune.go
+++ b/cmd/podman/system_prune.go
@@ -82,7 +82,6 @@ Are you sure you want to continue? [y/N] `, volumeString)
 	fmt.Println("Deleted Pods")
 	pruneValues := cliconfig.PodPruneValues{
 		PodmanCommand: c.PodmanCommand,
-		Force:         c.Force,
 	}
 	ctx := getContext()
 	ok, failures, lasterr := runtime.PrunePods(ctx, &pruneValues)

--- a/docs/source/markdown/podman-pod-prune.1.md
+++ b/docs/source/markdown/podman-pod-prune.1.md
@@ -1,16 +1,21 @@
 % podman-pod-prune(1)
 
 ## NAME
-podman-pod-prune - Remove all stopped pods
+podman-pod-prune - Remove all stopped pods and their containers
 
 ## SYNOPSIS
 **podman pod prune**
 
 ## DESCRIPTION
-**podman pod prune** removes all stopped pods from local storage.
+**podman pod prune** removes all stopped pods and their containers from local storage.
+
+## OPTIONS
+
+**--force** **-f**
+Force removal of all running pods and their containers. The default is false.
 
 ## EXAMPLES
-Remove all stopped pods from local storage
+Remove all stopped pods and their containers from local storage
 ```
 $ sudo podman pod prune
 22b8813332948064b6566370088c5e0230eeaf15a58b1c5646859fd9fc364fe7

--- a/docs/source/markdown/podman-pod-rm.1.md
+++ b/docs/source/markdown/podman-pod-rm.1.md
@@ -1,13 +1,13 @@
 % podman-pod-rm(1)
 
 ## NAME
-podman\-pod\-rm - Remove one or more pods
+podman\-pod\-rm - Remove one or more stopped pods and containers
 
 ## SYNOPSIS
 **podman pod rm** [*options*] *pod*
 
 ## DESCRIPTION
-**podman pod rm** will remove one or more pods from the host.  The pod name or ID can be used. The \-f option stops all containers and then removes them before removing the pod. Without the \-f option, a pod cannot be removed if it has associated containers.
+**podman pod rm** will remove one or more stopped pods and their containers from the host.  The pod name or ID can be used. The \-f option stops all containers and then removes them before removing the pod.
 
 ## OPTIONS
 

--- a/docs/source/markdown/podman-pod.1.md
+++ b/docs/source/markdown/podman-pod.1.md
@@ -18,10 +18,10 @@ podman pod is a set of subcommands that manage pods, or groups of containers.
 | inspect | [podman-pod-inspect(1)](podman-pod-inspect.1.md)  | Displays information describing a pod.                                            |
 | kill    | [podman-pod-kill(1)](podman-pod-kill.1.md)        | Kill the main process of each container in one or more pods.                      |
 | pause   | [podman-pod-pause(1)](podman-pod-pause.1.md)      | Pause one or more pods.                                                           |
-| prune   | [podman-pod-prune(1)](podman-pod-prune.1.md)      | Remove all stopped pods.                                                          |
+| prune   | [podman-pod-prune(1)](podman-pod-prune.1.md)      | Remove all stopped pods and their containers.                                                          |
 | ps      | [podman-pod-ps(1)](podman-pod-ps.1.md)            | Prints out information about pods.                                                |
 | restart | [podman-pod-restart(1)](podman-pod-restart.1.md)  | Restart one or more pods.                                                         |
-| rm      | [podman-pod-rm(1)](podman-pod-rm.1.md)            | Remove one or more pods.                                                          |
+| rm      | [podman-pod-rm(1)](podman-pod-rm.1.md)            | Remove one or more stopped pods and containers.                                                          |
 | start   | [podman-pod-start(1)](podman-pod-start.1.md)      | Start one or more pods.                                                           |
 | stats   | [podman-pod-stats(1)](podman-pod-stats.1.md)      | Display a live stream of resource usage stats for containers in one or more pods. |
 | stop    | [podman-pod-stop(1)](podman-pod-stop.1.md)        | Stop one or more pods.                                                            |

--- a/docs/source/pod.rst
+++ b/docs/source/pod.rst
@@ -11,13 +11,13 @@ Pod
 
 :doc:`pause <markdown/podman-pause.1>` Pause one or more pods
 
-:doc:`prune <markdown/podman-pod-prune.1>` Remove all stopped pods
+:doc:`prune <markdown/podman-pod-prune.1>` Remove all stopped pods and their containers
 
 :doc:`ps <markdown/podman-pod-ps.1>` List pods
 
 :doc:`restart <markdown/podman-pod-restart.1>` Restart one or more pods
 
-:doc:`rm <markdown/podman-pod-rm.1>` Remove one or more pods
+:doc:`rm <markdown/podman-pod-rm.1>` Remove one or more stopped pods and containers
 
 :doc:`start <markdown/podman-pod-start.1>` Start one or more pods
 

--- a/pkg/adapter/pods.go
+++ b/pkg/adapter/pods.go
@@ -77,7 +77,7 @@ func (r *LocalRuntime) PrunePods(ctx context.Context, cli *cliconfig.PodPruneVal
 		pool.Add(shared.Job{
 			ID: p.ID(),
 			Fn: func() error {
-				err := r.Runtime.RemovePod(ctx, p, cli.Force, cli.Force)
+				err := r.Runtime.RemovePod(ctx, p, true, cli.Force)
 				if err != nil {
 					logrus.Debugf("Failed to remove pod %s: %s", p.ID(), err.Error())
 				}
@@ -101,7 +101,7 @@ func (r *LocalRuntime) RemovePods(ctx context.Context, cli *cliconfig.PodRmValue
 	}
 
 	for _, p := range pods {
-		if err := r.Runtime.RemovePod(ctx, p, cli.Force, cli.Force); err != nil {
+		if err := r.Runtime.RemovePod(ctx, p, true, cli.Force); err != nil {
 			errs = append(errs, err)
 		} else {
 			podids = append(podids, p.ID())

--- a/pkg/varlinkapi/pods.go
+++ b/pkg/varlinkapi/pods.go
@@ -247,7 +247,7 @@ func (i *LibpodAPI) RemovePod(call iopodman.VarlinkCall, name string, force bool
 	if err != nil {
 		return call.ReplyPodNotFound(name, err.Error())
 	}
-	if err = i.Runtime.RemovePod(ctx, pod, force, force); err != nil {
+	if err = i.Runtime.RemovePod(ctx, pod, true, force); err != nil {
 		return call.ReplyErrorOccurred(err.Error())
 	}
 

--- a/test/e2e/pod_prune_test.go
+++ b/test/e2e/pod_prune_test.go
@@ -41,7 +41,24 @@ var _ = Describe("Podman pod prune", func() {
 		Expect(result.ExitCode()).To(Equal(0))
 	})
 
-	It("podman pod prune doesn't remove a pod with a container", func() {
+	It("podman pod prune doesn't remove a pod with a running container", func() {
+		_, ec, podid := podmanTest.CreatePod("")
+		Expect(ec).To(Equal(0))
+
+		ec2 := podmanTest.RunTopContainerInPod("", podid)
+		ec2.WaitWithDefaultTimeout()
+		Expect(ec2.ExitCode()).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"pod", "prune"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To((Equal(0)))
+
+		result = podmanTest.Podman([]string{"ps", "-qa"})
+		result.WaitWithDefaultTimeout()
+		Expect(len(result.OutputToStringArray())).To(Equal(1))
+	})
+
+	It("podman pod prune removes a pod with a stopped container", func() {
 		_, ec, podid := podmanTest.CreatePod("")
 		Expect(ec).To(Equal(0))
 
@@ -50,11 +67,11 @@ var _ = Describe("Podman pod prune", func() {
 
 		result := podmanTest.Podman([]string{"pod", "prune"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(125))
+		Expect(result.ExitCode()).To(Equal(0))
 
 		result = podmanTest.Podman([]string{"ps", "-qa"})
 		result.WaitWithDefaultTimeout()
-		Expect(len(result.OutputToStringArray())).To(Equal(1))
+		Expect(len(result.OutputToStringArray())).To(Equal(0))
 	})
 
 	It("podman pod prune -f does remove a running container", func() {

--- a/test/e2e/pod_rm_test.go
+++ b/test/e2e/pod_rm_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Podman pod rm", func() {
 		Expect(result.OutputToString()).To(Not(ContainSubstring(podid2)))
 	})
 
-	It("podman pod rm doesn't remove a pod with a container", func() {
+	It("podman pod rm removes a pod with a container", func() {
 		_, ec, podid := podmanTest.CreatePod("")
 		Expect(ec).To(Equal(0))
 
@@ -86,11 +86,11 @@ var _ = Describe("Podman pod rm", func() {
 
 		result := podmanTest.Podman([]string{"pod", "rm", podid})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(125))
+		Expect(result.ExitCode()).To(Equal(0))
 
 		result = podmanTest.Podman([]string{"ps", "-qa"})
 		result.WaitWithDefaultTimeout()
-		Expect(len(result.OutputToStringArray())).To(Equal(1))
+		Expect(len(result.OutputToStringArray())).To(Equal(0))
 	})
 
 	It("podman pod rm -f does remove a running container", func() {
@@ -136,7 +136,7 @@ var _ = Describe("Podman pod rm", func() {
 		result := podmanTest.Podman([]string{"pod", "rm", "-a"})
 		result.WaitWithDefaultTimeout()
 		Expect(result).To(ExitWithError())
-		foundExpectedError, _ := result.ErrorGrepString("contains containers and cannot be removed")
+		foundExpectedError, _ := result.ErrorGrepString("cannot be removed")
 		Expect(foundExpectedError).To(Equal(true))
 
 		num_pods = podmanTest.NumberOfPods()


### PR DESCRIPTION
fix #4346 

This path allows pod prune & pod rm to remove stopped containers in the pod before deleting the pod.
PrunePods and RemovePod should be able to remove containers without force removal of stopped pods.

Signed-off-by: Qi Wang <qiwan@redhat.com>