### PR TITLE
events: make sure the write channel is always closed

### DIFF
--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -54,6 +54,7 @@ func (e EventJournalD) Write(ee Event) error {
 
 // Read reads events from the journal and sends qualified events to the event channel
 func (e EventJournalD) Read(options ReadOptions) error {
+	defer close(options.EventChannel)
 	eventOptions, err := generateEventOptions(options.Filters, options.Since, options.Until)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate event options")
@@ -87,7 +88,6 @@ func (e EventJournalD) Read(options ReadOptions) error {
 	if err != nil {
 		return err
 	}
-	defer close(options.EventChannel)
 	for {
 		if _, err := j.Next(); err != nil {
 			return err

--- a/libpod/events/logfile.go
+++ b/libpod/events/logfile.go
@@ -41,6 +41,7 @@ func (e EventLogFile) Write(ee Event) error {
 
 // Reads from the log file
 func (e EventLogFile) Read(options ReadOptions) error {
+	defer close(options.EventChannel)
 	eventOptions, err := generateEventOptions(options.Filters, options.Since, options.Until)
 	if err != nil {
 		return errors.Wrapf(err, "unable to generate event options")
@@ -68,7 +69,6 @@ func (e EventLogFile) Read(options ReadOptions) error {
 			options.EventChannel <- event
 		}
 	}
-	close(options.EventChannel)
 	return nil
 }
 


### PR DESCRIPTION
in case of errors, the channel is not closed, blocking the reader
indefinitely.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1767663

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>