### PR TITLE
Ensure SizeRw is shown when a user does 'inspect --size -t container'.

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -118,7 +118,7 @@ type InspectContainerData struct {
 	BoundingCaps    []string                    `json:"BoundingCaps"`
 	ExecIDs         []string                    `json:"ExecIDs"`
 	GraphDriver     *driver.Data                `json:"GraphDriver"`
-	SizeRw          int64                       `json:"SizeRw,omitempty"`
+	SizeRw          *int64                      `json:"SizeRw,omitempty"`
 	SizeRootFs      int64                       `json:"SizeRootFs,omitempty"`
 	Mounts          []InspectMount              `json:"Mounts"`
 	Dependencies    []string                    `json:"Dependencies"`
@@ -809,12 +809,13 @@ func (c *Container) getContainerInspectData(size bool, driverData *driver.Data) 
 		if err != nil {
 			logrus.Errorf("error getting rootfs size %q: %v", config.ID, err)
 		}
+		data.SizeRootFs = rootFsSize
+
 		rwSize, err := c.rwSize()
 		if err != nil {
 			logrus.Errorf("error getting rw size %q: %v", config.ID, err)
 		}
-		data.SizeRootFs = rootFsSize
-		data.SizeRw = rwSize
+		data.SizeRw = &rwSize
 	}
 	return data, nil
 }

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -84,7 +84,7 @@ func (c *Container) rootFsSize() (int64, error) {
 	return size + layerSize, err
 }
 
-// rwSize Gets the size of the mutable top layer of the container.
+// rwSize gets the size of the mutable top layer of the container.
 func (c *Container) rwSize() (int64, error) {
 	if c.config.Rootfs != "" {
 		var size int64
@@ -103,14 +103,16 @@ func (c *Container) rwSize() (int64, error) {
 		return 0, err
 	}
 
-	// Get the size of the top layer by calculating the size of the diff
-	// between the layer and its parent.  The top layer of a container is
-	// the only RW layer, all others are immutable
-	layer, err := c.runtime.store.Layer(container.LayerID)
+	// The top layer of a container is
+	// the only readable/writeable layer, all others are immutable.
+	rwLayer, err := c.runtime.store.Layer(container.LayerID)
 	if err != nil {
 		return 0, err
 	}
-	return c.runtime.store.DiffSize(layer.Parent, layer.ID)
+
+	// Get the size of the top layer by calculating the size of the diff
+	// between the layer and its parent.
+	return c.runtime.store.DiffSize(rwLayer.Parent, rwLayer.ID)
 }
 
 // bundlePath returns the path to the container's root filesystem - where the OCI spec will be

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -86,6 +86,7 @@ var _ = Describe("Podman inspect", func() {
 		Expect(result.ExitCode()).To(Equal(0))
 		conData := result.InspectContainerToJSON()
 		Expect(conData[0].SizeRootFs).To(BeNumerically(">", 0))
+		Expect(*conData[0].SizeRw).To(BeNumerically(">=", 0))
 	})
 
 	It("podman inspect container and image", func() {


### PR DESCRIPTION
Currently, if a user requests the size on a container (inspect --size -t container),
the SizeRw does not show up if the value is 0. It's because InspectContainerData is
defined as int64 and there is an omit when empty.

We do want to display it even if the value is empty. I have changed the type of SizeRw to be a pointer to an int64 instead of an int64. It will allow us to distinguish the empty value to the missing value.

I updated the test "podman inspect container with size" to ensure we check thatSizeRw is displayed correctly.

**Diff between master and feature branch:**
```diff
+       "SizeRw": 0,
        "SizeRootFs": 742472,
            "ShmSize": 67108864,
            "ConsoleSize": [
```

If we don't request the size, we can see that `SizeRw` and `SizeRootFs` are not shown so it does not seem to generate regression:
```
./podman inspect -t container 549e4a3cde64-infra | grep ize -i
            "ShmSize": 67108864,
            "ConsoleSize": [
```
Closes #4744

Signed-off-by: NevilleC <neville.cain@qonto.eu>