### PR TITLE
Only install md2man if it does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,7 +487,7 @@ endef
 	fi
 
 .install.md2man: .gopathok
-	if [ ! -x "$(GOBIN)/go-md2man" ]; then \
+	if [ ! -x "$(GOMD2MAN)" ]; then \
 		   $(call go-get,github.com/cpuguy83/go-md2man); \
 	fi
 


### PR DESCRIPTION
Currently the Makefile always attempts to pull go-md2man even if it is
installed on the system.  This is breaking build systems that install go-md2man
from a package and do not have access to the internet.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>