### PR TITLE
[Issue #4703] Add the pod name when we use `podman ps -p`

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -31,6 +31,7 @@ const (
 	hsize    = "SIZE"
 	hinfra   = "IS INFRA" //nolint
 	hpod     = "POD"
+	hpodname = "POD NAME"
 	nspid    = "PID"
 	nscgroup = "CGROUPNS"
 	nsipc    = "IPC"
@@ -351,7 +352,7 @@ func psDisplay(c *cliconfig.PsValues, runtime *adapter.LocalRuntime) error {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s", hid, himage, hcommand, hcreated, hstatus, hports, hnames)
 		// User wants pod info
 		if opts.Pod {
-			fmt.Fprintf(w, "\t%s", hpod)
+			fmt.Fprintf(w, "\t%s\t%s", hpod, hpodname)
 		}
 		//User wants size info
 		if opts.Size {
@@ -370,7 +371,7 @@ func psDisplay(c *cliconfig.PsValues, runtime *adapter.LocalRuntime) error {
 			fmt.Fprintf(w, "\n%s\t%s\t%s\t%s\t%s\t%s\t%s", container.ID, container.Image, container.Command, container.Created, container.Status, container.Ports, container.Names)
 			// User wants pod info
 			if opts.Pod {
-				fmt.Fprintf(w, "\t%s", container.Pod)
+				fmt.Fprintf(w, "\t%s\t%s", container.Pod, container.PodName)
 			}
 			//User wants size info
 			if opts.Size {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -768,7 +768,7 @@ func (r *Runtime) GetContainers(filters ...ContainerFilter) ([]*Container, error
 		return nil, define.ErrRuntimeStopped
 	}
 
-	ctrs, err := r.state.AllContainers()
+	ctrs, err := r.GetAllContainers()
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -306,7 +306,29 @@ var _ = Describe("Podman ps", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 
 		Expect(session.OutputToString()).To(ContainSubstring(podid))
+	})
 
+	It("podman --pod with a non-empty pod name", func() {
+		SkipIfRemote()
+
+		podName := "testPodName"
+		_, ec, podid := podmanTest.CreatePod(podName)
+		Expect(ec).To(Equal(0))
+
+		session := podmanTest.RunTopContainerInPod("", podName)
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		// "--no-trunc" must be given. If not it will trunc the pod ID
+		// in the output and you will have to trunc it in the test too.
+		session = podmanTest.Podman([]string{"ps", "--pod", "--no-trunc"})
+
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		output := session.OutputToString()
+		Expect(output).To(ContainSubstring(podid))
+		Expect(output).To(ContainSubstring(podName))
 	})
 
 	It("podman ps test with port range", func() {


### PR DESCRIPTION
The pod name does not appear when doing `podman ps -p`.
It is missing as the documentation says:
`-p, --pod              Print the ID and name of the pod the containers are associated with`

When we create a container, the pod name will be added in the ps output.

On master:
```
[x libpod]$ sudo bin/podman pod ps
POD ID         NAME                 STATUS    CREATED          # OF CONTAINERS   INFRA ID
01ede9c31b4d   inspiring_driscoll   Created   20 seconds ago   1                 04e03f9f9d55
[x libpod]$ sudo bin/podman ps -ap
CONTAINER ID  IMAGE                                 COMMAND  CREATED         STATUS   PORTS  NAMES                      POD
04e03f9f9d55  k8s.gcr.io/pause:3.1                           20 seconds ago  Created         01ede9c31b4d-infra         01ede9c31b4d
```
We cannot see the pod name in the second command.

On the feature branch:
```
[x libpod]$ sudo bin/podman pod ps
POD ID         NAME                 STATUS    CREATED         # OF CONTAINERS   INFRA ID
01ede9c31b4d   inspiring_driscoll   Created   5 seconds ago   1                 04e03f9f9d55
[x libpod]$ sudo bin/podman ps -ap
CONTAINER ID  IMAGE                                 COMMAND  CREATED         STATUS   PORTS  NAMES                      POD           POD NAME
04e03f9f9d55  k8s.gcr.io/pause:3.1                           16 seconds ago  Created         01ede9c31b4d-infra         01ede9c31b4d  inspiring_driscoll
```
The pod name does appear.

Closes #4703

Signed-off-by: NevilleC <neville.cain@qonto.eu>