### PR TITLE
fix bug copy from container directory

### DIFF
--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -222,7 +222,7 @@ func copyBetweenHostAndContainer(runtime *libpod.Runtime, src string, dest strin
 		srcPath = os.Stdin.Name()
 		extract = true
 	}
-	return copy(srcPath, destPath, dest, idMappingOpts, &destOwner, extract, isFromHostToCtr)
+	return copy(srcPath, destPath, src, dest, idMappingOpts, &destOwner, extract, isFromHostToCtr)
 }
 
 func getUser(mountPoint string, userspec string) (specs.User, error) {
@@ -276,8 +276,8 @@ func getPathInfo(path string) (string, os.FileInfo, error) {
 	return path, srcfi, nil
 }
 
-func copy(src, destPath, dest string, idMappingOpts storage.IDMappingOptions, chownOpts *idtools.IDPair, extract, isFromHostToCtr bool) error {
-	srcPath, err := evalSymlinks(src)
+func copy(srcPath, destPath, src, dest string, idMappingOpts storage.IDMappingOptions, chownOpts *idtools.IDPair, extract, isFromHostToCtr bool) error {
+	srcPath, err := evalSymlinks(srcPath)
 	if err != nil {
 		return errors.Wrapf(err, "error evaluating symlinks %q", srcPath)
 	}

--- a/test/e2e/cp_test.go
+++ b/test/e2e/cp_test.go
@@ -112,6 +112,33 @@ var _ = Describe("Podman cp", func() {
 		session = podmanTest.Podman([]string{"cp", testDirPath, name + ":/foodir"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+
+		testctr := "testctr"
+		setup := podmanTest.RunTopContainer(testctr)
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"exec", testctr, "mkdir", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"cp", testDirPath + "/.", testctr + ":/foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"exec", testctr, "ls", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(len(session.OutputToString())).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"cp", testctr + ":/foo/.", testDirPath})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		cmd := exec.Command("ls", testDirPath)
+		res, err := cmd.Output()
+		Expect(err).To(BeNil())
+		Expect(len(res)).To(Equal(0))
+
+		os.RemoveAll(testDirPath)
 	})
 
 	It("podman cp stdin/stdout", func() {


### PR DESCRIPTION
fix #4717 
Keep the original input source path with "/." so podman can copy the content of the directory when copying from container to host.

Signed-off-by: Qi Wang <qiwan@redhat.com>