### PR TITLE
Add links to readthedocs on docs/readme

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -1,3 +1,10 @@
+# Podman Documentation
+
+The online man pages and other documents regarding Podman can be found at
+[Read The Docs](https://podman.readthedocs.io/en/latest/index.html).  The man pages
+can be found under the [Commands](https://podman.readthedocs.io/en/latest/Commands.html)
+link on that page.
+
 # Build the Docs
 
 ## Directory Structure


### PR DESCRIPTION
Add a couple of links to the new ReadTheDocs site
for the libpod man pages from the docs/readme.md.  Many users
go to github.com/{project}/docs looking for the man pages for
the project and their location is not evident on the current
readme.md.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>