### PR TITLE
Discard errors from Shutdown in `system renumber`

### DIFF
--- a/cmd/podman/system_renumber.go
+++ b/cmd/podman/system_renumber.go
@@ -44,9 +44,7 @@ func renumberCmd(c *cliconfig.SystemRenumberValues) error {
 	if err != nil {
 		return errors.Wrapf(err, "error renumbering locks")
 	}
-	if err := r.Shutdown(false); err != nil {
-		return err
-	}
+	_ = r.Shutdown(false)
 
 	return nil
 }


### PR DESCRIPTION
Every other Podman command discards errors from Shutdown, which will error if containers are running. Mirror that behavior, just ignore the errors.