### PR TITLE
create a separate install target for seccomp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,9 @@ install.man: docs
 install.config:
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(SHAREDIR_CONTAINERS)
 	install ${SELINUXOPT} -m 644 libpod.conf $(DESTDIR)$(SHAREDIR_CONTAINERS)/libpod.conf
+
+install.seccomp:
+	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(SHAREDIR_CONTAINERS)
 	install ${SELINUXOPT} -m 644 seccomp.json $(DESTDIR)$(SHAREDIR_CONTAINERS)/seccomp.json
 
 install.completions:


### PR DESCRIPTION
podman in Fedora gets seccomp.json from containers-common while
the one in Ubuntu PPA gets seccomp.json from containers-golang.

This change will let me use install.config target unmodified
in downstream packages.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>