### PR TITLE
Add --force flag to images prune

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -175,7 +175,8 @@ type HistoryValues struct {
 }
 type PruneImagesValues struct {
 	PodmanCommand
-	All bool
+	All   bool
+	Force bool
 }
 
 type PruneContainersValues struct {

--- a/cmd/podman/images_prune.go
+++ b/cmd/podman/images_prune.go
@@ -34,6 +34,7 @@ func init() {
 	pruneImagesCommand.SetUsageTemplate(UsageTemplate())
 	flags := pruneImagesCommand.Flags()
 	flags.BoolVarP(&pruneImagesCommand.All, "all", "a", false, "Remove all unused images, not just dangling ones")
+	flags.BoolVarP(&pruneImagesCommand.Force, "force", "f", false, "Do not prompt for confirmation on pruning images")
 }
 
 func pruneImagesCmd(c *cliconfig.PruneImagesValues) error {


### PR DESCRIPTION
Add a -f, --force flag to images prune. As there was previously no
prompt to force prune images, this commit does nothing to add such a
question, only make the cli command compatible with docker cli.

Resolves #4410

Signed-off-by: Tyler Ramer <tyaramer@gmail.com>

---
### Commentary

I can adjust the commit to include a prompt if --force is not included, so the cli is not just compatible with docker cli but identical.

However, if you want to add this, I wanted to propose the following thoughts:
- Other force flags don't remove a prompt - they do a potentially unsafe action (i.e. removing mounted volumes, removing networks that may be in use, etc). Pruning images may require additional build time, but is not unsafe, as far as I am aware.
- It is possible people are relying on the `image prune` cli not needing a `--force` flag - is it important to keep this cli backwards compatibility in that case? 