### PR TITLE
Fix golint errors

### DIFF
--- a/libpod/config/config.go
+++ b/libpod/config/config.go
@@ -72,7 +72,7 @@ const (
 // SetOptions contains a subset of options in a Config. It's used to indicate if
 // a given option has either been set by the user or by a parsed libpod
 // configuration file.  If not, the corresponding option might be overwritten by
-// values from the database.  This behavior guarantess backwards compat with
+// values from the database.  This behavior guarantees backwards compat with
 // older version of libpod and Podman.
 type SetOptions struct {
 	// StorageConfigRunRootSet indicates if the RunRoot has been explicitly set
@@ -119,7 +119,7 @@ type Config struct {
 	// SetOptions contains a subset of config options. It's used to indicate if
 	// a given option has either been set by the user or by a parsed libpod
 	// configuration file.  If not, the corresponding option might be
-	// overwritten by values from the database.  This behavior guarantess
+	// overwritten by values from the database.  This behavior guarantees
 	// backwards compat with older version of libpod and Podman.
 	SetOptions
 

--- a/libpod/config/config.go
+++ b/libpod/config/config.go
@@ -451,45 +451,47 @@ func NewConfig(userConfigPath string) (*Config, error) {
 	}
 
 	// Now, check if the user can access system configs and merge them if needed.
-	if configs, err := systemConfigs(); err != nil {
+	configs, err := systemConfigs()
+	if err != nil {
 		return nil, errors.Wrapf(err, "error finding config on system")
-	} else {
-		migrated := false
-		for _, path := range configs {
-			systemConfig, err := readConfigFromFile(path)
-			if err != nil {
-				return nil, errors.Wrapf(err, "error reading system config %q", path)
-			}
-			// Handle CGroups v2 configuration migration.
-			// Migrate only the first config, and do it before
-			// merging.
-			if !migrated {
-				if err := cgroupV2Check(path, systemConfig); err != nil {
-					return nil, errors.Wrapf(err, "error rewriting configuration file %s", userConfigPath)
-				}
-				migrated = true
-			}
-			// Merge the it into the config. Any unset field in config will be
-			// over-written by the systemConfig.
-			if err := config.mergeConfig(systemConfig); err != nil {
-				return nil, errors.Wrapf(err, "error merging system config")
-			}
-			logrus.Debugf("Merged system config %q: %v", path, config)
+	}
+
+	migrated := false
+	for _, path := range configs {
+		systemConfig, err := readConfigFromFile(path)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading system config %q", path)
 		}
+		// Handle CGroups v2 configuration migration.
+		// Migrate only the first config, and do it before
+		// merging.
+		if !migrated {
+			if err := cgroupV2Check(path, systemConfig); err != nil {
+				return nil, errors.Wrapf(err, "error rewriting configuration file %s", userConfigPath)
+			}
+			migrated = true
+		}
+		// Merge the it into the config. Any unset field in config will be
+		// over-written by the systemConfig.
+		if err := config.mergeConfig(systemConfig); err != nil {
+			return nil, errors.Wrapf(err, "error merging system config")
+		}
+		logrus.Debugf("Merged system config %q: %v", path, config)
 	}
 
 	// Finally, create a default config from memory and forcefully merge it into
 	// the config. This way we try to make sure that all fields are properly set
 	// and that user AND system config can partially set.
-	if defaultConfig, err := defaultConfigFromMemory(); err != nil {
+	defaultConfig, err := defaultConfigFromMemory()
+	if err != nil {
 		return nil, errors.Wrapf(err, "error generating default config from memory")
-	} else {
-		// Check if we need to switch to cgroupfs and logger=file on rootless.
-		defaultConfig.checkCgroupsAndLogger()
+	}
 
-		if err := config.mergeConfig(defaultConfig); err != nil {
-			return nil, errors.Wrapf(err, "error merging default config from memory")
-		}
+	// Check if we need to switch to cgroupfs and logger=file on rootless.
+	defaultConfig.checkCgroupsAndLogger()
+
+	if err := config.mergeConfig(defaultConfig); err != nil {
+		return nil, errors.Wrapf(err, "error merging default config from memory")
 	}
 
 	// Relative paths can cause nasty bugs, because core paths we use could

--- a/libpod/config/default.go
+++ b/libpod/config/default.go
@@ -26,11 +26,12 @@ const (
 // config is different for root and rootless. It also parses the storage.conf.
 func defaultConfigFromMemory() (*Config, error) {
 	c := new(Config)
-	if tmp, err := defaultTmpDir(); err != nil {
+	tmp, err := defaultTmpDir()
+	if err != nil {
 		return nil, err
-	} else {
-		c.TmpDir = tmp
 	}
+	c.TmpDir = tmp
+
 	c.EventsLogFilePath = filepath.Join(c.TmpDir, "events", "events.log")
 
 	storeOpts, err := storage.DefaultStoreOptions(rootless.IsRootless(), rootless.GetRootlessUID())

--- a/libpod/image/config.go
+++ b/libpod/image/config.go
@@ -2,7 +2,7 @@ package image
 
 // ImageDeleteResponse is the response for removing an image from storage and containers
 // what was untagged vs actually removed
-type ImageDeleteResponse struct {
+type ImageDeleteResponse struct { //nolint
 	Untagged []string `json:"untagged"`
 	Deleted  string   `json:"deleted"`
 }

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -709,7 +709,7 @@ func (r *ConmonOCIRuntime) ExecUpdateStatus(ctr *Container, sessionID string) (b
 	return true, nil
 }
 
-// ExecCleanupContainer cleans up files created when a command is run via
+// ExecContainerCleanup cleans up files created when a command is run via
 // ExecContainer. This includes the attach socket for the exec session.
 func (r *ConmonOCIRuntime) ExecContainerCleanup(ctr *Container, sessionID string) error {
 	// Clean up the sockets dir. Issue #3962

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -20,7 +20,9 @@ import (
 )
 
 var (
+	// NameRegex is a regular expression to validate container/pod names.
 	NameRegex  = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+	// RegexError is thrown in presence of an invalid container/pod name.
 	RegexError = errors.Wrapf(define.ErrInvalidArg, "names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*")
 )
 

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	// NameRegex is a regular expression to validate container/pod names.
-	NameRegex  = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+	NameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 	// RegexError is thrown in presence of an invalid container/pod name.
 	RegexError = errors.Wrapf(define.ErrInvalidArg, "names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*")
 )

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -213,11 +213,11 @@ func getLockManager(runtime *Runtime) (lock.Manager, error) {
 // Sets up containers/storage, state store, OCI runtime
 func makeRuntime(ctx context.Context, runtime *Runtime) (err error) {
 	// Find a working conmon binary
-	if cPath, err := runtime.config.FindConmon(); err != nil {
+	cPath, err := runtime.config.FindConmon()
+	if err != nil {
 		return err
-	} else {
-		runtime.conmonPath = cPath
 	}
+	runtime.conmonPath = cPath
 
 	// Make the static files directory if it does not exist
 	if err := os.MkdirAll(runtime.config.StaticDir, 0700); err != nil {

--- a/pkg/adapter/runtime.go
+++ b/pkg/adapter/runtime.go
@@ -84,7 +84,7 @@ func getRuntime(runtime *libpod.Runtime) (*LocalRuntime, error) {
 	}, nil
 }
 
-// GetFilterImages returns a slice of images in containerimages that are "filtered"
+// GetFilteredImages returns a slice of images in containerimages that are "filtered"
 func (r *LocalRuntime) GetFilteredImages(filters []string, rwOnly bool) ([]*ContainerImage, error) {
 	images, err := r.ImageRuntime().GetImagesWithFilters(filters)
 	if err != nil {
@@ -111,6 +111,8 @@ func (r *LocalRuntime) getImages(rwOnly bool) ([]*ContainerImage, error) {
 	return r.ImagestoContainerImages(images, rwOnly)
 }
 
+// ImagestoContainerImages converts the slice of *image.Image to a slice of
+// *ContainerImage.  ReadOnly images are skipped when rwOnly is set.
 func (r *LocalRuntime) ImagestoContainerImages(images []*image.Image, rwOnly bool) ([]*ContainerImage, error) {
 	var containerImages []*ContainerImage
 	for _, i := range images {

--- a/pkg/network/config.go
+++ b/pkg/network/config.go
@@ -90,6 +90,7 @@ func (p PortMapConfig) Bytes() ([]byte, error) {
 	return json.MarshalIndent(p, "", "\t")
 }
 
+// IPAMDHCP describes the ipamdhcp config
 type IPAMDHCP struct {
 	DHCP string `json:"type"`
 }

--- a/pkg/rootless/rootless.go
+++ b/pkg/rootless/rootless.go
@@ -7,6 +7,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// TryJoinPauseProcess attempts to join the namespaces of the pause PID via
+// TryJoinFromFilePaths.  If joining fails, it attempts to delete the specified
+// file.
 func TryJoinPauseProcess(pausePidPath string) (bool, int, error) {
 	if _, err := os.Stat(pausePidPath); err != nil {
 		return false, -1, nil

--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -514,6 +514,8 @@ func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []st
 
 	return joinUserAndMountNS(uint(pausePid), pausePidPath)
 }
+
+// ReadMappingsProc parses and returns the ID mappings at the specified path.
 func ReadMappingsProc(path string) ([]idtools.IDMap, error) {
 	file, err := os.Open(path)
 	if err != nil {

--- a/pkg/spec/namespaces.go
+++ b/pkg/spec/namespaces.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// ToCreateOptions converts the input to a slice of container create options.
 func (c *NetworkConfig) ToCreateOptions(runtime *libpod.Runtime, userns *UserConfig) ([]libpod.CtrCreateOption, error) {
 	var portBindings []ocicni.PortMapping
 	var err error
@@ -97,6 +98,8 @@ func (c *NetworkConfig) ToCreateOptions(runtime *libpod.Runtime, userns *UserCon
 	return options, nil
 }
 
+// ConfigureGenerator configures the generator based according to the current
+// state of the NetworkConfig.
 func (c *NetworkConfig) ConfigureGenerator(g *generate.Generator) error {
 	netMode := c.NetMode
 	if netMode.IsHost() {
@@ -183,6 +186,7 @@ func NatToOCIPortBindings(ports nat.PortMap) ([]ocicni.PortMapping, error) {
 	return portBindings, nil
 }
 
+// ToCreateOptions converts the input to container create options.
 func (c *CgroupConfig) ToCreateOptions(runtime *libpod.Runtime) ([]libpod.CtrCreateOption, error) {
 	options := make([]libpod.CtrCreateOption, 0)
 	if c.CgroupMode.IsNS() {
@@ -213,6 +217,7 @@ func (c *CgroupConfig) ToCreateOptions(runtime *libpod.Runtime) ([]libpod.CtrCre
 	return options, nil
 }
 
+// ToCreateOptions converts the input to container create options.
 func (c *UserConfig) ToCreateOptions(runtime *libpod.Runtime) ([]libpod.CtrCreateOption, error) {
 	options := make([]libpod.CtrCreateOption, 0)
 	if c.UsernsMode.IsNS() {
@@ -241,6 +246,8 @@ func (c *UserConfig) ToCreateOptions(runtime *libpod.Runtime) ([]libpod.CtrCreat
 	return options, nil
 }
 
+// ConfigureGenerator configures the generator according to the current state
+// of the UserConfig.
 func (c *UserConfig) ConfigureGenerator(g *generate.Generator) error {
 	if IsNS(string(c.UsernsMode)) {
 		if err := g.AddOrReplaceLinuxNamespace(string(spec.UserNamespace), NS(string(c.UsernsMode))); err != nil {
@@ -271,11 +278,14 @@ func (c *UserConfig) getPostConfigureNetNS() bool {
 	return postConfigureNetNS
 }
 
+// InNS returns true if the UserConfig indicates to be in a dedicated user
+// namespace.
 func (c *UserConfig) InNS(isRootless bool) bool {
 	hasUserns := c.UsernsMode.IsContainer() || c.UsernsMode.IsNS() || len(c.IDMappings.UIDMap) > 0 || len(c.IDMappings.GIDMap) > 0
 	return isRootless || (hasUserns && !c.UsernsMode.IsHost())
 }
 
+// ToCreateOptions converts the input to container create options.
 func (c *IpcConfig) ToCreateOptions(runtime *libpod.Runtime) ([]libpod.CtrCreateOption, error) {
 	options := make([]libpod.CtrCreateOption, 0)
 	if c.IpcMode.IsHost() {
@@ -293,6 +303,8 @@ func (c *IpcConfig) ToCreateOptions(runtime *libpod.Runtime) ([]libpod.CtrCreate
 	return options, nil
 }
 
+// ConfigureGenerator configures the generator according to the current state
+// of the IpcConfig.
 func (c *IpcConfig) ConfigureGenerator(g *generate.Generator) error {
 	ipcMode := c.IpcMode
 	if IsNS(string(ipcMode)) {
@@ -308,6 +320,8 @@ func (c *IpcConfig) ConfigureGenerator(g *generate.Generator) error {
 	return nil
 }
 
+// ConfigureGenerator configures the generator according to the current state
+// of the CgroupConfig.
 func (c *CgroupConfig) ConfigureGenerator(g *generate.Generator) error {
 	cgroupMode := c.CgroupMode
 	if cgroupMode.IsDefaultValue() {
@@ -337,6 +351,7 @@ func (c *CgroupConfig) ConfigureGenerator(g *generate.Generator) error {
 	return nil
 }
 
+// ToCreateOptions converts the input to container create options.
 func (c *PidConfig) ToCreateOptions(runtime *libpod.Runtime) ([]libpod.CtrCreateOption, error) {
 	options := make([]libpod.CtrCreateOption, 0)
 	if c.PidMode.IsContainer() {
@@ -351,6 +366,8 @@ func (c *PidConfig) ToCreateOptions(runtime *libpod.Runtime) ([]libpod.CtrCreate
 	return options, nil
 }
 
+// ConfigureGenerator configures the generator according to the current state
+// of the PidConfig.
 func (c *PidConfig) ConfigureGenerator(g *generate.Generator) error {
 	pidMode := c.PidMode
 	if IsNS(string(pidMode)) {
@@ -368,6 +385,7 @@ func (c *PidConfig) ConfigureGenerator(g *generate.Generator) error {
 	return nil
 }
 
+// ToCreateOptions converts the input to container create options.
 func (c *UtsConfig) ToCreateOptions(runtime *libpod.Runtime, pod *libpod.Pod) ([]libpod.CtrCreateOption, error) {
 	options := make([]libpod.CtrCreateOption, 0)
 	if IsPod(string(c.UtsMode)) {
@@ -391,6 +409,8 @@ func (c *UtsConfig) ToCreateOptions(runtime *libpod.Runtime, pod *libpod.Pod) ([
 	return options, nil
 }
 
+// ConfigureGenerator configures the generator according to the current state
+// of the UtsConfig.
 func (c *UtsConfig) ConfigureGenerator(g *generate.Generator, net *NetworkConfig, runtime *libpod.Runtime) error {
 	hostname := c.Hostname
 	var err error

--- a/pkg/spec/security.go
+++ b/pkg/spec/security.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ToCreateOptions convert the SecurityConfig to a slice of container create
+// options.
 func (c *SecurityConfig) ToCreateOptions() ([]libpod.CtrCreateOption, error) {
 	options := make([]libpod.CtrCreateOption, 0)
 	options = append(options, libpod.WithSecLabels(c.LabelOpts))
@@ -18,6 +20,8 @@ func (c *SecurityConfig) ToCreateOptions() ([]libpod.CtrCreateOption, error) {
 	return options, nil
 }
 
+// SetLabelOpts sets the label options of the SecurityConfig according to the
+// input.
 func (c *SecurityConfig) SetLabelOpts(runtime *libpod.Runtime, pidConfig *PidConfig, ipcConfig *IpcConfig) error {
 	if c.Privileged {
 		c.LabelOpts = label.DisableSecOpt()
@@ -57,6 +61,7 @@ func (c *SecurityConfig) SetLabelOpts(runtime *libpod.Runtime, pidConfig *PidCon
 	return nil
 }
 
+// SetSecurityOpts the the security options (labels, apparmor, seccomp, etc.).
 func (c *SecurityConfig) SetSecurityOpts(runtime *libpod.Runtime, securityOpts []string) error {
 	for _, opt := range securityOpts {
 		if opt == "no-new-privileges" {
@@ -91,6 +96,7 @@ func (c *SecurityConfig) SetSecurityOpts(runtime *libpod.Runtime, securityOpts [
 	return nil
 }
 
+// ConfigureGenerator configures the generator according to the input.
 func (c *SecurityConfig) ConfigureGenerator(g *generate.Generator, user *UserConfig) error {
 	// HANDLE CAPABILITIES
 	// NOTE: Must happen before SECCOMP

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -304,7 +304,7 @@ func GetImageConfig(changes []string) (ImageConfig, error) {
 	return config, nil
 }
 
-// Parse and validate a signal name or number
+// ParseSignal parses and validates a signal name or number.
 func ParseSignal(rawSignal string) (syscall.Signal, error) {
 	// Strip off leading dash, to allow -1 or -HUP
 	basename := strings.TrimPrefix(rawSignal, "-")

--- a/pkg/varlinkapi/virtwriter/virtwriter.go
+++ b/pkg/varlinkapi/virtwriter/virtwriter.go
@@ -27,13 +27,13 @@ const (
 	TerminalResize SocketDest = iota
 	// Quit and detach
 	Quit SocketDest = iota
-	// Quit from the client
+	// HangUpFromClient hangs up from the client
 	HangUpFromClient SocketDest = iota
 )
 
-// ClientHangup signifies that the client wants to drop its
-// connection from the server
-var ClientHangup = errors.New("client hangup")
+// ErrClientHangup signifies that the client wants to drop its connection from
+// the server.
+var ErrClientHangup = errors.New("client hangup")
 
 // IntToSocketDest returns a socketdest based on integer input
 func IntToSocketDest(i int) SocketDest {
@@ -177,7 +177,7 @@ func Reader(r *bufio.Reader, output, errput, input io.Writer, resize chan remote
 			//
 			// reproducer: echo hello | (podman-remote run -i alpine cat)
 			time.Sleep(1 * time.Second)
-			return ClientHangup
+			return ErrClientHangup
 		default:
 			// Something really went wrong
 			return errors.New("unknown multiplex destination")


### PR DESCRIPTION
I wanted to enable golangci-lint for the `test/` directory (which is currently not checked) and noticed that new errors were introduced to the rest of the code.  I have no idea how that was possible but now the linter is happy again.

@giuseppe @mheon @baude @TomSweeneyRedHat @rhatdan PTAL