### PR TITLE
Allow --ip and --mac to be set when joining a CNI net

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1041,8 +1041,8 @@ func WithStaticIP(ip net.IP) CtrCreateOption {
 			return errors.Wrapf(define.ErrInvalidArg, "cannot set a static IP if the container is not creating a network namespace")
 		}
 
-		if len(ctr.config.Networks) != 0 {
-			return errors.Wrapf(define.ErrInvalidArg, "cannot set a static IP if joining additional CNI networks")
+		if len(ctr.config.Networks) > 1 {
+			return errors.Wrapf(define.ErrInvalidArg, "cannot set a static IP if joining more than 1 CNI network")
 		}
 
 		ctr.config.StaticIP = ip
@@ -1066,8 +1066,8 @@ func WithStaticMAC(mac net.HardwareAddr) CtrCreateOption {
 			return errors.Wrapf(define.ErrInvalidArg, "cannot set a static MAC if the container is not creating a network namespace")
 		}
 
-		if len(ctr.config.Networks) != 0 {
-			return errors.Wrapf(define.ErrInvalidArg, "cannot set a static MAC if joining additional CNI networks")
+		if len(ctr.config.Networks) > 1 {
+			return errors.Wrapf(define.ErrInvalidArg, "cannot set a static MAC if joining more than 1 CNI network")
 		}
 
 		ctr.config.StaticMAC = mac

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -232,4 +232,18 @@ var _ = Describe("Podman run networking", func() {
 		Expect(session).To(ExitWithError())
 		Expect(session.ErrorToString()).To(ContainSubstring("stat /run/netns/xxy: no such file or directory"))
 	})
+
+	It("podman run in custom CNI network with --static-ip", func() {
+		SkipIfRootless()
+		netName := "podmantestnetwork"
+		ipAddr := "10.20.30.128"
+		create := podmanTest.Podman([]string{"network", "create", "--subnet", "10.20.30.0/24", netName})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(BeZero())
+
+		run := podmanTest.Podman([]string{"run", "-t", "-i", "--rm", "--net", netName, "--ip", ipAddr, ALPINE, "ip", "addr"})
+		run.WaitWithDefaultTimeout()
+		Expect(run.ExitCode()).To(BeZero())
+		Expect(run.OutputToString()).To(ContainSubstring(ipAddr))
+	})
 })


### PR DESCRIPTION
These only conflict when joining more than one network. We can still set a single CNI network and set a static IP and/or static MAC.

Fixes #4500