### PR TITLE
container config: add CreateCommand

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -804,6 +804,10 @@ func CreateContainerFromCreateConfig(r *libpod.Runtime, createConfig *cc.CreateC
 		return nil, err
 	}
 
+	// Set the CreateCommand explicitly.  Some (future) consumers of libpod
+	// might not want to set it.
+	options = append(options, libpod.WithCreateCommand())
+
 	ctr, err := r.NewContainer(ctx, runtimeSpec, options...)
 	if err != nil {
 		return nil, err

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -232,6 +232,10 @@ type ContainerConfig struct {
 	// ID of this container's lock
 	LockID uint32 `json:"lockID"`
 
+	// CreateCommand is the full command plus arguments of the process the
+	// container has been created with.
+	CreateCommand []string `json:"CreateCommand,omitempty"`
+
 	// TODO consider breaking these subsections up into smaller structs
 
 	// UID/GID mappings used by the storage

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -174,6 +174,9 @@ type InspectContainerConfig struct {
 	StopSignal uint `json:"StopSignal"`
 	// Configured healthcheck for the container
 	Healthcheck *manifest.Schema2HealthConfig `json:"Healthcheck,omitempty"`
+	// CreateCommand is the full command plus arguments of the process the
+	// container has been created with.
+	CreateCommand []string `json:"CreateCommand,omitempty"`
 }
 
 // InspectContainerHostConfig holds information used when the container was
@@ -946,6 +949,8 @@ func (c *Container) generateInspectContainerConfig(spec *spec.Spec) (*InspectCon
 	// TODO: should JSON deep copy this to ensure internal pointers don't
 	// leak.
 	ctrConfig.Healthcheck = c.config.HealthCheckConfig
+
+	ctrConfig.CreateCommand = c.config.CreateCommand
 
 	return ctrConfig, nil
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1413,6 +1413,18 @@ func WithHealthCheck(healthCheck *manifest.Schema2HealthConfig) CtrCreateOption 
 	}
 }
 
+// WithCreateCommand adds the full command plus arguments of the current
+// process to the container config.
+func WithCreateCommand() CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+		ctr.config.CreateCommand = os.Args
+		return nil
+	}
+}
+
 // Volume Creation Options
 
 // WithVolumeName sets the name of the volume.

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -117,6 +117,18 @@ var _ = Describe("Podman inspect", func() {
 		Expect(len(result.OutputToStringArray())).To(Equal(1))
 	})
 
+	It("podman inspect container and filter for CreateCommand", func() {
+		SkipIfRemote()
+		ls, ec, _ := podmanTest.RunLsContainer("")
+		Expect(ec).To(Equal(0))
+		cid := ls.OutputToString()
+
+		result := podmanTest.Podman([]string{"inspect", "--format={{.Config.CreateCommand}}", cid})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(len(result.OutputToStringArray())).To(Equal(1))
+	})
+
 	It("podman inspect -l with additional input should fail", func() {
 		SkipIfRemote()
 		result := podmanTest.Podman([]string{"inspect", "-l", "1234foobar"})


### PR DESCRIPTION
Store the full command plus arguments of the process the container has
been created with.  Expose this data as a `Config.CreateCommand` field
in the container-inspect data as well.

This information can be useful for debugging, as we can find out which
command has created the container, and, if being created via the Podman
CLI, we know exactly with which flags the container has been created
with.

The immediate motivation for this change is to use this information for
`podman-generate-systemd` to generate systemd-service files that allow
for creating new containers (in contrast to only starting existing
ones).

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>