### PR TITLE
Handle seccomp annotations in play kube

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -559,3 +559,12 @@ func (p *PodmanTestIntegration) RunHealthCheck(cid string) error {
 	}
 	return errors.Errorf("unable to detect %s as running", cid)
 }
+
+func (p *PodmanTestIntegration) CreateSeccompJson(in []byte) (string, error) {
+	jsonFile := filepath.Join(p.TempDir, "seccomp.json")
+	err := WriteJsonFile(in, jsonFile)
+	if err != nil {
+		return "", err
+	}
+	return jsonFile, nil
+}

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -160,9 +160,9 @@ var _ = Describe("Podman run", func() {
 	})
 
 	It("podman run seccomp test", func() {
-		jsonFile := filepath.Join(podmanTest.TempDir, "seccomp.json")
+
 		in := []byte(`{"defaultAction":"SCMP_ACT_ALLOW","syscalls":[{"name":"getcwd","action":"SCMP_ACT_ERRNO"}]}`)
-		err := WriteJsonFile(in, jsonFile)
+		jsonFile, err := podmanTest.CreateSeccompJson(in)
 		if err != nil {
 			fmt.Println(err)
 			Skip("Failed to prepare seccomp.json for test.")


### PR DESCRIPTION
This PR checks for annotations for a seccomp profile in a kube yaml, and applies them. ~It does not yet implement container level seccomp annotations. It is also technically not yet tested (airport wifi isn't letting me run the test suite). I'm mostly submitting the PR to see if the test works as expected~
being cooped up in an airplane lead me to pretty much finish this.

there's one inconsistency that needs to be addressed. k8s yaml format parses a profile path like
`localhost/<path>` with a global value `<seccomp_root>` filled, whereas now this PR does `localhost:<seccomp_root>/<path>`
Does anyone have any suggestions on a good default location? I was thinking `/etc/containers/seccomp/` but it doesn't already exist so I'm not sure.

closes:  https://github.com/containers/libpod/issues/3111