### PR TITLE
help message: don't parse the config for cgroup-manager default

### DIFF
--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/libpodruntime"
-	"github.com/containers/libpod/libpod/config"
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/cgroups"
 	"github.com/containers/libpod/pkg/rootless"
@@ -34,9 +33,6 @@ const remote = false
 
 func init() {
 	cgroupManager := define.SystemdCgroupsManager
-	if runtimeConfig, err := config.NewConfig(""); err == nil {
-		cgroupManager = runtimeConfig.CgroupManager
-	}
 	cgroupHelp := "Cgroup manager to use (cgroupfs or systemd)"
 	cgroupv2, _ := cgroups.IsCgroup2UnifiedMode()
 	if rootless.IsRootless() && !cgroupv2 {


### PR DESCRIPTION
Do not generate an entire `config.Config` for displaying the default
value for the --cgroup-manager flag and just default to systemd. Not
using the `config.Config` is okay as 1) the value may change at runtime
in any case (rootless, DBUS access, etc.), 2) it avoids to redundantly
parse the system config files and to generate the hard-coded default
config, and 3) the log-level and other attributes are not yet set during
init() causing undesirable side effects.

Fixes: #4456
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>