### PR TITLE
podman images --digest: always list a digest

### DIFF
--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -291,6 +291,10 @@ func getImagesTemplateOutput(ctx context.Context, images []*adapter.ContainerIma
 				if len(tag) == 71 && strings.HasPrefix(tag, "sha256:") {
 					imageDigest = digest.Digest(tag)
 					tag = ""
+				} else {
+					if img.Digest() != "" {
+						imageDigest = img.Digest()
+					}
 				}
 				params := imagesTemplateParams{
 					Repository:  repo,


### PR DESCRIPTION
When we're asked to display image digests, always provide them if we have values that we can provide.