### PR TITLE
(minor) fix broken links to container-policy.json.5

### DIFF
--- a/docs/source/markdown/podman-image-trust.1.md
+++ b/docs/source/markdown/podman-image-trust.1.md
@@ -86,7 +86,7 @@ Display trust as JSON
 
 ## SEE ALSO
 
-policy-json(5)
+containers-policy.json(5)
 
 ## HISTORY
 January 2019, updated by Tom Sweeney (tsweeney at redhat dot com)

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -271,7 +271,7 @@ The Network File System (NFS) and other distributed file systems (for example: L
 For more information, please refer to the [Podman Troubleshooting Page](https://github.com/containers/libpod/blob/master/troubleshooting.md).
 
 ## SEE ALSO
-`containers-mounts.conf(5)`, `containers-registries.conf(5)`, `containers-storage.conf(5)`, `buildah(1)`, `libpod.conf(5)`, `oci-hooks(5)`, `policy.json(5)`, `subuid(5)`, `subgid(5)`, `slirp4netns(1)`
+`containers-mounts.conf(5)`, `containers-registries.conf(5)`, `containers-storage.conf(5)`, `buildah(1)`, `libpod.conf(5)`, `oci-hooks(5)`, `containers-policy.json(5)`, `subuid(5)`, `subgid(5)`, `slirp4netns(1)`
 
 ## HISTORY
 Dec 2016, Originally compiled by Dan Walsh <dwalsh@redhat.com>


### PR DESCRIPTION
Two man pages had incorrect references to a nonexistent
policy.conf(5) or policy-conf(5) [dot vs dash]. Fix them.

Also checked for other broken references via:

   $ for i in registries.conf storage.conf policy.json ; do grep -R $i.5 docs/source | grep -v containers-$i;done

(No further results found. That's not a guarantee that there
aren't other broken links though).

Signed-off-by: Ed Santiago <santiago@redhat.com>