### PR TITLE
The --quiet flag does not conflict with templates in ps

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -204,11 +204,15 @@ func checkFlagsPassed(c *cliconfig.PsValues) error {
 	if c.Last >= 0 && c.Latest {
 		return errors.Errorf("last and latest are mutually exclusive")
 	}
-	// Quiet conflicts with size, namespace, and format with a Go template
+	// Quiet conflicts with size and namespace and is overridden by a Go
+	// template.
 	if c.Quiet {
-		if c.Size || c.Namespace || (c.Flag("format").Changed &&
-			c.Format != formats.JSONString) {
-			return errors.Errorf("quiet conflicts with size, namespace, and format with go template")
+		if c.Size || c.Namespace {
+			return errors.Errorf("quiet conflicts with size and namespace")
+		}
+		if c.Flag("format").Changed && c.Format != formats.JSONString {
+			// Quiet is overridden by Go template output.
+			c.Quiet = false
 		}
 	}
 	// Size and namespace conflict with each other

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -361,4 +361,19 @@ var _ = Describe("Podman ps", func() {
 		Expect(len(output)).To(Equal(1))
 		Expect(output[0]).To(Equal(fullCid))
 	})
+
+	It("podman ps quiet template", func() {
+		ctrName := "testCtr"
+		session := podmanTest.Podman([]string{"run", "-d", "--name", ctrName, ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		result := podmanTest.Podman([]string{"ps", "-q", "-a", "--format", "{{ .Names }}"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+
+		output := result.OutputToStringArray()
+		Expect(len(output)).To(Equal(1))
+		Expect(output[0]).To(Equal(ctrName))
+	})
 })


### PR DESCRIPTION
To match Docker behavior, make `--quiet` and `--format` with a Go template not conflict. Instead, just turn off `--quiet` in such cases, as we'll be using Go template output instead.