### PR TITLE
Enable shell completion for podman commands.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,13 @@ Well, you can now create your own branch, apply changes on it, and then submitti
 
 For further reading about branching [you can read this document](https://herve.beraud.io/containers/linux/podman/isolate/environment/2019/02/06/how-to-hack-on-podman.html).
 
+### Adding/Updating a new command
+
+When you add/update a new command, dont't forget to run 'make completion' to update
+the bash completion script.
+
+There is no need to update zsh completion script as it autogenerates completion.
+
 ## Submitting Pull Requests
 
 No Pull Request (PR) is too small! Typos, additional comments in the code,

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,9 @@ CROSS_BUILD_TARGETS := \
 
 all: binaries docs
 
+completion: binaries
+	bin/podman completion bash > completions/bash/podman
+
 default: help
 
 define PRINT_HELP_PYSCRIPT

--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -196,7 +196,7 @@ func buildCmd(c *cliconfig.BuildValues) error {
 	}
 
 	if len(cliArgs) > 0 {
-		// The context directory could be a URL.  Try to handle that.
+		// The context directory could be a URL. Try to handle that.
 		tempDir, subDir, err := imagebuildah.TempDirForURL("", "buildah", cliArgs[0])
 		if err != nil {
 			return errors.Wrapf(err, "error prepping temporary context directory")

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -31,6 +31,7 @@ var (
 // implemented.
 var mainCommands = []*cobra.Command{
 	_attachCommand,
+	_bashCompletionCommand,
 	_buildCommand,
 	_commitCommand,
 	_diffCommand,

--- a/cmd/podman/shell_auto_completion.go
+++ b/cmd/podman/shell_auto_completion.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	bashAutoCompletionDescription = `To load completion run
+
+podman completion bash >>~/.bashrc
+
+Reload your shell.
+
+To make it available in all your bash session, add this to your ~/.bashrc file:
+echo 'source <(podman completion bash)' >>~/.bashrc
+
+As an alternative, if 'bash-completion' is installed on your system, you can add it in:
+/etc/bash_completion.d/{your_file_name}
+`
+)
+
+var _bashCompletionCommand = &cobra.Command{
+	Use:   "completion",
+	Short: "Generates shell scripts for auto-completion",
+	// We do not intend to show this command to the user so
+	// we marked it as hidden. We should use them by using
+	// the "make completion" target to update the shell scripts
+	// enabling the auto-completion for podman.
+	Hidden:  true,
+	Example: `podman completion --help`,
+}
+
+func init() {
+	_bashCompletionCommand.AddCommand(
+		&cobra.Command{
+			Use:   "bash",
+			Short: "generate auto-completion for bash",
+			Long:  bashAutoCompletionDescription,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				// Writing the shell script to stdout allows the most flexible use
+				// as the user can redirect the outputt where it needs it.
+				return rootCmd.GenBashCompletion(os.Stdout)
+			},
+			Example: `podman completion bash >>~/.bashrc`,
+		},
+	)
+}

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1,3409 +1,10674 @@
-#
-# This bash script was originally copied and converted from the upstream
-# github.com:docker/docker project
-#
-: ${PROG:=$(basename ${BASH_SOURCE})}
+# bash completion for podman                               -*- shell-script -*-
 
-
-__podman_previous_extglob_setting=$(shopt -p extglob)
-shopt -s extglob
-
-__podman_q() {
-    podman ${host:+-H "$host"} ${config:+--config "$config"} 2>/dev/null "$@"
+__podman_debug()
+{
+    if [[ -n ${BASH_COMP_DEBUG_FILE} ]]; then
+        echo "$*" >> "${BASH_COMP_DEBUG_FILE}"
+    fi
 }
 
-# __podman_containers returns a list of containers. Additional options to
-# `podman ps` may be specified in order to filter the list, e.g.
-# `__podman_containers --filter status=running`
-# By default, only names are returned.
-# Set PODMAN_COMPLETION_SHOW_CONTAINER_IDS=yes to also complete IDs.
-# An optional first option `--id|--name` may be used to limit the
-# output to the IDs or names of matching items. This setting takes
-# precedence over the environment setting.
-__podman_containers() {
-	local format
-	if [ "$1" = "--id" ] ; then
-		format='{{.ID}}'
-		shift
-	elif [ "$1" = "--name" ] ; then
-		format='{{.Names}}'
-		shift
-	elif [ "${PODMAN_COMPLETION_SHOW_CONTAINER_IDS}" = yes ] ; then
-		format='{{.ID}} {{.Names}}'
-	else
-		format='{{.Names}}'
-	fi
-	__podman_q ps --format "$format" "$@"
+# Homebrew on Macs have version 1.3 of bash-completion which doesn't include
+# _init_completion. This is a very minimal version of that function.
+__podman_init_completion()
+{
+    COMPREPLY=()
+    _get_comp_words_by_ref "$@" cur prev words cword
 }
 
-__podman_list_registries() {
-        sed -n -e '/registries.*=/ {s/.*\[\([^]]*\).*/\1/p;q}' /etc/containers/registries.conf  | sed -e "s/[,']//g"
+__podman_index_of_word()
+{
+    local w word=$1
+    shift
+    index=0
+    for w in "$@"; do
+        [[ $w = "$word" ]] && return
+        index=$((index+1))
+    done
+    index=-1
 }
 
-# __podman_pods returns a list of pods. Additional options to
-# `podman pod ps` may be specified in order to filter the list, e.g.
-# `__podman_containers --filter status=running`
-# By default, only names are returned.
-# Set PODMAN_COMPLETION_SHOW_CONTAINER_IDS=yes to also complete IDs.
-# An optional first option `--id|--name` may be used to limit the
-# output to the IDs or names of matching items. This setting takes
-# precedence over the environment setting.
-__podman_pods() {
-	local format
-	if [ "$1" = "--id" ] ; then
-		format='{{.ID}}'
-		shift
-	elif [ "$1" = "--name" ] ; then
-		format='{{.Name}}'
-		shift
-	else
-		format='{{.Name}}'
-	fi
-	__podman_q pod ps --format "$format" "$@"
+__podman_contains_word()
+{
+    local w word=$1; shift
+    for w in "$@"; do
+        [[ $w = "$word" ]] && return
+    done
+    return 1
 }
 
-# __podman_complete_containers applies completion of containers based on the current
-# value of `$cur` or the value of the optional first option `--cur`, if given.
-# Additional filters may be appended, see `__podman_containers`.
-__podman_complete_containers() {
-	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
-		current="$2"
-		shift 2
-	fi
-	COMPREPLY=( $(compgen -W "$(__podman_containers "$@")" -- "$current") )
-}
-
-# __podman_complete_pods applies completion of pods based on the current
-# value of `$cur` or the value of the optional first option `--cur`, if given.
-# Additional filters may be appended, see `__podman_pods`.
-__podman_complete_pods() {
-	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
-		current="$2"
-		shift 2
-	fi
-	COMPREPLY=( $(compgen -W "$(__podman_pods "$@")" -- "$current") )
-}
-
-__podman_complete_pod_names() {
-	local names=( $(__podman_q pod ps --format={{.Name}}) )
-	COMPREPLY=( $(compgen -W "${names[*]}" -- "$cur") )
-}
-
-__podman_complete_containers_all() {
-	__podman_complete_containers "$@" --all
-}
-
-__podman_complete_containers_created() {
-	__podman_complete_containers "$@" --all --filter status=created
-}
-
-__podman_complete_containers_running() {
-	__podman_complete_containers "$@" --filter status=running
-}
-
-__podman_complete_containers_stopped() {
-	__podman_complete_containers "$@" --filter status=exited
-}
-
-__podman_complete_containers_unpauseable() {
-	__podman_complete_containers "$@" --all --filter status=paused
-}
-
-__podman_complete_container_names() {
-	local containers=( $(__podman_q ps -aq --no-trunc) )
-	local names=( $(__podman_q inspect --format '{{.Name}}' "${containers[@]}") )
-	names=( "${names[@]#/}" ) # trim off the leading "/" from the container names
-	COMPREPLY=( $(compgen -W "${names[*]}" -- "$cur") )
-}
-
-__podman_complete_container_ids() {
-	local containers=( $(__podman_q ps -aq) )
-	COMPREPLY=( $(compgen -W "${containers[*]}" -- "$cur") )
-}
-
-__podman_images() {
-	local images_args=""
-
-	case "$PODMAN_COMPLETION_SHOW_IMAGE_IDS" in
-		all)
-			images_args="--no-trunc -a"
-			;;
-		non-intermediate)
-			images_args="--no-trunc"
-			;;
-	esac
-
-	local repo_print_command
-	if [ "${PODMAN_COMPLETION_SHOW_TAGS:-yes}" = "yes" ]; then
-		repo_print_command='print $1; print $1":"$2'
-	else
-		repo_print_command='print $1'
-	fi
-
-	local awk_script
-	case "$PODMAN_COMPLETION_SHOW_IMAGE_IDS" in
-		all|non-intermediate)
-			awk_script='NR>1 { print $3; if ($1 != "<none>") { '"$repo_print_command"' } }'
-			;;
-		none|*)
-			awk_script='NR>1 && $1 != "<none>" { '"$repo_print_command"' }'
-			;;
-	esac
-
-	__podman_q images $images_args | awk "$awk_script" | grep -v '<none>$'
-}
-
-__podman_complete_images() {
-	COMPREPLY=( $(compgen -W "$(__podman_images)" -- "$cur") )
-	__ltrim_colon_completions "$cur"
-}
-
-__podman_complete_image_repos() {
-	local repos="$(__podman_q images | awk 'NR>1 && $1 != "<none>" { print $1 }')"
-	COMPREPLY=( $(compgen -W "$repos" -- "$cur") )
-}
-
-__podman_complete_image_repos_and_tags() {
-	local reposAndTags="$(__podman_q images | awk 'NR>1 && $1 != "<none>" { print $1; print $1":"$2 }')"
-	COMPREPLY=( $(compgen -W "$reposAndTags" -- "$cur") )
-	__ltrim_colon_completions "$cur"
-}
-
-# __podman_networks returns a list of all networks. Additional options to
-# `podman network ls` may be specified in order to filter the list, e.g.
-# `__podman_networks --filter type=custom`
-# By default, only names are returned.
-# Set PODMAN_COMPLETION_SHOW_NETWORK_IDS=yes to also complete IDs.
-# An optional first option `--id|--name` may be used to limit the
-# output to the IDs or names of matching items. This setting takes
-# precedence over the environment setting.
-__podman_networks() {
-	local format
-	if [ "$1" = "--id" ] ; then
-		format='{{.ID}}'
-		shift
-	elif [ "$1" = "--name" ] ; then
-		format='{{.Name}}'
-		shift
-	elif [ "${PODMAN_COMPLETION_SHOW_NETWORK_IDS}" = yes ] ; then
-		format='{{.ID}} {{.Name}}'
-	else
-		format='{{.Name}}'
-	fi
-	__podman_q network ls --format "$format" "$@"
-}
-
-# __podman_complete_networks applies completion of networks based on the current
-# value of `$cur` or the value of the optional first option `--cur`, if given.
-# Additional filters may be appended, see `__podman_networks`.
-__podman_complete_networks() {
-	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
-		current="$2"
-		shift 2
-	fi
-	COMPREPLY=( $(compgen -W "$(__podman_networks "$@")" -- "$current") )
-}
-
-__podman_complete_containers_in_network() {
-	local containers=$(__podman_q network inspect -f '{{range $i, $c := .Containers}}{{$i}} {{$c.Name}} {{end}}' "$1")
-	COMPREPLY=( $(compgen -W "$containers" -- "$cur") )
-}
-
-__podman_runtimes() {
-	__podman_q info | sed -n 's/^Runtimes: \(.*\)/\1/p'
-}
-
-__podman_complete_runtimes() {
-	COMPREPLY=( $(compgen -W "$(__podman_runtimes)" -- "$cur") )
-}
-
-# __podman_services returns a list of all services. Additional options to
-# `podman service ls` may be specified in order to filter the list, e.g.
-# `__podman_services --filter name=xxx`
-# By default, only node names are returned.
-# Set PODMAN_COMPLETION_SHOW_SERVICE_IDS=yes to also complete IDs.
-# An optional first option `--id|--name` may be used to limit the
-# output to the IDs or names of matching items. This setting takes
-# precedence over the environment setting.
-__podman_services() {
-	local fields='$2'  # default: service name only
-	[ "${PODMAN_COMPLETION_SHOW_SERVICE_IDS}" = yes ] && fields='$1,$2' # ID & name
-
-	if [ "$1" = "--id" ] ; then
-		fields='$1' # IDs only
-		shift
-	elif [ "$1" = "--name" ] ; then
-		fields='$2' # names only
-		shift
-	fi
-	__podman_q service ls "$@" | awk "NR>1 {print $fields}"
-}
-
-# __podman_complete_services applies completion of services based on the current
-# value of `$cur` or the value of the optional first option `--cur`, if given.
-# Additional filters may be appended, see `__podman_services`.
-__podman_complete_services() {
-	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
-		current="$2"
-		shift 2
-	fi
-	COMPREPLY=( $(compgen -W "$(__podman_services "$@")" -- "$current") )
-}
-
-# __podman_append_to_completions appends the word passed as an argument to every
-# word in `$COMPREPLY`.
-# Normally you do this with `compgen -S` while generating the completions.
-# This function allows you to append a suffix later. It allows you to use
-# the __podman_complete_XXX functions in cases where you need a suffix.
-__podman_append_to_completions() {
-	COMPREPLY=( ${COMPREPLY[@]/%/"$1"} )
-}
-
-# __podman_pos_first_nonflag finds the position of the first word that is neither
-# option nor an option's argument. If there are options that require arguments,
-# you should pass a glob describing those options, e.g. "--option1|-o|--option2"
-# Use this function to restrict completions to exact positions after the argument list.
-__podman_pos_first_nonflag() {
-	local argument_flags=$1
-
-	local counter=$((${subcommand_pos:-${command_pos}} + 1))
-	while [ $counter -le $cword ]; do
-		if [ -n "$argument_flags" ] && eval "case '${words[$counter]}' in $argument_flags) true ;; *) false ;; esac"; then
-			(( counter++ ))
-			# eat "=" in case of --option=arg syntax
-			[ "${words[$counter]}" = "=" ] && (( counter++ ))
-		else
-			case "${words[$counter]}" in
-				-*)
-					;;
-				*)
-					break
-					;;
-			esac
-		fi
-
-		# Bash splits words at "=", retaining "=" as a word, examples:
-		# "--debug=false" => 3 words, "--log-opt syslog-facility=daemon" => 4 words
-		while [ "${words[$counter + 1]}" = "=" ] ; do
-			counter=$(( counter + 2))
-		done
-
-		(( counter++ ))
-	done
-
-	echo $counter
-}
-
-# __podman_map_key_of_current_option returns `key` if we are currently completing the
-# value of a map option (`key=value`) which matches the extglob given as an argument.
-# This function is needed for key-specific completions.
-__podman_map_key_of_current_option() {
-	local glob="$1"
-
-	local key glob_pos
-	if [ "$cur" = "=" ] ; then        # key= case
-		key="$prev"
-		glob_pos=$((cword - 2))
-	elif [[ $cur == *=* ]] ; then     # key=value case (OSX)
-		key=${cur%=*}
-		glob_pos=$((cword - 1))
-	elif [ "$prev" = "=" ] ; then
-		key=${words[$cword - 2]}  # key=value case
-		glob_pos=$((cword - 3))
-	else
-		return
-	fi
-
-	[ "${words[$glob_pos]}" = "=" ] && ((glob_pos--))  # --option=key=value syntax
-
-	[[ ${words[$glob_pos]} == @($glob) ]] && echo "$key"
-}
-
-# __podman_value_of_option returns the value of the first option matching `option_glob`.
-# Valid values for `option_glob` are option names like `--log-level` and globs like
-# `--log-level|-l`
-# Only positions between the command and the current word are considered.
-__podman_value_of_option() {
-	local option_extglob=$(__podman_to_extglob "$1")
-
-	local counter=$((command_pos + 1))
-	while [ $counter -lt $cword ]; do
-		case ${words[$counter]} in
-			$option_extglob )
-				echo ${words[$counter + 1]}
-				break
-				;;
-		esac
-		(( counter++ ))
-	done
-}
-
-# __podman_to_alternatives transforms a multiline list of strings into a single line
-# string with the words separated by `|`.
-# This is used to prepare arguments to __podman_pos_first_nonflag().
-__podman_to_alternatives() {
-	local parts=( $1 )
-	local IFS='|'
-	echo "${parts[*]}"
-}
-
-# __podman_to_extglob transforms a multiline list of options into an extglob pattern
-# suitable for use in case statements.
-__podman_to_extglob() {
-	local extglob=$( __podman_to_alternatives "$1" )
-	echo "@($extglob)"
-}
-
-# __podman_subcommands processes subcommands
-# Locates the first occurrence of any of the subcommands contained in the
-# first argument. In case of a match, calls the corresponding completion
-# function and returns 0.
-# If no match is found, 1 is returned. The calling function can then
-# continue processing its completion.
-#
-# TODO if the preceding command has options that accept arguments and an
-# argument is equal ot one of the subcommands, this is falsely detected as
-# a match.
-__podman_subcommands() {
-	local subcommands="$1"
-
-	local counter=$(($command_pos + 1))
-
-	while [ $counter -lt $cword ]; do
-		case "${words[$counter]}" in
-			$(__podman_to_extglob "$subcommands") )
-				subcommand_pos=$counter
-				local subcommand=${words[$counter]}
-				local completions_func=_podman_${command}_${subcommand}
-				declare -F $completions_func >/dev/null && $completions_func
-				return 0
-				;;
-		esac
-		(( counter++ ))
-	done
-	return 1
-}
-
-# __podman_nospace suppresses trailing whitespace
-__podman_nospace() {
-	# compopt is not available in ancient bash versions
-	type compopt &>/dev/null && compopt -o nospace
-}
-
-__podman_complete_resolved_hostname() {
-	command -v host >/dev/null 2>&1 || return
-	COMPREPLY=( $(host 2>/dev/null "${cur%:}" | awk '/has address/ {print $4}') )
-}
-
-__podman_local_interfaces() {
-	command -v ip >/dev/null 2>&1 || return
-	ip addr show scope global 2>/dev/null | sed -n 's| \+inet \([0-9.]\+\).* \([^ ]\+\)|\1 \2|p'
-}
-
-__podman_complete_local_interfaces() {
-	local additional_interface
-	if [ "$1" = "--add" ] ; then
-		additional_interface="$2"
-	fi
-
-	COMPREPLY=( $( compgen -W "$(__podman_local_interfaces) $additional_interface" -- "$cur" ) )
-}
-
-__podman_complete_capabilities() {
-	# The list of capabilities is defined in types.go, ALL was added manually.
-	COMPREPLY=( $( compgen -W "
-		ALL
-		AUDIT_CONTROL
-		AUDIT_WRITE
-		AUDIT_READ
-		BLOCK_SUSPEND
-		CHOWN
-		DAC_OVERRIDE
-		DAC_READ_SEARCH
-		FOWNER
-		FSETID
-		IPC_LOCK
-		IPC_OWNER
-		KILL
-		LEASE
-		LINUX_IMMUTABLE
-		MAC_ADMIN
-		MAC_OVERRIDE
-		MKNOD
-		NET_ADMIN
-		NET_BIND_SERVICE
-		NET_BROADCAST
-		NET_RAW
-		SETFCAP
-		SETGID
-		SETPCAP
-		SETUID
-		SYS_ADMIN
-		SYS_BOOT
-		SYS_CHROOT
-		SYSLOG
-		SYS_MODULE
-		SYS_NICE
-		SYS_PACCT
-		SYS_PTRACE
-		SYS_RAWIO
-		SYS_RESOURCE
-		SYS_TIME
-		SYS_TTY_CONFIG
-		WAKE_ALARM
-	" -- "$cur" ) )
-}
-
-__podman_complete_detach_keys() {
-	case "$prev" in
-		--detach-keys)
-			case "$cur" in
-				*,)
-				    COMPREPLY=( $( compgen -W "${cur}ctrl-" -- "$cur" ) )
-				    ;;
-				*)
-				    COMPREPLY=( $( compgen -W "ctrl-" -- "$cur" ) )
-				    ;;
-			esac
-
-			__podman_nospace
-			return 0
-			;;
-	esac
-	return 1
-}
-
-__podman_complete_log_drivers() {
-	COMPREPLY=( $( compgen -W "
-		awslogs
-		etwlogs
-		fluentd
-		gcplogs
-		gelf
-		journald
-		json-file
-		logentries
-		none
-		splunk
-		syslog
-		k8s-file
-	" -- "$cur" ) )
-}
-
-__podman_complete_log_options() {
-	# see docs/reference/logging/index.md
-	local awslogs_options="awslogs-region awslogs-group awslogs-stream"
-	local fluentd_options="env fluentd-address fluentd-async-connect fluentd-buffer-limit fluentd-retry-wait fluentd-max-retries labels tag"
-	local gcplogs_options="env gcp-log-cmd gcp-project labels"
-	local gelf_options="env gelf-address gelf-compression-level gelf-compression-type labels tag"
-	local journald_options="env labels tag"
-	local json_file_options="env labels max-file max-size"
-	local logentries_options="logentries-token"
-	local syslog_options="env labels syslog-address syslog-facility syslog-format syslog-tls-ca-cert syslog-tls-cert syslog-tls-key syslog-tls-skip-verify tag"
-	local splunk_options="env labels splunk-caname splunk-capath splunk-format splunk-gzip splunk-gzip-level splunk-index splunk-insecureskipverify splunk-source splunk-sourcetype splunk-token splunk-url splunk-verify-connection tag"
-	local k8s_file_options="env labels max-file max-size"
-
-	local all_options="$fluentd_options $gcplogs_options $gelf_options $journald_options $logentries_options $json_file_options $syslog_options $splunk_options"
-
-	case $(__podman_value_of_option --log-driver) in
-		'')
-			COMPREPLY=( $( compgen -W "$all_options" -S = -- "$cur" ) )
-			;;
-		awslogs)
-			COMPREPLY=( $( compgen -W "$awslogs_options" -S = -- "$cur" ) )
-			;;
-		fluentd)
-			COMPREPLY=( $( compgen -W "$fluentd_options" -S = -- "$cur" ) )
-			;;
-		gcplogs)
-			COMPREPLY=( $( compgen -W "$gcplogs_options" -S = -- "$cur" ) )
-			;;
-		gelf)
-			COMPREPLY=( $( compgen -W "$gelf_options" -S = -- "$cur" ) )
-			;;
-		journald)
-			COMPREPLY=( $( compgen -W "$journald_options" -S = -- "$cur" ) )
-			;;
-		json-file)
-			COMPREPLY=( $( compgen -W "$json_file_options" -S = -- "$cur" ) )
-			;;
-		k8s-file)
-			COMPREPLY=( $( compgen -W "$k8s_file_options" -S = -- "$cur" ) )
-			;;
-		logentries)
-			COMPREPLY=( $( compgen -W "$logentries_options" -S = -- "$cur" ) )
-			;;
-		syslog)
-			COMPREPLY=( $( compgen -W "$syslog_options" -S = -- "$cur" ) )
-			;;
-		splunk)
-			COMPREPLY=( $( compgen -W "$splunk_options" -S = -- "$cur" ) )
-			;;
-		*)
-			return
-			;;
-	esac
-
-	__podman_nospace
-}
-
-__podman_complete_log_driver_options() {
-	local key=$(__podman_map_key_of_current_option '--log-opt')
-	case "$key" in
-		fluentd-async-connect)
-			COMPREPLY=( $( compgen -W "false true" -- "${cur##*=}" ) )
-			return
-			;;
-		gelf-address)
-			COMPREPLY=( $( compgen -W "udp" -S "://" -- "${cur##*=}" ) )
-			__podman_nospace
-			return
-			;;
-		gelf-compression-level)
-			COMPREPLY=( $( compgen -W "1 2 3 4 5 6 7 8 9" -- "${cur##*=}" ) )
-			return
-			;;
-		gelf-compression-type)
-			COMPREPLY=( $( compgen -W "gzip none zlib" -- "${cur##*=}" ) )
-			return
-			;;
-		syslog-address)
-			COMPREPLY=( $( compgen -W "tcp:// tcp+tls:// udp:// unix://" -- "${cur##*=}" ) )
-			__podman_nospace
-			__ltrim_colon_completions "${cur}"
-			return
-			;;
-		syslog-facility)
-			COMPREPLY=( $( compgen -W "
-				auth
-				authpriv
-				cron
-				daemon
-				ftp
-				kern
-				local0
-				local1
-				local2
-				local3
-				local4
-				local5
-				local6
-				local7
-				lpr
-				mail
-				news
-				syslog
-				user
-				uucp
-			" -- "${cur##*=}" ) )
-			return
-			;;
-		syslog-format)
-			COMPREPLY=( $( compgen -W "rfc3164 rfc5424 rfc5424micro" -- "${cur##*=}" ) )
-			return
-			;;
-		syslog-tls-ca-cert|syslog-tls-cert|syslog-tls-key)
-			_filedir
-			return
-			;;
-		syslog-tls-skip-verify)
-			COMPREPLY=( $( compgen -W "true" -- "${cur##*=}" ) )
-			return
-			;;
-		splunk-url)
-			COMPREPLY=( $( compgen -W "http:// https://" -- "${cur##*=}" ) )
-			__podman_nospace
-			__ltrim_colon_completions "${cur}"
-			return
-			;;
-		splunk-gzip|splunk-insecureskipverify|splunk-verify-connection)
-			COMPREPLY=( $( compgen -W "false true" -- "${cur##*=}" ) )
-			return
-			;;
-		splunk-format)
-			COMPREPLY=( $( compgen -W "inline json raw" -- "${cur##*=}" ) )
-			return
-			;;
-	esac
-	return 1
-}
-
-__podman_complete_log_levels() {
-	COMPREPLY=( $( compgen -W "debug info warn error fatal" -- "$cur" ) )
-}
-
-# __podman_complete_signals returns a subset of the available signals that is most likely
-# relevant in the context of podman containers
-__podman_complete_signals() {
-	local signals=(
-		SIGCONT
-		SIGHUP
-		SIGINT
-		SIGKILL
-		SIGQUIT
-		SIGSTOP
-		SIGTERM
-		SIGUSR1
-		SIGUSR2
-	)
-	COMPREPLY=( $( compgen -W "${signals[*]} ${signals[*]#SIG}" -- "$( echo $cur | tr '[:lower:]' '[:upper:]')" ) )
-}
-
-__podman_complete_user_group() {
-	if [[ $cur == *:* ]] ; then
-		COMPREPLY=( $(compgen -g -- "${cur#*:}") )
-	else
-		COMPREPLY=( $(compgen -u -S : -- "$cur") )
-		__podman_nospace
-	fi
-}
-
-__podman_list_images() {
-    COMPREPLY=($(compgen -W "$(podman images -q)" -- $cur))
-}
-
-__podman_list_containers() {
-    COMPREPLY=($(compgen -W "$(podman ps -aq)" -- $cur))
-}
-
-__podman_images() {
-	local images_args=""
-
-	case "$PODMAN_COMPLETION_SHOW_IMAGE_IDS" in
-		all)
-			images_args="--no-trunc -a"
-			;;
-		non-intermediate)
-			images_args="--no-trunc"
-			;;
-	esac
-
-	local repo_print_command
-	if [ "${PODMAN_COMPLETION_SHOW_TAGS:-yes}" = "yes" ]; then
-		repo_print_command='print $1; print $1":"$2'
-	else
-		repo_print_command='print $1'
-	fi
-
-	local awk_script
-	case "$PODMAN_COMPLETION_SHOW_IMAGE_IDS" in
-		all|non-intermediate)
-			awk_script='NR>1 { print $3; if ($1 != "<none>") { '"$repo_print_command"' } }'
-			;;
-		none|*)
-			awk_script='NR>1 && $1 != "<none>" { '"$repo_print_command"' }'
-			;;
-	esac
-
-	__podman_q images $images_args | awk "$awk_script" | grep -v '<none>$'
-}
-
-# __podman_complete_volumes applies completion of volumes based on the current
-# value of `$cur` or the value of the optional first option `--cur`, if given.
-__podman_complete_volumes() {
-	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
-		current="$2"
-		shift 2
-	fi
-	COMPREPLY=( $(compgen -W "$(__podman_volume "$@")" -- "$current") )
-}
-
-__podman_complete_volume_names() {
-	local names=( $(__podman_q volume ls --quiet) )
-	COMPREPLY=( $(compgen -W "${names[*]}" -- "$cur") )
-}
-
-
-_podman_attach() {
-     local options_with_args="
-     --detach-keys
-     "
-     local boolean_options="
-	  --help
-	  -h
-	  --latest
-	  -l
-	  --no-stdin
-	  --sig-proxy
-     "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_containers_running
-	    ;;
-    esac
-}
-
-_podman_container_attach() {
-     _podman_attach
-}
-
-_podman_container_checkpoint() {
-     local options_with_args="
-     -e
-     --export
-     "
-     local boolean_options="
-     -a
-     --all
-     -h
-     --help
-     -k
-     --keep
-     -l
-     --latest
-     -R
-     --leave-running
-     --tcp-established
-     --ignore-rootfs
-     "
-     case "$prev" in
-        -e|--export)
-            _filedir
-            return
+__podman_handle_reply()
+{
+    __podman_debug "${FUNCNAME[0]}"
+    case $cur in
+        -*)
+            if [[ $(type -t compopt) = "builtin" ]]; then
+                compopt -o nospace
+            fi
+            local allflags
+            if [ ${#must_have_one_flag[@]} -ne 0 ]; then
+                allflags=("${must_have_one_flag[@]}")
+            else
+                allflags=("${flags[*]} ${two_word_flags[*]}")
+            fi
+            COMPREPLY=( $(compgen -W "${allflags[*]}" -- "$cur") )
+            if [[ $(type -t compopt) = "builtin" ]]; then
+                [[ "${COMPREPLY[0]}" == *= ]] || compopt +o nospace
+            fi
+
+            # complete after --flag=abc
+            if [[ $cur == *=* ]]; then
+                if [[ $(type -t compopt) = "builtin" ]]; then
+                    compopt +o nospace
+                fi
+
+                local index flag
+                flag="${cur%=*}"
+                __podman_index_of_word "${flag}" "${flags_with_completion[@]}"
+                COMPREPLY=()
+                if [[ ${index} -ge 0 ]]; then
+                    PREFIX=""
+                    cur="${cur#*=}"
+                    ${flags_completion[${index}]}
+                    if [ -n "${ZSH_VERSION}" ]; then
+                        # zsh completion needs --flag= prefix
+                        eval "COMPREPLY=( \"\${COMPREPLY[@]/#/${flag}=}\" )"
+                    fi
+                fi
+            fi
+            return 0;
             ;;
-     esac
-     case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_containers_running
-	    ;;
-     esac
-}
-
-_podman_container_commit() {
-     _podman_commit
-}
-
-_podman_container_cp() {
-     _podman_cp
-}
-
-_podman_container_create() {
-     _podman_create
-}
-
-_podman_container_diff() {
-     _podman_diff
-}
-
-_podman_container_exec() {
-     _podman_exec
-}
-
-_podman_container_export() {
-     _podman_export
-}
-
-_podman_container_init() {
-     _podman_init
-}
-
-_podman_container_inspect() {
-     _podman_inspect
-}
-
-_podman_container_kill() {
-     _podman_kill
-}
-
-_podman_container_list() {
-     _podman_ls
-}
-
-_podman_container_ls() {
-     _podman_ls
-}
-
-_podman_container_logs() {
-     _podman_logs
-}
-
-_podman_container_mount() {
-     _podman_mount
-}
-
-_podman_container_pause() {
-     _podman_pause
-}
-
-_podman_container_port() {
-     _podman_port
-}
-
-_podman_container_ps() {
-     _podman_ls
-}
-
-_podman_container_refresh() {
-     local options_with_args="
-     "
-     local boolean_options="
-	--help
-	-h
-     "
-     _complete_ "$options_with_args" "$boolean_options"
-}
-
-_podman_container_restart() {
-     _podman_restart
-}
-
-_podman_container_restore() {
-     local options_with_args="
-     -i
-     --import
-     -n
-     --name
-     "
-     local boolean_options="
-	  -a
-	  --all
-	  -h
-	  --help
-	  -k
-	  --keep
-	  -l
-	  --latest
-	  --tcp-established
-	  --ignore-rootfs
-	  --ignore-static-ip
-	  --ignore-static-mac
-     "
-     case "$prev" in
-        -i|--import)
-            _filedir
-            return
-            ;;
-     esac
-     case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_containers_created
-	    ;;
-     esac
-}
-
-_podman_container_rm() {
-     _podman_rm
-}
-
-_podman_container_start() {
-     _podman_start
-}
-
-_podman_container_stats() {
-     _podman_stats
-}
-
-_podman_container_stop() {
-     _podman_stop
-}
-
-_podman_container_top() {
-     _podman_top
-}
-
-_podman_container_umount() {
-     _podman_umount
-}
-
-_podman_container_unmount() {
-     _podman_unmount
-}
-
-_podman_container_unpause() {
-     _podman_unpause
-}
-
-_podman_container_wait() {
-     _podman_wait
-}
-
-_podman_healthcheck() {
-    local boolean_options="
-	--help
-	-h
-	"
-     subcommands="
-	run
-     "
-     __podman_subcommands "$subcommands $aliases" && return
-
-     case "$cur" in
-	-*)
-		COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-		;;
-	*)
-		COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
-		;;
-     esac
-}
-
-_podman_network() {
-    local boolean_options="
-	--help
-	-h
-	"
-     subcommands="
-     create
-	 inspect
-	 ls
-	 rm
-     "
-     __podman_subcommands "$subcommands $aliases" && return
-
-     case "$cur" in
-	-*)
-		COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-		;;
-	*)
-		COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
-		;;
-     esac
-}
-
-_podman_network_create() {
-    local options_with_args="
-    -d
-    --driver
-    --gateway
-    --ip-range
-	--macvlan
-    --subnet
-     "
-    local boolean_options="
-    --disable-dns
-	--help
-	-h
-	--internal
-    "
-    _complete_ "$options_with_args" "$boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-    esac
-}
-_podman_network_inspect() {
-    local options_with_args="
-     "
-    local boolean_options="
-	--help
-	-h
-    "
-    _complete_ "$options_with_args" "$boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-    esac
-}
-
-_podman_network_ls() {
-    local options_with_args="
-     "
-    local boolean_options="
-    --help
-    -h
-	--quiet
-	-q
-    "
-    _complete_ "$options_with_args" "$boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-    esac
-}
-
-_podman_network_rm() {
-    local options_with_args="
-     "
-    local boolean_options="
-    --force
-    -f
-    --help
-    -h
-    "
-    _complete_ "$options_with_args" "$boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-    esac
-}
-
-_podman_generate() {
-    local boolean_options="
-	--help
-	-h
-	"
-     subcommands="
-	 kube
-	 systemd
-     "
-     __podman_subcommands "$subcommands $aliases" && return
-
-     case "$cur" in
-	-*)
-		COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-		;;
-	*)
-		COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
-		;;
-     esac
-}
-
-_podman_play() {
-    local boolean_options="
-	--help
-	-h
-	"
-     subcommands="
-	 kube
-     "
-     __podman_subcommands "$subcommands $aliases" && return
-
-     case "$cur" in
-	-*)
-		COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-		;;
-	*)
-		COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
-		;;
-     esac
-}
-_podman_container() {
-    local boolean_options="
-	--help
-	-h
-	"
-     subcommands="
-	 attach
-	 checkpoint
-	 commit
-	 cp
-	 create
-	 diff
-	 exec
-	 exists
-	 export
-	 inspect
-	 kill
-	 list
-	 logs
-	 mount
-	 pause
-	 port
-	 prune
-	 refresh
-	 restart
-	 restore
-	 rm
-	 run
-	 runlabel
-	 start
-	 stats
-	 stop
-	 top
-	 umount
-	 unmount
-	 unpause
-	 wait
-     "
-     local aliases="
-	 list
-	ps
-     "
-     __podman_subcommands "$subcommands $aliases" && return
-
-     case "$cur" in
-	-*)
-		COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-		;;
-	*)
-		COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
-		;;
-     esac
-}
-
-_podman_system_reset() {
-	local options_with_args="
-	"
-	local boolean_options="
-	     -h
-	     --help
-	     --force
-	"
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-    esac
-}
-
-_podman_system_df() {
-	local options_with_args="
-	--format
-	--verbose
-	"
-	local boolean_options="
-     -h
-     --help
-	 --verbose
-	 -v
-	"
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-    esac
-}
-
-_podman_system_info() {
-   _podman_info
-}
-
-_podman_system_prune() {
-    local options_with_args="
-    "
-
-    local boolean_options="
-     -a
-     --all
-     -f
-     --force
-     -h
-     --help
-     --volumes
-  "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-    esac
-}
-
-_podman_system() {
-    local boolean_options="
-	--help
-	-h
-	"
-     subcommands="
-	df
-	info
-	prune
-	reset
-     "
-     __podman_subcommands "$subcommands" && return
-
-     case "$cur" in
-	-*)
-		COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-		;;
-	*)
-		COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
-		;;
-     esac
-}
-
-_podman_commit() {
-    local options_with_args="
-	--author
-	-a
-	--change
-	-c
-	--message
-	-m
-     "
-    local boolean_options="
-	--help
-	-h
-	--pause
-	-p
-	--quiet
-	-q
-     "
-    _complete_ "$options_with_args" "$boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_container_names
-	    ;;
-    esac
-}
-
-_podman_build() {
-     local boolean_options="
-	  --force-rm
-	  --help
-	  -h
-	  --layers
-	  --no-cache
-	  --pull
-	  --pull-always
-	  --pull-never
-	  --quiet
-	  -q
-	  --rm
-	  --squash
-	  --squash-all
-	  --tls-verify
-  "
-
-     local options_with_args="
-     --add-host
-     --annotation
-     --authfile
-     --build-arg
-     --cap-add
-     --cap-drop
-     --cgroup-parent
-     --cni-config-dir
-     --cni-plugin-path
-     --cpu-period
-     --cpu-quota
-     --cpu-shares
-     --cpuset-cpus
-     --cpuset-mems
-     --creds
-     -f
-     --file
-     --format
-     --iidfile
-     --ipc
-     --label
-     -m
-     --memory
-     --memory-swap
-     --net
-     --network
-     --pid
-     --runtime
-     --runtime-flag
-     --security-opt
-     --shm-size
-     -t
-     --tag
-     --ulimit
-     --userns
-     --userns-uid-map
-     --userns-gid-map
-     --userns-uid-map-user
-     --userns-gid-map-group
-     --uts
-     --mount
-     --volume
-     -v
-  "
-
-     local all_options="$options_with_args $boolean_options"
-
-     case "$prev" in
-	 --runtime)
-	     COMPREPLY=($(compgen -W 'runc runv' -- "$cur"))
-	     ;;
-	 $(__podman_to_extglob "$options_with_args"))
- return
- ;;
- esac
-
- case "$cur" in
-     -*)
-	 COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	 ;;
- esac
-}
-
-_podman_diff() {
-    local options_with_args="
-     --format
-     "
-    local boolean_options="
-	--help
-	-h
-    "
-    _complete_ "$options_with_args" "$boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_container_names
-	    ;;
-    esac
-}
-
-_podman_exec() {
-    local options_with_args="
-    --detach-keys
-    -e
-    --env
-    --env-file
-    --user
-    -u
-    --workdir
-    -w
-     "
-    local boolean_options="
-	--help
-	-h
-	--latest
-	-l
-	--privileged
-	--tty
-	-t
-     "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_containers_running
-	    ;;
     esac
 
-}
-_podman_export() {
-    local options_with_args="
-     --output
-     -o
-     "
-    local boolean_options="
-	--help
-	-h
-     "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_container_names
-	    ;;
-    esac
-}
-
-_podman_history() {
-    local options_with_args="
-     --format
-     "
-    local boolean_options="
-	--help
-	-h
-	--human -H
-	--no-trunc
-	--quiet -q
-     "
-    _complete_ "$options_with_args" "$boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_images --id
-	    ;;
-    esac
-}
-
-
-_podman_import() {
-    local options_with_args="
-	--change
-	-c
-	--message
-	-m
-     "
-    local boolean_options="
-	--help
-	-h
-	--quiet
-	-q
-     "
-     case "$prev" in
-         --change|-c|--message|-m)
-		return
-		;;
-    esac
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    local counter=$(__podman_pos_first_nonflag '--change|-c|--message|-m')
-	    if [ "$cword" -eq "$counter" ]; then
-		_filedir
-		return
-	    elif [ "$cword" -eq "$((counter + 1))" ]; then
-		__podman_complete_images --repo --tag
-		return
-	    fi
-	    ;;
-    esac
-}
-
-_podman_info() {
-    local boolean_options="
-	 --help
-	 -h
-	 --debug
-     "
-    local options_with_args="
-    -f
-    --format
-  "
-
-    local all_options="$options_with_args $boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_list_images
-	    ;;
-    esac
-}
-
-_podman_image_build() {
-     _podman_build
-}
-
-_podman_image_history() {
-     _podman_history
-}
-
-_podman_image_import() {
-     _podman_import
-}
-
-_podman_image_inspect() {
-     _podman_inspect
-}
-
-_podman_image_load() {
-     _podman_load
-}
-
-_podman_image_list() {
-     _podman_images
-}
-
-_podman_image_ls() {
-     _podman_images
-}
-
-_podman_image_pull() {
-     _podman_pull
-}
-
-_podman_image_push() {
-     _podman_push
-}
-
-_podman_image_rm() {
-     _podman_rmi
-}
-
-_podman_image_save() {
-     _podman_save
-}
-
-_podman_image_tag() {
-     _podman_tag
-}
-
-_podman_image() {
-    local boolean_options="
-	--help
-	-h
-     "
-     subcommands="
-	 build
-	 exists
-	 history
-	 import
-	 inspect
-	 load
-	 ls
-	 prune
-	 pull
-	 push
-	 rm
-	 save
-	 sign
-	 tag
-	 trust
-     "
-     local aliases="
-	 list
-     "
-     __podman_subcommands "$subcommands $aliases" && return
-
-     case "$cur" in
-	-*)
-		COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-		;;
-	*)
-		COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
-		;;
-     esac
-}
-
-_podman_images() {
-    local boolean_options="
-	-a
-	--all
-	--digests
-	--digests
-	-f
-	--filter
-	-h
-	--help
-	--history
-	--no-trunc
-	--notruncate
-	-n
-	--noheading
-	-q
-	--quiet
-     "
-    local options_with_args="
-    --format
-    --sort
-  "
-
-    local all_options="$options_with_args $boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_images --id
-	    ;;
-    esac
-}
-
-_podman_inspect() {
-    local boolean_options="
-	 --help
-	 -h
-	 --latest
-	 -l
-    "
-    local options_with_args="
-    --format
-     -f
-     --type
-     -t
-     --size
-     -s
-  "
-
-  local all_options="$options_with_args $boolean_options"
-
-	local preselected_type
-	local type
-
-	if [ "$1" = "--type" ] ; then
-		preselected_type=yes
-		type="$2"
-	else
-		type=$(__podman_value_of_option --type)
-	fi
-
-	case "$prev" in
-		--format|-f)
-			return
-			;;
-		--type)
-			if [ -z "$preselected_type" ] ; then
-				COMPREPLY=( $( compgen -W "container image" -- "$cur" ) )
-				return
-			fi
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			local options="--format -f --help --size -s"
-			if [ -z "$preselected_type" ] ; then
-				options+=" --type"
-			fi
-			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
-			;;
-		*)
-			case "$type" in
-				'')
-					COMPREPLY=( $( compgen -W "
-						$(__podman_containers --all)
-						$(__podman_images --force-tag --id)
-					" -- "$cur" ) )
-					__ltrim_colon_completions "$cur"
-					;;
-				container)
-					__podman_complete_containers_all
-					;;
-				image)
-					__podman_complete_images --force-tag --id
-					;;
-			esac
-	esac
-}
-
-_podman_kill() {
-     local options_with_args="
-     --signal -s
-     "
-     local boolean_options="
-	  --all
-	  -a
-	  --help
-	  -h
-	  --latest
-	  -l
-     "
-     case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_containers_running
-	    ;;
-    esac
-}
-
-_podman_logs() {
-     local options_with_args="
-     --since
-     --tail
-     "
-     local boolean_options="
-	--follow
-	-f
-	--help
-	-h
-	--latest
-	-l
-	--timestamps
-	-t
-     "
-     _complete_ "$options_with_args" "$boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_list_containers
-	    ;;
-    esac
-}
-
-_podman_pull() {
-    local options_with_args="
-    --authfile
-    --creds
-    --cert-dir
-    "
-    local boolean_options="
-	--all-tags
-	-a
-	--help
-	-h
-	--quiet
-	-q
-	--tls-verify
-    "
-    _complete_ "$options_with_args" "$boolean_options"
-}
-
-_podman_search() {
-	local options_with_args="
-	--authfile
-	--filter -f
-	--format
-	--limit
-	"
-	local boolean_options="
-	      --help
-	      -h
-	      --no-trunc
-	"
-	_complete_ "$options_with_args" "$boolean_options"
-}
-
-_podman_unmount() {
-    _podman_umount $@
-}
-
-_podman_umount() {
-    local boolean_options="
-	--all
-	-a
-	--help
-	-h
-	--force
-	-f
-	--latest
-	-l
-    "
-    local options_with_args="
-    "
-
-    local all_options="$options_with_args $boolean_options"
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_container_names
-	    ;;
-    esac
-}
-
-_podman_mount() {
-    local boolean_options="
-       --all
-       -a
-       --help
-       -h
-       -l
-       --latest
-       --notruncate
-    "
-
-    local options_with_args="
-	  --format
-    "
-
-    local all_options="$options_with_args $boolean_options"
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_container_names
-	    ;;
-    esac
-}
-
-_podman_push() {
-    local boolean_options="
-	--compress
-	--digestflag
-	--help
-	-h
-	--quiet
-	-q
-	--tls-verify
-  "
-
-    local options_with_args="
-    --authfile
-	--format
-    --cert-dir
-    --creds
-    --sign-by
-  "
-
-    local all_options="$options_with_args $boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_images --id
-	    ;;
-    esac
-}
-
-_podman_container_run() {
-	local options_with_args="
-		--add-host
-		--annotation
-		--attach -a
-		--blkio-weight
-		--blkio-weight-device
-		--builtin-volume
-		--cap-add
-		--cap-drop
-		--cgroup-parent
-		--cidfile
-		--conmon-pidfile
-		--cpu-period
-		--cpu-quota
-		--cpu-rt-period
-		--cpu-rt-runtime
-		--cpuset-cpus
-		--cpus
-		--cpuset-mems
-		--cpu-shares -c
-		--device
-		--device-read-bps
-		--device-read-iops
-		--device-write-bps
-		--device-write-iops
-		--dns
-		--dns-option
-		--dns-search
-		--entrypoint
-		--env -e
-		--env-host
-		--env-file
-		--expose
-		--gidmap
-		--group-add
-		--hostname -h
-		--http-proxy
-		--image-volume
-		--init-path
-		--ip
-		--ipc
-		--kernel-memory
-		--label-file
-		--label -l
-		--log-driver
-		--log-opt
-		--mac-address
-		--memory -m
-		--memory-swap
-		--memory-swappiness
-		--memory-reservation
-		--name
-		--network
-		--no-hosts
-		--oom-score-adj
-		--pid
-		--pids-limit
-		--pod
-		--publish -p
-		--pull
-		--runtime
-		--rootfs
-		--security-opt
-		--shm-size
-		--stop-signal
-		--stop-timeout
-		--tmpfs
-		--subgidname
-		--subuidname
-		--sysctl
-		--systemd
-		--uidmap
-		--ulimit
-		--user -u
-		--userns
-		--uts
-		--volumes-from
-		--volume -v
-		--workdir -w
-	"
-
-	local boolean_options="
-	    --disable-content-trust=false
-	    --help
-	    -h
-	    --init
-	    --interactive -i
-	    --oom-kill-disable
-	    --privileged
-	    --publish-all -P
-	    --quiet
-	    --read-only
-	    --read-only-tmpfs
-	    --tty -t
-	"
-
-	if [ "$command" = "run" -o "$subcommand" = "run" ] ; then
-		options_with_args="$options_with_args
-			--detach-keys
-			--health-cmd
-			--health-interval
-			--health-retries
-			--health-timeout
-			--health-start-period
-		"
-		boolean_options="$boolean_options
-			--detach -d
-			--rm
-			--sig-proxy=false
-		"
-		__podman_complete_detach_keys && return
-	fi
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    return
-	    ;;
-	*)
-	    __podman_complete_images --id
-	    ;;
-    esac
-
-
-	__podman_complete_log_driver_options && return
-
-	local key=$(__podman_map_key_of_current_option '--security-opt')
-	case "$key" in
-		label)
-			[[ $cur == *: ]] && return
-			COMPREPLY=( $( compgen -W "user: role: type: level: disable" -- "${cur##*=}") )
-			if [ "${COMPREPLY[*]}" != "disable" ] ; then
-				__podman_nospace
-			fi
-			return
-			;;
-		seccomp)
-			local cur=${cur##*=}
-			_filedir
-			COMPREPLY+=( $( compgen -W "unconfined" -- "$cur" ) )
-			return
-			;;
-	esac
-
-	case "$prev" in
-		--add-host)
-			case "$cur" in
-				*:)
-					__podman_complete_resolved_hostname
-					return
-					;;
-			esac
-			;;
-		--attach|-a)
-			COMPREPLY=( $( compgen -W 'stdin stdout stderr' -- "$cur" ) )
-			return
-			;;
-		--cap-add|--cap-drop)
-			__podman_complete_capabilities
-			return
-			;;
-		--cidfile|--env-file|--init-path|--label-file)
-			_filedir
-			return
-			;;
-		--device|--tmpfs|--volume|-v)
-			case "$cur" in
-				*:*)
-					# TODO somehow do _filedir for stuff inside the image, if it's already specified (which is also somewhat difficult to determine)
-					;;
-				'')
-					COMPREPLY=( $( compgen -W '/' -- "$cur" ) )
-					__podman_nospace
-					;;
-				/*)
-					_filedir
-					__podman_nospace
-					;;
-			esac
-			return
-			;;
-		--env|-e)
-			# we do not append a "=" here because "-e VARNAME" is legal syntax, too
-			COMPREPLY=( $( compgen -e -- "$cur" ) )
-			__podman_nospace
-			return
-			;;
-		--ipc)
-			case "$cur" in
-				*:*)
-					cur="${cur#*:}"
-					__podman_complete_containers_running
-					;;
-				*)
-					COMPREPLY=( $( compgen -W 'host container:' -- "$cur" ) )
-					if [ "$COMPREPLY" = "container:" ]; then
-						__podman_nospace
-					fi
-					;;
-			esac
-			return
-			;;
-		--log-driver)
-			__podman_complete_log_drivers
-			return
-			;;
-		--log-opt)
-			__podman_complete_log_options
-			return
-			;;
-		--network)
-			case "$cur" in
-				container:*)
-					__podman_complete_containers_all --cur "${cur#*:}"
-					;;
-				*)
-					COMPREPLY=( $( compgen -W "$(__podman_plugins_bundled --type Network) $(__podman_networks) container:" -- "$cur") )
-					if [ "${COMPREPLY[*]}" = "container:" ] ; then
-						__podman_nospace
-					fi
-					;;
-			esac
-			return
-			;;
-		--pod)
-			__podman_complete_pod_names
-			return
-			;;
-		--pid)
-			case "$cur" in
-				*:*)
-					__podman_complete_containers_running --cur "${cur#*:}"
-					;;
-				*)
-					COMPREPLY=( $( compgen -W 'host container:' -- "$cur" ) )
-					if [ "$COMPREPLY" = "container:" ]; then
-						__podman_nospace
-					fi
-					;;
-			esac
-			return
-			;;
-		--runtime)
-			__podman_complete_runtimes
-			return
-			;;
-		--security-opt)
-			COMPREPLY=( $( compgen -W "apparmor= label= no-new-privileges seccomp=" -- "$cur") )
-			if [ "${COMPREPLY[*]}" != "no-new-privileges" ] ; then
-				__podman_nospace
-			fi
-			return
-			;;
-		--storage-opt)
-			COMPREPLY=( $( compgen -W "size" -S = -- "$cur") )
-			__podman_nospace
-			return
-			;;
-		--user|-u)
-			__podman_complete_user_group
-			return
-			;;
-		--userns)
-			COMPREPLY=( $( compgen -W "host" -- "$cur" ) )
-			return
-			;;
-		--volumes-from)
-			__podman_complete_containers_all
-			return
-			;;
-		$(__podman_to_extglob "$options_with_args") )
-			return
-			;;
-	esac
-
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "$all_options" -- "$cur" ) )
-			;;
-		*)
-			local counter=$( __podman_pos_first_nonflag $( __podman_to_alternatives "$options_with_args" ) )
-			if [ $cword -eq $counter ]; then
-				__podman_complete_images
-			fi
-			;;
-	esac
-}
-
-
-_podman_create() {
-	_podman_container_run
-}
-
-
-_podman_run() {
-	_podman_container_run
-}
-
-_podman_restart() {
-     local options_with_args="
-     --timeout -t
-     "
-     local boolean_options="
-	  --all
-	  -a
-	  --help
-	  -h
-	  --latest
-	  -l
-	  --running
-	  --timeout
-	  -t
-     "
-     case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_containers_running
-	    ;;
-    esac
-}
-
-_podman_rm() {
-    local boolean_options="
-	--all
-	-a
-	--cidfile
-	--force
-	-f
-	--help
-	-h
-	--ignore
-	-i
-	--latest
-	-l
-	--storage
-	--volumes
-	-v
-    "
-
-    local options_with_args="
-    "
-
-    local all_options="$options_with_args $boolean_options"
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_container_names
-	    ;;
-    esac
-}
-
-_podman_rmi() {
-    local boolean_options="
-	 --all
-	 -a
-	 --force
-	 -f
-	 --help
-	 -h
-  "
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_images --id
-	    ;;
-    esac
-}
-
-_podman_stats() {
-    local boolean_options="
-	 --all
-	 -a
-	 --help
-	 -h
-	 --no-stream
-	 --format
-	 --no-reset
-    "
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_containers_running
-	    ;;
-    esac
-}
-
-_podman_tag() {
-    local options_with_args="
-    "
-    local boolean_options="
-	--help
-	-h
-    "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_images
-	    ;;
-    esac
-}
-
-__podman_top_descriptors() {
-	podman top --list-descriptors
-}
-
-__podman_complete_top_descriptors() {
-	COMPREPLY=($(compgen -W "$(__podman_top_descriptors)" -- "$cur"))
-}
-
-_podman_top() {
-    local options_with_args="
-    "
-    local boolean_options="
-	--help
-	-h
-	--latest
-	-l
-    "
-
-    # podman-top works on only *one* container, which means that when we have
-    # three or more arguments, we can complete with top descriptors.
-    if [[ "${COMP_CWORD}" -ge 3 ]]; then
-	    __podman_complete_top_descriptors
-	    return
+    # check if we are handling a flag with special work handling
+    local index
+    __podman_index_of_word "${prev}" "${flags_with_completion[@]}"
+    if [[ ${index} -ge 0 ]]; then
+        ${flags_completion[${index}]}
+        return
     fi
 
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_containers_running
-	    ;;
-    esac
+    # we are parsing a flag and don't have a special handler, no completion
+    if [[ ${cur} != "${words[cword]}" ]]; then
+        return
+    fi
+
+    local completions
+    completions=("${commands[@]}")
+    if [[ ${#must_have_one_noun[@]} -ne 0 ]]; then
+        completions=("${must_have_one_noun[@]}")
+    fi
+    if [[ ${#must_have_one_flag[@]} -ne 0 ]]; then
+        completions+=("${must_have_one_flag[@]}")
+    fi
+    COMPREPLY=( $(compgen -W "${completions[*]}" -- "$cur") )
+
+    if [[ ${#COMPREPLY[@]} -eq 0 && ${#noun_aliases[@]} -gt 0 && ${#must_have_one_noun[@]} -ne 0 ]]; then
+        COMPREPLY=( $(compgen -W "${noun_aliases[*]}" -- "$cur") )
+    fi
+
+    if [[ ${#COMPREPLY[@]} -eq 0 ]]; then
+		if declare -F __podman_custom_func >/dev/null; then
+			# try command name qualified custom func
+			__podman_custom_func
+		else
+			# otherwise fall back to unqualified for compatibility
+			declare -F __custom_func >/dev/null && __custom_func
+		fi
+    fi
+
+    # available in bash-completion >= 2, not always present on macOS
+    if declare -F __ltrim_colon_completions >/dev/null; then
+        __ltrim_colon_completions "$cur"
+    fi
+
+    # If there is only 1 completion and it is a flag with an = it will be completed
+    # but we don't want a space after the =
+    if [[ "${#COMPREPLY[@]}" -eq "1" ]] && [[ $(type -t compopt) = "builtin" ]] && [[ "${COMPREPLY[0]}" == --*= ]]; then
+       compopt -o nospace
+    fi
 }
 
-_podman_version() {
-    local boolean_options="
-     --help
-     -h
-    "
-    local options_with_args="
-     --format
-     -f
-    "
-    local all_options="$options_with_args $boolean_options"
-
-    _complete_ "$options_with_args" "$boolean_options"
+# The arguments should be in the form "ext1|ext2|extn"
+__podman_handle_filename_extension_flag()
+{
+    local ext="$1"
+    _filedir "@(${ext})"
 }
 
-_podman_save() {
-     local options_with_args="
-     --output -o
-     --format
-     "
-     local boolean_options="
-	--compress
-	--help
-	-h
-	-q
-	--quiet
-     "
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_images --id
-	    ;;
-    esac
+__podman_handle_subdirs_in_dir_flag()
+{
+    local dir="$1"
+    pushd "${dir}" >/dev/null 2>&1 && _filedir -d && popd >/dev/null 2>&1
 }
 
-_podman_pause() {
-    local boolean_options="
-	--all
-	-a
-	--help
-	-h
-    "
-     local options_with_args="
-     "
-     local boolean_options=""
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_containers_running
-	    ;;
-    esac
-}
+__podman_handle_flag()
+{
+    __podman_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
 
-_podman_port() {
-     local options_with_args="
-     "
-     local boolean_options="
-	--all
-	-a
-	--help
-	-h
-	-l
-	--latest
-     "
-     case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_container_names
-	    ;;
-    esac
-}
+    # if a command required a flag, and we found it, unset must_have_one_flag()
+    local flagname=${words[c]}
+    local flagvalue
+    # if the word contained an =
+    if [[ ${words[c]} == *"="* ]]; then
+        flagvalue=${flagname#*=} # take in as flagvalue after the =
+        flagname=${flagname%=*} # strip everything after the =
+        flagname="${flagname}=" # but put the = back
+    fi
+    __podman_debug "${FUNCNAME[0]}: looking for ${flagname}"
+    if __podman_contains_word "${flagname}" "${must_have_one_flag[@]}"; then
+        must_have_one_flag=()
+    fi
 
-_podman_ls() {
-	     _podman_ps
-}
+    # if you set a flag which only applies to this command, don't show subcommands
+    if __podman_contains_word "${flagname}" "${local_nonpersistent_flags[@]}"; then
+      commands=()
+    fi
 
-_podman_ps() {
-     local options_with_args="
-     --filter -f
-     --format
-     --last -n
-     --sort
-     --watch -w
-     "
-     local boolean_options="
-	  --all -a
-	  --help -h
-	  --latest -l
-	  --no-trunc
-	  --pod -p
-	  --quiet -q
-	  --size -s
-	  --namespace --ns
-	  --sync
-     "
-     _complete_ "$options_with_args" "$boolean_options"
-}
+    # keep flag value with flagname as flaghash
+    # flaghash variable is an associative array which is only supported in bash > 3.
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        if [ -n "${flagvalue}" ] ; then
+            flaghash[${flagname}]=${flagvalue}
+        elif [ -n "${words[ $((c+1)) ]}" ] ; then
+            flaghash[${flagname}]=${words[ $((c+1)) ]}
+        else
+            flaghash[${flagname}]="true" # pad "true" for bool flag
+        fi
+    fi
 
-_podman_init() {
-    local boolean_options="
-        --all
-        -a
-        --help
-        -h
-        --latest
-        -l
-    "
-    local options_with_args="
-    "
-    case "$cur" in
-        -*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-            ;;
-        *)
-            __podman_complete_containers_unpauseable
-	    ;;
-    esac
-}
+    # skip the argument to a two word flag
+    if [[ ${words[c]} != *"="* ]] && __podman_contains_word "${words[c]}" "${two_word_flags[@]}"; then
+			  __podman_debug "${FUNCNAME[0]}: found a flag ${words[c]}, skip the next argument"
+        c=$((c+1))
+        # if we are looking for a flags value, don't show commands
+        if [[ $c -eq $cword ]]; then
+            commands=()
+        fi
+    fi
 
-_podman_start() {
-     local options_with_args="
-     --detach-keys
-     "
-
-     local boolean_options="
-	  --attach
-	  -a
-	  -h
-	  --help
-	  -i
-	  --interactive
-	  --latest
-	  -l
-	  --sig-proxy
-     "
-     case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_container_names
-	    ;;
-    esac
-}
-_podman_stop() {
-     local options_with_args="
-     --timeout -t
-     "
-     local boolean_options="
-	  --all
-	  -a
-	  --cidfile
-	  -h
-	  --help
-	  --ignore
-	  -i
-	  --latest
-	  -l
-    "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_containers_running
-	    ;;
-    esac
-}
-
-_podman_unpause() {
-    local boolean_options="
-	--all
-	-a
-	--help
-	-h
-    "
-     local options_with_args="
-     "
-     case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_containers_unpauseable
-	    ;;
-    esac
-}
-
-_podman_varlink() {
-     local options_with_args="
-     --timeout -t
-     "
-     local boolean_options="
-	  --help
-	  -h
-     "
-     _complete_ "$options_with_args" "$boolean_options"
-}
-
-_podman_wait() {
-     local options_with_args=""
-     local boolean_options="
-	--help
-	-h
-	-i
-	-l
-	--interval
-	--latest
-    "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_container_names
-	    ;;
-    esac
-}
-
-_complete_() {
-    local options_with_args=$1
-    local boolean_options="$2 -h --help"
-
-    case "$prev" in
-	$options_with_args)
-	    return
-	    ;;
-    esac
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=( $( compgen -W "$boolean_options $options_with_args" -- "$cur" ) )
-	    ;;
-    esac
-}
-
-_podman_load() {
-    local options_with_args="
-    --input -i
-    "
-    local boolean_options="
-	 --help
-	 -h
-	 --quiet
-	 -q
-    "
-    _complete_ "$options_with_args" "$boolean_options"
-}
-
-_podman_cp() {
-	local boolean_options="
-	  --help
-	  -h
-	  --extract
-	  --pause
-     "
-	_complete_ "$boolean_options"
-}
-
-_podman_login() {
-     local options_with_args="
-     --username
-     -u
-     --password
-     -p
-     --authfile
-     --get-login
-     "
-     local boolean_options="
-	  --help
-	  -h
-	  --password-stdin
-     "
-     _complete_ "$options_with_args" "$boolean_options"
-}
-
-_podman_logout() {
-     local options_with_args="
-     --authfile
-     "
-     local boolean_options="
-	  --all
-	  -a
-	  --help
-	  -h
-     "
-     _complete_ "$options_with_args" "$boolean_options"
-}
-
-_podman_healthcheck_run() {
-    local options_with_args=""
-
-    local boolean_options="
-    -h
-    --help
-    "
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    COMPREPLY=( $( compgen -W "
-			  $(__podman_containers --all)
-			  " -- "$cur" ) )
-	    __ltrim_colon_completions "$cur"
-	    ;;
-    esac
-}
-
-_podman_generate_kube() {
-     local options_with_args="
-     --filename -f
-     "
-
-    local boolean_options="
-    -h
-    --help
-    -s
-    --service
-    "
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    COMPREPLY=( $( compgen -W "
-			  $(__podman_containers --all)
-			  $(__podman_pods)
-			  " -- "$cur" ) )
-	    __ltrim_colon_completions "$cur"
-	    ;;
-    esac
-}
-
-_podman_generate_systemd() {
-    local options_with_args="
-    --restart-policy
-    -t
-    --timeout"
-
-    local boolean_options="
-    -h
-    --help
-    -n
-    --name
-    "
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    COMPREPLY=( $( compgen -W "
-			  $(__podman_containers --all)
-			  " -- "$cur" ) )
-	    __ltrim_colon_completions "$cur"
-	    ;;
-    esac
-}
-
-_podman_play_kube() {
-    local options_with_args="
-    --authfile
-    --cert-dir
-    --creds
-    "
-
-    local boolean_options="
-    -h
-    --help
-    --quiet
-    -q
-    --tls-verify
-    --seccomp-profile-root
-    "
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    _filedir
-	    ;;
-    esac
-}
-
-_podman_events() {
-    local options_with_args="
-     --help
-     --h
-     --filter
-     --format
-     --since
-     --until
-    "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$options_with_args" -- "$cur"))
-	    ;;
-    esac
-}
-
-_podman_container_runlabel() {
-    local options_with_args="
-     --authfile
-     --cert-dir
-     --creds
-     --name
-    "
-
-    local boolean_options="
-	 --display
-	 --help
-	 -h
-	 -q
-	 --quiet
-	 --replace
-	 --tls-verify
-  "
-
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_images --id
-	    ;;
-    esac
-}
-
-_podman_image_sign() {
-    local options_with_args="
-	--cert-dir
-	-d
-	--directory
-	--sign-by
-    "
-    local boolean_options="
-	--help
-	-h
-    "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_images
-	    ;;
-    esac
-}
-
-_podman_image_trust_set() {
-    echo hello
-    local options_with_args="
-	-f
-	--type
-	--pubkeysfile
-    "
-    local boolean_options="
-	--help
-	-h
-    "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    COMPREPLY=($(compgen -W "default $( __podman_list_registries )" -- "$cur"))
-	    ;;
-    esac
-}
-
-_podman_image_trust_show() {
-    local options_with_args="
-    "
-    local boolean_options="
-	--help
-	-h
-	-j
-	--json
-	--raw
-    "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_images
-	    ;;
-    esac
-}
-
-_podman_image_trust() {
-    local boolean_options="
-	--help
-	-h
-     "
-     subcommands="
-	 set
-	 show
-     "
-     local aliases="
-	 list
-     "
-     command=image_trust
-     __podman_subcommands "$subcommands $aliases" && return
-
-     case "$cur" in
-	-*)
-		COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-		;;
-	*)
-		COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
-		;;
-     esac
-}
-
-_podman_images_prune() {
-    local options_with_args="
-    "
-
-    local boolean_options="
-    -a
-    --all
-     -h
-	 --help
-  "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-    esac
-}
-
-_podman_container_prune() {
-    local options_with_args="
-	 --filter
-    "
-
-    local boolean_options="
-	 -f
-	 --force
-     -h
-	 --help
-  "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-    esac
-}
-
-_podman_container_exists() {
-    local options_with_args="
-    "
-
-    local boolean_options="
-  "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_images
-	    ;;
-    esac
+    c=$((c+1))
 
 }
 
-_podman_pod_exists() {
-    local options_with_args="
-    "
+__podman_handle_noun()
+{
+    __podman_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
 
-    local boolean_options="
-  "
+    if __podman_contains_word "${words[c]}" "${must_have_one_noun[@]}"; then
+        must_have_one_noun=()
+    elif __podman_contains_word "${words[c]}" "${noun_aliases[@]}"; then
+        must_have_one_noun=()
+    fi
+
+    nouns+=("${words[c]}")
+    c=$((c+1))
 }
 
-_podman_image_exists() {
-    local options_with_args="
-    "
+__podman_handle_command()
+{
+    __podman_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
 
-    local boolean_options="
-  "
+    local next_command
+    if [[ -n ${last_command} ]]; then
+        next_command="_${last_command}_${words[c]//:/__}"
+    else
+        if [[ $c -eq 0 ]]; then
+            next_command="_podman_root_command"
+        else
+            next_command="_${words[c]//:/__}"
+        fi
+    fi
+    c=$((c+1))
+    __podman_debug "${FUNCNAME[0]}: looking for ${next_command}"
+    declare -F "$next_command" >/dev/null && $next_command
 }
 
-_podman_pod_create() {
-  local options_with_args="
-      --cgroup-parent
-      --infra-command
-      --infra-image
-      --label-file
-      --label
-      -l
-      --name
-      --podidfile
-      --publish
-      -p
-      --share
-  "
-
-  local boolean_options="
-      --help
-      -h
-      --infra
-  "
-  _complete_ "$options_with_args" "$boolean_options"
+__podman_handle_word()
+{
+    if [[ $c -ge $cword ]]; then
+        __podman_handle_reply
+        return
+    fi
+    __podman_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+    if [[ "${words[c]}" == -* ]]; then
+        __podman_handle_flag
+    elif __podman_contains_word "${words[c]}" "${commands[@]}"; then
+        __podman_handle_command
+    elif [[ $c -eq 0 ]]; then
+        __podman_handle_command
+    elif __podman_contains_word "${words[c]}" "${command_aliases[@]}"; then
+        # aliashash variable is an associative array which is only supported in bash > 3.
+        if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+            words[c]=${aliashash[${words[c]}]}
+            __podman_handle_command
+        else
+            __podman_handle_noun
+        fi
+    else
+        __podman_handle_noun
+    fi
+    __podman_handle_word
 }
 
-_podman_pod_kill() {
-  local options_with_args="
-  "
+_podman_attach()
+{
+    last_command="podman_attach"
 
-  local boolean_options="
-      --all
-      -a
-      --help
-      -h
-      --signal
-      -s
-      --latest
-      -l
-  "
-  _complete_ "$options_with_args" "$boolean_options"
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_pod_names
-	    ;;
-    esac
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--detach-keys=")
+    two_word_flags+=("--detach-keys")
+    local_nonpersistent_flags+=("--detach-keys=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--no-stdin")
+    local_nonpersistent_flags+=("--no-stdin")
+    flags+=("--sig-proxy")
+    local_nonpersistent_flags+=("--sig-proxy")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-__podman_pod_ps() {
-  local options_with_args="
-   -f
-   --filter
-   --format
-   --sort
-  "
+_podman_build()
+{
+    last_command="podman_build"
 
-  local boolean_options="
-	 --cgroup
-	 --ctr-ids
-	 --ctr-names
-	 --ctr-status
-	 --help
-	 -h
-	 -q
-	 --quiet
-	 --no-trunc
-	 --labels
-	 -l
-	 --latest
-  "
-  _complete_ "$options_with_args" "$boolean_options"
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--add-host=")
+    two_word_flags+=("--add-host")
+    local_nonpersistent_flags+=("--add-host=")
+    flags+=("--annotation=")
+    two_word_flags+=("--annotation")
+    local_nonpersistent_flags+=("--annotation=")
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--build-arg=")
+    two_word_flags+=("--build-arg")
+    local_nonpersistent_flags+=("--build-arg=")
+    flags+=("--cache-from=")
+    two_word_flags+=("--cache-from")
+    local_nonpersistent_flags+=("--cache-from=")
+    flags+=("--cap-add=")
+    two_word_flags+=("--cap-add")
+    local_nonpersistent_flags+=("--cap-add=")
+    flags+=("--cap-drop=")
+    two_word_flags+=("--cap-drop")
+    local_nonpersistent_flags+=("--cap-drop=")
+    flags+=("--cert-dir=")
+    two_word_flags+=("--cert-dir")
+    local_nonpersistent_flags+=("--cert-dir=")
+    flags+=("--cgroup-parent=")
+    two_word_flags+=("--cgroup-parent")
+    local_nonpersistent_flags+=("--cgroup-parent=")
+    flags+=("--cni-plugin-path=")
+    two_word_flags+=("--cni-plugin-path")
+    local_nonpersistent_flags+=("--cni-plugin-path=")
+    flags+=("--compress")
+    local_nonpersistent_flags+=("--compress")
+    flags+=("--cpu-period=")
+    two_word_flags+=("--cpu-period")
+    local_nonpersistent_flags+=("--cpu-period=")
+    flags+=("--cpu-quota=")
+    two_word_flags+=("--cpu-quota")
+    local_nonpersistent_flags+=("--cpu-quota=")
+    flags+=("--cpu-shares=")
+    two_word_flags+=("--cpu-shares")
+    two_word_flags+=("-c")
+    local_nonpersistent_flags+=("--cpu-shares=")
+    flags+=("--cpuset-cpus=")
+    two_word_flags+=("--cpuset-cpus")
+    local_nonpersistent_flags+=("--cpuset-cpus=")
+    flags+=("--cpuset-mems=")
+    two_word_flags+=("--cpuset-mems")
+    local_nonpersistent_flags+=("--cpuset-mems=")
+    flags+=("--creds=")
+    two_word_flags+=("--creds")
+    local_nonpersistent_flags+=("--creds=")
+    flags+=("--device=")
+    two_word_flags+=("--device")
+    local_nonpersistent_flags+=("--device=")
+    flags+=("--disable-compression")
+    flags+=("-D")
+    local_nonpersistent_flags+=("--disable-compression")
+    flags+=("--disable-content-trust")
+    local_nonpersistent_flags+=("--disable-content-trust")
+    flags+=("--dns=")
+    two_word_flags+=("--dns")
+    local_nonpersistent_flags+=("--dns=")
+    flags+=("--dns-option=")
+    two_word_flags+=("--dns-option")
+    local_nonpersistent_flags+=("--dns-option=")
+    flags+=("--dns-search=")
+    two_word_flags+=("--dns-search")
+    local_nonpersistent_flags+=("--dns-search=")
+    flags+=("--file=")
+    two_word_flags+=("--file")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--file=")
+    flags+=("--force-rm")
+    local_nonpersistent_flags+=("--force-rm")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--http-proxy")
+    local_nonpersistent_flags+=("--http-proxy")
+    flags+=("--iidfile=")
+    two_word_flags+=("--iidfile")
+    local_nonpersistent_flags+=("--iidfile=")
+    flags+=("--ipc=")
+    two_word_flags+=("--ipc")
+    local_nonpersistent_flags+=("--ipc=")
+    flags+=("--isolation=")
+    two_word_flags+=("--isolation")
+    local_nonpersistent_flags+=("--isolation=")
+    flags+=("--label=")
+    two_word_flags+=("--label")
+    local_nonpersistent_flags+=("--label=")
+    flags+=("--layers")
+    local_nonpersistent_flags+=("--layers")
+    flags+=("--logfile=")
+    two_word_flags+=("--logfile")
+    local_nonpersistent_flags+=("--logfile=")
+    flags+=("--loglevel=")
+    two_word_flags+=("--loglevel")
+    local_nonpersistent_flags+=("--loglevel=")
+    flags+=("--memory=")
+    two_word_flags+=("--memory")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--memory=")
+    flags+=("--memory-swap=")
+    two_word_flags+=("--memory-swap")
+    local_nonpersistent_flags+=("--memory-swap=")
+    flags+=("--network=")
+    two_word_flags+=("--network")
+    local_nonpersistent_flags+=("--network=")
+    flags+=("--no-cache")
+    local_nonpersistent_flags+=("--no-cache")
+    flags+=("--pid=")
+    two_word_flags+=("--pid")
+    local_nonpersistent_flags+=("--pid=")
+    flags+=("--platform=")
+    two_word_flags+=("--platform")
+    local_nonpersistent_flags+=("--platform=")
+    flags+=("--pull")
+    local_nonpersistent_flags+=("--pull")
+    flags+=("--pull-always")
+    local_nonpersistent_flags+=("--pull-always")
+    flags+=("--pull-never")
+    local_nonpersistent_flags+=("--pull-never")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--rm")
+    local_nonpersistent_flags+=("--rm")
+    flags+=("--runtime-flag=")
+    two_word_flags+=("--runtime-flag")
+    local_nonpersistent_flags+=("--runtime-flag=")
+    flags+=("--security-opt=")
+    two_word_flags+=("--security-opt")
+    local_nonpersistent_flags+=("--security-opt=")
+    flags+=("--shm-size=")
+    two_word_flags+=("--shm-size")
+    local_nonpersistent_flags+=("--shm-size=")
+    flags+=("--squash")
+    local_nonpersistent_flags+=("--squash")
+    flags+=("--squash-all")
+    local_nonpersistent_flags+=("--squash-all")
+    flags+=("--tag=")
+    two_word_flags+=("--tag")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--tag=")
+    flags+=("--target=")
+    two_word_flags+=("--target")
+    local_nonpersistent_flags+=("--target=")
+    flags+=("--tls-verify")
+    local_nonpersistent_flags+=("--tls-verify")
+    flags+=("--ulimit=")
+    two_word_flags+=("--ulimit")
+    local_nonpersistent_flags+=("--ulimit=")
+    flags+=("--userns=")
+    two_word_flags+=("--userns")
+    local_nonpersistent_flags+=("--userns=")
+    flags+=("--userns-gid-map=")
+    two_word_flags+=("--userns-gid-map")
+    local_nonpersistent_flags+=("--userns-gid-map=")
+    flags+=("--userns-gid-map-group=")
+    two_word_flags+=("--userns-gid-map-group")
+    local_nonpersistent_flags+=("--userns-gid-map-group=")
+    flags+=("--userns-uid-map=")
+    two_word_flags+=("--userns-uid-map")
+    local_nonpersistent_flags+=("--userns-uid-map=")
+    flags+=("--userns-uid-map-user=")
+    two_word_flags+=("--userns-uid-map-user")
+    local_nonpersistent_flags+=("--userns-uid-map-user=")
+    flags+=("--uts=")
+    two_word_flags+=("--uts")
+    local_nonpersistent_flags+=("--uts=")
+    flags+=("--volume=")
+    two_word_flags+=("--volume")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--volume=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_pod_ls() {
-  __podman_pod_ps
+_podman_commit()
+{
+    last_command="podman_commit"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--author=")
+    two_word_flags+=("--author")
+    two_word_flags+=("-a")
+    local_nonpersistent_flags+=("--author=")
+    flags+=("--change=")
+    two_word_flags+=("--change")
+    two_word_flags+=("-c")
+    local_nonpersistent_flags+=("--change=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--include-volumes")
+    local_nonpersistent_flags+=("--include-volumes")
+    flags+=("--message=")
+    two_word_flags+=("--message")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--message=")
+    flags+=("--pause")
+    flags+=("-p")
+    local_nonpersistent_flags+=("--pause")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_pod_list() {
-  __podman_pod_ps
+_podman_attach()
+{
+    last_command="podman_attach"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--detach-keys=")
+    two_word_flags+=("--detach-keys")
+    local_nonpersistent_flags+=("--detach-keys=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--no-stdin")
+    local_nonpersistent_flags+=("--no-stdin")
+    flags+=("--sig-proxy")
+    local_nonpersistent_flags+=("--sig-proxy")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_pod_ps() {
-  __podman_pod_ps
+_podman_container_checkpoint()
+{
+    last_command="podman_container_checkpoint"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--export=")
+    two_word_flags+=("--export")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--export=")
+    flags+=("--ignore-rootfs")
+    local_nonpersistent_flags+=("--ignore-rootfs")
+    flags+=("--keep")
+    flags+=("-k")
+    local_nonpersistent_flags+=("--keep")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--leave-running")
+    flags+=("-R")
+    local_nonpersistent_flags+=("--leave-running")
+    flags+=("--tcp-established")
+    local_nonpersistent_flags+=("--tcp-established")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_pod_prune() {
-    local options_with_args="
-    "
+_podman_container_cleanup()
+{
+    last_command="podman_container_cleanup"
 
-    local boolean_options="
-     -f
-     -h
-	 --help
-  "
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-    esac
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--rm")
+    local_nonpersistent_flags+=("--rm")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_pod_restart() {
-  local options_with_args="
-  "
+_podman_commit()
+{
+    last_command="podman_commit"
 
-  local boolean_options="
-      --all
-      -a
-      --help
-      -h
-      --latest
-      -l
-  "
-  _complete_ "$options_with_args" "$boolean_options"
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_pod_names
-	    ;;
-    esac
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--author=")
+    two_word_flags+=("--author")
+    two_word_flags+=("-a")
+    local_nonpersistent_flags+=("--author=")
+    flags+=("--change=")
+    two_word_flags+=("--change")
+    two_word_flags+=("-c")
+    local_nonpersistent_flags+=("--change=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--include-volumes")
+    local_nonpersistent_flags+=("--include-volumes")
+    flags+=("--message=")
+    two_word_flags+=("--message")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--message=")
+    flags+=("--pause")
+    flags+=("-p")
+    local_nonpersistent_flags+=("--pause")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_pod_rm() {
-  local options_with_args="
-  "
+_podman_cp()
+{
+    last_command="podman_cp"
 
-  local boolean_options="
-      -a
-      --all
-      --help
-      -h
-	  --ignore
-	  -i
-      -f
-      --force
-      --latest
-      -l
-  "
-  _complete_ "$options_with_args" "$boolean_options"
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_pod_names
-	    ;;
-    esac
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--extract")
+    local_nonpersistent_flags+=("--extract")
+    flags+=("--pause")
+    local_nonpersistent_flags+=("--pause")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_pod_start() {
-  local options_with_args="
-  "
+_podman_create()
+{
+    last_command="podman_create"
 
-  local boolean_options="
-      --all
-      -a
-      --help
-      -h
-      --latest
-      -l
-  "
-  _complete_ "$options_with_args" "$boolean_options"
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_pod_names
-	    ;;
-    esac
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--add-host=")
+    two_word_flags+=("--add-host")
+    local_nonpersistent_flags+=("--add-host=")
+    flags+=("--annotation=")
+    two_word_flags+=("--annotation")
+    local_nonpersistent_flags+=("--annotation=")
+    flags+=("--attach=")
+    two_word_flags+=("--attach")
+    two_word_flags+=("-a")
+    local_nonpersistent_flags+=("--attach=")
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--blkio-weight=")
+    two_word_flags+=("--blkio-weight")
+    local_nonpersistent_flags+=("--blkio-weight=")
+    flags+=("--blkio-weight-device=")
+    two_word_flags+=("--blkio-weight-device")
+    local_nonpersistent_flags+=("--blkio-weight-device=")
+    flags+=("--cap-add=")
+    two_word_flags+=("--cap-add")
+    local_nonpersistent_flags+=("--cap-add=")
+    flags+=("--cap-drop=")
+    two_word_flags+=("--cap-drop")
+    local_nonpersistent_flags+=("--cap-drop=")
+    flags+=("--cgroup-parent=")
+    two_word_flags+=("--cgroup-parent")
+    local_nonpersistent_flags+=("--cgroup-parent=")
+    flags+=("--cgroupns=")
+    two_word_flags+=("--cgroupns")
+    local_nonpersistent_flags+=("--cgroupns=")
+    flags+=("--cgroups=")
+    two_word_flags+=("--cgroups")
+    local_nonpersistent_flags+=("--cgroups=")
+    flags+=("--cidfile=")
+    two_word_flags+=("--cidfile")
+    local_nonpersistent_flags+=("--cidfile=")
+    flags+=("--conmon-pidfile=")
+    two_word_flags+=("--conmon-pidfile")
+    local_nonpersistent_flags+=("--conmon-pidfile=")
+    flags+=("--cpu-period=")
+    two_word_flags+=("--cpu-period")
+    local_nonpersistent_flags+=("--cpu-period=")
+    flags+=("--cpu-quota=")
+    two_word_flags+=("--cpu-quota")
+    local_nonpersistent_flags+=("--cpu-quota=")
+    flags+=("--cpu-rt-period=")
+    two_word_flags+=("--cpu-rt-period")
+    local_nonpersistent_flags+=("--cpu-rt-period=")
+    flags+=("--cpu-rt-runtime=")
+    two_word_flags+=("--cpu-rt-runtime")
+    local_nonpersistent_flags+=("--cpu-rt-runtime=")
+    flags+=("--cpu-shares=")
+    two_word_flags+=("--cpu-shares")
+    local_nonpersistent_flags+=("--cpu-shares=")
+    flags+=("--cpus=")
+    two_word_flags+=("--cpus")
+    local_nonpersistent_flags+=("--cpus=")
+    flags+=("--cpuset-cpus=")
+    two_word_flags+=("--cpuset-cpus")
+    local_nonpersistent_flags+=("--cpuset-cpus=")
+    flags+=("--cpuset-mems=")
+    two_word_flags+=("--cpuset-mems")
+    local_nonpersistent_flags+=("--cpuset-mems=")
+    flags+=("--detach")
+    flags+=("-d")
+    local_nonpersistent_flags+=("--detach")
+    flags+=("--detach-keys=")
+    two_word_flags+=("--detach-keys")
+    local_nonpersistent_flags+=("--detach-keys=")
+    flags+=("--device=")
+    two_word_flags+=("--device")
+    local_nonpersistent_flags+=("--device=")
+    flags+=("--device-read-bps=")
+    two_word_flags+=("--device-read-bps")
+    local_nonpersistent_flags+=("--device-read-bps=")
+    flags+=("--device-read-iops=")
+    two_word_flags+=("--device-read-iops")
+    local_nonpersistent_flags+=("--device-read-iops=")
+    flags+=("--device-write-bps=")
+    two_word_flags+=("--device-write-bps")
+    local_nonpersistent_flags+=("--device-write-bps=")
+    flags+=("--device-write-iops=")
+    two_word_flags+=("--device-write-iops")
+    local_nonpersistent_flags+=("--device-write-iops=")
+    flags+=("--dns=")
+    two_word_flags+=("--dns")
+    local_nonpersistent_flags+=("--dns=")
+    flags+=("--dns-opt=")
+    two_word_flags+=("--dns-opt")
+    local_nonpersistent_flags+=("--dns-opt=")
+    flags+=("--dns-search=")
+    two_word_flags+=("--dns-search")
+    local_nonpersistent_flags+=("--dns-search=")
+    flags+=("--entrypoint=")
+    two_word_flags+=("--entrypoint")
+    local_nonpersistent_flags+=("--entrypoint=")
+    flags+=("--env=")
+    two_word_flags+=("--env")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--env=")
+    flags+=("--env-file=")
+    two_word_flags+=("--env-file")
+    local_nonpersistent_flags+=("--env-file=")
+    flags+=("--env-host")
+    local_nonpersistent_flags+=("--env-host")
+    flags+=("--expose=")
+    two_word_flags+=("--expose")
+    local_nonpersistent_flags+=("--expose=")
+    flags+=("--gidmap=")
+    two_word_flags+=("--gidmap")
+    local_nonpersistent_flags+=("--gidmap=")
+    flags+=("--group-add=")
+    two_word_flags+=("--group-add")
+    local_nonpersistent_flags+=("--group-add=")
+    flags+=("--health-cmd=")
+    two_word_flags+=("--health-cmd")
+    local_nonpersistent_flags+=("--health-cmd=")
+    flags+=("--health-interval=")
+    two_word_flags+=("--health-interval")
+    local_nonpersistent_flags+=("--health-interval=")
+    flags+=("--health-retries=")
+    two_word_flags+=("--health-retries")
+    local_nonpersistent_flags+=("--health-retries=")
+    flags+=("--health-start-period=")
+    two_word_flags+=("--health-start-period")
+    local_nonpersistent_flags+=("--health-start-period=")
+    flags+=("--health-timeout=")
+    two_word_flags+=("--health-timeout")
+    local_nonpersistent_flags+=("--health-timeout=")
+    flags+=("--hostname=")
+    two_word_flags+=("--hostname")
+    two_word_flags+=("-h")
+    local_nonpersistent_flags+=("--hostname=")
+    flags+=("--http-proxy")
+    local_nonpersistent_flags+=("--http-proxy")
+    flags+=("--image-volume=")
+    two_word_flags+=("--image-volume")
+    local_nonpersistent_flags+=("--image-volume=")
+    flags+=("--init")
+    local_nonpersistent_flags+=("--init")
+    flags+=("--init-path=")
+    two_word_flags+=("--init-path")
+    local_nonpersistent_flags+=("--init-path=")
+    flags+=("--interactive")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--interactive")
+    flags+=("--ip=")
+    two_word_flags+=("--ip")
+    local_nonpersistent_flags+=("--ip=")
+    flags+=("--ipc=")
+    two_word_flags+=("--ipc")
+    local_nonpersistent_flags+=("--ipc=")
+    flags+=("--kernel-memory=")
+    two_word_flags+=("--kernel-memory")
+    local_nonpersistent_flags+=("--kernel-memory=")
+    flags+=("--label=")
+    two_word_flags+=("--label")
+    two_word_flags+=("-l")
+    local_nonpersistent_flags+=("--label=")
+    flags+=("--label-file=")
+    two_word_flags+=("--label-file")
+    local_nonpersistent_flags+=("--label-file=")
+    flags+=("--log-driver=")
+    two_word_flags+=("--log-driver")
+    local_nonpersistent_flags+=("--log-driver=")
+    flags+=("--log-opt=")
+    two_word_flags+=("--log-opt")
+    local_nonpersistent_flags+=("--log-opt=")
+    flags+=("--mac-address=")
+    two_word_flags+=("--mac-address")
+    local_nonpersistent_flags+=("--mac-address=")
+    flags+=("--memory=")
+    two_word_flags+=("--memory")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--memory=")
+    flags+=("--memory-reservation=")
+    two_word_flags+=("--memory-reservation")
+    local_nonpersistent_flags+=("--memory-reservation=")
+    flags+=("--memory-swap=")
+    two_word_flags+=("--memory-swap")
+    local_nonpersistent_flags+=("--memory-swap=")
+    flags+=("--memory-swappiness=")
+    two_word_flags+=("--memory-swappiness")
+    local_nonpersistent_flags+=("--memory-swappiness=")
+    flags+=("--mount=")
+    two_word_flags+=("--mount")
+    local_nonpersistent_flags+=("--mount=")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    local_nonpersistent_flags+=("--name=")
+    flags+=("--net=")
+    two_word_flags+=("--net")
+    local_nonpersistent_flags+=("--net=")
+    flags+=("--network=")
+    two_word_flags+=("--network")
+    local_nonpersistent_flags+=("--network=")
+    flags+=("--no-hosts")
+    local_nonpersistent_flags+=("--no-hosts")
+    flags+=("--oom-kill-disable")
+    local_nonpersistent_flags+=("--oom-kill-disable")
+    flags+=("--oom-score-adj=")
+    two_word_flags+=("--oom-score-adj")
+    local_nonpersistent_flags+=("--oom-score-adj=")
+    flags+=("--pid=")
+    two_word_flags+=("--pid")
+    local_nonpersistent_flags+=("--pid=")
+    flags+=("--pids-limit=")
+    two_word_flags+=("--pids-limit")
+    local_nonpersistent_flags+=("--pids-limit=")
+    flags+=("--pod=")
+    two_word_flags+=("--pod")
+    local_nonpersistent_flags+=("--pod=")
+    flags+=("--privileged")
+    local_nonpersistent_flags+=("--privileged")
+    flags+=("--publish=")
+    two_word_flags+=("--publish")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--publish=")
+    flags+=("--publish-all")
+    flags+=("-P")
+    local_nonpersistent_flags+=("--publish-all")
+    flags+=("--pull=")
+    two_word_flags+=("--pull")
+    local_nonpersistent_flags+=("--pull=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--read-only")
+    local_nonpersistent_flags+=("--read-only")
+    flags+=("--read-only-tmpfs")
+    local_nonpersistent_flags+=("--read-only-tmpfs")
+    flags+=("--restart=")
+    two_word_flags+=("--restart")
+    local_nonpersistent_flags+=("--restart=")
+    flags+=("--rm")
+    local_nonpersistent_flags+=("--rm")
+    flags+=("--rootfs")
+    local_nonpersistent_flags+=("--rootfs")
+    flags+=("--security-opt=")
+    two_word_flags+=("--security-opt")
+    local_nonpersistent_flags+=("--security-opt=")
+    flags+=("--shm-size=")
+    two_word_flags+=("--shm-size")
+    local_nonpersistent_flags+=("--shm-size=")
+    flags+=("--stop-signal=")
+    two_word_flags+=("--stop-signal")
+    local_nonpersistent_flags+=("--stop-signal=")
+    flags+=("--stop-timeout=")
+    two_word_flags+=("--stop-timeout")
+    local_nonpersistent_flags+=("--stop-timeout=")
+    flags+=("--subgidname=")
+    two_word_flags+=("--subgidname")
+    local_nonpersistent_flags+=("--subgidname=")
+    flags+=("--subuidname=")
+    two_word_flags+=("--subuidname")
+    local_nonpersistent_flags+=("--subuidname=")
+    flags+=("--sysctl=")
+    two_word_flags+=("--sysctl")
+    local_nonpersistent_flags+=("--sysctl=")
+    flags+=("--systemd=")
+    two_word_flags+=("--systemd")
+    local_nonpersistent_flags+=("--systemd=")
+    flags+=("--tmpfs=")
+    two_word_flags+=("--tmpfs")
+    local_nonpersistent_flags+=("--tmpfs=")
+    flags+=("--tty")
+    flags+=("-t")
+    local_nonpersistent_flags+=("--tty")
+    flags+=("--uidmap=")
+    two_word_flags+=("--uidmap")
+    local_nonpersistent_flags+=("--uidmap=")
+    flags+=("--ulimit=")
+    two_word_flags+=("--ulimit")
+    local_nonpersistent_flags+=("--ulimit=")
+    flags+=("--user=")
+    two_word_flags+=("--user")
+    two_word_flags+=("-u")
+    local_nonpersistent_flags+=("--user=")
+    flags+=("--userns=")
+    two_word_flags+=("--userns")
+    local_nonpersistent_flags+=("--userns=")
+    flags+=("--uts=")
+    two_word_flags+=("--uts")
+    local_nonpersistent_flags+=("--uts=")
+    flags+=("--volume=")
+    two_word_flags+=("--volume")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--volume=")
+    flags+=("--volumes-from=")
+    two_word_flags+=("--volumes-from")
+    local_nonpersistent_flags+=("--volumes-from=")
+    flags+=("--workdir=")
+    two_word_flags+=("--workdir")
+    two_word_flags+=("-w")
+    local_nonpersistent_flags+=("--workdir=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_pod_stop() {
-  local options_with_args="
-      -t
-      --timeout
-  "
+_podman_diff()
+{
+    last_command="podman_diff"
 
-  local boolean_options="
-      --all
-      -a
-      --cleanup
-      --help
-	  --ignore
-	  -i
-      -h
-      --latest
-      -l
-  "
-  _complete_ "$options_with_args" "$boolean_options"
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_pod_names
-	    ;;
-    esac
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_pod_pause() {
-  local options_with_args="
-  "
+_podman_exec()
+{
+    last_command="podman_exec"
 
-  local boolean_options="
-      --all
-      -a
-      --help
-      -h
-      --latest
-      -l
-  "
-  _complete_ "$options_with_args" "$boolean_options"
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_pod_names
-	    ;;
-    esac
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--detach-keys=")
+    two_word_flags+=("--detach-keys")
+    local_nonpersistent_flags+=("--detach-keys=")
+    flags+=("--env=")
+    two_word_flags+=("--env")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--env=")
+    flags+=("--env-file=")
+    two_word_flags+=("--env-file")
+    local_nonpersistent_flags+=("--env-file=")
+    flags+=("--interactive")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--interactive")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--preserve-fds=")
+    two_word_flags+=("--preserve-fds")
+    local_nonpersistent_flags+=("--preserve-fds=")
+    flags+=("--privileged")
+    local_nonpersistent_flags+=("--privileged")
+    flags+=("--tty")
+    flags+=("-t")
+    local_nonpersistent_flags+=("--tty")
+    flags+=("--user=")
+    two_word_flags+=("--user")
+    two_word_flags+=("-u")
+    local_nonpersistent_flags+=("--user=")
+    flags+=("--workdir=")
+    two_word_flags+=("--workdir")
+    two_word_flags+=("-w")
+    local_nonpersistent_flags+=("--workdir=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_pod_unpause() {
-  local options_with_args="
-  "
+_podman_container_exists()
+{
+    last_command="podman_container_exists"
 
-  local boolean_options="
-      --all
-      -a
-      --help
-      -h
-      --latest
-      -l
-  "
-  _complete_ "$options_with_args" "$boolean_options"
-    case "$cur" in
-	-*)
-	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-	    ;;
-	*)
-	    __podman_complete_pod_names
-	    ;;
-    esac
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_pod() {
-    local boolean_options="
-	--help
-	-h
-    "
-    subcommands="
-     create
-     kill
-     pause
-     ps
-     restart
-     rm
-     start
-     stats
-     stop
-     top
-     unpause
-    "
-    local aliases="
-     list
-     ls
-    "
-     __podman_subcommands "$subcommands $aliases" && return
+_podman_export()
+{
+    last_command="podman_export"
 
-     case "$cur" in
-    -*)
-	COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-	;;
-    *)
-	COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
-	;;
-     esac
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+    local_nonpersistent_flags+=("--output=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_volume_create() {
-  local options_with_args="
-      --driver
-      --label
-      -l
-      --opt
-      -o
-  "
+_podman_init()
+{
+    last_command="podman_init"
 
-  local boolean_options="
-    --help
-    -h
-  "
+    command_aliases=()
 
-  _complete_ "$options_with_args" "$boolean_options"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_volume_ls() {
-  local options_with_args="
-      --filter
-      --format
-      -f
-  "
+_podman_container_inspect()
+{
+    last_command="podman_container_inspect"
 
-  local boolean_options="
-    --help
-    -h
-    --quiet
-    -q
-  "
+    command_aliases=()
 
-  _complete_ "$options_with_args" "$boolean_options"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--size")
+    flags+=("-s")
+    local_nonpersistent_flags+=("--size")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_volume_inspect() {
-  local options_with_args="
-      --format
-      -f
-  "
+_podman_kill()
+{
+    last_command="podman_kill"
 
-  local boolean_options="
-    --all
-    -a
-    --help
-    -h
-  "
+    command_aliases=()
 
-  _complete_ "$options_with_args" "$boolean_options"
-    case "$cur" in
-        -*)
-            COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-            ;;
-        *)
-            __podman_complete_volume_names
-            ;;
-    esac
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--signal=")
+    two_word_flags+=("--signal")
+    two_word_flags+=("-s")
+    local_nonpersistent_flags+=("--signal=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_volume_rm() {
-  local options_with_args=""
+_podman_container_list()
+{
+    last_command="podman_container_list"
 
-  local boolean_options="
-    --all
-    -a
-    --force
-    -f
-    --help
-    -h
-  "
+    command_aliases=()
 
-  _complete_ "$options_with_args" "$boolean_options"
-    case "$cur" in
-        -*)
-            COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
-            ;;
-        *)
-            __podman_complete_volume_names
-            ;;
-    esac
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--filter=")
+    two_word_flags+=("--filter")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--filter=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--last=")
+    two_word_flags+=("--last")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--last=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--no-trunc")
+    local_nonpersistent_flags+=("--no-trunc")
+    flags+=("--ns")
+    local_nonpersistent_flags+=("--ns")
+    flags+=("--pod")
+    flags+=("-p")
+    local_nonpersistent_flags+=("--pod")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--size")
+    flags+=("-s")
+    local_nonpersistent_flags+=("--size")
+    flags+=("--sort=")
+    two_word_flags+=("--sort")
+    local_nonpersistent_flags+=("--sort=")
+    flags+=("--sync")
+    local_nonpersistent_flags+=("--sync")
+    flags+=("--watch=")
+    two_word_flags+=("--watch")
+    two_word_flags+=("-w")
+    local_nonpersistent_flags+=("--watch=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_volume_prune() {
-  local options_with_args=""
+_podman_logs()
+{
+    last_command="podman_logs"
 
-  local boolean_options="
-    --force
-    -f
-    --help
-    -h
-  "
+    command_aliases=()
 
-  _complete_ "$options_with_args" "$boolean_options"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--follow")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--follow")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--since=")
+    two_word_flags+=("--since")
+    local_nonpersistent_flags+=("--since=")
+    flags+=("--tail=")
+    two_word_flags+=("--tail")
+    local_nonpersistent_flags+=("--tail=")
+    flags+=("--timestamps")
+    flags+=("-t")
+    local_nonpersistent_flags+=("--timestamps")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_volume() {
-    local boolean_options="
-    --help
-    -h
-    "
-    subcommands="
-     create
-     inspect
-     ls
-     rm
-     prune
-    "
-    local aliases="
-     list
-     remove
-    "
-     __podman_subcommands "$subcommands $aliases" && return
+_podman_mount()
+{
+    last_command="podman_mount"
 
-     case "$cur" in
-    -*)
-        COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-        ;;
-    *)
-        COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
-        ;;
-     esac
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--notruncate")
+    local_nonpersistent_flags+=("--notruncate")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_podman_podman() {
-     local options_with_args="
-	   --config -c
-	   --cpu-profile
-	   --root
-	   --runroot
-	   --storage-driver
-	   --storage-opt
-	   --log-level
-	   --namespace
-    "
-     local boolean_options="
-	   --help
-	   -h
-	   --version
-	   -v
-	   --syslog
-     "
-     commands="
-    attach
-    build
-    commit
-    container
-    cp
-    create
-    diff
-    events
-    exec
-    export
-    generate
-    healthcheck
-    history
-    image
-    images
-    import
-    info
-    inspect
-    kill
-    load
-    login
-    logout
-    logs
-    mount
-    pause
-    pod
-    port
-    ps
-    pull
-    push
-    play
-    restart
-    rm
-    rmi
-    run
-    save
-    search
-    start
-    stats
-    stop
-    tag
-    top
-    umount
-    unmount
-    unpause
-    varlink
-    version
-    volume
-    wait
-     "
+_podman_pause()
+{
+    last_command="podman_pause"
 
-     case "$prev" in
-	 $main_options_with_args_glob )
-	     return
-	     ;;
-     esac
+    command_aliases=()
 
-     case "$cur" in
-	 -*)
-	     COMPREPLY=( $( compgen -W "$boolean_options $options_with_args" -- "$cur" ) )
-	     ;;
-	 *)
-	     COMPREPLY=( $( compgen -W "${commands[*]} help" -- "$cur" ) )
-	     ;;
-     esac
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-_cli_bash_autocomplete() {
-     local cur opts base
+_podman_port()
+{
+    last_command="podman_port"
 
-     COMPREPLY=()
-     cur="${COMP_WORDS[COMP_CWORD]}"
-     COMPREPLY=()
-     local cur prev words cword
+    command_aliases=()
 
-     _get_comp_words_by_ref -n : cur prev words cword
+    commands=()
 
-     local command=${PROG} cpos=0
-     local counter=1
-     counter=1
-     while [ $counter -lt $cword ]; do
-	 case "!${words[$counter]}" in
-	     *)
-		 command=$(echo "${words[$counter]}" | sed 's/-/_/g')
-		 cpos=$counter
-		 (( cpos++ ))
-		 break
-		 ;;
-	 esac
-	 (( counter++ ))
-     done
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
 
-     local completions_func=_podman_${command}
-     declare -F $completions_func >/dev/null && $completions_func
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
 
-     eval "$previous_extglob_setting"
-     return 0
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
 }
 
-complete -F _cli_bash_autocomplete podman
+_podman_container_prune()
+{
+    last_command="podman_container_prune"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--filter=")
+    two_word_flags+=("--filter")
+    local_nonpersistent_flags+=("--filter=")
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_restart()
+{
+    last_command="podman_restart"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--running")
+    local_nonpersistent_flags+=("--running")
+    flags+=("--time=")
+    two_word_flags+=("--time")
+    local_nonpersistent_flags+=("--time=")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--timeout=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_container_restore()
+{
+    last_command="podman_container_restore"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--ignore-rootfs")
+    local_nonpersistent_flags+=("--ignore-rootfs")
+    flags+=("--ignore-static-ip")
+    local_nonpersistent_flags+=("--ignore-static-ip")
+    flags+=("--ignore-static-mac")
+    local_nonpersistent_flags+=("--ignore-static-mac")
+    flags+=("--import=")
+    two_word_flags+=("--import")
+    two_word_flags+=("-i")
+    local_nonpersistent_flags+=("--import=")
+    flags+=("--keep")
+    flags+=("-k")
+    local_nonpersistent_flags+=("--keep")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name=")
+    flags+=("--tcp-established")
+    local_nonpersistent_flags+=("--tcp-established")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_rm()
+{
+    last_command="podman_rm"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--cidfile=")
+    two_word_flags+=("--cidfile")
+    local_nonpersistent_flags+=("--cidfile=")
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--ignore")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--ignore")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--storage")
+    local_nonpersistent_flags+=("--storage")
+    flags+=("--volumes")
+    flags+=("-v")
+    local_nonpersistent_flags+=("--volumes")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_run()
+{
+    last_command="podman_run"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--add-host=")
+    two_word_flags+=("--add-host")
+    local_nonpersistent_flags+=("--add-host=")
+    flags+=("--annotation=")
+    two_word_flags+=("--annotation")
+    local_nonpersistent_flags+=("--annotation=")
+    flags+=("--attach=")
+    two_word_flags+=("--attach")
+    two_word_flags+=("-a")
+    local_nonpersistent_flags+=("--attach=")
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--blkio-weight=")
+    two_word_flags+=("--blkio-weight")
+    local_nonpersistent_flags+=("--blkio-weight=")
+    flags+=("--blkio-weight-device=")
+    two_word_flags+=("--blkio-weight-device")
+    local_nonpersistent_flags+=("--blkio-weight-device=")
+    flags+=("--cap-add=")
+    two_word_flags+=("--cap-add")
+    local_nonpersistent_flags+=("--cap-add=")
+    flags+=("--cap-drop=")
+    two_word_flags+=("--cap-drop")
+    local_nonpersistent_flags+=("--cap-drop=")
+    flags+=("--cgroup-parent=")
+    two_word_flags+=("--cgroup-parent")
+    local_nonpersistent_flags+=("--cgroup-parent=")
+    flags+=("--cgroupns=")
+    two_word_flags+=("--cgroupns")
+    local_nonpersistent_flags+=("--cgroupns=")
+    flags+=("--cgroups=")
+    two_word_flags+=("--cgroups")
+    local_nonpersistent_flags+=("--cgroups=")
+    flags+=("--cidfile=")
+    two_word_flags+=("--cidfile")
+    local_nonpersistent_flags+=("--cidfile=")
+    flags+=("--conmon-pidfile=")
+    two_word_flags+=("--conmon-pidfile")
+    local_nonpersistent_flags+=("--conmon-pidfile=")
+    flags+=("--cpu-period=")
+    two_word_flags+=("--cpu-period")
+    local_nonpersistent_flags+=("--cpu-period=")
+    flags+=("--cpu-quota=")
+    two_word_flags+=("--cpu-quota")
+    local_nonpersistent_flags+=("--cpu-quota=")
+    flags+=("--cpu-rt-period=")
+    two_word_flags+=("--cpu-rt-period")
+    local_nonpersistent_flags+=("--cpu-rt-period=")
+    flags+=("--cpu-rt-runtime=")
+    two_word_flags+=("--cpu-rt-runtime")
+    local_nonpersistent_flags+=("--cpu-rt-runtime=")
+    flags+=("--cpu-shares=")
+    two_word_flags+=("--cpu-shares")
+    local_nonpersistent_flags+=("--cpu-shares=")
+    flags+=("--cpus=")
+    two_word_flags+=("--cpus")
+    local_nonpersistent_flags+=("--cpus=")
+    flags+=("--cpuset-cpus=")
+    two_word_flags+=("--cpuset-cpus")
+    local_nonpersistent_flags+=("--cpuset-cpus=")
+    flags+=("--cpuset-mems=")
+    two_word_flags+=("--cpuset-mems")
+    local_nonpersistent_flags+=("--cpuset-mems=")
+    flags+=("--detach")
+    flags+=("-d")
+    local_nonpersistent_flags+=("--detach")
+    flags+=("--detach-keys=")
+    two_word_flags+=("--detach-keys")
+    local_nonpersistent_flags+=("--detach-keys=")
+    flags+=("--device=")
+    two_word_flags+=("--device")
+    local_nonpersistent_flags+=("--device=")
+    flags+=("--device-read-bps=")
+    two_word_flags+=("--device-read-bps")
+    local_nonpersistent_flags+=("--device-read-bps=")
+    flags+=("--device-read-iops=")
+    two_word_flags+=("--device-read-iops")
+    local_nonpersistent_flags+=("--device-read-iops=")
+    flags+=("--device-write-bps=")
+    two_word_flags+=("--device-write-bps")
+    local_nonpersistent_flags+=("--device-write-bps=")
+    flags+=("--device-write-iops=")
+    two_word_flags+=("--device-write-iops")
+    local_nonpersistent_flags+=("--device-write-iops=")
+    flags+=("--dns=")
+    two_word_flags+=("--dns")
+    local_nonpersistent_flags+=("--dns=")
+    flags+=("--dns-opt=")
+    two_word_flags+=("--dns-opt")
+    local_nonpersistent_flags+=("--dns-opt=")
+    flags+=("--dns-search=")
+    two_word_flags+=("--dns-search")
+    local_nonpersistent_flags+=("--dns-search=")
+    flags+=("--entrypoint=")
+    two_word_flags+=("--entrypoint")
+    local_nonpersistent_flags+=("--entrypoint=")
+    flags+=("--env=")
+    two_word_flags+=("--env")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--env=")
+    flags+=("--env-file=")
+    two_word_flags+=("--env-file")
+    local_nonpersistent_flags+=("--env-file=")
+    flags+=("--env-host")
+    local_nonpersistent_flags+=("--env-host")
+    flags+=("--expose=")
+    two_word_flags+=("--expose")
+    local_nonpersistent_flags+=("--expose=")
+    flags+=("--gidmap=")
+    two_word_flags+=("--gidmap")
+    local_nonpersistent_flags+=("--gidmap=")
+    flags+=("--group-add=")
+    two_word_flags+=("--group-add")
+    local_nonpersistent_flags+=("--group-add=")
+    flags+=("--health-cmd=")
+    two_word_flags+=("--health-cmd")
+    local_nonpersistent_flags+=("--health-cmd=")
+    flags+=("--health-interval=")
+    two_word_flags+=("--health-interval")
+    local_nonpersistent_flags+=("--health-interval=")
+    flags+=("--health-retries=")
+    two_word_flags+=("--health-retries")
+    local_nonpersistent_flags+=("--health-retries=")
+    flags+=("--health-start-period=")
+    two_word_flags+=("--health-start-period")
+    local_nonpersistent_flags+=("--health-start-period=")
+    flags+=("--health-timeout=")
+    two_word_flags+=("--health-timeout")
+    local_nonpersistent_flags+=("--health-timeout=")
+    flags+=("--hostname=")
+    two_word_flags+=("--hostname")
+    two_word_flags+=("-h")
+    local_nonpersistent_flags+=("--hostname=")
+    flags+=("--http-proxy")
+    local_nonpersistent_flags+=("--http-proxy")
+    flags+=("--image-volume=")
+    two_word_flags+=("--image-volume")
+    local_nonpersistent_flags+=("--image-volume=")
+    flags+=("--init")
+    local_nonpersistent_flags+=("--init")
+    flags+=("--init-path=")
+    two_word_flags+=("--init-path")
+    local_nonpersistent_flags+=("--init-path=")
+    flags+=("--interactive")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--interactive")
+    flags+=("--ip=")
+    two_word_flags+=("--ip")
+    local_nonpersistent_flags+=("--ip=")
+    flags+=("--ipc=")
+    two_word_flags+=("--ipc")
+    local_nonpersistent_flags+=("--ipc=")
+    flags+=("--kernel-memory=")
+    two_word_flags+=("--kernel-memory")
+    local_nonpersistent_flags+=("--kernel-memory=")
+    flags+=("--label=")
+    two_word_flags+=("--label")
+    two_word_flags+=("-l")
+    local_nonpersistent_flags+=("--label=")
+    flags+=("--label-file=")
+    two_word_flags+=("--label-file")
+    local_nonpersistent_flags+=("--label-file=")
+    flags+=("--log-driver=")
+    two_word_flags+=("--log-driver")
+    local_nonpersistent_flags+=("--log-driver=")
+    flags+=("--log-opt=")
+    two_word_flags+=("--log-opt")
+    local_nonpersistent_flags+=("--log-opt=")
+    flags+=("--mac-address=")
+    two_word_flags+=("--mac-address")
+    local_nonpersistent_flags+=("--mac-address=")
+    flags+=("--memory=")
+    two_word_flags+=("--memory")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--memory=")
+    flags+=("--memory-reservation=")
+    two_word_flags+=("--memory-reservation")
+    local_nonpersistent_flags+=("--memory-reservation=")
+    flags+=("--memory-swap=")
+    two_word_flags+=("--memory-swap")
+    local_nonpersistent_flags+=("--memory-swap=")
+    flags+=("--memory-swappiness=")
+    two_word_flags+=("--memory-swappiness")
+    local_nonpersistent_flags+=("--memory-swappiness=")
+    flags+=("--mount=")
+    two_word_flags+=("--mount")
+    local_nonpersistent_flags+=("--mount=")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    local_nonpersistent_flags+=("--name=")
+    flags+=("--net=")
+    two_word_flags+=("--net")
+    local_nonpersistent_flags+=("--net=")
+    flags+=("--network=")
+    two_word_flags+=("--network")
+    local_nonpersistent_flags+=("--network=")
+    flags+=("--no-hosts")
+    local_nonpersistent_flags+=("--no-hosts")
+    flags+=("--oom-kill-disable")
+    local_nonpersistent_flags+=("--oom-kill-disable")
+    flags+=("--oom-score-adj=")
+    two_word_flags+=("--oom-score-adj")
+    local_nonpersistent_flags+=("--oom-score-adj=")
+    flags+=("--pid=")
+    two_word_flags+=("--pid")
+    local_nonpersistent_flags+=("--pid=")
+    flags+=("--pids-limit=")
+    two_word_flags+=("--pids-limit")
+    local_nonpersistent_flags+=("--pids-limit=")
+    flags+=("--pod=")
+    two_word_flags+=("--pod")
+    local_nonpersistent_flags+=("--pod=")
+    flags+=("--privileged")
+    local_nonpersistent_flags+=("--privileged")
+    flags+=("--publish=")
+    two_word_flags+=("--publish")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--publish=")
+    flags+=("--publish-all")
+    flags+=("-P")
+    local_nonpersistent_flags+=("--publish-all")
+    flags+=("--pull=")
+    two_word_flags+=("--pull")
+    local_nonpersistent_flags+=("--pull=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--read-only")
+    local_nonpersistent_flags+=("--read-only")
+    flags+=("--read-only-tmpfs")
+    local_nonpersistent_flags+=("--read-only-tmpfs")
+    flags+=("--restart=")
+    two_word_flags+=("--restart")
+    local_nonpersistent_flags+=("--restart=")
+    flags+=("--rm")
+    local_nonpersistent_flags+=("--rm")
+    flags+=("--rootfs")
+    local_nonpersistent_flags+=("--rootfs")
+    flags+=("--security-opt=")
+    two_word_flags+=("--security-opt")
+    local_nonpersistent_flags+=("--security-opt=")
+    flags+=("--shm-size=")
+    two_word_flags+=("--shm-size")
+    local_nonpersistent_flags+=("--shm-size=")
+    flags+=("--sig-proxy")
+    local_nonpersistent_flags+=("--sig-proxy")
+    flags+=("--stop-signal=")
+    two_word_flags+=("--stop-signal")
+    local_nonpersistent_flags+=("--stop-signal=")
+    flags+=("--stop-timeout=")
+    two_word_flags+=("--stop-timeout")
+    local_nonpersistent_flags+=("--stop-timeout=")
+    flags+=("--subgidname=")
+    two_word_flags+=("--subgidname")
+    local_nonpersistent_flags+=("--subgidname=")
+    flags+=("--subuidname=")
+    two_word_flags+=("--subuidname")
+    local_nonpersistent_flags+=("--subuidname=")
+    flags+=("--sysctl=")
+    two_word_flags+=("--sysctl")
+    local_nonpersistent_flags+=("--sysctl=")
+    flags+=("--systemd=")
+    two_word_flags+=("--systemd")
+    local_nonpersistent_flags+=("--systemd=")
+    flags+=("--tmpfs=")
+    two_word_flags+=("--tmpfs")
+    local_nonpersistent_flags+=("--tmpfs=")
+    flags+=("--tty")
+    flags+=("-t")
+    local_nonpersistent_flags+=("--tty")
+    flags+=("--uidmap=")
+    two_word_flags+=("--uidmap")
+    local_nonpersistent_flags+=("--uidmap=")
+    flags+=("--ulimit=")
+    two_word_flags+=("--ulimit")
+    local_nonpersistent_flags+=("--ulimit=")
+    flags+=("--user=")
+    two_word_flags+=("--user")
+    two_word_flags+=("-u")
+    local_nonpersistent_flags+=("--user=")
+    flags+=("--userns=")
+    two_word_flags+=("--userns")
+    local_nonpersistent_flags+=("--userns=")
+    flags+=("--uts=")
+    two_word_flags+=("--uts")
+    local_nonpersistent_flags+=("--uts=")
+    flags+=("--volume=")
+    two_word_flags+=("--volume")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--volume=")
+    flags+=("--volumes-from=")
+    two_word_flags+=("--volumes-from")
+    local_nonpersistent_flags+=("--volumes-from=")
+    flags+=("--workdir=")
+    two_word_flags+=("--workdir")
+    two_word_flags+=("-w")
+    local_nonpersistent_flags+=("--workdir=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_container_runlabel()
+{
+    last_command="podman_container_runlabel"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--cert-dir=")
+    two_word_flags+=("--cert-dir")
+    local_nonpersistent_flags+=("--cert-dir=")
+    flags+=("--creds=")
+    two_word_flags+=("--creds")
+    local_nonpersistent_flags+=("--creds=")
+    flags+=("--display")
+    local_nonpersistent_flags+=("--display")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    local_nonpersistent_flags+=("--name=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--replace")
+    local_nonpersistent_flags+=("--replace")
+    flags+=("--tls-verify")
+    local_nonpersistent_flags+=("--tls-verify")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_start()
+{
+    last_command="podman_start"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--attach")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--attach")
+    flags+=("--detach-keys=")
+    two_word_flags+=("--detach-keys")
+    local_nonpersistent_flags+=("--detach-keys=")
+    flags+=("--interactive")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--interactive")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--sig-proxy")
+    local_nonpersistent_flags+=("--sig-proxy")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_stats()
+{
+    last_command="podman_stats"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--no-reset")
+    local_nonpersistent_flags+=("--no-reset")
+    flags+=("--no-stream")
+    local_nonpersistent_flags+=("--no-stream")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_stop()
+{
+    last_command="podman_stop"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--cidfile=")
+    two_word_flags+=("--cidfile")
+    local_nonpersistent_flags+=("--cidfile=")
+    flags+=("--ignore")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--ignore")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--time=")
+    two_word_flags+=("--time")
+    local_nonpersistent_flags+=("--time=")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--timeout=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_top()
+{
+    last_command="podman_top"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_umount()
+{
+    last_command="podman_umount"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_unpause()
+{
+    last_command="podman_unpause"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_wait()
+{
+    last_command="podman_wait"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--interval=")
+    two_word_flags+=("--interval")
+    two_word_flags+=("-i")
+    local_nonpersistent_flags+=("--interval=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_container()
+{
+    last_command="podman_container"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("attach")
+    commands+=("checkpoint")
+    commands+=("cleanup")
+    commands+=("commit")
+    commands+=("cp")
+    commands+=("create")
+    commands+=("diff")
+    commands+=("exec")
+    commands+=("exists")
+    commands+=("export")
+    commands+=("init")
+    commands+=("inspect")
+    commands+=("kill")
+    commands+=("list")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("ls")
+        aliashash["ls"]="list"
+    fi
+    commands+=("logs")
+    commands+=("mount")
+    commands+=("pause")
+    commands+=("port")
+    commands+=("prune")
+    commands+=("restart")
+    commands+=("restore")
+    commands+=("rm")
+    commands+=("run")
+    commands+=("runlabel")
+    commands+=("start")
+    commands+=("stats")
+    commands+=("stop")
+    commands+=("top")
+    commands+=("umount")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("unmount")
+        aliashash["unmount"]="umount"
+    fi
+    commands+=("unpause")
+    commands+=("wait")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_cp()
+{
+    last_command="podman_cp"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--extract")
+    local_nonpersistent_flags+=("--extract")
+    flags+=("--pause")
+    local_nonpersistent_flags+=("--pause")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_create()
+{
+    last_command="podman_create"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--add-host=")
+    two_word_flags+=("--add-host")
+    local_nonpersistent_flags+=("--add-host=")
+    flags+=("--annotation=")
+    two_word_flags+=("--annotation")
+    local_nonpersistent_flags+=("--annotation=")
+    flags+=("--attach=")
+    two_word_flags+=("--attach")
+    two_word_flags+=("-a")
+    local_nonpersistent_flags+=("--attach=")
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--blkio-weight=")
+    two_word_flags+=("--blkio-weight")
+    local_nonpersistent_flags+=("--blkio-weight=")
+    flags+=("--blkio-weight-device=")
+    two_word_flags+=("--blkio-weight-device")
+    local_nonpersistent_flags+=("--blkio-weight-device=")
+    flags+=("--cap-add=")
+    two_word_flags+=("--cap-add")
+    local_nonpersistent_flags+=("--cap-add=")
+    flags+=("--cap-drop=")
+    two_word_flags+=("--cap-drop")
+    local_nonpersistent_flags+=("--cap-drop=")
+    flags+=("--cgroup-parent=")
+    two_word_flags+=("--cgroup-parent")
+    local_nonpersistent_flags+=("--cgroup-parent=")
+    flags+=("--cgroupns=")
+    two_word_flags+=("--cgroupns")
+    local_nonpersistent_flags+=("--cgroupns=")
+    flags+=("--cgroups=")
+    two_word_flags+=("--cgroups")
+    local_nonpersistent_flags+=("--cgroups=")
+    flags+=("--cidfile=")
+    two_word_flags+=("--cidfile")
+    local_nonpersistent_flags+=("--cidfile=")
+    flags+=("--conmon-pidfile=")
+    two_word_flags+=("--conmon-pidfile")
+    local_nonpersistent_flags+=("--conmon-pidfile=")
+    flags+=("--cpu-period=")
+    two_word_flags+=("--cpu-period")
+    local_nonpersistent_flags+=("--cpu-period=")
+    flags+=("--cpu-quota=")
+    two_word_flags+=("--cpu-quota")
+    local_nonpersistent_flags+=("--cpu-quota=")
+    flags+=("--cpu-rt-period=")
+    two_word_flags+=("--cpu-rt-period")
+    local_nonpersistent_flags+=("--cpu-rt-period=")
+    flags+=("--cpu-rt-runtime=")
+    two_word_flags+=("--cpu-rt-runtime")
+    local_nonpersistent_flags+=("--cpu-rt-runtime=")
+    flags+=("--cpu-shares=")
+    two_word_flags+=("--cpu-shares")
+    local_nonpersistent_flags+=("--cpu-shares=")
+    flags+=("--cpus=")
+    two_word_flags+=("--cpus")
+    local_nonpersistent_flags+=("--cpus=")
+    flags+=("--cpuset-cpus=")
+    two_word_flags+=("--cpuset-cpus")
+    local_nonpersistent_flags+=("--cpuset-cpus=")
+    flags+=("--cpuset-mems=")
+    two_word_flags+=("--cpuset-mems")
+    local_nonpersistent_flags+=("--cpuset-mems=")
+    flags+=("--detach")
+    flags+=("-d")
+    local_nonpersistent_flags+=("--detach")
+    flags+=("--detach-keys=")
+    two_word_flags+=("--detach-keys")
+    local_nonpersistent_flags+=("--detach-keys=")
+    flags+=("--device=")
+    two_word_flags+=("--device")
+    local_nonpersistent_flags+=("--device=")
+    flags+=("--device-read-bps=")
+    two_word_flags+=("--device-read-bps")
+    local_nonpersistent_flags+=("--device-read-bps=")
+    flags+=("--device-read-iops=")
+    two_word_flags+=("--device-read-iops")
+    local_nonpersistent_flags+=("--device-read-iops=")
+    flags+=("--device-write-bps=")
+    two_word_flags+=("--device-write-bps")
+    local_nonpersistent_flags+=("--device-write-bps=")
+    flags+=("--device-write-iops=")
+    two_word_flags+=("--device-write-iops")
+    local_nonpersistent_flags+=("--device-write-iops=")
+    flags+=("--dns=")
+    two_word_flags+=("--dns")
+    local_nonpersistent_flags+=("--dns=")
+    flags+=("--dns-opt=")
+    two_word_flags+=("--dns-opt")
+    local_nonpersistent_flags+=("--dns-opt=")
+    flags+=("--dns-search=")
+    two_word_flags+=("--dns-search")
+    local_nonpersistent_flags+=("--dns-search=")
+    flags+=("--entrypoint=")
+    two_word_flags+=("--entrypoint")
+    local_nonpersistent_flags+=("--entrypoint=")
+    flags+=("--env=")
+    two_word_flags+=("--env")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--env=")
+    flags+=("--env-file=")
+    two_word_flags+=("--env-file")
+    local_nonpersistent_flags+=("--env-file=")
+    flags+=("--env-host")
+    local_nonpersistent_flags+=("--env-host")
+    flags+=("--expose=")
+    two_word_flags+=("--expose")
+    local_nonpersistent_flags+=("--expose=")
+    flags+=("--gidmap=")
+    two_word_flags+=("--gidmap")
+    local_nonpersistent_flags+=("--gidmap=")
+    flags+=("--group-add=")
+    two_word_flags+=("--group-add")
+    local_nonpersistent_flags+=("--group-add=")
+    flags+=("--health-cmd=")
+    two_word_flags+=("--health-cmd")
+    local_nonpersistent_flags+=("--health-cmd=")
+    flags+=("--health-interval=")
+    two_word_flags+=("--health-interval")
+    local_nonpersistent_flags+=("--health-interval=")
+    flags+=("--health-retries=")
+    two_word_flags+=("--health-retries")
+    local_nonpersistent_flags+=("--health-retries=")
+    flags+=("--health-start-period=")
+    two_word_flags+=("--health-start-period")
+    local_nonpersistent_flags+=("--health-start-period=")
+    flags+=("--health-timeout=")
+    two_word_flags+=("--health-timeout")
+    local_nonpersistent_flags+=("--health-timeout=")
+    flags+=("--hostname=")
+    two_word_flags+=("--hostname")
+    two_word_flags+=("-h")
+    local_nonpersistent_flags+=("--hostname=")
+    flags+=("--http-proxy")
+    local_nonpersistent_flags+=("--http-proxy")
+    flags+=("--image-volume=")
+    two_word_flags+=("--image-volume")
+    local_nonpersistent_flags+=("--image-volume=")
+    flags+=("--init")
+    local_nonpersistent_flags+=("--init")
+    flags+=("--init-path=")
+    two_word_flags+=("--init-path")
+    local_nonpersistent_flags+=("--init-path=")
+    flags+=("--interactive")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--interactive")
+    flags+=("--ip=")
+    two_word_flags+=("--ip")
+    local_nonpersistent_flags+=("--ip=")
+    flags+=("--ipc=")
+    two_word_flags+=("--ipc")
+    local_nonpersistent_flags+=("--ipc=")
+    flags+=("--kernel-memory=")
+    two_word_flags+=("--kernel-memory")
+    local_nonpersistent_flags+=("--kernel-memory=")
+    flags+=("--label=")
+    two_word_flags+=("--label")
+    two_word_flags+=("-l")
+    local_nonpersistent_flags+=("--label=")
+    flags+=("--label-file=")
+    two_word_flags+=("--label-file")
+    local_nonpersistent_flags+=("--label-file=")
+    flags+=("--log-driver=")
+    two_word_flags+=("--log-driver")
+    local_nonpersistent_flags+=("--log-driver=")
+    flags+=("--log-opt=")
+    two_word_flags+=("--log-opt")
+    local_nonpersistent_flags+=("--log-opt=")
+    flags+=("--mac-address=")
+    two_word_flags+=("--mac-address")
+    local_nonpersistent_flags+=("--mac-address=")
+    flags+=("--memory=")
+    two_word_flags+=("--memory")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--memory=")
+    flags+=("--memory-reservation=")
+    two_word_flags+=("--memory-reservation")
+    local_nonpersistent_flags+=("--memory-reservation=")
+    flags+=("--memory-swap=")
+    two_word_flags+=("--memory-swap")
+    local_nonpersistent_flags+=("--memory-swap=")
+    flags+=("--memory-swappiness=")
+    two_word_flags+=("--memory-swappiness")
+    local_nonpersistent_flags+=("--memory-swappiness=")
+    flags+=("--mount=")
+    two_word_flags+=("--mount")
+    local_nonpersistent_flags+=("--mount=")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    local_nonpersistent_flags+=("--name=")
+    flags+=("--net=")
+    two_word_flags+=("--net")
+    local_nonpersistent_flags+=("--net=")
+    flags+=("--network=")
+    two_word_flags+=("--network")
+    local_nonpersistent_flags+=("--network=")
+    flags+=("--no-hosts")
+    local_nonpersistent_flags+=("--no-hosts")
+    flags+=("--oom-kill-disable")
+    local_nonpersistent_flags+=("--oom-kill-disable")
+    flags+=("--oom-score-adj=")
+    two_word_flags+=("--oom-score-adj")
+    local_nonpersistent_flags+=("--oom-score-adj=")
+    flags+=("--pid=")
+    two_word_flags+=("--pid")
+    local_nonpersistent_flags+=("--pid=")
+    flags+=("--pids-limit=")
+    two_word_flags+=("--pids-limit")
+    local_nonpersistent_flags+=("--pids-limit=")
+    flags+=("--pod=")
+    two_word_flags+=("--pod")
+    local_nonpersistent_flags+=("--pod=")
+    flags+=("--privileged")
+    local_nonpersistent_flags+=("--privileged")
+    flags+=("--publish=")
+    two_word_flags+=("--publish")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--publish=")
+    flags+=("--publish-all")
+    flags+=("-P")
+    local_nonpersistent_flags+=("--publish-all")
+    flags+=("--pull=")
+    two_word_flags+=("--pull")
+    local_nonpersistent_flags+=("--pull=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--read-only")
+    local_nonpersistent_flags+=("--read-only")
+    flags+=("--read-only-tmpfs")
+    local_nonpersistent_flags+=("--read-only-tmpfs")
+    flags+=("--restart=")
+    two_word_flags+=("--restart")
+    local_nonpersistent_flags+=("--restart=")
+    flags+=("--rm")
+    local_nonpersistent_flags+=("--rm")
+    flags+=("--rootfs")
+    local_nonpersistent_flags+=("--rootfs")
+    flags+=("--security-opt=")
+    two_word_flags+=("--security-opt")
+    local_nonpersistent_flags+=("--security-opt=")
+    flags+=("--shm-size=")
+    two_word_flags+=("--shm-size")
+    local_nonpersistent_flags+=("--shm-size=")
+    flags+=("--stop-signal=")
+    two_word_flags+=("--stop-signal")
+    local_nonpersistent_flags+=("--stop-signal=")
+    flags+=("--stop-timeout=")
+    two_word_flags+=("--stop-timeout")
+    local_nonpersistent_flags+=("--stop-timeout=")
+    flags+=("--subgidname=")
+    two_word_flags+=("--subgidname")
+    local_nonpersistent_flags+=("--subgidname=")
+    flags+=("--subuidname=")
+    two_word_flags+=("--subuidname")
+    local_nonpersistent_flags+=("--subuidname=")
+    flags+=("--sysctl=")
+    two_word_flags+=("--sysctl")
+    local_nonpersistent_flags+=("--sysctl=")
+    flags+=("--systemd=")
+    two_word_flags+=("--systemd")
+    local_nonpersistent_flags+=("--systemd=")
+    flags+=("--tmpfs=")
+    two_word_flags+=("--tmpfs")
+    local_nonpersistent_flags+=("--tmpfs=")
+    flags+=("--tty")
+    flags+=("-t")
+    local_nonpersistent_flags+=("--tty")
+    flags+=("--uidmap=")
+    two_word_flags+=("--uidmap")
+    local_nonpersistent_flags+=("--uidmap=")
+    flags+=("--ulimit=")
+    two_word_flags+=("--ulimit")
+    local_nonpersistent_flags+=("--ulimit=")
+    flags+=("--user=")
+    two_word_flags+=("--user")
+    two_word_flags+=("-u")
+    local_nonpersistent_flags+=("--user=")
+    flags+=("--userns=")
+    two_word_flags+=("--userns")
+    local_nonpersistent_flags+=("--userns=")
+    flags+=("--uts=")
+    two_word_flags+=("--uts")
+    local_nonpersistent_flags+=("--uts=")
+    flags+=("--volume=")
+    two_word_flags+=("--volume")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--volume=")
+    flags+=("--volumes-from=")
+    two_word_flags+=("--volumes-from")
+    local_nonpersistent_flags+=("--volumes-from=")
+    flags+=("--workdir=")
+    two_word_flags+=("--workdir")
+    two_word_flags+=("-w")
+    local_nonpersistent_flags+=("--workdir=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_diff()
+{
+    last_command="podman_diff"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_events()
+{
+    last_command="podman_events"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--filter=")
+    two_word_flags+=("--filter")
+    local_nonpersistent_flags+=("--filter=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--since=")
+    two_word_flags+=("--since")
+    local_nonpersistent_flags+=("--since=")
+    flags+=("--until=")
+    two_word_flags+=("--until")
+    local_nonpersistent_flags+=("--until=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_exec()
+{
+    last_command="podman_exec"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--detach-keys=")
+    two_word_flags+=("--detach-keys")
+    local_nonpersistent_flags+=("--detach-keys=")
+    flags+=("--env=")
+    two_word_flags+=("--env")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--env=")
+    flags+=("--env-file=")
+    two_word_flags+=("--env-file")
+    local_nonpersistent_flags+=("--env-file=")
+    flags+=("--interactive")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--interactive")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--preserve-fds=")
+    two_word_flags+=("--preserve-fds")
+    local_nonpersistent_flags+=("--preserve-fds=")
+    flags+=("--privileged")
+    local_nonpersistent_flags+=("--privileged")
+    flags+=("--tty")
+    flags+=("-t")
+    local_nonpersistent_flags+=("--tty")
+    flags+=("--user=")
+    two_word_flags+=("--user")
+    two_word_flags+=("-u")
+    local_nonpersistent_flags+=("--user=")
+    flags+=("--workdir=")
+    two_word_flags+=("--workdir")
+    two_word_flags+=("-w")
+    local_nonpersistent_flags+=("--workdir=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_export()
+{
+    last_command="podman_export"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+    local_nonpersistent_flags+=("--output=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_generate_kube()
+{
+    last_command="podman_generate_kube"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--filename=")
+    two_word_flags+=("--filename")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--filename=")
+    flags+=("--service")
+    flags+=("-s")
+    local_nonpersistent_flags+=("--service")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_generate_systemd()
+{
+    last_command="podman_generate_systemd"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--files")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--files")
+    flags+=("--name")
+    flags+=("-n")
+    local_nonpersistent_flags+=("--name")
+    flags+=("--restart-policy=")
+    two_word_flags+=("--restart-policy")
+    local_nonpersistent_flags+=("--restart-policy=")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--timeout=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_generate()
+{
+    last_command="podman_generate"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("kube")
+    commands+=("systemd")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_healthcheck_run()
+{
+    last_command="podman_healthcheck_run"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_healthcheck()
+{
+    last_command="podman_healthcheck"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("run")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_history()
+{
+    last_command="podman_history"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--human")
+    flags+=("-H")
+    local_nonpersistent_flags+=("--human")
+    flags+=("--no-trunc")
+    local_nonpersistent_flags+=("--no-trunc")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_build()
+{
+    last_command="podman_build"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--add-host=")
+    two_word_flags+=("--add-host")
+    local_nonpersistent_flags+=("--add-host=")
+    flags+=("--annotation=")
+    two_word_flags+=("--annotation")
+    local_nonpersistent_flags+=("--annotation=")
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--build-arg=")
+    two_word_flags+=("--build-arg")
+    local_nonpersistent_flags+=("--build-arg=")
+    flags+=("--cache-from=")
+    two_word_flags+=("--cache-from")
+    local_nonpersistent_flags+=("--cache-from=")
+    flags+=("--cap-add=")
+    two_word_flags+=("--cap-add")
+    local_nonpersistent_flags+=("--cap-add=")
+    flags+=("--cap-drop=")
+    two_word_flags+=("--cap-drop")
+    local_nonpersistent_flags+=("--cap-drop=")
+    flags+=("--cert-dir=")
+    two_word_flags+=("--cert-dir")
+    local_nonpersistent_flags+=("--cert-dir=")
+    flags+=("--cgroup-parent=")
+    two_word_flags+=("--cgroup-parent")
+    local_nonpersistent_flags+=("--cgroup-parent=")
+    flags+=("--cni-plugin-path=")
+    two_word_flags+=("--cni-plugin-path")
+    local_nonpersistent_flags+=("--cni-plugin-path=")
+    flags+=("--compress")
+    local_nonpersistent_flags+=("--compress")
+    flags+=("--cpu-period=")
+    two_word_flags+=("--cpu-period")
+    local_nonpersistent_flags+=("--cpu-period=")
+    flags+=("--cpu-quota=")
+    two_word_flags+=("--cpu-quota")
+    local_nonpersistent_flags+=("--cpu-quota=")
+    flags+=("--cpu-shares=")
+    two_word_flags+=("--cpu-shares")
+    two_word_flags+=("-c")
+    local_nonpersistent_flags+=("--cpu-shares=")
+    flags+=("--cpuset-cpus=")
+    two_word_flags+=("--cpuset-cpus")
+    local_nonpersistent_flags+=("--cpuset-cpus=")
+    flags+=("--cpuset-mems=")
+    two_word_flags+=("--cpuset-mems")
+    local_nonpersistent_flags+=("--cpuset-mems=")
+    flags+=("--creds=")
+    two_word_flags+=("--creds")
+    local_nonpersistent_flags+=("--creds=")
+    flags+=("--device=")
+    two_word_flags+=("--device")
+    local_nonpersistent_flags+=("--device=")
+    flags+=("--disable-compression")
+    flags+=("-D")
+    local_nonpersistent_flags+=("--disable-compression")
+    flags+=("--disable-content-trust")
+    local_nonpersistent_flags+=("--disable-content-trust")
+    flags+=("--dns=")
+    two_word_flags+=("--dns")
+    local_nonpersistent_flags+=("--dns=")
+    flags+=("--dns-option=")
+    two_word_flags+=("--dns-option")
+    local_nonpersistent_flags+=("--dns-option=")
+    flags+=("--dns-search=")
+    two_word_flags+=("--dns-search")
+    local_nonpersistent_flags+=("--dns-search=")
+    flags+=("--file=")
+    two_word_flags+=("--file")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--file=")
+    flags+=("--force-rm")
+    local_nonpersistent_flags+=("--force-rm")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--http-proxy")
+    local_nonpersistent_flags+=("--http-proxy")
+    flags+=("--iidfile=")
+    two_word_flags+=("--iidfile")
+    local_nonpersistent_flags+=("--iidfile=")
+    flags+=("--ipc=")
+    two_word_flags+=("--ipc")
+    local_nonpersistent_flags+=("--ipc=")
+    flags+=("--isolation=")
+    two_word_flags+=("--isolation")
+    local_nonpersistent_flags+=("--isolation=")
+    flags+=("--label=")
+    two_word_flags+=("--label")
+    local_nonpersistent_flags+=("--label=")
+    flags+=("--layers")
+    local_nonpersistent_flags+=("--layers")
+    flags+=("--logfile=")
+    two_word_flags+=("--logfile")
+    local_nonpersistent_flags+=("--logfile=")
+    flags+=("--loglevel=")
+    two_word_flags+=("--loglevel")
+    local_nonpersistent_flags+=("--loglevel=")
+    flags+=("--memory=")
+    two_word_flags+=("--memory")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--memory=")
+    flags+=("--memory-swap=")
+    two_word_flags+=("--memory-swap")
+    local_nonpersistent_flags+=("--memory-swap=")
+    flags+=("--network=")
+    two_word_flags+=("--network")
+    local_nonpersistent_flags+=("--network=")
+    flags+=("--no-cache")
+    local_nonpersistent_flags+=("--no-cache")
+    flags+=("--pid=")
+    two_word_flags+=("--pid")
+    local_nonpersistent_flags+=("--pid=")
+    flags+=("--platform=")
+    two_word_flags+=("--platform")
+    local_nonpersistent_flags+=("--platform=")
+    flags+=("--pull")
+    local_nonpersistent_flags+=("--pull")
+    flags+=("--pull-always")
+    local_nonpersistent_flags+=("--pull-always")
+    flags+=("--pull-never")
+    local_nonpersistent_flags+=("--pull-never")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--rm")
+    local_nonpersistent_flags+=("--rm")
+    flags+=("--runtime-flag=")
+    two_word_flags+=("--runtime-flag")
+    local_nonpersistent_flags+=("--runtime-flag=")
+    flags+=("--security-opt=")
+    two_word_flags+=("--security-opt")
+    local_nonpersistent_flags+=("--security-opt=")
+    flags+=("--shm-size=")
+    two_word_flags+=("--shm-size")
+    local_nonpersistent_flags+=("--shm-size=")
+    flags+=("--squash")
+    local_nonpersistent_flags+=("--squash")
+    flags+=("--squash-all")
+    local_nonpersistent_flags+=("--squash-all")
+    flags+=("--tag=")
+    two_word_flags+=("--tag")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--tag=")
+    flags+=("--target=")
+    two_word_flags+=("--target")
+    local_nonpersistent_flags+=("--target=")
+    flags+=("--tls-verify")
+    local_nonpersistent_flags+=("--tls-verify")
+    flags+=("--ulimit=")
+    two_word_flags+=("--ulimit")
+    local_nonpersistent_flags+=("--ulimit=")
+    flags+=("--userns=")
+    two_word_flags+=("--userns")
+    local_nonpersistent_flags+=("--userns=")
+    flags+=("--userns-gid-map=")
+    two_word_flags+=("--userns-gid-map")
+    local_nonpersistent_flags+=("--userns-gid-map=")
+    flags+=("--userns-gid-map-group=")
+    two_word_flags+=("--userns-gid-map-group")
+    local_nonpersistent_flags+=("--userns-gid-map-group=")
+    flags+=("--userns-uid-map=")
+    two_word_flags+=("--userns-uid-map")
+    local_nonpersistent_flags+=("--userns-uid-map=")
+    flags+=("--userns-uid-map-user=")
+    two_word_flags+=("--userns-uid-map-user")
+    local_nonpersistent_flags+=("--userns-uid-map-user=")
+    flags+=("--uts=")
+    two_word_flags+=("--uts")
+    local_nonpersistent_flags+=("--uts=")
+    flags+=("--volume=")
+    two_word_flags+=("--volume")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--volume=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_image_exists()
+{
+    last_command="podman_image_exists"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_history()
+{
+    last_command="podman_history"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--human")
+    flags+=("-H")
+    local_nonpersistent_flags+=("--human")
+    flags+=("--no-trunc")
+    local_nonpersistent_flags+=("--no-trunc")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_import()
+{
+    last_command="podman_import"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--change=")
+    two_word_flags+=("--change")
+    two_word_flags+=("-c")
+    local_nonpersistent_flags+=("--change=")
+    flags+=("--message=")
+    two_word_flags+=("--message")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--message=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_image_inspect()
+{
+    last_command="podman_image_inspect"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_image_list()
+{
+    last_command="podman_image_list"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--digests")
+    local_nonpersistent_flags+=("--digests")
+    flags+=("--filter=")
+    two_word_flags+=("--filter")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--filter=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--history")
+    local_nonpersistent_flags+=("--history")
+    flags+=("--no-trunc")
+    local_nonpersistent_flags+=("--no-trunc")
+    flags+=("--noheading")
+    flags+=("-n")
+    local_nonpersistent_flags+=("--noheading")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--sort=")
+    two_word_flags+=("--sort")
+    local_nonpersistent_flags+=("--sort=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_load()
+{
+    last_command="podman_load"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--input=")
+    two_word_flags+=("--input")
+    two_word_flags+=("-i")
+    local_nonpersistent_flags+=("--input=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_image_prune()
+{
+    last_command="podman_image_prune"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--filter=")
+    two_word_flags+=("--filter")
+    local_nonpersistent_flags+=("--filter=")
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pull()
+{
+    last_command="podman_pull"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all-tags")
+    local_nonpersistent_flags+=("--all-tags")
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--cert-dir=")
+    two_word_flags+=("--cert-dir")
+    local_nonpersistent_flags+=("--cert-dir=")
+    flags+=("--creds=")
+    two_word_flags+=("--creds")
+    local_nonpersistent_flags+=("--creds=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--tls-verify")
+    local_nonpersistent_flags+=("--tls-verify")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_push()
+{
+    last_command="podman_push"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--cert-dir=")
+    two_word_flags+=("--cert-dir")
+    local_nonpersistent_flags+=("--cert-dir=")
+    flags+=("--compress")
+    local_nonpersistent_flags+=("--compress")
+    flags+=("--creds=")
+    two_word_flags+=("--creds")
+    local_nonpersistent_flags+=("--creds=")
+    flags+=("--digestfile=")
+    two_word_flags+=("--digestfile")
+    local_nonpersistent_flags+=("--digestfile=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--remove-signatures")
+    local_nonpersistent_flags+=("--remove-signatures")
+    flags+=("--sign-by=")
+    two_word_flags+=("--sign-by")
+    local_nonpersistent_flags+=("--sign-by=")
+    flags+=("--tls-verify")
+    local_nonpersistent_flags+=("--tls-verify")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_image_rm()
+{
+    last_command="podman_image_rm"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_save()
+{
+    last_command="podman_save"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--compress")
+    local_nonpersistent_flags+=("--compress")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+    local_nonpersistent_flags+=("--output=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_image_sign()
+{
+    last_command="podman_image_sign"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cert-dir=")
+    two_word_flags+=("--cert-dir")
+    local_nonpersistent_flags+=("--cert-dir=")
+    flags+=("--directory=")
+    two_word_flags+=("--directory")
+    two_word_flags+=("-d")
+    local_nonpersistent_flags+=("--directory=")
+    flags+=("--sign-by=")
+    two_word_flags+=("--sign-by")
+    local_nonpersistent_flags+=("--sign-by=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_tag()
+{
+    last_command="podman_tag"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_image_tree()
+{
+    last_command="podman_image_tree"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--whatrequires")
+    local_nonpersistent_flags+=("--whatrequires")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_image_trust_set()
+{
+    last_command="podman_image_trust_set"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--pubkeysfile=")
+    two_word_flags+=("--pubkeysfile")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--pubkeysfile=")
+    flags+=("--type=")
+    two_word_flags+=("--type")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--type=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_image_trust_show()
+{
+    last_command="podman_image_trust_show"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--json")
+    flags+=("-j")
+    local_nonpersistent_flags+=("--json")
+    flags+=("--raw")
+    local_nonpersistent_flags+=("--raw")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_image_trust()
+{
+    last_command="podman_image_trust"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("set")
+    commands+=("show")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_image()
+{
+    last_command="podman_image"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("build")
+    commands+=("exists")
+    commands+=("history")
+    commands+=("import")
+    commands+=("inspect")
+    commands+=("list")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("ls")
+        aliashash["ls"]="list"
+    fi
+    commands+=("load")
+    commands+=("prune")
+    commands+=("pull")
+    commands+=("push")
+    commands+=("rm")
+    commands+=("save")
+    commands+=("sign")
+    commands+=("tag")
+    commands+=("tree")
+    commands+=("trust")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_images()
+{
+    last_command="podman_images"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--digests")
+    local_nonpersistent_flags+=("--digests")
+    flags+=("--filter=")
+    two_word_flags+=("--filter")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--filter=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--history")
+    local_nonpersistent_flags+=("--history")
+    flags+=("--no-trunc")
+    local_nonpersistent_flags+=("--no-trunc")
+    flags+=("--noheading")
+    flags+=("-n")
+    local_nonpersistent_flags+=("--noheading")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--sort=")
+    two_word_flags+=("--sort")
+    local_nonpersistent_flags+=("--sort=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_import()
+{
+    last_command="podman_import"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--change=")
+    two_word_flags+=("--change")
+    two_word_flags+=("-c")
+    local_nonpersistent_flags+=("--change=")
+    flags+=("--message=")
+    two_word_flags+=("--message")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--message=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_system_info()
+{
+    last_command="podman_system_info"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--debug")
+    flags+=("-D")
+    local_nonpersistent_flags+=("--debug")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_init()
+{
+    last_command="podman_init"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_inspect()
+{
+    last_command="podman_inspect"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--size")
+    flags+=("-s")
+    local_nonpersistent_flags+=("--size")
+    flags+=("--type=")
+    two_word_flags+=("--type")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--type=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_kill()
+{
+    last_command="podman_kill"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--signal=")
+    two_word_flags+=("--signal")
+    two_word_flags+=("-s")
+    local_nonpersistent_flags+=("--signal=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_load()
+{
+    last_command="podman_load"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--input=")
+    two_word_flags+=("--input")
+    two_word_flags+=("-i")
+    local_nonpersistent_flags+=("--input=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_login()
+{
+    last_command="podman_login"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--cert-dir=")
+    two_word_flags+=("--cert-dir")
+    local_nonpersistent_flags+=("--cert-dir=")
+    flags+=("--get-login")
+    local_nonpersistent_flags+=("--get-login")
+    flags+=("--password=")
+    two_word_flags+=("--password")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--password=")
+    flags+=("--password-stdin")
+    local_nonpersistent_flags+=("--password-stdin")
+    flags+=("--tls-verify")
+    local_nonpersistent_flags+=("--tls-verify")
+    flags+=("--username=")
+    two_word_flags+=("--username")
+    two_word_flags+=("-u")
+    local_nonpersistent_flags+=("--username=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_logout()
+{
+    last_command="podman_logout"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_logs()
+{
+    last_command="podman_logs"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--follow")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--follow")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--since=")
+    two_word_flags+=("--since")
+    local_nonpersistent_flags+=("--since=")
+    flags+=("--tail=")
+    two_word_flags+=("--tail")
+    local_nonpersistent_flags+=("--tail=")
+    flags+=("--timestamps")
+    flags+=("-t")
+    local_nonpersistent_flags+=("--timestamps")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_mount()
+{
+    last_command="podman_mount"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--notruncate")
+    local_nonpersistent_flags+=("--notruncate")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_network_create()
+{
+    last_command="podman_network_create"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--disable-dns")
+    local_nonpersistent_flags+=("--disable-dns")
+    flags+=("--driver=")
+    two_word_flags+=("--driver")
+    two_word_flags+=("-d")
+    local_nonpersistent_flags+=("--driver=")
+    flags+=("--gateway=")
+    two_word_flags+=("--gateway")
+    local_nonpersistent_flags+=("--gateway=")
+    flags+=("--internal")
+    local_nonpersistent_flags+=("--internal")
+    flags+=("--ip-range=")
+    two_word_flags+=("--ip-range")
+    local_nonpersistent_flags+=("--ip-range=")
+    flags+=("--macvlan=")
+    two_word_flags+=("--macvlan")
+    local_nonpersistent_flags+=("--macvlan=")
+    flags+=("--subnet=")
+    two_word_flags+=("--subnet")
+    local_nonpersistent_flags+=("--subnet=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_network_inspect()
+{
+    last_command="podman_network_inspect"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_network_ls()
+{
+    last_command="podman_network_ls"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_network_rm()
+{
+    last_command="podman_network_rm"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_network()
+{
+    last_command="podman_network"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("create")
+    commands+=("inspect")
+    commands+=("ls")
+    commands+=("rm")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pause()
+{
+    last_command="podman_pause"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_play_kube()
+{
+    last_command="podman_play_kube"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--cert-dir=")
+    two_word_flags+=("--cert-dir")
+    local_nonpersistent_flags+=("--cert-dir=")
+    flags+=("--creds=")
+    two_word_flags+=("--creds")
+    local_nonpersistent_flags+=("--creds=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--seccomp-profile-root=")
+    two_word_flags+=("--seccomp-profile-root")
+    local_nonpersistent_flags+=("--seccomp-profile-root=")
+    flags+=("--tls-verify")
+    local_nonpersistent_flags+=("--tls-verify")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_play()
+{
+    last_command="podman_play"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("kube")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_create()
+{
+    last_command="podman_pod_create"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-parent=")
+    two_word_flags+=("--cgroup-parent")
+    local_nonpersistent_flags+=("--cgroup-parent=")
+    flags+=("--hostname=")
+    two_word_flags+=("--hostname")
+    local_nonpersistent_flags+=("--hostname=")
+    flags+=("--infra")
+    local_nonpersistent_flags+=("--infra")
+    flags+=("--infra-command=")
+    two_word_flags+=("--infra-command")
+    local_nonpersistent_flags+=("--infra-command=")
+    flags+=("--infra-image=")
+    two_word_flags+=("--infra-image")
+    local_nonpersistent_flags+=("--infra-image=")
+    flags+=("--label=")
+    two_word_flags+=("--label")
+    two_word_flags+=("-l")
+    local_nonpersistent_flags+=("--label=")
+    flags+=("--label-file=")
+    two_word_flags+=("--label-file")
+    local_nonpersistent_flags+=("--label-file=")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name=")
+    flags+=("--pod-id-file=")
+    two_word_flags+=("--pod-id-file")
+    local_nonpersistent_flags+=("--pod-id-file=")
+    flags+=("--publish=")
+    two_word_flags+=("--publish")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--publish=")
+    flags+=("--share=")
+    two_word_flags+=("--share")
+    local_nonpersistent_flags+=("--share=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_exists()
+{
+    last_command="podman_pod_exists"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_inspect()
+{
+    last_command="podman_pod_inspect"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_kill()
+{
+    last_command="podman_pod_kill"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--signal=")
+    two_word_flags+=("--signal")
+    two_word_flags+=("-s")
+    local_nonpersistent_flags+=("--signal=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_pause()
+{
+    last_command="podman_pod_pause"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_prune()
+{
+    last_command="podman_pod_prune"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_ps()
+{
+    last_command="podman_pod_ps"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--ctr-ids")
+    local_nonpersistent_flags+=("--ctr-ids")
+    flags+=("--ctr-names")
+    local_nonpersistent_flags+=("--ctr-names")
+    flags+=("--ctr-status")
+    local_nonpersistent_flags+=("--ctr-status")
+    flags+=("--filter=")
+    two_word_flags+=("--filter")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--filter=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--no-trunc")
+    local_nonpersistent_flags+=("--no-trunc")
+    flags+=("--ns")
+    local_nonpersistent_flags+=("--ns")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--sort=")
+    two_word_flags+=("--sort")
+    local_nonpersistent_flags+=("--sort=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_restart()
+{
+    last_command="podman_pod_restart"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_rm()
+{
+    last_command="podman_pod_rm"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--ignore")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--ignore")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_start()
+{
+    last_command="podman_pod_start"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_stats()
+{
+    last_command="podman_pod_stats"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--no-reset")
+    local_nonpersistent_flags+=("--no-reset")
+    flags+=("--no-stream")
+    local_nonpersistent_flags+=("--no-stream")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_stop()
+{
+    last_command="podman_pod_stop"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--ignore")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--ignore")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--timeout=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_top()
+{
+    last_command="podman_pod_top"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--latest,")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest,")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod_unpause()
+{
+    last_command="podman_pod_unpause"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pod()
+{
+    last_command="podman_pod"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("create")
+    commands+=("exists")
+    commands+=("inspect")
+    commands+=("kill")
+    commands+=("pause")
+    commands+=("prune")
+    commands+=("ps")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("list")
+        aliashash["list"]="ps"
+        command_aliases+=("ls")
+        aliashash["ls"]="ps"
+    fi
+    commands+=("restart")
+    commands+=("rm")
+    commands+=("start")
+    commands+=("stats")
+    commands+=("stop")
+    commands+=("top")
+    commands+=("unpause")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_port()
+{
+    last_command="podman_port"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_ps()
+{
+    last_command="podman_ps"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--filter=")
+    two_word_flags+=("--filter")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--filter=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--last=")
+    two_word_flags+=("--last")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--last=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--no-trunc")
+    local_nonpersistent_flags+=("--no-trunc")
+    flags+=("--ns")
+    local_nonpersistent_flags+=("--ns")
+    flags+=("--pod")
+    flags+=("-p")
+    local_nonpersistent_flags+=("--pod")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--size")
+    flags+=("-s")
+    local_nonpersistent_flags+=("--size")
+    flags+=("--sort=")
+    two_word_flags+=("--sort")
+    local_nonpersistent_flags+=("--sort=")
+    flags+=("--sync")
+    local_nonpersistent_flags+=("--sync")
+    flags+=("--watch=")
+    two_word_flags+=("--watch")
+    two_word_flags+=("-w")
+    local_nonpersistent_flags+=("--watch=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_pull()
+{
+    last_command="podman_pull"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all-tags")
+    local_nonpersistent_flags+=("--all-tags")
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--cert-dir=")
+    two_word_flags+=("--cert-dir")
+    local_nonpersistent_flags+=("--cert-dir=")
+    flags+=("--creds=")
+    two_word_flags+=("--creds")
+    local_nonpersistent_flags+=("--creds=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--tls-verify")
+    local_nonpersistent_flags+=("--tls-verify")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_push()
+{
+    last_command="podman_push"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--cert-dir=")
+    two_word_flags+=("--cert-dir")
+    local_nonpersistent_flags+=("--cert-dir=")
+    flags+=("--compress")
+    local_nonpersistent_flags+=("--compress")
+    flags+=("--creds=")
+    two_word_flags+=("--creds")
+    local_nonpersistent_flags+=("--creds=")
+    flags+=("--digestfile=")
+    two_word_flags+=("--digestfile")
+    local_nonpersistent_flags+=("--digestfile=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--remove-signatures")
+    local_nonpersistent_flags+=("--remove-signatures")
+    flags+=("--sign-by=")
+    two_word_flags+=("--sign-by")
+    local_nonpersistent_flags+=("--sign-by=")
+    flags+=("--tls-verify")
+    local_nonpersistent_flags+=("--tls-verify")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_restart()
+{
+    last_command="podman_restart"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--running")
+    local_nonpersistent_flags+=("--running")
+    flags+=("--time=")
+    two_word_flags+=("--time")
+    local_nonpersistent_flags+=("--time=")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--timeout=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_rm()
+{
+    last_command="podman_rm"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--cidfile=")
+    two_word_flags+=("--cidfile")
+    local_nonpersistent_flags+=("--cidfile=")
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--ignore")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--ignore")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--storage")
+    local_nonpersistent_flags+=("--storage")
+    flags+=("--volumes")
+    flags+=("-v")
+    local_nonpersistent_flags+=("--volumes")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_rmi()
+{
+    last_command="podman_rmi"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_run()
+{
+    last_command="podman_run"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--add-host=")
+    two_word_flags+=("--add-host")
+    local_nonpersistent_flags+=("--add-host=")
+    flags+=("--annotation=")
+    two_word_flags+=("--annotation")
+    local_nonpersistent_flags+=("--annotation=")
+    flags+=("--attach=")
+    two_word_flags+=("--attach")
+    two_word_flags+=("-a")
+    local_nonpersistent_flags+=("--attach=")
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--blkio-weight=")
+    two_word_flags+=("--blkio-weight")
+    local_nonpersistent_flags+=("--blkio-weight=")
+    flags+=("--blkio-weight-device=")
+    two_word_flags+=("--blkio-weight-device")
+    local_nonpersistent_flags+=("--blkio-weight-device=")
+    flags+=("--cap-add=")
+    two_word_flags+=("--cap-add")
+    local_nonpersistent_flags+=("--cap-add=")
+    flags+=("--cap-drop=")
+    two_word_flags+=("--cap-drop")
+    local_nonpersistent_flags+=("--cap-drop=")
+    flags+=("--cgroup-parent=")
+    two_word_flags+=("--cgroup-parent")
+    local_nonpersistent_flags+=("--cgroup-parent=")
+    flags+=("--cgroupns=")
+    two_word_flags+=("--cgroupns")
+    local_nonpersistent_flags+=("--cgroupns=")
+    flags+=("--cgroups=")
+    two_word_flags+=("--cgroups")
+    local_nonpersistent_flags+=("--cgroups=")
+    flags+=("--cidfile=")
+    two_word_flags+=("--cidfile")
+    local_nonpersistent_flags+=("--cidfile=")
+    flags+=("--conmon-pidfile=")
+    two_word_flags+=("--conmon-pidfile")
+    local_nonpersistent_flags+=("--conmon-pidfile=")
+    flags+=("--cpu-period=")
+    two_word_flags+=("--cpu-period")
+    local_nonpersistent_flags+=("--cpu-period=")
+    flags+=("--cpu-quota=")
+    two_word_flags+=("--cpu-quota")
+    local_nonpersistent_flags+=("--cpu-quota=")
+    flags+=("--cpu-rt-period=")
+    two_word_flags+=("--cpu-rt-period")
+    local_nonpersistent_flags+=("--cpu-rt-period=")
+    flags+=("--cpu-rt-runtime=")
+    two_word_flags+=("--cpu-rt-runtime")
+    local_nonpersistent_flags+=("--cpu-rt-runtime=")
+    flags+=("--cpu-shares=")
+    two_word_flags+=("--cpu-shares")
+    local_nonpersistent_flags+=("--cpu-shares=")
+    flags+=("--cpus=")
+    two_word_flags+=("--cpus")
+    local_nonpersistent_flags+=("--cpus=")
+    flags+=("--cpuset-cpus=")
+    two_word_flags+=("--cpuset-cpus")
+    local_nonpersistent_flags+=("--cpuset-cpus=")
+    flags+=("--cpuset-mems=")
+    two_word_flags+=("--cpuset-mems")
+    local_nonpersistent_flags+=("--cpuset-mems=")
+    flags+=("--detach")
+    flags+=("-d")
+    local_nonpersistent_flags+=("--detach")
+    flags+=("--detach-keys=")
+    two_word_flags+=("--detach-keys")
+    local_nonpersistent_flags+=("--detach-keys=")
+    flags+=("--device=")
+    two_word_flags+=("--device")
+    local_nonpersistent_flags+=("--device=")
+    flags+=("--device-read-bps=")
+    two_word_flags+=("--device-read-bps")
+    local_nonpersistent_flags+=("--device-read-bps=")
+    flags+=("--device-read-iops=")
+    two_word_flags+=("--device-read-iops")
+    local_nonpersistent_flags+=("--device-read-iops=")
+    flags+=("--device-write-bps=")
+    two_word_flags+=("--device-write-bps")
+    local_nonpersistent_flags+=("--device-write-bps=")
+    flags+=("--device-write-iops=")
+    two_word_flags+=("--device-write-iops")
+    local_nonpersistent_flags+=("--device-write-iops=")
+    flags+=("--dns=")
+    two_word_flags+=("--dns")
+    local_nonpersistent_flags+=("--dns=")
+    flags+=("--dns-opt=")
+    two_word_flags+=("--dns-opt")
+    local_nonpersistent_flags+=("--dns-opt=")
+    flags+=("--dns-search=")
+    two_word_flags+=("--dns-search")
+    local_nonpersistent_flags+=("--dns-search=")
+    flags+=("--entrypoint=")
+    two_word_flags+=("--entrypoint")
+    local_nonpersistent_flags+=("--entrypoint=")
+    flags+=("--env=")
+    two_word_flags+=("--env")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--env=")
+    flags+=("--env-file=")
+    two_word_flags+=("--env-file")
+    local_nonpersistent_flags+=("--env-file=")
+    flags+=("--env-host")
+    local_nonpersistent_flags+=("--env-host")
+    flags+=("--expose=")
+    two_word_flags+=("--expose")
+    local_nonpersistent_flags+=("--expose=")
+    flags+=("--gidmap=")
+    two_word_flags+=("--gidmap")
+    local_nonpersistent_flags+=("--gidmap=")
+    flags+=("--group-add=")
+    two_word_flags+=("--group-add")
+    local_nonpersistent_flags+=("--group-add=")
+    flags+=("--health-cmd=")
+    two_word_flags+=("--health-cmd")
+    local_nonpersistent_flags+=("--health-cmd=")
+    flags+=("--health-interval=")
+    two_word_flags+=("--health-interval")
+    local_nonpersistent_flags+=("--health-interval=")
+    flags+=("--health-retries=")
+    two_word_flags+=("--health-retries")
+    local_nonpersistent_flags+=("--health-retries=")
+    flags+=("--health-start-period=")
+    two_word_flags+=("--health-start-period")
+    local_nonpersistent_flags+=("--health-start-period=")
+    flags+=("--health-timeout=")
+    two_word_flags+=("--health-timeout")
+    local_nonpersistent_flags+=("--health-timeout=")
+    flags+=("--hostname=")
+    two_word_flags+=("--hostname")
+    two_word_flags+=("-h")
+    local_nonpersistent_flags+=("--hostname=")
+    flags+=("--http-proxy")
+    local_nonpersistent_flags+=("--http-proxy")
+    flags+=("--image-volume=")
+    two_word_flags+=("--image-volume")
+    local_nonpersistent_flags+=("--image-volume=")
+    flags+=("--init")
+    local_nonpersistent_flags+=("--init")
+    flags+=("--init-path=")
+    two_word_flags+=("--init-path")
+    local_nonpersistent_flags+=("--init-path=")
+    flags+=("--interactive")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--interactive")
+    flags+=("--ip=")
+    two_word_flags+=("--ip")
+    local_nonpersistent_flags+=("--ip=")
+    flags+=("--ipc=")
+    two_word_flags+=("--ipc")
+    local_nonpersistent_flags+=("--ipc=")
+    flags+=("--kernel-memory=")
+    two_word_flags+=("--kernel-memory")
+    local_nonpersistent_flags+=("--kernel-memory=")
+    flags+=("--label=")
+    two_word_flags+=("--label")
+    two_word_flags+=("-l")
+    local_nonpersistent_flags+=("--label=")
+    flags+=("--label-file=")
+    two_word_flags+=("--label-file")
+    local_nonpersistent_flags+=("--label-file=")
+    flags+=("--log-driver=")
+    two_word_flags+=("--log-driver")
+    local_nonpersistent_flags+=("--log-driver=")
+    flags+=("--log-opt=")
+    two_word_flags+=("--log-opt")
+    local_nonpersistent_flags+=("--log-opt=")
+    flags+=("--mac-address=")
+    two_word_flags+=("--mac-address")
+    local_nonpersistent_flags+=("--mac-address=")
+    flags+=("--memory=")
+    two_word_flags+=("--memory")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--memory=")
+    flags+=("--memory-reservation=")
+    two_word_flags+=("--memory-reservation")
+    local_nonpersistent_flags+=("--memory-reservation=")
+    flags+=("--memory-swap=")
+    two_word_flags+=("--memory-swap")
+    local_nonpersistent_flags+=("--memory-swap=")
+    flags+=("--memory-swappiness=")
+    two_word_flags+=("--memory-swappiness")
+    local_nonpersistent_flags+=("--memory-swappiness=")
+    flags+=("--mount=")
+    two_word_flags+=("--mount")
+    local_nonpersistent_flags+=("--mount=")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    local_nonpersistent_flags+=("--name=")
+    flags+=("--net=")
+    two_word_flags+=("--net")
+    local_nonpersistent_flags+=("--net=")
+    flags+=("--network=")
+    two_word_flags+=("--network")
+    local_nonpersistent_flags+=("--network=")
+    flags+=("--no-hosts")
+    local_nonpersistent_flags+=("--no-hosts")
+    flags+=("--oom-kill-disable")
+    local_nonpersistent_flags+=("--oom-kill-disable")
+    flags+=("--oom-score-adj=")
+    two_word_flags+=("--oom-score-adj")
+    local_nonpersistent_flags+=("--oom-score-adj=")
+    flags+=("--pid=")
+    two_word_flags+=("--pid")
+    local_nonpersistent_flags+=("--pid=")
+    flags+=("--pids-limit=")
+    two_word_flags+=("--pids-limit")
+    local_nonpersistent_flags+=("--pids-limit=")
+    flags+=("--pod=")
+    two_word_flags+=("--pod")
+    local_nonpersistent_flags+=("--pod=")
+    flags+=("--privileged")
+    local_nonpersistent_flags+=("--privileged")
+    flags+=("--publish=")
+    two_word_flags+=("--publish")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--publish=")
+    flags+=("--publish-all")
+    flags+=("-P")
+    local_nonpersistent_flags+=("--publish-all")
+    flags+=("--pull=")
+    two_word_flags+=("--pull")
+    local_nonpersistent_flags+=("--pull=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--read-only")
+    local_nonpersistent_flags+=("--read-only")
+    flags+=("--read-only-tmpfs")
+    local_nonpersistent_flags+=("--read-only-tmpfs")
+    flags+=("--restart=")
+    two_word_flags+=("--restart")
+    local_nonpersistent_flags+=("--restart=")
+    flags+=("--rm")
+    local_nonpersistent_flags+=("--rm")
+    flags+=("--rootfs")
+    local_nonpersistent_flags+=("--rootfs")
+    flags+=("--security-opt=")
+    two_word_flags+=("--security-opt")
+    local_nonpersistent_flags+=("--security-opt=")
+    flags+=("--shm-size=")
+    two_word_flags+=("--shm-size")
+    local_nonpersistent_flags+=("--shm-size=")
+    flags+=("--sig-proxy")
+    local_nonpersistent_flags+=("--sig-proxy")
+    flags+=("--stop-signal=")
+    two_word_flags+=("--stop-signal")
+    local_nonpersistent_flags+=("--stop-signal=")
+    flags+=("--stop-timeout=")
+    two_word_flags+=("--stop-timeout")
+    local_nonpersistent_flags+=("--stop-timeout=")
+    flags+=("--subgidname=")
+    two_word_flags+=("--subgidname")
+    local_nonpersistent_flags+=("--subgidname=")
+    flags+=("--subuidname=")
+    two_word_flags+=("--subuidname")
+    local_nonpersistent_flags+=("--subuidname=")
+    flags+=("--sysctl=")
+    two_word_flags+=("--sysctl")
+    local_nonpersistent_flags+=("--sysctl=")
+    flags+=("--systemd=")
+    two_word_flags+=("--systemd")
+    local_nonpersistent_flags+=("--systemd=")
+    flags+=("--tmpfs=")
+    two_word_flags+=("--tmpfs")
+    local_nonpersistent_flags+=("--tmpfs=")
+    flags+=("--tty")
+    flags+=("-t")
+    local_nonpersistent_flags+=("--tty")
+    flags+=("--uidmap=")
+    two_word_flags+=("--uidmap")
+    local_nonpersistent_flags+=("--uidmap=")
+    flags+=("--ulimit=")
+    two_word_flags+=("--ulimit")
+    local_nonpersistent_flags+=("--ulimit=")
+    flags+=("--user=")
+    two_word_flags+=("--user")
+    two_word_flags+=("-u")
+    local_nonpersistent_flags+=("--user=")
+    flags+=("--userns=")
+    two_word_flags+=("--userns")
+    local_nonpersistent_flags+=("--userns=")
+    flags+=("--uts=")
+    two_word_flags+=("--uts")
+    local_nonpersistent_flags+=("--uts=")
+    flags+=("--volume=")
+    two_word_flags+=("--volume")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--volume=")
+    flags+=("--volumes-from=")
+    two_word_flags+=("--volumes-from")
+    local_nonpersistent_flags+=("--volumes-from=")
+    flags+=("--workdir=")
+    two_word_flags+=("--workdir")
+    two_word_flags+=("-w")
+    local_nonpersistent_flags+=("--workdir=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_save()
+{
+    last_command="podman_save"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--compress")
+    local_nonpersistent_flags+=("--compress")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--output=")
+    two_word_flags+=("--output")
+    two_word_flags+=("-o")
+    local_nonpersistent_flags+=("--output=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_search()
+{
+    last_command="podman_search"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--authfile=")
+    two_word_flags+=("--authfile")
+    local_nonpersistent_flags+=("--authfile=")
+    flags+=("--filter=")
+    two_word_flags+=("--filter")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--filter=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--limit=")
+    two_word_flags+=("--limit")
+    local_nonpersistent_flags+=("--limit=")
+    flags+=("--no-trunc")
+    local_nonpersistent_flags+=("--no-trunc")
+    flags+=("--tls-verify")
+    local_nonpersistent_flags+=("--tls-verify")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_start()
+{
+    last_command="podman_start"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--attach")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--attach")
+    flags+=("--detach-keys=")
+    two_word_flags+=("--detach-keys")
+    local_nonpersistent_flags+=("--detach-keys=")
+    flags+=("--interactive")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--interactive")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--sig-proxy")
+    local_nonpersistent_flags+=("--sig-proxy")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_stats()
+{
+    last_command="podman_stats"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--no-reset")
+    local_nonpersistent_flags+=("--no-reset")
+    flags+=("--no-stream")
+    local_nonpersistent_flags+=("--no-stream")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_stop()
+{
+    last_command="podman_stop"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--cidfile=")
+    two_word_flags+=("--cidfile")
+    local_nonpersistent_flags+=("--cidfile=")
+    flags+=("--ignore")
+    flags+=("-i")
+    local_nonpersistent_flags+=("--ignore")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--time=")
+    two_word_flags+=("--time")
+    local_nonpersistent_flags+=("--time=")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--timeout=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_system_df()
+{
+    last_command="podman_system_df"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--verbose")
+    flags+=("-v")
+    local_nonpersistent_flags+=("--verbose")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_system_info()
+{
+    last_command="podman_system_info"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--debug")
+    flags+=("-D")
+    local_nonpersistent_flags+=("--debug")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_system_migrate()
+{
+    last_command="podman_system_migrate"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--new-runtime=")
+    two_word_flags+=("--new-runtime")
+    local_nonpersistent_flags+=("--new-runtime=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_system_prune()
+{
+    last_command="podman_system_prune"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--volumes")
+    local_nonpersistent_flags+=("--volumes")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_system_renumber()
+{
+    last_command="podman_system_renumber"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_system_reset()
+{
+    last_command="podman_system_reset"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_system()
+{
+    last_command="podman_system"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("df")
+    commands+=("info")
+    commands+=("migrate")
+    commands+=("prune")
+    commands+=("renumber")
+    commands+=("reset")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_tag()
+{
+    last_command="podman_tag"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_top()
+{
+    last_command="podman_top"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_umount()
+{
+    last_command="podman_umount"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_unpause()
+{
+    last_command="podman_unpause"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_unshare()
+{
+    last_command="podman_unshare"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_varlink()
+{
+    last_command="podman_varlink"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--timeout=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_version()
+{
+    last_command="podman_version"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_volume_create()
+{
+    last_command="podman_volume_create"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--driver=")
+    two_word_flags+=("--driver")
+    local_nonpersistent_flags+=("--driver=")
+    flags+=("--label=")
+    two_word_flags+=("--label")
+    two_word_flags+=("-l")
+    local_nonpersistent_flags+=("--label=")
+    flags+=("--opt=")
+    two_word_flags+=("--opt")
+    two_word_flags+=("-o")
+    local_nonpersistent_flags+=("--opt=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_volume_inspect()
+{
+    last_command="podman_volume_inspect"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_volume_ls()
+{
+    last_command="podman_volume_ls"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--filter=")
+    two_word_flags+=("--filter")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--filter=")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--quiet")
+    flags+=("-q")
+    local_nonpersistent_flags+=("--quiet")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_volume_prune()
+{
+    last_command="podman_volume_prune"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_volume_rm()
+{
+    last_command="podman_volume_rm"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    flags+=("-a")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--force")
+    flags+=("-f")
+    local_nonpersistent_flags+=("--force")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_volume()
+{
+    last_command="podman_volume"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("create")
+    commands+=("inspect")
+    commands+=("ls")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("list")
+        aliashash["list"]="ls"
+    fi
+    commands+=("prune")
+    commands+=("rm")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("remove")
+        aliashash["remove"]="rm"
+    fi
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_wait()
+{
+    last_command="podman_wait"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--interval=")
+    two_word_flags+=("--interval")
+    two_word_flags+=("-i")
+    local_nonpersistent_flags+=("--interval=")
+    flags+=("--latest")
+    flags+=("-l")
+    local_nonpersistent_flags+=("--latest")
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_podman_root_command()
+{
+    last_command="podman"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("attach")
+    commands+=("build")
+    commands+=("commit")
+    commands+=("container")
+    commands+=("cp")
+    commands+=("create")
+    commands+=("diff")
+    commands+=("events")
+    commands+=("exec")
+    commands+=("export")
+    commands+=("generate")
+    commands+=("healthcheck")
+    commands+=("history")
+    commands+=("image")
+    commands+=("images")
+    commands+=("import")
+    commands+=("info")
+    commands+=("init")
+    commands+=("inspect")
+    commands+=("kill")
+    commands+=("load")
+    commands+=("login")
+    commands+=("logout")
+    commands+=("logs")
+    commands+=("mount")
+    commands+=("network")
+    commands+=("pause")
+    commands+=("play")
+    commands+=("pod")
+    commands+=("port")
+    commands+=("ps")
+    commands+=("pull")
+    commands+=("push")
+    commands+=("restart")
+    commands+=("rm")
+    commands+=("rmi")
+    commands+=("run")
+    commands+=("save")
+    commands+=("search")
+    commands+=("start")
+    commands+=("stats")
+    commands+=("stop")
+    commands+=("system")
+    commands+=("tag")
+    commands+=("top")
+    commands+=("umount")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("unmount")
+        aliashash["unmount"]="umount"
+    fi
+    commands+=("unpause")
+    commands+=("unshare")
+    commands+=("varlink")
+    commands+=("version")
+    commands+=("volume")
+    commands+=("wait")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cgroup-manager=")
+    two_word_flags+=("--cgroup-manager")
+    flags+=("--cni-config-dir=")
+    two_word_flags+=("--cni-config-dir")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--conmon=")
+    two_word_flags+=("--conmon")
+    flags+=("--cpu-profile=")
+    two_word_flags+=("--cpu-profile")
+    flags+=("--events-backend=")
+    two_word_flags+=("--events-backend")
+    flags+=("--help")
+    flags+=("--hooks-dir=")
+    two_word_flags+=("--hooks-dir")
+    flags+=("--log-level=")
+    two_word_flags+=("--log-level")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    flags+=("--network-cmd-path=")
+    two_word_flags+=("--network-cmd-path")
+    flags+=("--root=")
+    two_word_flags+=("--root")
+    flags+=("--runroot=")
+    two_word_flags+=("--runroot")
+    flags+=("--runtime=")
+    two_word_flags+=("--runtime")
+    flags+=("--storage-driver=")
+    two_word_flags+=("--storage-driver")
+    flags+=("--storage-opt=")
+    two_word_flags+=("--storage-opt")
+    flags+=("--syslog")
+    flags+=("--tmpdir=")
+    two_word_flags+=("--tmpdir")
+    flags+=("--trace")
+    flags+=("--version")
+    flags+=("-v")
+    local_nonpersistent_flags+=("--version")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+__start_podman()
+{
+    local cur prev words cword
+    declare -A flaghash 2>/dev/null || :
+    declare -A aliashash 2>/dev/null || :
+    if declare -F _init_completion >/dev/null 2>&1; then
+        _init_completion -s || return
+    else
+        __podman_init_completion -n "=" || return
+    fi
+
+    local c=0
+    local flags=()
+    local two_word_flags=()
+    local local_nonpersistent_flags=()
+    local flags_with_completion=()
+    local flags_completion=()
+    local commands=("podman")
+    local must_have_one_flag=()
+    local must_have_one_noun=()
+    local last_command
+    local nouns=()
+
+    __podman_handle_word
+}
+
+if [[ $(type -t compopt) = "builtin" ]]; then
+    complete -o default -F __start_podman podman
+else
+    complete -o default -o nospace -F __start_podman podman
+fi
+
+# ex: ts=4 sw=4 et filetype=sh


### PR DESCRIPTION
I added a command completion that generates
the shell scripts that would enable the shell
completion, using the cobra function `GenBash/ZshCompletion`.

Closes #3878

```shell
[vagrant@localhost libpod]$ podman build -f Dockerfile[tab][tab]
Dockerfile         Dockerfile.centos  Dockerfile.fedora
```
Signed-off-by: Neville Cain <neville.cain@qonto.eu>