### PR TITLE
podman rm/stop --cidfile

### DIFF
--- a/cmd/podman/checkpoint.go
+++ b/cmd/podman/checkpoint.go
@@ -26,7 +26,7 @@ var (
 			return checkpointCmd(&checkpointCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman container checkpoint --keep ctrID
   podman container checkpoint --all

--- a/cmd/podman/cleanup.go
+++ b/cmd/podman/cleanup.go
@@ -27,7 +27,7 @@ var (
 			return cleanupCmd(&cleanupCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman container cleanup --latest
   podman container cleanup ctrID1 ctrID2 ctrID3

--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -480,11 +480,12 @@ type RestoreValues struct {
 
 type RmValues struct {
 	PodmanCommand
-	All     bool
-	Force   bool
-	Latest  bool
-	Storage bool
-	Volumes bool
+	All      bool
+	Force    bool
+	Latest   bool
+	Storage  bool
+	Volumes  bool
+	CIDFiles []string
 }
 
 type RmiValues struct {
@@ -557,9 +558,10 @@ type StatsValues struct {
 
 type StopValues struct {
 	PodmanCommand
-	All     bool
-	Latest  bool
-	Timeout uint
+	All      bool
+	Latest   bool
+	Timeout  uint
+	CIDFiles []string
 }
 
 type TopValues struct {

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -39,24 +39,45 @@ func shortID(id string) string {
 	return id
 }
 
-// checkAllAndLatest checks that --all and --latest are used correctly
-func checkAllAndLatest(c *cobra.Command, args []string, ignoreArgLen bool) error {
+// checkAllLatestAndCIDFile checks that --all and --latest are used correctly.
+// If cidfile is set, also check for the --cidfile flag.
+func checkAllLatestAndCIDFile(c *cobra.Command, args []string, ignoreArgLen bool, cidfile bool) error {
 	argLen := len(args)
 	if c.Flags().Lookup("all") == nil || c.Flags().Lookup("latest") == nil {
-		return errors.New("unable to lookup values for 'latest' or 'all'")
+		if !cidfile {
+			return errors.New("unable to lookup values for 'latest' or 'all'")
+		} else if c.Flags().Lookup("cidfile") == nil {
+			return errors.New("unable to lookup values for 'latest', 'all' or 'cidfile'")
+		}
 	}
-	all, _ := c.Flags().GetBool("all")
-	latest, _ := c.Flags().GetBool("latest")
-	if all && latest {
+
+	specifiedAll, _ := c.Flags().GetBool("all")
+	specifiedLatest, _ := c.Flags().GetBool("latest")
+	specifiedCIDFile := false
+	if cid, _ := c.Flags().GetStringArray("cidfile"); len(cid) > 0 {
+		specifiedCIDFile = true
+	}
+
+	if specifiedCIDFile && (specifiedAll || specifiedLatest) {
+		return errors.Errorf("--all, --latest and --cidfile cannot be used together")
+	} else if specifiedAll && specifiedLatest {
 		return errors.Errorf("--all and --latest cannot be used together")
 	}
+
 	if ignoreArgLen {
 		return nil
 	}
-	if (all || latest) && argLen > 0 {
+	if (argLen > 0) && (specifiedAll || specifiedLatest) {
 		return errors.Errorf("no arguments are needed with --all or --latest")
+	} else if cidfile && (argLen > 0) && (specifiedAll || specifiedLatest || specifiedCIDFile) {
+		return errors.Errorf("no arguments are needed with --all, --latest or --cidfile")
 	}
-	if argLen < 1 && !all && !latest {
+
+	if specifiedCIDFile {
+		return nil
+	}
+
+	if argLen < 1 && !specifiedAll && !specifiedLatest && !specifiedCIDFile {
 		return errors.Errorf("you must provide at least one name or id")
 	}
 	return nil

--- a/cmd/podman/init.go
+++ b/cmd/podman/init.go
@@ -23,7 +23,7 @@ var (
 			return initCmd(&initCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman init --latest
   podman init 3c45ef19d893

--- a/cmd/podman/kill.go
+++ b/cmd/podman/kill.go
@@ -24,7 +24,7 @@ var (
 			return killCmd(&killCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman kill mywebserver
   podman kill 860a4b23

--- a/cmd/podman/mount.go
+++ b/cmd/podman/mount.go
@@ -35,7 +35,7 @@ var (
 			return mountCmd(&mountCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, true)
+			return checkAllLatestAndCIDFile(cmd, args, true, false)
 		},
 	}
 )

--- a/cmd/podman/pod_kill.go
+++ b/cmd/podman/pod_kill.go
@@ -28,7 +28,7 @@ var (
 			return podKillCmd(&podKillCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman pod kill podID
   podman pod kill --signal TERM mywebserver

--- a/cmd/podman/pod_pause.go
+++ b/cmd/podman/pod_pause.go
@@ -25,7 +25,7 @@ var (
 			return podPauseCmd(&podPauseCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman pod pause podID1 podID2
   podman pod pause --latest

--- a/cmd/podman/pod_restart.go
+++ b/cmd/podman/pod_restart.go
@@ -26,7 +26,7 @@ var (
 			return podRestartCmd(&podRestartCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman pod restart podID1 podID2
   podman pod restart --latest

--- a/cmd/podman/pod_rm.go
+++ b/cmd/podman/pod_rm.go
@@ -26,7 +26,7 @@ var (
 			return podRmCmd(&podRmCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman pod rm mywebserverpod
   podman pod rm -f 860a4b23

--- a/cmd/podman/pod_start.go
+++ b/cmd/podman/pod_start.go
@@ -26,7 +26,7 @@ var (
 			return podStartCmd(&podStartCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman pod start podID
   podman pod start --latest

--- a/cmd/podman/pod_stop.go
+++ b/cmd/podman/pod_stop.go
@@ -27,7 +27,7 @@ var (
 			return podStopCmd(&podStopCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman pod stop mywebserverpod
   podman pod stop --latest

--- a/cmd/podman/pod_unpause.go
+++ b/cmd/podman/pod_unpause.go
@@ -26,7 +26,7 @@ var (
 			return podUnpauseCmd(&podUnpauseCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman pod unpause podID1 podID2
   podman pod unpause --all

--- a/cmd/podman/port.go
+++ b/cmd/podman/port.go
@@ -26,7 +26,7 @@ var (
 			return portCmd(&portCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, true)
+			return checkAllLatestAndCIDFile(cmd, args, true, false)
 		},
 		Example: `podman port --all
   podman port ctrID 80/tcp

--- a/cmd/podman/restart.go
+++ b/cmd/podman/restart.go
@@ -23,7 +23,7 @@ var (
 			return restartCmd(&restartCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman restart ctrID
   podman restart --latest

--- a/cmd/podman/restore.go
+++ b/cmd/podman/restore.go
@@ -26,7 +26,7 @@ var (
 			return restoreCmd(&restoreCommand, cmd)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, true)
+			return checkAllLatestAndCIDFile(cmd, args, true, false)
 		},
 		Example: `podman container restore ctrID
   podman container restore --latest

--- a/cmd/podman/rm.go
+++ b/cmd/podman/rm.go
@@ -25,7 +25,7 @@ var (
 			return rmCmd(&rmCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, true)
 		},
 		Example: `podman rm imageID
   podman rm mywebserver myflaskserver 860a4b23
@@ -44,8 +44,10 @@ func init() {
 	flags.BoolVarP(&rmCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&rmCommand.Storage, "storage", false, "Remove container from storage library")
 	flags.BoolVarP(&rmCommand.Volumes, "volumes", "v", false, "Remove anonymous volumes associated with the container")
+	flags.StringArrayVarP(&rmCommand.CIDFiles, "cidfile", "", nil, "Read the container ID from the file")
 	markFlagHiddenForRemoteClient("storage", flags)
 	markFlagHiddenForRemoteClient("latest", flags)
+	markFlagHiddenForRemoteClient("cidfile", flags)
 }
 
 // rmCmd removes one or more containers
@@ -58,8 +60,8 @@ func rmCmd(c *cliconfig.RmValues) error {
 
 	// Storage conflicts with --all/--latest/--volumes
 	if c.Storage {
-		if c.All || c.Latest || c.Volumes {
-			return errors.Errorf("--storage conflicts with --volumes, --all, and --latest")
+		if c.All || c.Latest || c.Volumes || c.CIDFiles != nil {
+			return errors.Errorf("--storage conflicts with --volumes, --all, --latest and --cidfile")
 		}
 	}
 

--- a/cmd/podman/stop.go
+++ b/cmd/podman/stop.go
@@ -25,7 +25,7 @@ var (
 			return stopCmd(&stopCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, true)
 		},
 		Example: `podman stop ctrID
   podman stop --latest
@@ -42,7 +42,9 @@ func init() {
 	flags.BoolVarP(&stopCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.UintVar(&stopCommand.Timeout, "time", define.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
 	flags.UintVarP(&stopCommand.Timeout, "timeout", "t", define.CtrRemoveTimeout, "Seconds to wait for stop before killing the container")
+	flags.StringArrayVarP(&stopCommand.CIDFiles, "cidfile", "", nil, "Read the container ID from the file")
 	markFlagHiddenForRemoteClient("latest", flags)
+	markFlagHiddenForRemoteClient("cidfile", flags)
 }
 
 // stopCmd stops a container or containers

--- a/cmd/podman/umount.go
+++ b/cmd/podman/umount.go
@@ -28,7 +28,7 @@ var (
 			return umountCmd(&umountCommand)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			return checkAllAndLatest(cmd, args, false)
+			return checkAllLatestAndCIDFile(cmd, args, false, false)
 		},
 		Example: `podman umount ctrID
   podman umount ctrID1 ctrID2 ctrID3

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2150,6 +2150,7 @@ _podman_rm() {
     local boolean_options="
 	--all
 	-a
+	--cidfile
 	--force
 	-f
 	--help
@@ -2426,6 +2427,7 @@ _podman_stop() {
      local boolean_options="
 	  --all
 	  -a
+	  --cidfile
 	  -h
 	  --help
 	  --latest

--- a/docs/source/markdown/podman-rm.1.md
+++ b/docs/source/markdown/podman-rm.1.md
@@ -18,6 +18,10 @@ Running or unusable containers will not be removed without the `-f` option.
 
 Remove all containers.  Can be used in conjunction with -f as well.
 
+**--cidfile**
+
+Read container ID from the specified file and remove the container.  Can be specified multiple times.
+
 **--force**, **-f**
 
 Force the removal of running and paused containers. Forcing a container removal also
@@ -50,9 +54,15 @@ Remove a container by its name *mywebserver*
 ```
 podman rm mywebserver
 ```
+
 Remove several containers by name and container id.
 ```
 podman rm mywebserver myflaskserver 860a4b23
+```
+
+Remove several containers reading their IDs from files.
+```
+podman rm --cidfile ./cidfile-1 --cidfile /home/user/cidfile-2
 ```
 
 Forcibly remove a container by container ID.

--- a/docs/source/markdown/podman-stop.1.md
+++ b/docs/source/markdown/podman-stop.1.md
@@ -21,6 +21,10 @@ container and also via command line when creating the container.
 
 Stop all running containers.  This does not include paused containers.
 
+**--cidfile**
+
+Read container ID from the specified file and remove the container.  Can be specified multiple times.
+
 **--latest**, **-l**
 
 Instead of providing the container name or ID, use the last created container. If you use methods other than Podman
@@ -39,6 +43,10 @@ podman stop mywebserver
 podman stop 860a4b235279
 
 podman stop mywebserver 860a4b235279
+
+podman stop --cidfile /home/user/cidfile-1
+
+podman stop --cidfile /home/user/cidfile-1 --cidfile ./cidfile-2
 
 podman stop --timeout 2 860a4b235279
 

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -79,7 +79,17 @@ func (r *LocalRuntime) StopContainers(ctx context.Context, cli *cliconfig.StopVa
 	}
 	logrus.Debugf("Setting maximum stop workers to %d", maxWorkers)
 
-	ctrs, err := shortcuts.GetContainersByContext(cli.All, cli.Latest, cli.InputArgs, r.Runtime)
+	names := cli.InputArgs
+	for _, cidFile := range cli.CIDFiles {
+		content, err := ioutil.ReadFile(cidFile)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "error reading CIDFile")
+		}
+		id := strings.Split(string(content), "\n")[0]
+		names = append(names, id)
+	}
+
+	ctrs, err := shortcuts.GetContainersByContext(cli.All, cli.Latest, names, r.Runtime)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -203,7 +213,17 @@ func (r *LocalRuntime) RemoveContainers(ctx context.Context, cli *cliconfig.RmVa
 		return ok, failures, nil
 	}
 
-	ctrs, err := shortcuts.GetContainersByContext(cli.All, cli.Latest, cli.InputArgs, r.Runtime)
+	names := cli.InputArgs
+	for _, cidFile := range cli.CIDFiles {
+		content, err := ioutil.ReadFile(cidFile)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "error reading CIDFile")
+		}
+		id := strings.Split(string(content), "\n")[0]
+		names = append(names, id)
+	}
+
+	ctrs, err := shortcuts.GetContainersByContext(cli.All, cli.Latest, names, r.Runtime)
 	if err != nil {
 		// Failed to get containers. If force is specified, get the containers ID
 		// and evict them

--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"io/ioutil"
 	"os"
 
 	. "github.com/containers/libpod/test/utils"
@@ -138,11 +139,86 @@ var _ = Describe("Podman rm", func() {
 
 	})
 
+	It("podman rm --cidfile", func() {
+		SkipIfRemote()
+
+		tmpDir, err := ioutil.TempDir("", "")
+		Expect(err).To(BeNil())
+		tmpFile := tmpDir + "cid"
+
+		defer os.RemoveAll(tmpDir)
+
+		session := podmanTest.Podman([]string{"create", "--cidfile", tmpFile, ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid := session.OutputToStringArray()[0]
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+
+		result := podmanTest.Podman([]string{"rm", "--cidfile", tmpFile})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		output := result.OutputToString()
+		Expect(output).To(ContainSubstring(cid))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
+	})
+
+	It("podman rm multiple --cidfile", func() {
+		SkipIfRemote()
+
+		tmpDir, err := ioutil.TempDir("", "")
+		Expect(err).To(BeNil())
+		tmpFile1 := tmpDir + "cid-1"
+		tmpFile2 := tmpDir + "cid-2"
+
+		defer os.RemoveAll(tmpDir)
+
+		session := podmanTest.Podman([]string{"create", "--cidfile", tmpFile1, ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid1 := session.OutputToStringArray()[0]
+		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
+
+		session = podmanTest.Podman([]string{"create", "--cidfile", tmpFile2, ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cid2 := session.OutputToStringArray()[0]
+		Expect(podmanTest.NumberOfContainers()).To(Equal(2))
+
+		result := podmanTest.Podman([]string{"rm", "--cidfile", tmpFile1, "--cidfile", tmpFile2})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		output := result.OutputToString()
+		Expect(output).To(ContainSubstring(cid1))
+		Expect(output).To(ContainSubstring(cid2))
+		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
+	})
+
+	It("podman rm invalid --latest and --cidfile and --all", func() {
+		SkipIfRemote()
+
+		result := podmanTest.Podman([]string{"rm", "--cidfile", "foobar", "--latest"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(125))
+
+		result = podmanTest.Podman([]string{"rm", "--cidfile", "foobar", "--all"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(125))
+
+		result = podmanTest.Podman([]string{"rm", "--cidfile", "foobar", "--all", "--latest"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(125))
+
+		result = podmanTest.Podman([]string{"rm", "--latest", "--all"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(125))
+	})
+
 	It("podman rm bogus container", func() {
 		session := podmanTest.Podman([]string{"rm", "bogus"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(1))
 	})
+
 	It("podman rm bogus container and a running container", func() {
 		session := podmanTest.RunTopContainer("test1")
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Add a --cidfile flag to podman rm/stop to pass a container ID via a
file.  Podman run already provides the functionaly to store the ID
in a specified file which we now complete with rm/stop.  This allows
for a better life-cycle management in systemd services.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>