### PR TITLE
troubleshooting: warn about secure boot

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -413,7 +413,6 @@ You'll need to either:
 
 ### 17) rootless containers exit once the user session exits
 
-
 You need to set lingering mode through loginctl to prevent user processes to be killed once
 the user session completed.
 
@@ -429,3 +428,17 @@ You'll need to either:
 or as root if your user has not enough privileges.
 
 * sudo loginctl enable-linger $UID
+
+### 18) `podman run` fails with "bpf create: permission denied error"
+
+The Kernel Lockdown patches deny eBPF programs when Secure Boot is enabled in the BIOS. [Matthew Garrett's post](https://mjg59.dreamwidth.org/50577.html) desribes the relationship between Lockdown and Secure Boot and [Jan-Philip Gehrcke's](https://gehrcke.de/2019/09/running-an-ebpf-program-may-require-lifting-the-kernel-lockdown/) connects this with eBPF. [RH bug 1768125](https://bugzilla.redhat.com/show_bug.cgi?id=1768125) contains some additional details.
+
+#### Symptom
+
+Attempts to run podman result in
+
+```Error: bpf create : Operation not permitted: OCI runtime permission denied error```
+
+#### Solution
+
+One workaround is to disable Secure Boot in your BIOS.


### PR DESCRIPTION
Add an additional troubleshooting item to warn users that Secure Boot can prevent Podman from running containers. The error messages and initial debugging steps don't make it clear that this stems from a BIOS setting. Hopefully adding this item to the troubleshooting doc will avoid future headaches.