### PR TITLE
rootless: use SYS_renameat2 instead of __NR_renameat2

### DIFF
--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -27,9 +27,13 @@ int renameat2 (int olddirfd, const char *oldpath, int newdirfd, const char *newp
 # ifdef SYS_renameat2
   return (int) syscall (SYS_renameat2, olddirfd, oldpath, newdirfd, newpath, flags);
 # else
-  /* no way to implement it atomically.  */
-  errno = ENOSYS;
-  return -1;
+  /* This might be an issue if another process is trying to read the file while it is empty.  */
+  int fd = open (newpath, O_EXCL|O_CREAT, 0700);
+  if (fd < 0)
+    return fd;
+  close (fd);
+  /* We are sure we created the file, let's overwrite it.  */
+  return rename (oldpath, newpath);
 # endif
 }
 #endif

--- a/pkg/rootless/rootless_linux.c
+++ b/pkg/rootless/rootless_linux.c
@@ -24,8 +24,8 @@
 
 int renameat2 (int olddirfd, const char *oldpath, int newdirfd, const char *newpath, unsigned int flags)
 {
-# ifdef __NR_renameat2
-  return (int) syscall (__NR_renameat2, olddirfd, oldpath, newdirfd, newpath, flags);
+# ifdef SYS_renameat2
+  return (int) syscall (SYS_renameat2, olddirfd, oldpath, newdirfd, newpath, flags);
 # else
   /* no way to implement it atomically.  */
   errno = ENOSYS;


### PR DESCRIPTION
use the correct definition for the syscall number.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>