### PR TITLE
libpod: do not use kill --all with PID namespace

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -463,7 +463,8 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 
 	// Check that the container's in a good state to be removed
 	if c.state.State == define.ContainerStateRunning {
-		if err := c.stop(c.StopTimeout(), true); err != nil {
+		all := !HasNamespace(c.config.Spec, spec.PIDNamespace)
+		if err := c.stop(c.StopTimeout(), all); err != nil {
 			return errors.Wrapf(err, "cannot remove container %s as it could not be stopped", c.ID())
 		}
 	}

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -49,6 +49,19 @@ func RemoveScientificNotationFromFloat(x float64) (float64, error) {
 	return result, nil
 }
 
+// HasNamespace returns whether the spec has the specified namespace
+func HasNamespace(spec *spec.Spec, namespace spec.LinuxNamespaceType) bool {
+	if spec == nil || spec.Linux == nil {
+		return false
+	}
+	for _, n := range spec.Linux.Namespaces {
+		if n.Type == namespace {
+			return true
+		}
+	}
+	return false
+}
+
 // MountExists returns true if dest exists in the list of mounts
 func MountExists(specMounts []spec.Mount, dest string) bool {
 	for _, m := range specMounts {


### PR DESCRIPTION
if the container has a PID namespace, there is no need to use kill
--all and use cgroups to read the list of processes but it is enough
to kill the main process.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>