### PR TITLE
container-restore: Fix restore with user namespace

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -884,7 +884,12 @@ func (c *Container) restore(ctx context.Context, options ContainerCheckpointOpti
 
 	// We want to have the same network namespace as before.
 	if c.config.CreateNetNS {
-		if err := g.AddOrReplaceLinuxNamespace(string(spec.NetworkNamespace), c.state.NetNS.Path()); err != nil {
+		netNSPath := ""
+		if !c.config.PostConfigureNetNS {
+			netNSPath = c.state.NetNS.Path()
+		}
+
+		if err := g.AddOrReplaceLinuxNamespace(string(spec.NetworkNamespace), netNSPath); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When restoring a container with user namespace, the user namespace is created by the OCI runtime, and the network namespace is created after the user namespace to ensure correct ownership.

In this case `PostConfigureNetNS` will be set and the value of `c.state.NetNS` would be nil. Hence, the following error occurs:

    $ sudo podman run --name cr \
	   --uidmap 0:1000:500 \
	   -d docker.io/library/alpine \
	   /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'

    $ sudo podman container checkpoint cr
    $ sudo podman container restore cr
    ...
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x13a5e3c]