### PR TITLE
Ensure volumes reacquire locks on state refresh

### DIFF
--- a/libpod/volume_internal.go
+++ b/libpod/volume_internal.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/containers/libpod/libpod/define"
+	"github.com/pkg/errors"
 )
 
 // Creates a new volume
@@ -45,4 +46,15 @@ func (v *Volume) update() error {
 // save() saves the volume state to the DB
 func (v *Volume) save() error {
 	return v.runtime.state.SaveVolume(v)
+}
+
+// Refresh volume state after a restart.
+func (v *Volume) refresh() error {
+	lock, err := v.runtime.lockManager.AllocateAndRetrieveLock(v.config.LockID)
+	if err != nil {
+		return errors.Wrapf(err, "error acquiring lock %d for volume %s", v.config.LockID, v.Name())
+	}
+	v.lock = lock
+
+	return nil
 }


### PR DESCRIPTION
After a restart, pods and containers both run a refresh() function to prepare to run after a reboot. Until now, volumes have not had a similar function, because they had no per-boot setup to perform.

Unfortunately, this was not noticed when in-memory locking was introduced to volumes. The refresh() routine is, among other things, responsible for ensuring that locks are reserved after a reboot, ensuring they cannot be taken by a freshly-created container, pod, or volume. If this reservation is not done, we can end up with two objects using the same lock, potentially needing to lock each other for some operations - classic recipe for deadlocks.

Add a refresh() function to volumes to perform lock reservation and ensure it is called as part of overall refresh().

Fixes #4605
Fixes #4621