### PR TITLE
libpod/config: default: use `crun` on Cgroups v2

### DIFF
--- a/libpod.conf
+++ b/libpod.conf
@@ -142,8 +142,13 @@ runc = [
 ]
 
 crun = [
-	    "/usr/bin/crun",
-	    "/usr/local/bin/crun",
+		"/usr/bin/crun",
+		"/usr/sbin/crun",
+		"/usr/local/bin/crun",
+		"/usr/local/sbin/crun",
+		"/sbin/crun",
+		"/bin/crun",
+		"/run/current-system/sw/bin/crun",
 ]
 
 # The [runtimes] table MUST be the last thing in this file.


### PR DESCRIPTION
When running on a node with Cgroups v2, default to using `crun` instead
of `runc`.  Note that this only impacts the hard-coded default config.
No user config will be over-written.

Fixes: #4463
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>