### PR TITLE
Bump to v1.6.4

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ package version
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-const Version = "1.6.4-dev"
+const Version = "1.6.4"
 
 // RemoteAPIVersion is the version for the remote
 // client API.  It is used to determine compatibility


### PR DESCRIPTION
As the title says.

We're doing two releases today, a v1.6.4 stable release with backports, and v1.7.0 on top of master. v1.6.4 will come first, so if any autobuilders are out there, they will definitely supersede with v1.7.0 when that comes later today.