### PR TITLE
libpod: fix stats for rootless pods

### DIFF
--- a/libpod/container.go
+++ b/libpod/container.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/containernetworking/cni/pkg/types"
@@ -1072,7 +1073,14 @@ func (c *Container) CGroupPath() (string, error) {
 	case define.SystemdCgroupsManager:
 		if rootless.IsRootless() {
 			uid := rootless.GetRootlessUID()
-			return filepath.Join(c.config.CgroupParent, fmt.Sprintf("user-%d.slice/user@%d.service/user.slice", uid, uid), createUnitName("libpod", c.ID())), nil
+			parts := strings.SplitN(c.config.CgroupParent, "/", 2)
+
+			dir := ""
+			if len(parts) > 1 {
+				dir = parts[1]
+			}
+
+			return filepath.Join(parts[0], fmt.Sprintf("user-%d.slice/user@%d.service/user.slice/%s", uid, uid, dir), createUnitName("libpod", c.ID())), nil
 		}
 		return filepath.Join(c.config.CgroupParent, createUnitName("libpod", c.ID())), nil
 	default:

--- a/test/e2e/pod_stats_test.go
+++ b/test/e2e/pod_stats_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"os"
 
+	"github.com/containers/libpod/pkg/cgroups"
 	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,12 +14,17 @@ import (
 var _ = Describe("Podman pod stats", func() {
 	var (
 		tempdir    string
-		err        error
 		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
-		SkipIfRootless()
+		cgroupsv2, err := cgroups.IsCgroup2UnifiedMode()
+		Expect(err).To(BeNil())
+
+		if os.Geteuid() != 0 && !cgroupsv2 {
+			Skip("This function is not enabled for rootless podman not running on cgroups v2")
+		}
+
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/containers/libpod/pkg/cgroups"
 	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,12 +17,16 @@ import (
 var _ = Describe("Podman stats", func() {
 	var (
 		tempdir    string
-		err        error
 		podmanTest *PodmanTestIntegration
 	)
 
 	BeforeEach(func() {
-		SkipIfRootless()
+		cgroupsv2, err := cgroups.IsCgroup2UnifiedMode()
+		Expect(err).To(BeNil())
+
+		if os.Geteuid() != 0 && !cgroupsv2 {
+			Skip("This function is not enabled for rootless podman not running on cgroups v2")
+		}
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
honor the systemd parent directory when specified.

also enable all the stats tests for rootless on cgroups v2.

Closes: https://github.com/containers/libpod/issues/4634

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
