### PR TITLE
zsh completion: ignore multi-line output in Flags

### DIFF
--- a/completions/zsh/_podman
+++ b/completions/zsh/_podman
@@ -47,6 +47,7 @@ _read_podman_flags() {
     # The result will be, e.g. '-f,--foo=string  Description of Option'
     _call_program podman podman "$@" --help |\
         sed -n -e '0,/^Flags:/d' -e '/^$/q;p' |\
+        grep '^ \+-' |\
         sed -e 's/^ *//' -e 's/^\(-.,\) --/\1--/' |\
         sed -e 's/^\(-[^ ]\+\) \([^ ]\+\)  /\1=\2  /' |\
         while read flags desc;do


### PR DESCRIPTION
PR #4475 introduced an interesting twist on --help: a help
string that spans multiple lines. This broke zsh completion.

I'm not keen on that multi-line output, but it shouldn't
break completion. Fix is simple: look only for flag lines
beginning with '-', filter out anything else.

Fixes: #4738

Signed-off-by: Ed Santiago <santiago@redhat.com>