### PR TITLE
Avoid git warnings by using detach on checkout

### DIFF
--- a/.copr/prepare.sh
+++ b/.copr/prepare.sh
@@ -34,6 +34,6 @@ if [ ! -d conmon ]; then
     git clone -n --quiet https://github.com/containers/conmon
 fi
 pushd conmon
-git checkout 6f3572558b97bc60dd8f8c7f0807748e6ce2c440
+git checkout --detach 6f3572558b97bc60dd8f8c7f0807748e6ce2c440
 git archive --prefix "conmon/" --format "tar.gz" HEAD -o "../build/conmon.tar.gz"
 popd

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN set -x \
 	&& git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc" \
 	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
 	&& git fetch origin --tags \
-	&& git checkout -q "$RUNC_COMMIT" \
+	&& git checkout --detach -q "$RUNC_COMMIT" \
 	&& make static BUILDTAGS="seccomp selinux" \
 	&& cp runc /usr/bin/runc \
 	&& rm -rf "$GOPATH"
@@ -62,7 +62,7 @@ RUN set -x \
 	&& git clone https://github.com/containers/conmon.git "$GOPATH/src/github.com/containers/conmon.git" \
 	&& cd "$GOPATH/src/github.com/containers/conmon.git" \
 	&& git fetch origin --tags \
-	&& git checkout -q "$CONMON_COMMIT" \
+	&& git checkout --detach -q "$CONMON_COMMIT" \
 	&& make \
 	&& install -D -m 755 bin/conmon /usr/libexec/podman/conmon \
 	&& rm -rf "$GOPATH"
@@ -73,7 +73,7 @@ RUN set -x \
        && export GOPATH="$(mktemp -d)" GOCACHE="$(mktemp -d)" \
        && git clone https://github.com/containernetworking/plugins.git "$GOPATH/src/github.com/containernetworking/plugins" \
        && cd "$GOPATH/src/github.com/containernetworking/plugins" \
-       && git checkout -q "$CNI_COMMIT" \
+       && git checkout --detach -q "$CNI_COMMIT" \
        && ./build_linux.sh \
        && mkdir -p /usr/libexec/cni \
        && cp bin/* /usr/libexec/cni \

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -35,7 +35,7 @@ RUN set -x \
        && export GOPATH="$(mktemp -d)" GOCACHE="$(mktemp -d)" \
        && git clone https://github.com/containernetworking/plugins.git "$GOPATH/src/github.com/containernetworking/plugins" \
        && cd "$GOPATH/src/github.com/containernetworking/plugins" \
-       && git checkout -q "$CNI_COMMIT" \
+       && git checkout --detach -q "$CNI_COMMIT" \
        && ./build_linux.sh \
        && mkdir -p /usr/libexec/cni \
        && cp bin/* /usr/libexec/cni \
@@ -59,7 +59,7 @@ RUN set -x \
 	&& git clone https://github.com/containers/conmon.git "$GOPATH/src/github.com/containers/conmon.git" \
 	&& cd "$GOPATH/src/github.com/containers/conmon.git" \
 	&& git fetch origin --tags \
-	&& git checkout -q "$CONMON_COMMIT" \
+	&& git checkout --detach -q "$CONMON_COMMIT" \
 	&& make \
 	&& install -D -m 755 bin/conmon /usr/libexec/podman/conmon \
 	&& rm -rf "$GOPATH"

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -52,7 +52,7 @@ RUN set -x \
 	&& git clone https://github.com/containers/conmon.git "$GOPATH/src/github.com/containers/conmon.git" \
 	&& cd "$GOPATH/src/github.com/containers/conmon.git" \
 	&& git fetch origin --tags \
-	&& git checkout -q "$CONMON_COMMIT" \
+	&& git checkout --detach -q "$CONMON_COMMIT" \
 	&& make \
 	&& install -D -m 755 bin/conmon /usr/libexec/podman/conmon \
 	&& rm -rf "$GOPATH"

--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ endef
 	if [ ! -x "$(GOBIN)/gometalinter" ]; then \
 		$(call go-get,github.com/alecthomas/gometalinter); \
 		cd $(FIRST_GOPATH)/src/github.com/alecthomas/gometalinter; \
-		git checkout e8d801238da6f0dfd14078d68f9b53fa50a7eeb5; \
+		git checkout --detach e8d801238da6f0dfd14078d68f9b53fa50a7eeb5; \
 		$(GO) install github.com/alecthomas/gometalinter; \
 		$(GOBIN)/gometalinter --install; \
 	fi
@@ -498,7 +498,7 @@ varlink_api_generate: .gopathok API.md
 install.libseccomp.sudo:
 	rm -rf ../../seccomp/libseccomp
 	git clone https://github.com/seccomp/libseccomp ../../seccomp/libseccomp
-	cd ../../seccomp/libseccomp && git checkout $(LIBSECCOMP_COMMIT) && ./autogen.sh && ./configure --prefix=/usr && make all && make install
+	cd ../../seccomp/libseccomp && git checkout --detach $(LIBSECCOMP_COMMIT) && ./autogen.sh && ./configure --prefix=/usr && make all && make install
 
 
 cmd/podman/varlink/iopodman.go: cmd/podman/varlink/io.podman.varlink


### PR DESCRIPTION
Git displays a huge and confusing warning when doing a checkout of
a specific commit if the --detach option is not mentioned.

This cleans up our build logs, making it easier to spot real problems.