### PR TITLE
podman images history test - clean up

### DIFF
--- a/test/system/010-images.bats
+++ b/test/system/010-images.bats
@@ -45,18 +45,33 @@ size       | [0-9]\\\+
 }
 
 @test "podman images - history output" {
-    run_podman images --format json
-    actual=$(echo $output | jq -r '.[0].history | length')
-    is "$actual" "0"
+    # podman history is persistent: it permanently alters our base image.
+    # Create a dummy image here so we leave our setup as we found it.
+    run_podman run --name my-container $IMAGE true
+    run_podman commit my-container my-test-image
 
-    run_podman tag $PODMAN_TEST_IMAGE_REGISTRY/$PODMAN_TEST_IMAGE_USER/$PODMAN_TEST_IMAGE_NAME:$PODMAN_TEST_IMAGE_TAG test-image
-    run_podman images --format json
-    actual=$(echo $output | jq -r '.[1].history | length')
-    is "$actual" "0"
-    actual=$(echo $output | jq -r '.[0].history | length')
-    is "$actual" "1"
-    actual=$(echo $output | jq -r '.[0].history[0]')
-    is "$actual" "$PODMAN_TEST_IMAGE_REGISTRY/$PODMAN_TEST_IMAGE_USER/$PODMAN_TEST_IMAGE_NAME:$PODMAN_TEST_IMAGE_TAG"
+    run_podman images my-test-image --format '{{ .History }}'
+    is "$output" "" "Image has empty history to begin with"
+
+    # Generate two randomish tags; 'tr' because they must be all lower-case
+    rand_name1="test-image-history-$(random_string 10 | tr A-Z a-z)"
+    rand_name2="test-image-history-$(random_string 10 | tr A-Z a-z)"
+
+    # Tag once, rmi, and make sure the tag name appears in history
+    run_podman tag my-test-image $rand_name1
+    run_podman rmi $rand_name1
+    run_podman images my-test-image --format '{{ .History }}'
+    is "$output" "localhost/${rand_name1}:latest" "image history after one tag"
+
+    # Repeat with second tag. Now both tags should be in history
+    run_podman tag my-test-image $rand_name2
+    run_podman rmi $rand_name2
+    run_podman images my-test-image --format '{{ .History }}'
+    is "$output" "localhost/${rand_name2}:latest, localhost/${rand_name1}:latest" \
+       "image history after two tags"
+
+    run_podman rmi my-test-image
+    run_podman rm my-container
 }
 
 # vim: filetype=sh

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -36,7 +36,7 @@ function basic_setup() {
         if [ "$1" == "$PODMAN_TEST_IMAGE_FQN" ]; then
             found_needed_image=1
         else
-            echo "# setup(): removing stray images" >&3
+            echo "# setup(): removing stray images $1 $2" >&3
             run_podman rmi --force "$1" >/dev/null 2>&1 || true
             run_podman rmi --force "$2" >/dev/null 2>&1 || true
         fi


### PR DESCRIPTION
As initially written the test does not work other than in
a CI environment because it relies on an empty tag history.
Rewrite so we can guarantee that, by creating a new image.

Also add slightly more helpful tests: the initial tests
would just show "expected 0, got 1" which is unhelpful.
Tweak so we test on actual history contents, which will
show more informative messages on failure.

And, finally, clean up after ourselves.

(Side commit: more informative cleanup message in helpers.bash)

Signed-off-by: Ed Santiago <santiago@redhat.com>