### PR TITLE
allow exec to read files of environment variables

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -128,6 +128,7 @@ type ExecValues struct {
 	PodmanCommand
 	DetachKeys  string
 	Env         []string
+	EnvFile     []string
 	Privileged  bool
 	Interactive bool
 	Tty         bool

--- a/cmd/podman/exec.go
+++ b/cmd/podman/exec.go
@@ -40,6 +40,7 @@ func init() {
 	// priority
 	execCommand.DetachKeys = ""
 	flags.StringArrayVarP(&execCommand.Env, "env", "e", []string{}, "Set environment variables")
+	flags.StringSliceVar(&execCommand.EnvFile, "env-file", []string{}, "Read in a file of environment variables")
 	flags.BoolVarP(&execCommand.Interactive, "interactive", "i", false, "Keep STDIN open even if not attached")
 	flags.BoolVarP(&execCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&execCommand.Privileged, "privileged", false, "Give the process extended Linux capabilities inside the container.  The default is false")
@@ -48,6 +49,7 @@ func init() {
 
 	flags.IntVar(&execCommand.PreserveFDs, "preserve-fds", 0, "Pass N additional file descriptors to the container")
 	flags.StringVarP(&execCommand.Workdir, "workdir", "w", "", "Working directory inside the container")
+	markFlagHiddenForRemoteClient("env-file", flags)
 	markFlagHiddenForRemoteClient("latest", flags)
 	markFlagHiddenForRemoteClient("preserve-fds", flags)
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1359,6 +1359,7 @@ _podman_exec() {
     --detach-keys
     -e
     --env
+    --env-file
     --user
     -u
     --workdir

--- a/docs/source/markdown/podman-exec.1.md
+++ b/docs/source/markdown/podman-exec.1.md
@@ -22,6 +22,10 @@ Specify the key sequence for detaching a container. Format is a single character
 You may specify arbitrary environment variables that are available for the
 command to be executed.
 
+**--env-file**=*file*
+
+Read in a line delimited file of environment variables.
+
 **--interactive**, **-i**=*true|false*
 
 When set to true, keep stdin open even if not attached. The default is *false*.

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -1024,7 +1024,7 @@ func (r *LocalRuntime) ExecContainer(ctx context.Context, cli *cliconfig.ExecVal
 
 	// Validate given environment variables
 	env := map[string]string{}
-	if err := parse.ReadKVStrings(env, []string{}, cli.Env); err != nil {
+	if err := parse.ReadKVStrings(env, cli.EnvFile, cli.Env); err != nil {
 		return ec, errors.Wrapf(err, "unable to process environment variables")
 	}
 


### PR DESCRIPTION
we want the ability to define environment variables in files for the
exec command.

Fixes: #1782408

Signed-off-by: baude <bbaude@redhat.com>