### PR TITLE
Make doc building in spec optional

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -3,6 +3,7 @@
 %global with_debug 1
 %global with_check 0
 %global with_unit_test 0
+%global with_doc 1
 
 %if 0%{?fedora} >= 28
 %bcond_without varlink
@@ -57,7 +58,9 @@ BuildRequires: glib2-devel
 BuildRequires: glibc-devel
 BuildRequires: glibc-static
 BuildRequires: git
+%if 0%{?with_doc}
 BuildRequires: go-md2man
+%endif
 BuildRequires: gpgme-devel
 BuildRequires: libassuan-devel
 BuildRequires: libgpg-error-devel
@@ -357,7 +360,9 @@ tar zxf %{SOURCE1}
 
 sed -i 's/install.remote: podman-remote/install.remote:/' Makefile
 sed -i 's/install.bin: podman/install.bin:/' Makefile
+%if 0%{?with_doc}
 sed -i 's/install.man: docs/install.man:/' Makefile
+%endif
 
 %build
 mkdir _build
@@ -370,8 +375,12 @@ export GOPATH=$(pwd)/_build:$(pwd):$(pwd):%{gopath}
 export BUILDTAGS="varlink selinux seccomp $(hack/btrfs_installed_tag.sh) $(hack/btrfs_tag.sh) $(hack/libdm_tag.sh) exclude_graphdriver_devicemapper"
 
 GOPATH=$GOPATH go generate ./cmd/podman/varlink/...
-BUILDTAGS=$BUILDTAGS make binaries docs
 
+%if 0%{?with_doc}
+BUILDTAGS=$BUILDTAGS make binaries docs
+%else
+BUILDTAGS=$BUILDTAGS make binaries
+%endif
 # build conmon
 pushd conmon
 
@@ -477,8 +486,10 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/vendor:%{gopath}
 %license LICENSE
 %doc README.md CONTRIBUTING.md pkg/hooks/README-hooks.md install.md code-of-conduct.md transfer.md
 %{_bindir}/%{name}
+%if 0%{?with_doc}
 %{_mandir}/man1/*.1*
 %{_mandir}/man5/*.5*
+%endif
 %{_datadir}/bash-completion/completions/*
 %{_datadir}/zsh/site-functions/*
 %{_libexecdir}/%{name}/conmon


### PR DESCRIPTION
since go-man2md is not available in CentOS 8, making it
optional allows them to build the rpm.

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>