### PR TITLE
Enable multi-platform rpm building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ BUILDTAGS ?= \
 	exclude_graphdriver_devicemapper \
 	seccomp \
 	varlink
-PYTHON ?= $(shell command -v python python3)
+PYTHON ?= $(shell command -v python python3|head -n1)
+PKG_MANAGER ?= $(shell command -v dnf yum|head -n1)
+
 
 GO_BUILD=$(GO) build
 # Go module support: set `-mod=vendor` to use the vendored sources
@@ -543,12 +545,19 @@ vendor-in-container:
 	install.libseccomp.sudo \
 	lint \
 	pause \
+	package \
+	package-install \
 	shell \
 	uninstall \
 	validate \
 	validate.completions \
 	vendor
 
-rpm:
-	@echo "Building rpms ..."
+package:  ## Build rpm packages
+	## TODO(ssbarnea): make version number predictable, it should not change
+	## on each execution, producing duplicates.
+	rm -f  ~/rpmbuild/RPMS/x86_64/* ~/rpmbuild/RPMS/noarch/*
 	./contrib/build_rpm.sh
+
+package-install: package  ## Install rpm packages
+	sudo ${PKG_MANAGER} -y install --allowerasing ${HOME}/rpmbuild/RPMS/*/*.rpm

--- a/install.md
+++ b/install.md
@@ -95,7 +95,9 @@ system](https://bodhi.fedoraproject.org/updates/?packages=podman).
 
 **Required**
 
-Fedora, CentOS, RHEL, and related distributions:
+Fedora, CentOS, RHEL, and related distributions you should try to run
+`make package-install` which will install dependencies, build the source,
+produce rpms for the current platform and install them in the end.
 
 ```bash
 sudo yum install -y \


### PR DESCRIPTION
- make: fix python detection for multiple interpreters
- make: create generic `package` and `package-install` targets
- build_rpm.sh: move package installation into package-install
- build_rpm.sh: fix dnf/yum detection
- build_rpm.sh: install md2man rpm only on platfroms where is available
- build_rpm.sh: temporary skip packaging docs and debug on rhel-8
- docs: `make package-install`

This change is validated by [new CI jobs run by rdoproject](https://review.rdoproject.org/r/#/c/23943/). 

Fixes: #4627
Fixes: #4612