### PR TITLE
Correctly export the root file-system changes

### DIFF
--- a/libpod/diff.go
+++ b/libpod/diff.go
@@ -1,7 +1,6 @@
 package libpod
 
 import (
-	"archive/tar"
 	"io"
 
 	"github.com/containers/libpod/libpod/layers"
@@ -45,49 +44,6 @@ func (r *Runtime) GetDiff(from, to string) ([]archive.Change, error) {
 		}
 	}
 	return rchanges, err
-}
-
-// skipFileInTarAchive is an archive.TarModifierFunc function
-// which tells archive.ReplaceFileTarWrapper to skip files
-// from the tarstream
-func skipFileInTarAchive(path string, header *tar.Header, content io.Reader) (*tar.Header, []byte, error) {
-	return nil, nil, nil
-}
-
-// GetDiffTarStream returns the differences between the two images, layers, or containers.
-// It is the same functionality as GetDiff() except that it returns a tarstream
-func (r *Runtime) GetDiffTarStream(from, to string) (io.ReadCloser, error) {
-	toLayer, err := r.getLayerID(to)
-	if err != nil {
-		return nil, err
-	}
-	fromLayer := ""
-	if from != "" {
-		fromLayer, err = r.getLayerID(from)
-		if err != nil {
-			return nil, err
-		}
-	}
-	rc, err := r.store.Diff(fromLayer, toLayer, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// Skip files in the tar archive which are listed
-	// in containerMounts map. Just as in the GetDiff()
-	// function from above
-	filterMap := make(map[string]archive.TarModifierFunc)
-	for key := range containerMounts {
-		filterMap[key[1:]] = skipFileInTarAchive
-		// In the tarstream directories always include a trailing '/'.
-		// For simplicity this duplicates every entry from
-		// containerMounts with a trailing '/', as containerMounts
-		// does not use trailing '/' for directories.
-		filterMap[key[1:]+"/"] = skipFileInTarAchive
-	}
-
-	filteredTarStream := archive.ReplaceFileTarWrapper(rc, filterMap)
-	return filteredTarStream, nil
 }
 
 // ApplyDiffTarStream applies the changes stored in 'diff' to the layer 'to'

--- a/pkg/adapter/checkpoint_restore.go
+++ b/pkg/adapter/checkpoint_restore.go
@@ -60,6 +60,7 @@ func crImportCheckpoint(ctx context.Context, runtime *libpod.Runtime, input stri
 			"ctr.log",
 			"rootfs-diff.tar",
 			"network.status",
+			"deleted.files",
 		},
 	}
 	dir, err := ioutil.TempDir("", "checkpoint")

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -439,6 +439,18 @@ var _ = Describe("Podman checkpoint", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 
+		result = podmanTest.Podman([]string{"exec", "-l", "/bin/sh", "-c", "rm /etc/motd"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		result = podmanTest.Podman([]string{"diff", "-l"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(result.OutputToString()).To(ContainSubstring("C /etc"))
+		Expect(result.OutputToString()).To(ContainSubstring("A /test.output"))
+		Expect(result.OutputToString()).To(ContainSubstring("D /etc/motd"))
+		Expect(len(result.OutputToStringArray())).To(Equal(3))
+
 		// Checkpoint the container
 		result = podmanTest.Podman([]string{"container", "checkpoint", "-l", "-e", fileName})
 		result.WaitWithDefaultTimeout()
@@ -461,6 +473,14 @@ var _ = Describe("Podman checkpoint", func() {
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(0))
 		Expect(result.OutputToString()).To(ContainSubstring("test" + cid + "test"))
+
+		result = podmanTest.Podman([]string{"diff", "-l"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(result.OutputToString()).To(ContainSubstring("C /etc"))
+		Expect(result.OutputToString()).To(ContainSubstring("A /test.output"))
+		Expect(result.OutputToString()).To(ContainSubstring("D /etc/motd"))
+		Expect(len(result.OutputToStringArray())).To(Equal(3))
 
 		// Remove exported checkpoint
 		os.Remove(fileName)


### PR DESCRIPTION
When doing a checkpoint with `--export` the root file-system diff was not working as expected. Instead of getting the changes from the running container to the highest storage layer it got the changes from the highest layer to that parent's layer. For a one layer container this could mean that the complete root file-system is part of the checkpoint.

With this commit this changes to use the same functionality as `podman diff`. This actually enables to correctly diff the root file-system including tracking deleted files.

This also removes the non-working helper functions from `libpod/diff.go`.

Fixes: #4606