### PR TITLE
Support specifying user networks when creating pods

### DIFF
--- a/API.md
+++ b/API.md
@@ -1934,6 +1934,8 @@ infraCommand [string](https://godoc.org/builtin#string)
 
 infraImage [string](https://godoc.org/builtin#string)
 
+networks [[]string](#[]string)
+
 publish [[]string](#[]string)
 ### <a name="PodmanInfo"></a>type PodmanInfo
 

--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -325,6 +325,7 @@ type PodCreateValues struct {
 	LabelFile    []string
 	Labels       []string
 	Name         string
+	Networks     []string
 	Hostname     string
 	PodIDFile    string
 	Publish      []string

--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -52,6 +52,7 @@ func init() {
 	flags.StringSliceVar(&podCreateCommand.LabelFile, "label-file", []string{}, "Read in a line delimited file of labels")
 	flags.StringSliceVarP(&podCreateCommand.Labels, "label", "l", []string{}, "Set metadata on pod (default [])")
 	flags.StringVarP(&podCreateCommand.Name, "name", "n", "", "Assign a name to the pod")
+	flags.StringSliceVar(&podCreateCommand.Networks, "network", []string{}, "Connect a network to the infra container")
 	flags.StringVarP(&podCreateCommand.Hostname, "hostname", "", "", "Set a hostname to the pod")
 	flags.StringVar(&podCreateCommand.PodIDFile, "pod-id-file", "", "Write the pod ID to the file")
 	flags.StringSliceVarP(&podCreateCommand.Publish, "publish", "p", []string{}, "Publish a container's port, or a range of ports, to the host (default [])")

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -451,6 +451,7 @@ type PodCreate (
     infra: bool,
     infraCommand: string,
     infraImage: string,
+    networks: []string,
     publish: []string
 )
 

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -47,6 +47,14 @@ Read in a line delimited file of labels
 
 Assign a name to the pod
 
+**--network**="*network-name*"
+
+Specify a user-defined network to attach to the pod
+
+By default, the first user network is attached to the pod via the infra container. Specify this option if you have multiple user networks configured and would like to select a particular one. Specifying this flag multiple times will attach multiple network interfaces, one per user network.
+
+NOTE: This cannot be modified once the pod is created.
+
 **--podidfile**=*podid*
 
 Write the pod ID to the file

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1751,3 +1751,14 @@ func WithInfraContainerPorts(bindings []ocicni.PortMapping) PodCreateOption {
 		return nil
 	}
 }
+
+// WithPodNetworks tells the pod to add user networks to the pause container
+func WithPodNetworks(nets []string) PodCreateOption {
+	return func(pod *Pod) error {
+		if pod.valid {
+			return define.ErrPodFinalized
+		}
+		pod.config.InfraContainer.UserNetworks = nets
+		return nil
+	}
+}

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -99,6 +99,7 @@ type PodContainerInfo struct {
 type InfraContainerConfig struct {
 	HasInfraContainer bool                 `json:"makeInfraContainer"`
 	PortBindings      []ocicni.PortMapping `json:"infraPortBindings"`
+	UserNetworks      []string             `json:"infraNetworks"`
 }
 
 // ID retrieves the pod's ID

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -94,7 +94,7 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, imgID
 	options = append(options, withIsInfra())
 
 	// Since user namespace sharing is not implemented, we only need to check if it's rootless
-	networks := make([]string, 0)
+	networks := p.config.InfraContainer.UserNetworks
 	netmode := "bridge"
 	if isRootless {
 		netmode = "slirp4netns"

--- a/pkg/adapter/pods.go
+++ b/pkg/adapter/pods.go
@@ -269,6 +269,10 @@ func (r *LocalRuntime) CreatePod(ctx context.Context, cli *cliconfig.PodCreateVa
 			return "", err
 		}
 		options = append(options, nsOptions...)
+
+		if cli.Flag("network").Changed {
+			options = append(options, libpod.WithPodNetworks(cli.Networks))
+		}
 	}
 
 	if len(cli.Publish) > 0 {

--- a/pkg/adapter/pods_remote.go
+++ b/pkg/adapter/pods_remote.go
@@ -185,6 +185,7 @@ func (r *LocalRuntime) CreatePod(ctx context.Context, cli *cliconfig.PodCreateVa
 		Infra:        cli.Infra,
 		InfraCommand: cli.InfraCommand,
 		InfraImage:   cli.InfraCommand,
+		Networks:     cli.Networks,
 		Publish:      cli.Publish,
 	}
 


### PR DESCRIPTION
This is my attempt at implementing the wiring to support #4718 as-is.

This --network argument is slightly different than the --net/--network argument accepted when creating containers. I'm sure there's also other inconsistencies and such. If this general direction is welcomed then I'll revise as necessary; however I haven't managed to run the tests yet to know how well my test works. If waiting for a proper refactor as discussed in #4718 is preferred then ignore this PR i guess.