### PR TITLE
Add podman system reset command

### DIFF
--- a/API.md
+++ b/API.md
@@ -149,6 +149,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func RemovePod(name: string, force: bool) string](#RemovePod)
 
+[func Reset() ](#Reset)
+
 [func RestartContainer(name: string, timeout: int) string](#RestartContainer)
 
 [func RestartPod(name: string) string](#RestartPod)
@@ -1059,6 +1061,12 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.RemovePod '{"name": "62f4
   "pod": "62f4fd98cb57f529831e8f90610e54bba74bd6f02920ffb485e15376ed365c20"
 }
 ~~~
+### <a name="Reset"></a>func Reset
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method Reset() </div>
+Reset resets Podman back to its initial state.
+Removes all Pods, Containers, Images and Volumes
 ### <a name="RestartContainer"></a>func RestartContainer
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 

--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -658,6 +658,11 @@ type SystemPruneValues struct {
 	Volume bool
 }
 
+type SystemResetValues struct {
+	PodmanCommand
+	Force bool
+}
+
 type SystemRenumberValues struct {
 	PodmanCommand
 }

--- a/cmd/podman/reset.go
+++ b/cmd/podman/reset.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/containers/libpod/cmd/podman/cliconfig"
+	"github.com/containers/libpod/pkg/adapter"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	systemResetCommand     cliconfig.SystemResetValues
+	systemResetDescription = `Reset podman storage back to default state"
+
+  All containers will be stopped and removed, and all images, volumes and container content will be removed.
+`
+	_systemResetCommand = &cobra.Command{
+		Use:   "reset",
+		Args:  noSubArgs,
+		Short: "Reset podman storage",
+		Long:  systemResetDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			systemResetCommand.InputArgs = args
+			systemResetCommand.GlobalFlags = MainGlobalOpts
+			systemResetCommand.Remote = remoteclient
+			return systemResetCmd(&systemResetCommand)
+		},
+	}
+)
+
+func init() {
+	systemResetCommand.Command = _systemResetCommand
+	flags := systemResetCommand.Flags()
+	flags.BoolVarP(&systemResetCommand.Force, "force", "f", false, "Do not prompt for confirmation")
+
+	systemResetCommand.SetHelpTemplate(HelpTemplate())
+	systemResetCommand.SetUsageTemplate(UsageTemplate())
+}
+
+func systemResetCmd(c *cliconfig.SystemResetValues) error {
+	// Prompt for confirmation if --force is not set
+	if !c.Force {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Print(`
+WARNING! This will remove:
+        - all containers
+        - all pods
+        - all images
+        - all build cache
+Are you sure you want to continue? [y/N] `)
+		ans, err := reader.ReadString('\n')
+		if err != nil {
+			return errors.Wrapf(err, "error reading input")
+		}
+		if strings.ToLower(ans)[0] != 'y' {
+			return nil
+		}
+	}
+
+	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
+	if err != nil {
+		return errors.Wrapf(err, "error creating libpod runtime")
+	}
+	// No shutdown, since storage will be destroyed when command completes
+
+	return runtime.Reset()
+}

--- a/cmd/podman/system.go
+++ b/cmd/podman/system.go
@@ -19,6 +19,7 @@ var (
 )
 
 var systemCommands = []*cobra.Command{
+	_systemResetCommand,
 	_infoCommand,
 	_pruneSystemCommand,
 }

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -536,6 +536,10 @@ method GetVersion() -> (
     remote_api_version: int
 )
 
+# Reset resets Podman back to its initial state.
+# Removes all Pods, Containers, Images and Volumes
+method Reset() -> ()
+
 # GetInfo returns a [PodmanInfo](#PodmanInfo) struct that describes podman and its host such as storage stats,
 # build information of Podman, and system-wide registries.
 method GetInfo() -> (info: PodmanInfo)

--- a/commands.md
+++ b/commands.md
@@ -78,6 +78,12 @@
 | [podman-stats(1)](/docs/source/markdown/podman-stats.1.md)                               | Display a live stream of one or more containers' resource usage statistics |
 | [podman-stop(1)](/docs/source/markdown/podman-stop.1.md)                                 | Stops one or more running containers                                       |
 | [podman-system(1)](/docs/source/markdown/podman-system.1.md)                             | Manage podman                                                              |
+| [podman-system-df(1)](/docs/source/markdown/podman-system-df.1.md)                       | Show podman disk usage.                                                    |
+| [podman-system-info(1)](/docs/source/markdown/podman-info.1.md)                          | Displays Podman related system information.                                |
+| [podman-system-migrate(1)](/docs/source/markdown/podman-system-migrate.1.md)             | Migrate existing containers to a new podman version.                       |
+| [podman-system-prune(1)](/docs/source/markdown/podman-system-prune.1.md)                 | Remove all unused container, image and volume data.                        |
+| [podman-system-renumber(1)](/docs/source/markdown/podman-system-renumber.1.md)           | Migrate lock numbers to handle a change in maximum number of locks.        |
+| [podman-system-reset(1)](/docs/source/markdown/podman-system-reset.1.md)                 | Reset storage back to original state.  Remove all pods, containers, images, volumes. |
 | [podman-tag(1)](/docs/source/markdown/podman-tag.1.md)                                   | Add an additional name to a local image                                    | [![...](/docs/source/markdown/play.png)](https://asciinema.org/a/133803)                    |
 | [podman-top(1)](/docs/source/markdown/podman-top.1.md)                                   | Display the running processes of a container                               |
 | [podman-umount(1)](/docs/source/markdown/podman-umount.1.md)                             | Unmount a working container's root filesystem                              |

--- a/commands.md
+++ b/commands.md
@@ -6,89 +6,89 @@
 
 | Command                                                                  | Description                                                                | Demo                                                                        | Script                                                                              |
 | :----------------------------------------------------------------------- | :------------------------------------------------------------------------- | :-------------------------------------------------------------------------- | :---------------------------------------------------------------------------------- |
-| [podman(1)](/docs/podman.1.md)                                           | Simple management tool for pods and images                                 |
-| [podman-attach(1)](/docs/podman-attach.1.md)                             | Attach to a running container                                              |
-| [podman-build(1)](/docs/podman-build.1.md)                               | Build an image using instructions from Dockerfiles                         |
-| [podman-commit(1)](/docs/podman-commit.1.md)                             | Create new image based on the changed container                            |
-| [podman-container(1)](/docs/podman-container.1.md)                       | Manage Containers                                                          |
-| [podman-container-checkpoint(1)](/docs/podman-container-checkpoint.1.md) | Checkpoints one or more running containers                                 |
-| [podman-container-cleanup(1)](/docs/podman-container-cleanup.1.md)       | Cleanup Container storage and networks                                     |
-| [podman-container-exists(1)](/docs/podman-container-exists.1.md)         | Check if an container exists in local storage                              |
-| [podman-container-prune(1)](/docs/podman-container-prune.1.md)           | Remove all stopped containers                                              |
-| [podman-container-refresh(1)](/docs/podman-container-refresh.1.md)       | Refresh all containers state in database                                   |
-| [podman-container-restore(1)](/docs/podman-container-restore.1.md)       | Restores one or more running containers                                    |
-| [podman-container-runlabel(1)](/docs/podman-container-runlabel.1.md)     | Execute Image Label Method                                                 |
-| [podman-cp(1)](/docs/podman-cp.1.md)                                     | Copy files/folders between a container and the local filesystem            |
-| [podman-create(1)](/docs/podman-create.1.md)                             | Create a new container                                                     |
-| [podman-diff(1)](/docs/podman-diff.1.md)                                 | Inspect changes on a container or image's filesystem                       |
-| [podman-events(1)](/docs/podman-events.1.md)                             | Monitor Podman events                                                      |
-| [podman-exec(1)](/docs/podman-exec.1.md)                                 | Execute a command in a running container                                   |
-| [podman-export(1)](/docs/podman-export.1.md)                             | Export container's filesystem contents as a tar archive                    |
-| [podman-generate(1)](/docs/podman-generate.1.md)                         | Generate structured output based on Podman containers and pods             |
-| [podman-generate-kube(1)](/docs/podman-generate-kube.1.md)               | Generate Kubernetes YAML based on a container or Pod                       |
-| [podman-generate-systemd(1)](/docs/podman-generate-systemd.1.md)         | Generate a Systemd unit file for a container                               |
-| [podman-history(1)](/docs/podman-history.1.md)                           | Shows the history of an image                                              |
-| [podman-image(1)](/docs/podman-image.1.md)                               | Manage Images                                                              |
-| [podman-image-exists(1)](/docs/podman-image-exists.1.md)                 | Check if an image exists in local storage                                  |
-| [podman-image-prune(1)](/docs/podman-image-prune.1.md)                   | Remove all unused images                                                   |
-| [podman-image-sign(1)](/docs/podman-image-sign.1.md)                     | Create a signature for an image                                            |
-| [podman-image-trust(1)](/docs/podman-image-trust.1.md)                   | Manage container registry image trust policy                               |
-| [podman-images(1)](/docs/podman-images.1.md)                             | List images in local storage                                               | [![...](/docs/play.png)](https://podman.io/asciinema/podman/images/)        | [Here](https://github.com/containers/Demos/blob/master/podman_cli/podman_images.sh) |
-| [podman-import(1)](/docs/podman-import.1.md)                             | Import a tarball and save it as a filesystem image                         |
-| [podman-info(1)](/docs/podman-info.1.md)                                 | Display system information                                                 |
-| [podman-init(1)](/docs/podman-init.1.md)                                 | Initialize a container                                                     |
-| [podman-inspect(1)](/docs/podman-inspect.1.md)                           | Display the configuration of a container or image                          | [![...](/docs/play.png)](https://asciinema.org/a/133418)                    |
-| [podman-kill(1)](/docs/podman-kill.1.md)                                 | Kill the main process in one or more running containers                    |
-| [podman-load(1)](/docs/podman-load.1.md)                                 | Load an image from a container image archive                               |
-| [podman-login(1)](/docs/podman-login.1.md)                               | Login to a container registry                                              |
-| [podman-logout(1)](/docs/podman-logout.1.md)                             | Logout of a container registry                                             |
-| [podman-logs(1)](/docs/podman-logs.1.md)                                 | Display the logs of a container                                            |
-| [podman-mount(1)](/docs/podman-mount.1.md)                               | Mount a working container's root filesystem                                |
-| [podman-network(1)](/docs/podman-network.1.md)                           | Manage Podman CNI networks             |
-| [podman-network-create(1)](/docs/podman-network-create.1.md)             | Create a CNI network             |
-| [podman-network-inspect(1)](/docs/podman-network-inspect.1.md)           | Inspect one or more Podman networks             |
-| [podman-network-ls(1)](/docs/podman-network-ls.1.md)                     | Display a summary of Podman networks             |
-| [podman-network-rm(1)](/docs/podman-network-rm.1.md)                     | Remove one or more Podman networks             |
-| [podman-pause(1)](/docs/podman-pause.1.md)                               | Pause one or more running containers                                       | [![...](/docs/play.png)](https://podman.io/asciinema/podman/pause_unpause/)        | [Here](https://github.com/containers/Demos/blob/master/podman_cli/podman_pause_unpause.sh) |
-| [podman-play(1)](/docs/podman-play.1.md)                                 | Play pods and containers based on a structured input file                  |
-| [podman-pod(1)](/docs/podman-pod.1.md)                                   | Simple management tool for groups of containers, called pods               |
-| [podman-pod-create(1)](/docs/podman-pod-create.1.md)                     | Create a new pod                                                           |
-| [podman-pod-inspect(1)](/docs/podman-pod-inspect.1.md)                   | Inspect a pod                                                              |
+| [podman(1)](/docs/source/markdown/podman.1.md)                                           | Simple management tool for pods and images                                 |
+| [podman-attach(1)](/docs/source/markdown/podman-attach.1.md)                             | Attach to a running container                                              |
+| [podman-build(1)](/docs/source/markdown/podman-build.1.md)                               | Build an image using instructions from Dockerfiles                         |
+| [podman-commit(1)](/docs/source/markdown/podman-commit.1.md)                             | Create new image based on the changed container                            |
+| [podman-container(1)](/docs/source/markdown/podman-container.1.md)                       | Manage Containers                                                          |
+| [podman-container-checkpoint(1)](/docs/source/markdown/podman-container-checkpoint.1.md) | Checkpoints one or more running containers                                 |
+| [podman-container-cleanup(1)](/docs/source/markdown/podman-container-cleanup.1.md)       | Cleanup Container storage and networks                                     |
+| [podman-container-exists(1)](/docs/source/markdown/podman-container-exists.1.md)         | Check if an container exists in local storage                              |
+| [podman-container-prune(1)](/docs/source/markdown/podman-container-prune.1.md)           | Remove all stopped containers                                              |
+| [podman-container-refresh(1)](/docs/source/markdown/podman-container-refresh.1.md)       | Refresh all containers state in database                                   |
+| [podman-container-restore(1)](/docs/source/markdown/podman-container-restore.1.md)       | Restores one or more running containers                                    |
+| [podman-container-runlabel(1)](/docs/source/markdown/podman-container-runlabel.1.md)     | Execute Image Label Method                                                 |
+| [podman-cp(1)](/docs/source/markdown/podman-cp.1.md)                                     | Copy files/folders between a container and the local filesystem            |
+| [podman-create(1)](/docs/source/markdown/podman-create.1.md)                             | Create a new container                                                     |
+| [podman-diff(1)](/docs/source/markdown/podman-diff.1.md)                                 | Inspect changes on a container or image's filesystem                       |
+| [podman-events(1)](/docs/source/markdown/podman-events.1.md)                             | Monitor Podman events                                                      |
+| [podman-exec(1)](/docs/source/markdown/podman-exec.1.md)                                 | Execute a command in a running container                                   |
+| [podman-export(1)](/docs/source/markdown/podman-export.1.md)                             | Export container's filesystem contents as a tar archive                    |
+| [podman-generate(1)](/docs/source/markdown/podman-generate.1.md)                         | Generate structured output based on Podman containers and pods             |
+| [podman-generate-kube(1)](/docs/source/markdown/podman-generate-kube.1.md)               | Generate Kubernetes YAML based on a container or Pod                       |
+| [podman-generate-systemd(1)](/docs/source/markdown/podman-generate-systemd.1.md)         | Generate a Systemd unit file for a container                               |
+| [podman-history(1)](/docs/source/markdown/podman-history.1.md)                           | Shows the history of an image                                              |
+| [podman-image(1)](/docs/source/markdown/podman-image.1.md)                               | Manage Images                                                              |
+| [podman-image-exists(1)](/docs/source/markdown/podman-image-exists.1.md)                 | Check if an image exists in local storage                                  |
+| [podman-image-prune(1)](/docs/source/markdown/podman-image-prune.1.md)                   | Remove all unused images                                                   |
+| [podman-image-sign(1)](/docs/source/markdown/podman-image-sign.1.md)                     | Create a signature for an image                                            |
+| [podman-image-trust(1)](/docs/source/markdown/podman-image-trust.1.md)                   | Manage container registry image trust policy                               |
+| [podman-images(1)](/docs/source/markdown/podman-images.1.md)                             | List images in local storage                                               | [![...](/docs/source/markdown/play.png)](https://podman.io/asciinema/podman/images/)        | [Here](https://github.com/containers/Demos/blob/master/podman_cli/podman_images.sh) |
+| [podman-import(1)](/docs/source/markdown/podman-import.1.md)                             | Import a tarball and save it as a filesystem image                         |
+| [podman-info(1)](/docs/source/markdown/podman-info.1.md)                                 | Display system information                                                 |
+| [podman-init(1)](/docs/source/markdown/podman-init.1.md)                                 | Initialize a container                                                     |
+| [podman-inspect(1)](/docs/source/markdown/podman-inspect.1.md)                           | Display the configuration of a container or image                          | [![...](/docs/source/markdown/play.png)](https://asciinema.org/a/133418)                    |
+| [podman-kill(1)](/docs/source/markdown/podman-kill.1.md)                                 | Kill the main process in one or more running containers                    |
+| [podman-load(1)](/docs/source/markdown/podman-load.1.md)                                 | Load an image from a container image archive                               |
+| [podman-login(1)](/docs/source/markdown/podman-login.1.md)                               | Login to a container registry                                              |
+| [podman-logout(1)](/docs/source/markdown/podman-logout.1.md)                             | Logout of a container registry                                             |
+| [podman-logs(1)](/docs/source/markdown/podman-logs.1.md)                                 | Display the logs of a container                                            |
+| [podman-mount(1)](/docs/source/markdown/podman-mount.1.md)                               | Mount a working container's root filesystem                                |
+| [podman-network(1)](/docs/source/markdown/podman-network.1.md)                           | Manage Podman CNI networks             |
+| [podman-network-create(1)](/docs/source/markdown/podman-network-create.1.md)             | Create a CNI network             |
+| [podman-network-inspect(1)](/docs/source/markdown/podman-network-inspect.1.md)           | Inspect one or more Podman networks             |
+| [podman-network-ls(1)](/docs/source/markdown/podman-network-ls.1.md)                     | Display a summary of Podman networks             |
+| [podman-network-rm(1)](/docs/source/markdown/podman-network-rm.1.md)                     | Remove one or more Podman networks             |
+| [podman-pause(1)](/docs/source/markdown/podman-pause.1.md)                               | Pause one or more running containers                                       | [![...](/docs/source/markdown/play.png)](https://podman.io/asciinema/podman/pause_unpause/)        | [Here](https://github.com/containers/Demos/blob/master/podman_cli/podman_pause_unpause.sh) |
+| [podman-play(1)](/docs/source/markdown/podman-play.1.md)                                 | Play pods and containers based on a structured input file                  |
+| [podman-pod(1)](/docs/source/markdown/podman-pod.1.md)                                   | Simple management tool for groups of containers, called pods               |
+| [podman-pod-create(1)](/docs/source/markdown/podman-pod-create.1.md)                     | Create a new pod                                                           |
+| [podman-pod-inspect(1)](/docs/source/markdown/podman-pod-inspect.1.md)                   | Inspect a pod                                                              |
 | [podman-pod-kill(1)](podman-pod-kill.1.md)                               | Kill the main process of each container in pod.                            |
-| [podman-pod-ps(1)](/docs/podman-pod-ps.1.md)                             | List the pods on the system                                                |
+| [podman-pod-ps(1)](/docs/source/markdown/podman-pod-ps.1.md)                             | List the pods on the system                                                |
 | [podman-pod-pause(1)](podman-pod-pause.1.md)                             | Pause one or more pods.                                                    |
-| [podman-pod-restart](/docs/podman-pod-restart.1.md)                      | Restart one or more pods                                                   |
-| [podman-pod-rm(1)](/docs/podman-pod-rm.1.md)                             | Remove one or more pods                                                    |
-| [podman-pod-start(1)](/docs/podman-pod-start.1.md)                       | Start one or more pods                                                     |
-| [podman-pod-stats(1)](/docs/podman-pod-stats.1.md)                       | Display a live stream of one or more pods' resource usage statistics       |                                                                             |                                                                                     |
-| [podman-pod-stop(1)](/docs/podman-pod-stop.1.md)                         | Stop one or more pods                                                      |
-| [podman-pod-top(1)](/docs/podman-pod-top.1.md)                           | Display the running processes of a pod                                     |
+| [podman-pod-restart](/docs/source/markdown/podman-pod-restart.1.md)                      | Restart one or more pods                                                   |
+| [podman-pod-rm(1)](/docs/source/markdown/podman-pod-rm.1.md)                             | Remove one or more pods                                                    |
+| [podman-pod-start(1)](/docs/source/markdown/podman-pod-start.1.md)                       | Start one or more pods                                                     |
+| [podman-pod-stats(1)](/docs/source/markdown/podman-pod-stats.1.md)                       | Display a live stream of one or more pods' resource usage statistics       |                                                                             |                                                                                     |
+| [podman-pod-stop(1)](/docs/source/markdown/podman-pod-stop.1.md)                         | Stop one or more pods                                                      |
+| [podman-pod-top(1)](/docs/source/markdown/podman-pod-top.1.md)                           | Display the running processes of a pod                                     |
 | [podman-pod-unpause(1)](podman-pod-unpause.1.md)                         | Unpause one or more pods.                                                  |
-| [podman-port(1)](/docs/podman-port.1.md)                                 | List port mappings for running containers                                  |
-| [podman-ps(1)](/docs/podman-ps.1.md)                                     | Prints out information about containers                                    |
-| [podman-pull(1)](/docs/podman-pull.1.md)                                 | Pull an image from a registry                                              |
-| [podman-push(1)](/docs/podman-push.1.md)                                 | Push an image to a specified destination                                   | [![...](/docs/play.png)](https://asciinema.org/a/133276)                    |
-| [podman-restart](/docs/podman-restart.1.md)                              | Restarts one or more containers                                            | [![...](/docs/play.png)](https://asciinema.org/a/jiqxJAxcVXw604xdzMLTkQvHM) |
-| [podman-rm(1)](/docs/podman-rm.1.md)                                     | Removes one or more containers                                             |
-| [podman-rmi(1)](/docs/podman-rmi.1.md)                                   | Removes one or more images                                                 |
-| [podman-run(1)](/docs/podman-run.1.md)                                   | Run a command in a container                                               |
-| [podman-save(1)](/docs/podman-save.1.md)                                 | Saves an image to an archive                                               |
-| [podman-search(1)](/docs/podman-search.1.md)                             | Search a registry for an image                                             |
-| [podman-start(1)](/docs/podman-start.1.md)                               | Starts one or more containers                                              |
-| [podman-stats(1)](/docs/podman-stats.1.md)                               | Display a live stream of one or more containers' resource usage statistics |
-| [podman-stop(1)](/docs/podman-stop.1.md)                                 | Stops one or more running containers                                       |
-| [podman-system(1)](/docs/podman-system.1.md)                             | Manage podman                                                              |
-| [podman-tag(1)](/docs/podman-tag.1.md)                                   | Add an additional name to a local image                                    | [![...](/docs/play.png)](https://asciinema.org/a/133803)                    |
-| [podman-top(1)](/docs/podman-top.1.md)                                   | Display the running processes of a container                               |
-| [podman-umount(1)](/docs/podman-umount.1.md)                             | Unmount a working container's root filesystem                              |
-| [podman-unpause(1)](/docs/podman-unpause.1.md)                           | Unpause one or more running containers                                     | [![...](/docs/play.png)](https://podman.io/asciinema/podman/pause_unpause/)        | [Here](https://github.com/containers/Demos/blob/master/podman_cli/podman_pause_unpause.sh) |
-| [podman-unshare(1)](/docs/podman-unshare.1.md)                           | Run a command inside of a modified user namespace.                         |
-| [podman-varlink(1)](/docs/podman-varlink.1.md)                           | Run the varlink backend                                                    |
-| [podman-version(1)](/docs/podman-version.1.md)                           | Display the version information                                            |
-| [podman-volume(1)](/docs/podman-volume.1.md)                             | Manage Volumes                                                             |
-| [podman-volume-create(1)](/docs/podman-volume-create.1.md)               | Create a volume                                                            |
-| [podman-volume-inspect(1)](/docs/podman-volume-inspect.1.md)             | Get detailed information on one or more volumes                            |
-| [podman-volume-ls(1)](/docs/podman-volume-ls.1.md)                       | List all the available volumes                                             |
-| [podman-volume-rm(1)](/docs/podman-volume-rm.1.md)                       | Remove one or more volumes                                                 |
-| [podman-volume-prune(1)](/docs/podman-volume-prune.1.md)                 | Remove all unused volumes                                                  |
-| [podman-wait(1)](/docs/podman-wait.1.md)                                 | Wait on one or more containers to stop and print their exit codes          |
+| [podman-port(1)](/docs/source/markdown/podman-port.1.md)                                 | List port mappings for running containers                                  |
+| [podman-ps(1)](/docs/source/markdown/podman-ps.1.md)                                     | Prints out information about containers                                    |
+| [podman-pull(1)](/docs/source/markdown/podman-pull.1.md)                                 | Pull an image from a registry                                              |
+| [podman-push(1)](/docs/source/markdown/podman-push.1.md)                                 | Push an image to a specified destination                                   | [![...](/docs/source/markdown/play.png)](https://asciinema.org/a/133276)                    |
+| [podman-restart](/docs/source/markdown/podman-restart.1.md)                              | Restarts one or more containers                                            | [![...](/docs/source/markdown/play.png)](https://asciinema.org/a/jiqxJAxcVXw604xdzMLTkQvHM) |
+| [podman-rm(1)](/docs/source/markdown/podman-rm.1.md)                                     | Removes one or more containers                                             |
+| [podman-rmi(1)](/docs/source/markdown/podman-rmi.1.md)                                   | Removes one or more images                                                 |
+| [podman-run(1)](/docs/source/markdown/podman-run.1.md)                                   | Run a command in a container                                               |
+| [podman-save(1)](/docs/source/markdown/podman-save.1.md)                                 | Saves an image to an archive                                               |
+| [podman-search(1)](/docs/source/markdown/podman-search.1.md)                             | Search a registry for an image                                             |
+| [podman-start(1)](/docs/source/markdown/podman-start.1.md)                               | Starts one or more containers                                              |
+| [podman-stats(1)](/docs/source/markdown/podman-stats.1.md)                               | Display a live stream of one or more containers' resource usage statistics |
+| [podman-stop(1)](/docs/source/markdown/podman-stop.1.md)                                 | Stops one or more running containers                                       |
+| [podman-system(1)](/docs/source/markdown/podman-system.1.md)                             | Manage podman                                                              |
+| [podman-tag(1)](/docs/source/markdown/podman-tag.1.md)                                   | Add an additional name to a local image                                    | [![...](/docs/source/markdown/play.png)](https://asciinema.org/a/133803)                    |
+| [podman-top(1)](/docs/source/markdown/podman-top.1.md)                                   | Display the running processes of a container                               |
+| [podman-umount(1)](/docs/source/markdown/podman-umount.1.md)                             | Unmount a working container's root filesystem                              |
+| [podman-unpause(1)](/docs/source/markdown/podman-unpause.1.md)                           | Unpause one or more running containers                                     | [![...](/docs/source/markdown/play.png)](https://podman.io/asciinema/podman/pause_unpause/)        | [Here](https://github.com/containers/Demos/blob/master/podman_cli/podman_pause_unpause.sh) |
+| [podman-unshare(1)](/docs/source/markdown/podman-unshare.1.md)                           | Run a command inside of a modified user namespace.                         |
+| [podman-varlink(1)](/docs/source/markdown/podman-varlink.1.md)                           | Run the varlink backend                                                    |
+| [podman-version(1)](/docs/source/markdown/podman-version.1.md)                           | Display the version information                                            |
+| [podman-volume(1)](/docs/source/markdown/podman-volume.1.md)                             | Manage Volumes                                                             |
+| [podman-volume-create(1)](/docs/source/markdown/podman-volume-create.1.md)               | Create a volume                                                            |
+| [podman-volume-inspect(1)](/docs/source/markdown/podman-volume-inspect.1.md)             | Get detailed information on one or more volumes                            |
+| [podman-volume-ls(1)](/docs/source/markdown/podman-volume-ls.1.md)                       | List all the available volumes                                             |
+| [podman-volume-rm(1)](/docs/source/markdown/podman-volume-rm.1.md)                       | Remove one or more volumes                                                 |
+| [podman-volume-prune(1)](/docs/source/markdown/podman-volume-prune.1.md)                 | Remove all unused volumes                                                  |
+| [podman-wait(1)](/docs/source/markdown/podman-wait.1.md)                                 | Wait on one or more containers to stop and print their exit codes          |

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1142,6 +1142,21 @@ _podman_container() {
      esac
 }
 
+_podman_system_reset() {
+	local options_with_args="
+	"
+	local boolean_options="
+	     -h
+	     --help
+	     --force
+	"
+    case "$cur" in
+	-*)
+	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+	    ;;
+    esac
+}
+
 _podman_system_df() {
 	local options_with_args="
 	--format
@@ -1193,6 +1208,7 @@ _podman_system() {
 	df
 	info
 	prune
+	reset
      "
      __podman_subcommands "$subcommands" && return
 

--- a/docs/source/markdown/podman-system-reset.1.md
+++ b/docs/source/markdown/podman-system-reset.1.md
@@ -1,0 +1,25 @@
+% podman-system-reset(1)
+
+## NAME
+podman\-system\-reset - Reset storage back to initial state
+
+## SYNOPSIS
+**podman system reset**
+
+## DESCRIPTION
+**podman system reset** removes all pods, containers, images and volumes.
+
+## OPTIONS
+**--force**, **-f**
+
+Do not prompt for confirmation
+
+**--help**, **-h**
+
+Print usage statement
+
+## SEE ALSO
+`podman(1)`, `podman-system(1)`
+
+## HISTORY
+November 2019, Originally compiled by Dan Walsh (dwalsh at redhat dot com)

--- a/docs/source/markdown/podman-system.1.md
+++ b/docs/source/markdown/podman-system.1.md
@@ -15,9 +15,10 @@ The system command allows you to manage the podman systems
 | -------  | --------------------------------------------------- | ---------------------------------------------------------------------------- |
 | df       | [podman-system-df(1)](podman-system-df.1.md)        | Show podman disk usage.                                                      |
 | info     | [podman-system-info(1)](podman-info.1.md)           | Displays Podman related system information.                                  |
-| prune    | [podman-system-prune(1)](podman-system-prune.1.md)  | Remove all unused container, image and volume data                              |
-| renumber | [podman-system-renumber(1)](podman-system-renumber.1.md)| Migrate lock numbers to handle a change in maximum number of locks.      |
 | migrate  | [podman-system-migrate(1)](podman-system-migrate.1.md)| Migrate existing containers to a new podman version.                       |
+| prune    | [podman-system-prune(1)](podman-system-prune.1.md)  | Remove all unused container, image and volume data.                          |
+| renumber | [podman-system-renumber(1)](podman-system-renumber.1.md)| Migrate lock numbers to handle a change in maximum number of locks.      |
+| reset    | [podman-system-reset(1)](podman-system-reset.1.md)  | Reset storage back to initial state.                                         |
 
 ## SEE ALSO
 podman(1)

--- a/libpod/reset.go
+++ b/libpod/reset.go
@@ -1,0 +1,107 @@
+package libpod
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/libpod/libpod/define"
+	"github.com/containers/libpod/pkg/rootless"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// Reset removes all storage
+func (r *Runtime) Reset(ctx context.Context) error {
+
+	pods, err := r.GetAllPods()
+	if err != nil {
+		return err
+	}
+	for _, p := range pods {
+		if err := r.RemovePod(ctx, p, true, true); err != nil {
+			if errors.Cause(err) == define.ErrNoSuchPod {
+				continue
+			}
+			logrus.Errorf("Error removing Pod %s: %v", p.ID(), err)
+		}
+	}
+
+	ctrs, err := r.GetAllContainers()
+	if err != nil {
+		return err
+	}
+
+	for _, c := range ctrs {
+		if err := r.RemoveContainer(ctx, c, true, true); err != nil {
+			if err := r.RemoveStorageContainer(c.ID(), true); err != nil {
+				if errors.Cause(err) == define.ErrNoSuchCtr {
+					continue
+				}
+				logrus.Errorf("Error removing container %s: %v", c.ID(), err)
+			}
+		}
+	}
+
+	if err := stopPauseProcess(); err != nil {
+		logrus.Errorf("Error stopping pause process: %v", err)
+	}
+
+	ir := r.ImageRuntime()
+	images, err := ir.GetImages()
+	if err != nil {
+		return err
+	}
+
+	for _, i := range images {
+		if err := i.Remove(ctx, true); err != nil {
+			if errors.Cause(err) == define.ErrNoSuchImage {
+				continue
+			}
+			logrus.Errorf("Error removing image %s: %v", i.ID(), err)
+		}
+	}
+	volumes, err := r.state.AllVolumes()
+	if err != nil {
+		return err
+	}
+	for _, v := range volumes {
+		if err := r.RemoveVolume(ctx, v, true); err != nil {
+			if errors.Cause(err) == define.ErrNoSuchVolume {
+				continue
+			}
+			logrus.Errorf("Error removing volume %s: %v", v.config.Name, err)
+		}
+	}
+
+	_, prevError := r.store.Shutdown(true)
+	if err := os.RemoveAll(r.store.GraphRoot()); err != nil {
+		if prevError != nil {
+			logrus.Error(prevError)
+		}
+		prevError = err
+	}
+	if err := os.RemoveAll(r.store.RunRoot()); err != nil {
+		if prevError != nil {
+			logrus.Error(prevError)
+		}
+		prevError = err
+	}
+	if err := os.RemoveAll(r.config.TmpDir); err != nil {
+		if prevError != nil {
+			logrus.Error(prevError)
+		}
+		prevError = err
+	}
+	if rootless.IsRootless() {
+		configPath := filepath.Join(os.Getenv("HOME"), ".config/containers")
+		if err := os.RemoveAll(configPath); err != nil {
+			if prevError != nil {
+				logrus.Error(prevError)
+			}
+			prevError = err
+		}
+	}
+
+	return prevError
+}

--- a/libpod/runtime_migrate_unsupported.go
+++ b/libpod/runtime_migrate_unsupported.go
@@ -9,3 +9,7 @@ import (
 func (r *Runtime) migrate(ctx context.Context) error {
 	return nil
 }
+
+func stopPauseProcess() error {
+	return nil
+}

--- a/pkg/adapter/reset.go
+++ b/pkg/adapter/reset.go
@@ -1,0 +1,13 @@
+// +build !remoteclient
+
+package adapter
+
+import (
+	"context"
+)
+
+// Reset the container storage back to initial states.
+// Removes all Pods, Containers, Images and Volumes.
+func (r *LocalRuntime) Reset() error {
+	return r.Runtime.Reset(context.TODO())
+}

--- a/pkg/adapter/reset_remote.go
+++ b/pkg/adapter/reset_remote.go
@@ -1,0 +1,12 @@
+// +build remoteclient
+
+package adapter
+
+import (
+	"github.com/containers/libpod/cmd/podman/varlink"
+)
+
+// Info returns information for the host system and its components
+func (r RemoteRuntime) Reset() error {
+	return iopodman.Reset().Call(r.Conn)
+}

--- a/test/e2e/libpod_suite_test.go
+++ b/test/e2e/libpod_suite_test.go
@@ -135,3 +135,7 @@ func removeCache() {
 func (p *PodmanTestIntegration) SeedImages() error {
 	return nil
 }
+
+// We don't support running Varlink when local
+func (p *PodmanTestIntegration) StartVarlink() {
+}

--- a/test/e2e/system_reset_test.go
+++ b/test/e2e/system_reset_test.go
@@ -1,0 +1,83 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("podman system reset", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest *PodmanTestIntegration
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanTestCreate(tempdir)
+		podmanTest.Setup()
+		podmanTest.SeedImages()
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+		f := CurrentGinkgoTestDescription()
+		timedResult := fmt.Sprintf("Test: %s completed in %f seconds", f.TestText, f.Duration.Seconds())
+		GinkgoWriter.Write([]byte(timedResult))
+	})
+
+	It("podman system reset", func() {
+		// system reset will not remove additional store images, so need to grab length
+
+		session := podmanTest.Podman([]string{"rmi", "--force", "--all"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"images", "-n"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		l := len(session.OutputToStringArray())
+
+		session = podmanTest.Podman([]string{"pull", ALPINE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"volume", "create", "data"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"create", "-v", "data:/data", ALPINE, "echo", "hello"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"system", "reset", "-f"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		// If remote then the varlink service should have exited
+		// On local tests this is a noop
+		podmanTest.StartVarlink()
+
+		session = podmanTest.Podman([]string{"images", "-n"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(l))
+
+		session = podmanTest.Podman([]string{"volume", "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"container", "ls", "-q"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToStringArray())).To(Equal(0))
+	})
+})


### PR DESCRIPTION
This command will destroy all data created via podman.
It will remove containers, images, volumes, pods.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>