### PR TITLE
WIP - unlock container before starting it via an OCI runtime

### DIFF
--- a/libpod/oci_attach_unsupported.go
+++ b/libpod/oci_attach_unsupported.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, started chan bool) error {
+func (c *Container) attach(streams *AttachStreams, keys string, resize <-chan remotecommand.TerminalSize, startContainer bool, attachChan chan error) error {
 	return define.ErrNotImplemented
 }
 


### PR DESCRIPTION
If needed, unlock the container before starting it via the OCI
runtime. We do not have any control how long the starting process
may take, and there are some cases [1] where the runtime may even
deadlock. Unlocking it here, will prevent a deadlock with other
Podman processes attempting to acquire the container's lock.

In order to be able to acquire the lock in `(*Container).start()`, we
need to change the attach workflow a bit.  `attach(...)` has in some
cases beeen executed in a goroutine ultimately yielding to panics when
trying to acquire the lock since the posix semaphores used to implement
the container locks do not allow for another thread to unlock.  This
required moving the final attaching to a goroutine and passing down the
attach error channel to `attach(...)`.  A nice sideeffect is that most
complexity is now hidden from the callers.

Note that [1] is caused by a known issue when the NOTIFY_SOCKET is set.
In that case, the OCI runtime will block until the container sends
sdnotify messages.  This behaviour is legit but it's equally dangerous
for the aforementioned deadlock potential.  This change generalizes the
deadlock potential as the OCI runtimes and anything they might
be calling is outside of our immediate control and we should not
keep the lock until we return.

Further note that the Podman process will still be blocked by
`StartContainer(...)` but it won't block others anymore.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1781506

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>