### PR TITLE
Return empty runtime directory if we're not rootless

### DIFF
--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -20,6 +20,10 @@ import (
 func GetRuntimeDir() (string, error) {
 	var rootlessRuntimeDirError error
 
+	if !rootless.IsRootless() {
+		return "", nil
+	}
+
 	rootlessRuntimeDirOnce.Do(func() {
 		runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
 		uid := fmt.Sprintf("%d", rootless.GetRootlessUID())


### PR DESCRIPTION
Currently, we return a runtime directory of the form
`/run/user/<uid>`, even when running as root.  Depending on configuration,
that directory may be deleted when the user logs out, which is quite
awkward when the container is started as a systemd service and then
someone logs in and out as root.

This patch fixes the problem by returning an empty runtime directory if the
container is being started by root.  The runtime should automatically use
the default runtime directory (`/run/crun` when crun is used), which should
be accessible to root.

Tested in Fedora 31 by running containers under both root and a regular
user.  State for root containers is stored in `/run/crun`, while state for
rootless containers is in `/run/user/<uid>/crun`.

Note that this change will have some odd effects if podman containers are running when podman is updated with this fix.  It may make sense for a %post script to move state information from `/run/user/0/crun` to `/run/crun`.