### PR TITLE
Do not initialize store on rootless podman

### DIFF
--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -159,7 +159,7 @@ func setupRootless(cmd *cobra.Command, args []string) error {
 		Remote:      remoteclient,
 	}
 
-	runtime, err := libpodruntime.GetRuntime(getContext(), &podmanCmd)
+	runtime, err := libpodruntime.GetRuntimeNoStore(getContext(), &podmanCmd)
 	if err != nil {
 		return errors.Wrapf(err, "could not get runtime")
 	}


### PR DESCRIPTION
This fixes a double-locking issue of the container storage when running
rootless podman.

Closes #4591
