### PR TITLE
Add the rmi flag to podman-run to delete container image

### DIFF
--- a/cmd/podman/cleanup.go
+++ b/cmd/podman/cleanup.go
@@ -44,6 +44,7 @@ func init() {
 	flags.BoolVarP(&cleanupCommand.All, "all", "a", false, "Cleans up all containers")
 	flags.BoolVarP(&cleanupCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&cleanupCommand.Remove, "rm", false, "After cleanup, remove the container entirely")
+	flags.BoolVar(&cleanupCommand.RemoveImage, "rmi", false, "After cleanup, remove the image entirely")
 	markFlagHiddenForRemoteClient("latest", flags)
 }
 

--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -658,9 +658,10 @@ type VolumeRmValues struct {
 
 type CleanupValues struct {
 	PodmanCommand
-	All    bool
-	Latest bool
-	Remove bool
+	All         bool
+	Latest      bool
+	Remove      bool
+	RemoveImage bool
 }
 
 type SystemPruneValues struct {

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1967,6 +1967,7 @@ _podman_container_run() {
 		boolean_options="$boolean_options
 			--detach -d
 			--rm
+			--rmi
 			--sig-proxy=false
 		"
 		__podman_complete_detach_keys && return

--- a/docs/source/markdown/podman-container-cleanup.1.md
+++ b/docs/source/markdown/podman-container-cleanup.1.md
@@ -22,6 +22,14 @@ to run containers such as CRI-O, the last started container could be from either
 
 The latest option is not supported on the remote client.
 
+**--rm**
+
+After cleanup, remove the container entirely.
+
+**--rmi**
+
+After cleanup, remove the image entirely.
+
 ## EXAMPLE
 
 `podman container cleanup mywebserver`

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -689,6 +689,11 @@ Note that the container will not be removed when it could not be created or
 started successfully. This allows the user to inspect the container after
 failure.
 
+**--rmi**=*true|false*
+
+After exit of the container, remove the image unless another
+container is using it. The default is *false*.
+
 **--rootfs**
 
 If specified, the first argument refers to an exploded container on the file system.

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -156,6 +156,7 @@ type CreateConfig struct {
 	Resources         CreateResourceConfig
 	RestartPolicy     string
 	Rm                bool           //rm
+	Rmi               bool           //rmi
 	StopSignal        syscall.Signal // stop-signal
 	StopTimeout       uint           // stop-timeout
 	Systemd           bool
@@ -231,6 +232,10 @@ func (c *CreateConfig) createExitCommand(runtime *libpod.Runtime) ([]string, err
 
 	if c.Rm {
 		command = append(command, "--rm")
+	}
+
+	if c.Rmi {
+		command = append(command, "--rmi")
 	}
 
 	return command, nil

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -136,4 +136,21 @@ echo $rand        |   0 | $rand
     run_podman rmi busybox
 }
 
+# 'run --rmi' deletes the image in the end unless it's used by another container.
+@test "podman run --rmi - remove image" {
+    skip_if_remote "podman-remote does not emit 'Trying to pull' msgs"
+    run_podman 0 run --rmi --rm redis /bin/true
+    run_podman 1 image exists redis
+}
+
+
+@test "podman run --rmi - not remove image" {
+    skip_if_remote "podman-remote does not emit 'Trying to pull' msgs"
+    run_podman run redis /bin/true
+    run_podman images | grep redis
+    run_podman run --rmi --rm redis /bin/true
+    run_podman images | grep redis
+    run_podman 0 rm -a
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
The --rmi flag will delete the container image after its execution unless that image is already been used by another container(s).

This is useful when one wants to execute a container once and remove any resources attached to it.

closes #4628 
