### PR TITLE
Improve hack/get_release_info.sh

### DIFF
--- a/hack/get_release_info.sh
+++ b/hack/get_release_info.sh
@@ -4,9 +4,10 @@
 # a script allows uniform behavior across multiple environments and
 # distributions.  The script expects a single argument, as reflected below.
 
-set -e
+set -euo pipefail
 
-cd "${GOSRC:-$(dirname $0)/../}"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${GOSRC:-${DIR}/../}"
 
 valid_args() {
     REGEX='^\s+[[:upper:]]+\*[)]'


### PR DESCRIPTION
- Adopt bash strict mode
- Avoid cd errors as seen on CI vendor jobs:
hack/get_release_info.sh: line 9: cd: /go/src/github.com/containers/libpod: No such file or directory

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>