### PR TITLE
Add tag --restore/-r flag to tag command

### DIFF
--- a/API.md
+++ b/API.md
@@ -157,6 +157,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func RestartPod(name: string) string](#RestartPod)
 
+[func RestorePreviousName(name: string) string](#RestorePreviousName)
+
 [func SearchImages(query: string, limit: ?int, filter: ImageSearchFilter) ImageSearchResult](#SearchImages)
 
 [func SendFile(type: string, length: int) string](#SendFile)
@@ -1101,6 +1103,13 @@ $ varlink call -m unix:/run/podman/io.podman/io.podman.RestartPod '{"name": "135
   "pod": "135d71b9495f7c3967f536edad57750bfdb569336cd107d8aabab45565ffcfb6"
 }
 ~~~
+### <a name="RestorePreviousName"></a>func RestorePreviousName
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method RestorePreviousName(name: [string](https://godoc.org/builtin#string)) [string](https://godoc.org/builtin#string)</div>
+RestorePreviousName takes the name or ID of an image in local storage and undos the latest tag operation.  If the image
+cannot be found, an [ImageNotFound](#ImageNotFound) error will be returned;
+otherwise, the ID of the image is returned on success.
 ### <a name="SearchImages"></a>func SearchImages
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 

--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -78,6 +78,7 @@ type EventValues struct {
 
 type TagValues struct {
 	PodmanCommand
+	Restore bool
 }
 
 type TreeValues struct {

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -855,6 +855,11 @@ method PushImage(name: string, tag: string, compress: bool, format: string, remo
 # be found, an [ImageNotFound](#ImageNotFound) error will be returned; otherwise, the ID of the image is returned on success.
 method TagImage(name: string, tagged: string) -> (image: string)
 
+# RestorePreviousName takes the name or ID of an image in local storage and undos the latest tag operation.  If the image
+# cannot be found, an [ImageNotFound](#ImageNotFound) error will be returned;
+# otherwise, the ID of the image is returned on success.
+method RestorePreviousName(name: string) -> (image: string)
+
 # RemoveImage takes the name or ID of an image as well as a boolean that determines if containers using that image
 # should be deleted.  If the image cannot be found, an [ImageNotFound](#ImageNotFound) error will be returned.  The
 # ID of the removed image is returned when complete.  See also [DeleteUnusedImages](DeleteUnusedImages).

--- a/docs/source/markdown/podman-tag.1.md
+++ b/docs/source/markdown/podman-tag.1.md
@@ -19,14 +19,19 @@ the *image* and the *target-name*.
 
 Print usage statement
 
+**--restore**, **-r**
+
+Undo the latest tag operation and restore the previous tag
+
 ## EXAMPLES
 
 ```
 $ podman tag 0e3bbc2 fedora:latest
 
 $ podman tag httpd myregistryhost:5000/fedora/httpd:v2
-```
 
+$ podman tag 0e3bbc2 --restore
+```
 
 ## SEE ALSO
 podman(1)

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -407,6 +407,12 @@ func (ci *ContainerImage) TopLayer() string {
 	return ci.remoteImage.TopLayer
 }
 
+// RestorePreviousName undos a tag operation and restores the previous image tag
+func (ci *ContainerImage) RestorePreviousName() error {
+	_, err := iopodman.RestorePreviousName().Call(ci.Runtime.Conn, ci.ID())
+	return err
+}
+
 // TagImage ...
 func (ci *ContainerImage) TagImage(tag string) error {
 	_, err := iopodman.TagImage().Call(ci.Runtime.Conn, ci.ID(), tag)

--- a/test/e2e/tag_test.go
+++ b/test/e2e/tag_test.go
@@ -84,4 +84,27 @@ var _ = Describe("Podman tag", func() {
 		verify.WaitWithDefaultTimeout()
 		Expect(verify.ExitCode()).To(Equal(0))
 	})
+
+	It("podman tag undo succeed", func() {
+		const TAGGED_IMAGE = "foobar:latest"
+		session := podmanTest.PodmanNoCache([]string{"tag", ALPINE, TAGGED_IMAGE})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		restore := podmanTest.PodmanNoCache([]string{"tag", TAGGED_IMAGE, "--restore"})
+		restore.WaitWithDefaultTimeout()
+		Expect(restore.ExitCode()).To(Equal(0))
+
+		result := podmanTest.PodmanNoCache([]string{"images"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		Expect(result.LineInOutputContains(ALPINE)).To(BeTrue())
+		Expect(result.LineInOutputContains(TAGGED_IMAGE)).To(BeFalse())
+	})
+
+	It("podman tag undo failed no history", func() {
+		restore := podmanTest.PodmanNoCache([]string{"tag", ALPINE, "--restore"})
+		restore.WaitWithDefaultTimeout()
+		Expect(restore.ExitCode()).NotTo(Equal(0))
+	})
 })


### PR DESCRIPTION
It is now possible to undo tag operations if the names history is able
to restore the latest tag of a image.