### PR TITLE
add struct response for removal of images

### DIFF
--- a/API.md
+++ b/API.md
@@ -149,6 +149,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func RemoveImage(name: string, force: bool) string](#RemoveImage)
 
+[func RemoveImageWithResponse(name: string, force: bool) RemoveImageResponse](#RemoveImageWithResponse)
+
 [func RemovePod(name: string, force: bool) string](#RemovePod)
 
 [func Reset() ](#Reset)
@@ -256,6 +258,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 [type PsContainer](#PsContainer)
 
 [type PsOpts](#PsOpts)
+
+[type RemoveImageResponse](#RemoveImageResponse)
 
 [type Runlabel](#Runlabel)
 
@@ -1052,6 +1056,13 @@ varlink call -m unix:/run/podman/io.podman/io.podman.RemoveImage '{"name": "regi
   "image": "426866d6fa419873f97e5cbd320eeb22778244c1dfffa01c944db3114f55772e"
 }
 ~~~
+### <a name="RemoveImageWithResponse"></a>func RemoveImageWithResponse
+<div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
+
+method RemoveImageWithResponse(name: [string](https://godoc.org/builtin#string), force: [bool](https://godoc.org/builtin#bool)) [RemoveImageResponse](#RemoveImageResponse)</div>
+RemoveImageWithResponse takes the name or ID of an image as well as a boolean that determines if containers using that image
+should be deleted.  If the image cannot be found, an [ImageNotFound](#ImageNotFound) error will be returned. The reponse is
+in the form of a RemoveImageResponse .
 ### <a name="RemovePod"></a>func RemovePod
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
@@ -2026,6 +2037,13 @@ size [?bool](#?bool)
 sort [?string](#?string)
 
 sync [?bool](#?bool)
+### <a name="RemoveImageResponse"></a>type RemoveImageResponse
+
+
+
+untagged [[]string](#[]string)
+
+deleted [string](https://godoc.org/builtin#string)
 ### <a name="Runlabel"></a>type Runlabel
 
 Runlabel describes the required input for container runlabel

--- a/cmd/podman/rmi.go
+++ b/cmd/podman/rmi.go
@@ -68,7 +68,7 @@ func rmiCmd(c *cliconfig.RmiValues) error {
 	images := args[:]
 
 	removeImage := func(img *adapter.ContainerImage) {
-		msg, err := runtime.RemoveImage(ctx, img, c.Force)
+		response, err := runtime.RemoveImage(ctx, img, c.Force)
 		if err != nil {
 			if errors.Cause(err) == storage.ErrImageUsedByContainer {
 				fmt.Printf("A container associated with containers/storage, i.e. via Buildah, CRI-O, etc., may be associated with this image: %-12.12s\n", img.ID())
@@ -83,7 +83,14 @@ func rmiCmd(c *cliconfig.RmiValues) error {
 			lastError = err
 			return
 		}
-		fmt.Println(msg)
+		// Iterate if any images tags were deleted
+		for _, i := range response.Untagged {
+			fmt.Printf("Untagged: %s\n", i)
+		}
+		// Make sure an image was deleted (and not just untagged); else print it
+		if len(response.Deleted) > 0 {
+			fmt.Printf("Deleted: %s\n", response.Deleted)
+		}
 	}
 
 	if removeAll {

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -18,6 +18,11 @@ type StringResponse (
     message: string
 )
 
+type RemoveImageResponse (
+    untagged: []string,
+    deleted: string
+)
+
 type LogLine (
     device: string,
     parseLogType : string,
@@ -866,6 +871,11 @@ method TagImage(name: string, tagged: string) -> (image: string)
 # }
 # ~~~
 method RemoveImage(name: string, force: bool) -> (image: string)
+
+# RemoveImageWithResponse takes the name or ID of an image as well as a boolean that determines if containers using that image
+# should be deleted.  If the image cannot be found, an [ImageNotFound](#ImageNotFound) error will be returned. The reponse is
+# in the form of a RemoveImageResponse .
+method RemoveImageWithResponse(name: string, force: bool) -> (response: RemoveImageResponse)
 
 # SearchImages searches available registries for images that contain the
 # contents of "query" in their name. If "limit" is given, limits the amount of

--- a/libpod/image/config.go
+++ b/libpod/image/config.go
@@ -1,0 +1,8 @@
+package image
+
+// ImageDeleteResponse is the response for removing an image from storage and containers
+// what was untagged vs actually removed
+type ImageDeleteResponse struct {
+	Untagged []string `json:"untagged"`
+	Deleted  string   `json:"deleted"`
+}

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -155,7 +155,7 @@ func (r *LocalRuntime) New(ctx context.Context, name, signaturePolicyPath, authf
 }
 
 // RemoveImage calls into local storage and removes an image
-func (r *LocalRuntime) RemoveImage(ctx context.Context, img *ContainerImage, force bool) (string, error) {
+func (r *LocalRuntime) RemoveImage(ctx context.Context, img *ContainerImage, force bool) (*image.ImageDeleteResponse, error) {
 	return r.Runtime.RemoveImage(ctx, img.Image, force)
 }
 

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -414,8 +414,15 @@ func (ci *ContainerImage) TagImage(tag string) error {
 }
 
 // RemoveImage calls varlink to remove an image
-func (r *LocalRuntime) RemoveImage(ctx context.Context, img *ContainerImage, force bool) (string, error) {
-	return iopodman.RemoveImage().Call(r.Conn, img.InputName, force)
+func (r *LocalRuntime) RemoveImage(ctx context.Context, img *ContainerImage, force bool) (*image.ImageDeleteResponse, error) {
+	ir := image.ImageDeleteResponse{}
+	response, err := iopodman.RemoveImageWithResponse().Call(r.Conn, img.InputName, force)
+	if err != nil {
+		return nil, err
+	}
+	ir.Deleted = response.Deleted
+	ir.Untagged = append(ir.Untagged, response.Untagged...)
+	return &ir, nil
 }
 
 // History returns the history of an image and its layers

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -465,6 +465,24 @@ func (i *LibpodAPI) RemoveImage(call iopodman.VarlinkCall, name string, force bo
 	return call.ReplyRemoveImage(newImage.ID())
 }
 
+// RemoveImageWithResponse accepts an image name and force bool.  It returns details about what
+// was done in removeimageresponse struct.
+func (i *LibpodAPI) RemoveImageWithResponse(call iopodman.VarlinkCall, name string, force bool) error {
+	ir := iopodman.RemoveImageResponse{}
+	ctx := getContext()
+	newImage, err := i.Runtime.ImageRuntime().NewFromLocal(name)
+	if err != nil {
+		return call.ReplyImageNotFound(name, err.Error())
+	}
+	response, err := i.Runtime.RemoveImage(ctx, newImage, force)
+	if err != nil {
+		return call.ReplyErrorOccurred(err.Error())
+	}
+	ir.Untagged = append(ir.Untagged, response.Untagged...)
+	ir.Deleted = response.Deleted
+	return call.ReplyRemoveImageWithResponse(ir)
+}
+
 // SearchImages searches all registries configured in /etc/containers/registries.conf for an image
 // Requires an image name and a search limit as int
 func (i *LibpodAPI) SearchImages(call iopodman.VarlinkCall, query string, limit *int64, filter iopodman.ImageSearchFilter) error {


### PR DESCRIPTION
when removing an image from storage, we should return a struct that
details what was untagged vs deleted.  this replaces the simple
println's used previously and assists in API development.

Signed-off-by: baude <bbaude@redhat.com>