### PR TITLE
Add support for RunAsUser and RunAsGroup

### DIFF
--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -487,13 +487,16 @@ func generateKubeSecurityContext(c *Container) (*v1.SecurityContext, error) {
 		if err := c.syncContainer(); err != nil {
 			return nil, errors.Wrapf(err, "unable to sync container during YAML generation")
 		}
+
 		logrus.Debugf("Looking in container for user: %s", c.User())
-		u, err := lookup.GetUser(c.state.Mountpoint, c.User())
+		execUser, err := lookup.GetUserGroupInfo(c.state.Mountpoint, c.User(), nil)
 		if err != nil {
 			return nil, err
 		}
-		user := int64(u.Uid)
-		sc.RunAsUser = &user
+		uid := int64(execUser.Uid)
+		gid := int64(execUser.Gid)
+		sc.RunAsUser = &uid
+		sc.RunAsGroup = &gid
 	}
 	return &sc, nil
 }

--- a/test/e2e/test.yaml
+++ b/test/e2e/test.yaml
@@ -24,6 +24,9 @@ spec:
     name: test
     resources: {}
     securityContext:
+      runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 2000
       allowPrivilegeEscalation: true
       capabilities: {}
       privileged: false


### PR DESCRIPTION
Currently podman generate kube does not generate the correct RunAsUser and RunAsGroup
options in the yaml file.  This patch fixes this.

This patch also make `podman play kube` use the RunAdUser and RunAsGroup options if
they are specified in the yaml file.
  
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
