### PR TITLE
Fix podman-remote version to print client and server

### DIFF
--- a/docs/source/markdown/podman-version.1.md
+++ b/docs/source/markdown/podman-version.1.md
@@ -34,8 +34,8 @@ OS/Arch:       linux/amd64
 
 Filtering out only the version:
 ```
-$ podman version --format '{{.Version}}'
-0.11.2
+$ podman version --format '{{.Client.Version}}'
+1.6.3
 ```
 
 ## SEE ALSO

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -33,7 +33,6 @@ var _ = Describe("Podman version", func() {
 	})
 
 	It("podman version", func() {
-		SkipIfRemote()
 		session := podmanTest.Podman([]string{"version"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -43,7 +42,6 @@ var _ = Describe("Podman version", func() {
 	})
 
 	It("podman -v", func() {
-		SkipIfRemote()
 		session := podmanTest.Podman([]string{"-v"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -52,7 +50,6 @@ var _ = Describe("Podman version", func() {
 	})
 
 	It("podman --version", func() {
-		SkipIfRemote()
 		session := podmanTest.Podman([]string{"--version"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -61,7 +58,6 @@ var _ = Describe("Podman version", func() {
 	})
 
 	It("podman version --format json", func() {
-		SkipIfRemote()
 		session := podmanTest.Podman([]string{"version", "--format", "json"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -69,7 +65,6 @@ var _ = Describe("Podman version", func() {
 	})
 
 	It("podman version --format json", func() {
-		SkipIfRemote()
 		session := podmanTest.Podman([]string{"version", "--format", "{{ json .}}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -77,8 +72,15 @@ var _ = Describe("Podman version", func() {
 	})
 
 	It("podman version --format GO template", func() {
-		SkipIfRemote()
-		session := podmanTest.Podman([]string{"version", "--format", "{{ .Version }}"})
+		session := podmanTest.Podman([]string{"version", "--format", "{{ .Client.Version }}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"version", "--format", "{{ .Server.Version }}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"version", "--format", "{{ .Version }}"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})


### PR DESCRIPTION
If the user specifies .Server.* on a non podman-remote,
substitute .Client for .Server and return the value.
This is for compatability with Docker.

Since prior versions documented --format {{ .Version }}, we
have to continue to support that.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>