### PR TITLE
Reap exec sessions on cleanup and removal

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -594,7 +594,12 @@ func (c *Container) Cleanup(ctx context.Context) error {
 
 	// If we didn't restart, we perform a normal cleanup
 
-	// Check if we have active exec sessions
+	// Reap exec sessions first.
+	if err := c.reapExecSessions(); err != nil {
+		return err
+	}
+
+	// Check if we have active exec sessions after reaping.
 	if len(c.state.ExecSessions) != 0 {
 		return errors.Wrapf(define.ErrCtrStateInvalid, "container %s has active exec sessions, refusing to clean up", c.ID())
 	}

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -23,9 +23,6 @@ type OCIRuntime interface {
 	// CreateContainer creates the container in the OCI runtime.
 	CreateContainer(ctr *Container, restoreOptions *ContainerCheckpointOptions) error
 	// UpdateContainerStatus updates the status of the given container.
-	// It includes a switch for whether to perform a hard query of the
-	// runtime. If unset, the exit file (if supported by the implementation)
-	// will be used.
 	UpdateContainerStatus(ctr *Container) error
 	// StartContainer starts the given container.
 	StartContainer(ctr *Container) error
@@ -59,6 +56,9 @@ type OCIRuntime interface {
 	// If timeout is 0, SIGKILL will be sent immediately, and SIGTERM will
 	// be omitted.
 	ExecStopContainer(ctr *Container, sessionID string, timeout uint) error
+	// ExecUpdateStatus checks the status of a given exec session.
+	// Returns true if the session is still running, or false if it exited.
+	ExecUpdateStatus(ctr *Container, sessionID string) (bool, error)
 	// ExecContainerCleanup cleans up after an exec session exits.
 	// It removes any files left by the exec session that are no longer
 	// needed, including the attach socket.

--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -120,6 +120,11 @@ func (r *MissingRuntime) ExecStopContainer(ctr *Container, sessionID string, tim
 	return r.printError()
 }
 
+// ExecUpdateStatus is not available as the runtime is missing.
+func (r *MissingRuntime) ExecUpdateStatus(ctr *Container, sessionID string) (bool, error) {
+	return false, r.printError()
+}
+
 // ExecContainerCleanup is not available as the runtime is missing
 func (r *MissingRuntime) ExecContainerCleanup(ctr *Container, sessionID string) error {
 	return r.printError()


### PR DESCRIPTION
We currently rely on exec sessions being removed from the state by the Exec() API itself, on detecting the session stopping. This is not a reliable method, though. The Podman frontend for exec could be killed before the session ended, or another Podman process could be holding the lock and prevent update (most notable in `run --rm`, when a container with an active exec session is stopped).

To resolve this, add a function to reap active exec sessions from the state, and use it on cleanup (to clear sessions after the container stops) and remove (to do the same when --rm is passed). This is a bit more complicated than it ought to be because Kata and company exist, and we can't guarantee the exec session has a PID on the host, so we have to plumb this through to the OCI runtime.

Fixes #4666
