### PR TITLE
Disable checkpointing of containers started with --rm

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -676,6 +676,10 @@ func (c *Container) checkpoint(ctx context.Context, options ContainerCheckpointO
 		return errors.Wrapf(define.ErrCtrStateInvalid, "%q is not running, cannot checkpoint", c.state.State)
 	}
 
+	if c.AutoRemove() && options.TargetFile == "" {
+		return errors.Errorf("Cannot checkpoint containers that have been started with '--rm' unless '--export' is used")
+	}
+
 	if err := c.checkpointRestoreLabelLog("dump.log"); err != nil {
 		return err
 	}


### PR DESCRIPTION
Trying to checkpoint a container started with --rm works, but it makes no sense as the container, including the checkpoint, will be deleted after writing the checkpoint. This commit inhibits checkpointing containers started with '--rm' unless '--export' is used. If the checkpoint is exported it can easily be restored from the exported checkpoint, even if '--rm' is used. To restore a container from a checkpoint it is even necessary to manually run 'podman rm' if the container is not started with '--rm'.