### PR TITLE
Disable btrfs for RHEL in podman spec

### DIFF
--- a/contrib/build_rpm.sh
+++ b/contrib/build_rpm.sh
@@ -28,9 +28,7 @@ declare -a PKGS=(device-mapper-devel \
                 libseccomp-devel \
                 libselinux-devel \
                 make \
-                golang-github-cpuguy83-go-md2man \
                 rpm-build \
-                btrfs-progs-devel \
                 go-compilers-golang-compiler \
                 )
 
@@ -38,6 +36,12 @@ if [ $pkg_manager == "/usr/bin/dnf" ]; then
     PKGS+=(python3-devel \
         python3-varlink \
         )
+# btrfs-progs-devel is not available in CentOS/RHEL-8
+    if ! grep -i -q 'Red Hat\|CentOS' /etc/redhat-release; then
+        PKGS+=(btrfs-progs-devel)
+    fi
+
+
 fi
 
 echo ${PKGS[*]}

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -52,7 +52,10 @@ ExclusiveArch: aarch64 %{arm} ppc64le s390x x86_64
 # The COPR process will uncomment this
 #BuildRequires: golang-bin
 #
+# btrfs-progs-devel package is not available in CentOS/RHEL-8
+%if 0%{?rhel} != 8 && 0%{?centos} != 8
 BuildRequires: btrfs-progs-devel
+%endif
 BuildRequires: glib2-devel
 BuildRequires: glibc-devel
 BuildRequires: glibc-static


### PR DESCRIPTION
Since btrfs-progs-devel is not available in RHEL8 and the spec
fails to build it. Making the btrfs conditional in spec file
as well as build_rpm.sh fixes the issue.

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>