### PR TITLE
if container is not in a pid namespace, stop all processes

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -183,7 +183,7 @@ func (c *Container) StopWithTimeout(timeout uint) error {
 		return errors.Wrapf(define.ErrCtrStateInvalid, "can only stop created or running containers. %s is in state %s", c.ID(), c.state.State.String())
 	}
 
-	return c.stop(timeout, false)
+	return c.stop(timeout)
 }
 
 // Kill sends a signal to a container
@@ -715,7 +715,7 @@ func (c *Container) Refresh(ctx context.Context) error {
 
 	// Next, if the container is running, stop it
 	if c.state.State == define.ContainerStateRunning {
-		if err := c.stop(c.config.StopTimeout, false); err != nil {
+		if err := c.stop(c.config.StopTimeout); err != nil {
 			return err
 		}
 	}

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -123,7 +123,7 @@ func (p *Pod) StopWithTimeout(ctx context.Context, cleanup bool, timeout int) (m
 		if timeout > -1 {
 			stopTimeout = uint(timeout)
 		}
-		if err := ctr.stop(stopTimeout, false); err != nil {
+		if err := ctr.stop(stopTimeout); err != nil {
 			ctr.lock.Unlock()
 			ctrErrors[ctr.ID()] = err
 			continue

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -463,7 +463,7 @@ func (r *Runtime) removeContainer(ctx context.Context, c *Container, force bool,
 
 	// Check that the container's in a good state to be removed
 	if c.state.State == define.ContainerStateRunning {
-		if err := c.stop(c.StopTimeout(), true); err != nil {
+		if err := c.stop(c.StopTimeout()); err != nil {
 			return errors.Wrapf(err, "cannot remove container %s as it could not be stopped", c.ID())
 		}
 	}


### PR DESCRIPTION
When a container is in a PID namespace, it is enought to send
the stop signal to the PID 1 of the namespace, only send signals
to all processes in the container when the container is not in
a pid namespace.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>