### PR TITLE
packaging: validate installed rpms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -572,10 +572,13 @@ vendor-in-container:
 package:  ## Build rpm packages
 	## TODO(ssbarnea): make version number predictable, it should not change
 	## on each execution, producing duplicates.
-	rm -f  ~/rpmbuild/RPMS/x86_64/* ~/rpmbuild/RPMS/noarch/*
+	rm -rf build/* *.src.rpm ~/rpmbuild/RPMS/*
 	./contrib/build_rpm.sh
 
+# Remember that rpms install exec to /usr/bin/podman while a `make install`
+# installs them to /usr/local/bin/podman which is likely before. Always use
+# a full path to test installed podman or you risk to call another executable.
 package-install: package  ## Install rpm packages
-	sudo ${PKG_MANAGER} -y remove podman podman-remote
-	sudo ${PKG_MANAGER} -y clean all
 	sudo ${PKG_MANAGER} -y install ${HOME}/rpmbuild/RPMS/*/*.rpm
+	/usr/bin/podman version
+	/usr/bin/podman info  # will catch a broken conmon

--- a/contrib/build_rpm.sh
+++ b/contrib/build_rpm.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 # returned path can vary: /usr/bin/dnf /bin/dnf ...
-pkg_manager=`command -v dnf yum | head -n1`
+pkg_manager=$(command -v dnf yum | head -n1)
 echo "Package manager binary: $pkg_manager"
 
 
@@ -14,25 +14,32 @@ enabled=1
 gpgcheck=0" > /etc/yum.repos.d/container_virt.repo
 fi
 
-declare -a PKGS=(device-mapper-devel \
+declare -a PKGS=(\
+                createrepo \
+                device-mapper-devel \
                 git \
                 glib2-devel \
                 glibc-static \
+                go-compilers-golang-compiler \
                 golang \
                 gpgme-devel \
                 libassuan-devel \
                 libseccomp-devel \
                 libselinux-devel \
                 make \
+                redhat-rpm-config \
                 rpm-build \
-                go-compilers-golang-compiler \
+                rpmdevtools \
                 systemd-devel \
                 )
 
 if [[ $pkg_manager == *dnf ]]; then
     # We need to enable PowerTools if we want to get
     # install all the pkgs we define in PKGS
-    sudo dnf config-manager --set-enabled PowerTools
+    # PowerTools exists on centos-8 but not on fedora-30 and rhel-8
+    if (dnf -v -C repolist all|grep "Repo-id      : PowerTools" >/dev/null); then
+        sudo dnf config-manager --set-enabled PowerTools
+    fi
 
     PKGS+=(python3-devel \
         python3-varlink \
@@ -53,6 +60,9 @@ export extra_arg="--without doc --without debug"
 echo ${PKGS[*]}
 sudo $pkg_manager install -y ${PKGS[*]}
 
+# clean up src.rpm as it's been built
+sudo rm -f podman-*.src.rpm
+
 make -f .copr/Makefile
 # workaround for https://github.com/containers/libpod/issues/4627
 if [ -d ~/rpmbuild/BUILD ]; then
@@ -60,6 +70,3 @@ if [ -d ~/rpmbuild/BUILD ]; then
 fi
 
 rpmbuild --rebuild ${extra_arg:-} podman-*.src.rpm
-
-# clean up src.rpm as it's been built
-sudo rm -f podman-*.src.rpm


### PR DESCRIPTION
Previously we builded RPMs that contained an outdated conmon which was not compatible. From now on `make-install` will also call `podman version` and `podman info` in order to perform a minimal sanity check of the installation.

Fixes: #4665