### PR TITLE
Use systemd/sd-daemon.h headers for systemd presence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 ifeq (,$(findstring systemd,$(BUILDTAGS)))
 $(warning \
 	Podman is being compiled without the systemd build tag.\
-	Install libsystemd for journald support)
+	Install libsystemd on Ubuntu or systemd-devel on rpm based distro for journald support)
 endif
 
 BUILDTAGS_CROSS ?= containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay

--- a/contrib/build_rpm.sh
+++ b/contrib/build_rpm.sh
@@ -26,6 +26,7 @@ declare -a PKGS=(device-mapper-devel \
                 make \
                 rpm-build \
                 go-compilers-golang-compiler \
+                systemd-devel \
                 )
 
 if [[ $pkg_manager == *dnf ]]; then

--- a/hack/systemd_tag.sh
+++ b/hack/systemd_tag.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
-if pkg-config --exists libsystemd; then
-    echo systemd
+cc -E - > /dev/null 2> /dev/null << EOF
+#include <systemd/sd-daemon.h>
+EOF
+if test $? -eq 0 ; then
+	echo systemd
 fi


### PR DESCRIPTION
Finding systemd devel packages using libsystemd does not work as
in RHEL based distro the package name is systemd-devel and for
deb/ubunutu it is libsystemd. It is also giving false result when
podman rpm is built with systemd but hack/systemd_tag.sh does not
return anything.

Moving to systemd/sd-daemon.h header files which comes from devel
packages fixes the issue.

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>