### PR TITLE
container prune command fixed as per docker prune command

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -183,7 +183,8 @@ type PruneImagesValues struct {
 
 type PruneContainersValues struct {
 	PodmanCommand
-	Force bool
+	Force  bool
+	Filter []string
 }
 
 type PodPruneValues struct {

--- a/cmd/podman/containers_prune.go
+++ b/cmd/podman/containers_prune.go
@@ -41,6 +41,7 @@ func init() {
 	pruneContainersCommand.SetUsageTemplate(UsageTemplate())
 	flags := pruneContainersCommand.Flags()
 	flags.BoolVarP(&pruneContainersCommand.Force, "force", "f", false, "Force removal of a running container.  The default is false")
+	flags.StringArrayVar(&pruneContainersCommand.Filter, "filter", []string{}, "Provide filter values (e.g. 'until=<timestamp>')")
 }
 
 func pruneContainersCmd(c *cliconfig.PruneContainersValues) error {
@@ -67,7 +68,7 @@ Are you sure you want to continue? [y/N] `)
 	if c.GlobalIsSet("max-workers") {
 		maxWorkers = c.GlobalFlags.MaxWorks
 	}
-	ok, failures, err := runtime.Prune(getContext(), maxWorkers, c.Force)
+	ok, failures, err := runtime.Prune(getContext(), maxWorkers, c.Force, c.Filter)
 	if err != nil {
 		if errors.Cause(err) == define.ErrNoSuchCtr {
 			if len(c.InputArgs) > 1 {

--- a/cmd/podman/containers_prune.go
+++ b/cmd/podman/containers_prune.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/shared"
 	"github.com/containers/libpod/libpod/define"
@@ -39,6 +44,19 @@ func init() {
 }
 
 func pruneContainersCmd(c *cliconfig.PruneContainersValues) error {
+	if !c.Force {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Printf(`WARNING! This will remove all stopped containers.
+Are you sure you want to continue? [y/N] `)
+		ans, err := reader.ReadString('\n')
+		if err != nil {
+			return errors.Wrapf(err, "error reading input")
+		}
+		if strings.ToLower(ans)[0] != 'y' {
+			return nil
+		}
+	}
+
 	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")

--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/image"
+	"github.com/containers/libpod/pkg/timetype"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/docker/go-units"
@@ -272,7 +273,8 @@ func worker(wg *sync.WaitGroup, jobs <-chan workerInput, results chan<- PsContai
 	}
 }
 
-func generateContainerFilterFuncs(filter, filterValue string, r *libpod.Runtime) (func(container *libpod.Container) bool, error) {
+// GenerateContainerFilterFuncs return ContainerFilter functions based of filter.
+func GenerateContainerFilterFuncs(filter, filterValue string, r *libpod.Runtime) (func(container *libpod.Container) bool, error) {
 	switch filter {
 	case "id":
 		return func(c *libpod.Container) bool {
@@ -394,6 +396,22 @@ func generateContainerFilterFuncs(filter, filterValue string, r *libpod.Runtime)
 			}
 			return hcStatus == filterValue
 		}, nil
+	case "until":
+		ts, err := timetype.GetTimestamp(filterValue, time.Now())
+		if err != nil {
+			return nil, err
+		}
+		seconds, nanoseconds, err := timetype.ParseTimestamps(ts, 0)
+		if err != nil {
+			return nil, err
+		}
+		until := time.Unix(seconds, nanoseconds)
+		return func(c *libpod.Container) bool {
+			if !until.IsZero() && c.CreatedTime().After((until)) {
+				return true
+			}
+			return false
+		}, nil
 	}
 	return nil, errors.Errorf("%s is an invalid filter", filter)
 }
@@ -411,7 +429,7 @@ func GetPsContainerOutput(r *libpod.Runtime, opts PsOptions, filters []string, m
 			if len(filterSplit) < 2 {
 				return nil, errors.Errorf("filter input must be in the form of filter=value: %s is invalid", f)
 			}
-			generatedFunc, err := generateContainerFilterFuncs(filterSplit[0], filterSplit[1], r)
+			generatedFunc, err := GenerateContainerFilterFuncs(filterSplit[0], filterSplit[1], r)
 			if err != nil {
 				return nil, errors.Wrapf(err, "invalid filter")
 			}

--- a/cmd/podman/system_prune.go
+++ b/cmd/podman/system_prune.go
@@ -92,7 +92,7 @@ Are you sure you want to continue? [y/N] `, volumeString)
 
 	rmWorkers := shared.Parallelize("rm")
 	fmt.Println("Deleted Containers")
-	ok, failures, err = runtime.Prune(ctx, rmWorkers, false)
+	ok, failures, err = runtime.Prune(ctx, rmWorkers, false, []string{})
 	if err != nil {
 		if lasterr != nil {
 			logrus.Errorf("%q", err)

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2816,9 +2816,12 @@ _podman_images_prune() {
 
 _podman_container_prune() {
     local options_with_args="
+	 --filter
     "
 
     local boolean_options="
+	 -f
+	 --force
      -h
 	 --help
   "

--- a/docs/source/markdown/podman-container-prune.1.md
+++ b/docs/source/markdown/podman-container-prune.1.md
@@ -20,12 +20,34 @@ Print usage statement
 Remove all stopped containers from local storage
 ```
 $ sudo podman container prune
+WARNING! This will remove all stopped containers.
+Are you sure you want to continue? [y/N] y
 878392adf2e6c5c9bb1fc19b69d37d2e98c8abf9d539c0bce4b15b46bbcce471
 37664467fbe3618bf9479c34393ac29c02696675addf1750f9e346581636cde7
 ed0c6468b8e1cb641b4621d1fe30cb477e1fefc5c0bceb66feaf2f7cb50e5962
 6ac6c8f0067b7a4682e6b8e18902665b57d1a0e07e885d9abcd382232a543ccd
 fff1c5b6c3631746055ec40598ce8ecaa4b82aef122f9e3a85b03b55c0d06c23
 602d343cd47e7cb3dfc808282a9900a3e4555747787ec6723bb68cedab8384d5
+```
+
+Remove all stopped containers from local storage without confirmation.
+```
+$ sudo podman container prune -f
+878392adf2e6c5c9bb1fc19b69d37d2e98c8abf9d539c0bce4b15b46bbcce471
+37664467fbe3618bf9479c34393ac29c02696675addf1750f9e346581636cde7
+ed0c6468b8e1cb641b4621d1fe30cb477e1fefc5c0bceb66feaf2f7cb50e5962
+6ac6c8f0067b7a4682e6b8e18902665b57d1a0e07e885d9abcd382232a543ccd
+fff1c5b6c3631746055ec40598ce8ecaa4b82aef122f9e3a85b03b55c0d06c23
+602d343cd47e7cb3dfc808282a9900a3e4555747787ec6723bb68cedab8384d5
+
+```
+
+Remove all stopped containers from local storage created within last 10 minutes
+```
+$ sudo podman container prune --filter until="10m"
+WARNING! This will remove all stopped containers.
+Are you sure you want to continue? [y/N] y
+3d366295e33d8cc612c4d873199bacadd55088d90d17dcafaa9a2d317ad50b4e
 ```
 
 ## SEE ALSO

--- a/pkg/adapter/containers_remote.go
+++ b/pkg/adapter/containers_remote.go
@@ -922,7 +922,7 @@ func (r *LocalRuntime) Top(cli *cliconfig.TopValues) ([]string, error) {
 }
 
 // Prune removes stopped containers
-func (r *LocalRuntime) Prune(ctx context.Context, maxWorkers int, force bool) ([]string, map[string]error, error) {
+func (r *LocalRuntime) Prune(ctx context.Context, maxWorkers int, force bool, filter []string) ([]string, map[string]error, error) {
 
 	var (
 		ok       = []string{}

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Podman prune", func() {
 		stop.WaitWithDefaultTimeout()
 		Expect(stop.ExitCode()).To(Equal(0))
 
-		prune := podmanTest.Podman([]string{"container", "prune"})
+		prune := podmanTest.Podman([]string{"container", "prune", "-f"})
 		prune.WaitWithDefaultTimeout()
 		Expect(prune.ExitCode()).To(Equal(0))
 


### PR DESCRIPTION
makes `podman container prune` aligned with docker image prune command.
_This PR is in continuation of https://github.com/containers/libpod/pull/4512 for `container prune` command_

This PR makes following changes.

- default `podman container prune` now ask for confirmation from user with warning message.

```
$ .podman container prune
WARNING! This will remove all stopped containers.
Are you sure you want to continue? [y/N] 
```
- adds ``--filter`` flag, which supports label & until format.
e.g.

```
$ podman container prune -a --filter until=10m             
WARNING! This will remove all stopped containers.
Are you sure you want to continue? [y/N] 

$ podman container prune -a --filter label=test-app                            
WARNING! This will remove all stopped containers.
Are you sure you want to continue? [y/N] 
```

Signed-off-by: Kunal Kushwaha kunal.kushwaha@gmail.com