### PR TITLE
Also delete winsz fifo

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -652,6 +652,11 @@ func (c *Container) removeConmonFiles() error {
 		return errors.Wrapf(err, "error removing container %s ctl file", c.ID())
 	}
 
+	winszFile := filepath.Join(c.bundlePath(), "winsz")
+	if err := os.Remove(winszFile); err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "error removing container %s winsz file", c.ID())
+	}
+
 	oomFile := filepath.Join(c.bundlePath(), "oom")
 	if err := os.Remove(oomFile); err != nil && !os.IsNotExist(err) {
 		return errors.Wrapf(err, "error removing container %s OOM file", c.ID())


### PR DESCRIPTION
In conmon 2.0.3, we add another fifo to handle window resizing. This needs to be cleaned up for commands like restore, where the same path is used.

fixes: https://github.com/containers/conmon/issues/85 

Signed-off-by: Peter Hunt <pehunt@redhat.com>