### PR TITLE
Update `tag` documentation regarding 'alias' usage

### DIFF
--- a/cmd/podman/tag.go
+++ b/cmd/podman/tag.go
@@ -12,7 +12,7 @@ var (
 
 	tagDescription = "Adds one or more additional names to locally-stored image."
 	_tagCommand    = &cobra.Command{
-		Use:   "tag [flags] IMAGE TAG [TAG...]",
+		Use:   "tag [flags] IMAGE TARGET_NAME [TARGET_NAME...]",
 		Short: "Add an additional name to a local image",
 		Long:  tagDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -51,7 +51,7 @@ func tagCmd(c *cliconfig.TagValues) error {
 
 	for _, tagName := range args[1:] {
 		if err := newImage.TagImage(tagName); err != nil {
-			return errors.Wrapf(err, "error adding '%s' to image %q", tagName, newImage.InputName)
+			return errors.Wrapf(err, "error adding %q to image %q", tagName, newImage.InputName)
 		}
 	}
 	return nil

--- a/docs/source/markdown/podman-tag.1.md
+++ b/docs/source/markdown/podman-tag.1.md
@@ -4,14 +4,15 @@
 podman\-tag - Add an additional name to a local image
 
 ## SYNOPSIS
-**podman tag** *image*[:*tag*] *target-name*[:*tag*] [*options*]
+**podman tag** *image*[:*tag*] [*target-name*[:*tag*]...] [*options*]
 
-**podman image tag** *image*[:*tag*] *target-name*[:*tag*] [*options*]
+**podman image tag** *image*[:*tag*] [*target-name*[:*tag*]...] [*options*]
 
 ## DESCRIPTION
-Assigns a new alias to an image.  An alias refers to the entire image name, including the optional
-*tag* after the `:`.  If you do not provide *tag*, podman will default to `latest` for both
-the *image* and the *target-name*.
+Assigns a new image name to an existing image.  A full name refers to the entire
+image name, including the optional *tag* after the `:`.  If there is no *tag*
+provided, then podman will default to `latest` for both the *image* and the
+*target-name*.
 
 ## OPTIONS
 
@@ -32,4 +33,5 @@ $ podman tag httpd myregistryhost:5000/fedora/httpd:v2
 podman(1)
 
 ## HISTORY
+December 2019, Update description to refer to 'name' instead of 'alias' by Sascha Grunert <sgrunert@suse.com>
 July 2017, Originally compiled by Ryan Cole <rycole@redhat.com>


### PR DESCRIPTION
The word `alias` is not very common when speaking about image names and
tags. So we just refer to image name as the overall identifier of an
image.

Refers to https://github.com/containers/libpod/pull/4712#discussion_r358463230