### PR TITLE
build: improved prepare.sh

### DIFF
--- a/.copr/prepare.sh
+++ b/.copr/prepare.sh
@@ -1,12 +1,14 @@
 #!/bin/sh -euf
-set -x
+set -euxo pipefail
 OS_TEST=${OS_TEST:=0}
 
 if [ ! -e /usr/bin/git ]; then
     dnf -y install git-core
 fi
 
-git fetch --unshallow || :
+if [ -f $(git rev-parse --git-dir)/shallow ]; then
+    git fetch --unshallow
+fi
 
 COMMIT=$(git rev-parse HEAD)
 COMMIT_SHORT=$(git rev-parse --short=8 HEAD)
@@ -26,7 +28,12 @@ if [ ${OS_TEST} -eq 0 ]; then
     sed -i "s/${BR}/${NEWBR}/g" contrib/spec/podman.spec
 fi
 
-mkdir build/
+mkdir -p build/
 git archive --prefix "libpod-${COMMIT_SHORT}/" --format "tar.gz" HEAD -o "build/libpod-${COMMIT_SHORT}.tar.gz"
-git clone https://github.com/containers/conmon
-cd conmon && git checkout 6f3572558b97bc60dd8f8c7f0807748e6ce2c440 && git archive --prefix "conmon/" --format "tar.gz" HEAD -o "../build/conmon.tar.gz"
+if [ ! -d conmon ]; then
+    git clone -n --quiet https://github.com/containers/conmon
+fi
+pushd conmon
+git checkout 6f3572558b97bc60dd8f8c7f0807748e6ce2c440
+git archive --prefix "conmon/" --format "tar.gz" HEAD -o "../build/conmon.tar.gz"
+popd


### PR DESCRIPTION
* assure we use bash strict mode
* avoid shallow errors on full clones
* make script bit more idempotent

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>