### PR TITLE
exec: fix pipes

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -546,6 +546,10 @@ func (r *ConmonOCIRuntime) ExecContainer(c *Container, sessionID string, options
 		args = append(args, "-t")
 	}
 
+	if options.Streams.AttachInput {
+		args = append(args, "-i")
+	}
+
 	// Append container ID and command
 	args = append(args, "-e")
 	// TODO make this optional when we can detach
@@ -558,9 +562,8 @@ func (r *ConmonOCIRuntime) ExecContainer(c *Container, sessionID string, options
 	execCmd := exec.Command(r.conmonPath, args...)
 
 	if options.Streams != nil {
-		if options.Streams.AttachInput {
-			execCmd.Stdin = options.Streams.InputStream
-		}
+		// Don't add the InputStream to the execCmd. Instead, the data should be passed
+		// through CopyDetachable
 		if options.Streams.AttachOutput {
 			execCmd.Stdout = options.Streams.OutputStream
 		}


### PR DESCRIPTION
In a largely anticlimatic solution to the saga of piped input from conmon, we come to this solution.

When we pass the Stdin stream to the exec.Command structure, it's immediately consumed and lost, instead of being consumed through CopyDetachable().

When we don't pass -i in, conmon is not told to create a masterfd_stdin, and won't pass anything to the container.

With both, we can do

echo hi | podman exec -til cat

and get the expected hi

fixes: https://github.com/containers/libpod/issues/4785
fixes: https://github.com/containers/libpod/issues/4326
fixes: https://github.com/containers/libpod/issues/3302

Signed-off-by: Peter Hunt <pehunt@redhat.com>