### PR TITLE
play kube: make seccomp handling better conform to k8s

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -308,12 +308,13 @@ type HealthCheckValues struct {
 
 type KubePlayValues struct {
 	PodmanCommand
-	Authfile        string
-	CertDir         string
-	Creds           string
-	Quiet           bool
-	SignaturePolicy string
-	TlsVerify       bool
+	Authfile           string
+	CertDir            string
+	Creds              string
+	Quiet              bool
+	SignaturePolicy    string
+	TlsVerify          bool
+	SeccompProfileRoot string
 }
 
 type PodCreateValues struct {

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -28,6 +28,8 @@ var (
 		},
 		Example: `podman play kube demo.yml`,
 	}
+	// https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
+	defaultSeccompRoot = "/var/lib/kubelet/seccomp"
 )
 
 func init() {
@@ -46,6 +48,7 @@ func init() {
 		flags.StringVar(&playKubeCommand.CertDir, "cert-dir", "", "`Pathname` of a directory containing TLS certificates and keys")
 		flags.StringVar(&playKubeCommand.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
 		flags.BoolVar(&playKubeCommand.TlsVerify, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+		flags.StringVar(&playKubeCommand.SeccompProfileRoot, "seccomp-profile-root", defaultSeccompRoot, "Directory path for seccomp profiles")
 		markFlagHidden(flags, "signature-policy")
 	}
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2672,6 +2672,7 @@ _podman_play_kube() {
     --quiet
     -q
     --tls-verify
+    --seccomp-profile-root
     "
 
     case "$cur" in

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -40,6 +40,10 @@ value can be entered.  The password is entered without echo.
 
 Suppress output information when pulling images
 
+**--seccomp-profile-root**=*path*
+
+Directory path for seccomp profiles (default: "/var/lib/kubelet/seccomp"). (Not available for remote commands)
+
 **--tls-verify**=*true|false*
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -358,10 +358,11 @@ var _ = Describe("Podman generate kube", func() {
 		ctrAnnotation := "container.seccomp.security.alpha.kubernetes.io/" + defaultCtrName
 		ctr := getCtr(withCmd([]string{"pwd"}))
 
-		err = generateKubeYaml(getPod(withCtr(ctr), withAnnotation(ctrAnnotation, "localhost:"+jsonFile)), kubeYaml)
+		err = generateKubeYaml(getPod(withCtr(ctr), withAnnotation(ctrAnnotation, "localhost/"+filepath.Base(jsonFile))), kubeYaml)
 		Expect(err).To(BeNil())
 
-		kube := podmanTest.Podman([]string{"play", "kube", kubeYaml})
+		// CreateSeccompJson will put the profile into podmanTest.TempDir. Use --seccomp-profile-root to tell play kube where to look
+		kube := podmanTest.Podman([]string{"play", "kube", "--seccomp-profile-root", podmanTest.TempDir, kubeYaml})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube.ExitCode()).To(Equal(0))
 
@@ -378,13 +379,15 @@ var _ = Describe("Podman generate kube", func() {
 			fmt.Println(err)
 			Skip("Failed to prepare seccomp.json for test.")
 		}
+		defer os.Remove(jsonFile)
 
 		ctr := getCtr(withCmd([]string{"pwd"}))
 
-		err = generateKubeYaml(getPod(withCtr(ctr), withAnnotation("seccomp.security.alpha.kubernetes.io/pod", "localhost:"+jsonFile)), kubeYaml)
+		err = generateKubeYaml(getPod(withCtr(ctr), withAnnotation("seccomp.security.alpha.kubernetes.io/pod", "localhost/"+filepath.Base(jsonFile))), kubeYaml)
 		Expect(err).To(BeNil())
 
-		kube := podmanTest.Podman([]string{"play", "kube", kubeYaml})
+		// CreateSeccompJson will put the profile into podmanTest.TempDir. Use --seccomp-profile-root to tell play kube where to look
+		kube := podmanTest.Podman([]string{"play", "kube", "--seccomp-profile-root", podmanTest.TempDir, kubeYaml})
 		kube.WaitWithDefaultTimeout()
 		Expect(kube.ExitCode()).To(Equal(0))
 


### PR DESCRIPTION
Add flag --seccomp-profile-root in play kube to allow users to specify where to look for seccomp profiles

fixes https://github.com/containers/libpod/issues/4555
Signed-off-by: Peter Hunt <pehunt@redhat.com>