### PR TITLE
Fix presentation of man page tables

### DIFF
--- a/docs/source/markdown/podman-history.1.md
+++ b/docs/source/markdown/podman-history.1.md
@@ -22,7 +22,7 @@ Valid placeholders for the Go template are listed below:
 | **Placeholder** | **Description**                                                               |
 | --------------- | ----------------------------------------------------------------------------- |
 | .ID             | Image ID                                                                      |
-| .Created        | if **--human**, time elapsed since creation, otherwise time stamp of creation |
+| .Created        | if --human, time elapsed since creation, otherwise time stamp of creation     |
 | .CreatedBy      | Command used to create the layer                                              |
 | .Size           | Size of layer on disk                                                         |
 | .Comment        | Comment for the layer                                                         |

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -105,7 +105,7 @@ Valid filters are listed below:
 | name            | [Name] Container's name                                                          |
 | label           | [Key] or [Key=Value] Label assigned to a container                               |
 | exited          | [Int] Container's exit code                                                      |
-| status          | [Status] Container's status: *created*, *exited*, *paused*, *running*, *unknown* |
+| status          | [Status] Container's status: 'created', 'exited', 'paused', 'running', 'unknown' |
 | ancestor        | [ImageName] Image or descendant used to create container                         |
 | before          | [ID] or [Name] Containers created before this container                          |
 | since           | [ID] or [Name] Containers created since this container                           |


### PR DESCRIPTION
Currently the use of "*" in tables is causing go-md2man
to screw up the format of the man page.

This PR removes the "*" since it is not really necessary.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>