### PR TITLE
Generate binaries only if there are changes in src code.

### DIFF
--- a/.copr/prepare.sh
+++ b/.copr/prepare.sh
@@ -34,6 +34,6 @@ if [ ! -d conmon ]; then
     git clone -n --quiet https://github.com/containers/conmon
 fi
 pushd conmon
-git checkout --detach 6f3572558b97bc60dd8f8c7f0807748e6ce2c440
+git checkout --detach d532caebc788fafdd2a305b68cd1983b4039bea4
 git archive --prefix "conmon/" --format "tar.gz" HEAD -o "../build/conmon.tar.gz"
 popd

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -39,7 +39,7 @@
 # People want conmon packaged with the copr rpm
 %global import_path_conmon      github.com/containers/conmon
 %global git_conmon      https://%{import_path_conmon}
-%global commit_conmon   6f3572558b97bc60dd8f8c7f0807748e6ce2c440
+%global commit_conmon   d532caebc788fafdd2a305b68cd1983b4039bea4
 %global shortcommit_conmon %(c=%{commit_conmon}; echo ${c:0:7})
 
 Name: podman
@@ -79,7 +79,6 @@ Requires: runc
 Requires: skopeo-containers
 Requires: containernetworking-plugins >= 0.6.0-3
 Requires: iptables
-Requires: oci-systemd-hook
 %if 0%{?rhel} <= 7
 Requires: container-selinux
 %else


### PR DESCRIPTION
Changes I am making:
1. The target `.gopathok` was listed in `.PHONY` which looks wrong as it regenerates `.gopathok` every time we re-run it, which was a part of the issue #4367. I removed it to avoid that. If `.gopathok` is present', makefile should not need to rerun it.
2. Ensure the binaries are created only if they don't exist by renaming `podman` to `bin/podman` and `podman-remote` to `bin/podman-remote`.
3. Add a `SOURCES = $(shell find . -name "*.go")` and put it as a dependency of the podman binaries target. It allows us to re-generate the binaries only when there is a change in the source files. The downside is it increases the running time of the command that generates them (20 seconds on my virtual machine running Centos 7). If this is a problem, we could introduce a hidden file that would list all the files to track, that would need to be updated only when a dev is introducing new files.

We can now run `make && sudo make install` without error, so if this solution is accepted, I believe it should solve the issue listed here.

Closes #4367

Signed-off-by: NevilleC neville.cain@qonto.eu