### PR TITLE
Update podmanimage build process

### DIFF
--- a/contrib/podmanimage/stable/Dockerfile
+++ b/contrib/podmanimage/stable/Dockerfile
@@ -9,9 +9,9 @@
 FROM fedora:latest
 
 # Don't include container-selinux and remove
-# directories used by dnf that are just taking
+# directories used by yum that are just taking
 # up space.
-RUN yum -y install podman fuse-overlayfs --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install podman fuse-overlayfs --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf

--- a/contrib/podmanimage/testing/Dockerfile
+++ b/contrib/podmanimage/testing/Dockerfile
@@ -11,9 +11,9 @@
 FROM fedora:latest
 
 # Don't include container-selinux and remove
-# directories used by dnf that are just taking
+# directories used by yum that are just taking
 # up space.
-RUN yum -y install podman fuse-overlayfs --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install podman fuse-overlayfs --exclude container-selinux --enablerepo updates-testing; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf

--- a/contrib/podmanimage/upstream/Dockerfile
+++ b/contrib/podmanimage/upstream/Dockerfile
@@ -17,7 +17,7 @@ ENV GOPATH=/root/podman
 # to the container.
 # Finally remove the podman directory and a few other packages
 # that are needed for building but not running Podman
-RUN dnf -y install --exclude container-selinux \
+RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install --exclude container-selinux \
      --enablerepo=updates-testing \
      atomic-registries \
      btrfs-progs-devel \
@@ -63,8 +63,8 @@ RUN dnf -y install --exclude container-selinux \
      # Adjust libpod.conf to write logging to a file
      sed -i 's/# events_logger = "journald"/events_logger = "file"/g' /usr/share/containers/libpod.conf; \
      rm -rf /root/podman/*; \
-     dnf -y remove git golang go-md2man make; \
-     dnf clean all;
+     yum -y remove git golang go-md2man make; \
+     yum clean all;
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf


### PR DESCRIPTION
(Stealing from: @rhatdan 's https://github.com/containers/buildah/pull/2038 )

1 We need to update all packages in the podman image to make sure they are
up2date.
2 reinstall shadow-utils. For some reason the fedora base image does not
include the file capabilities assigned to /usr/bin/newuidmap and
/usr/bin/newgidmap. Reinstalling shadow-utils, brings them back.
3 Add a default user build to the system. This will create the
/etc/subuid and /etc/subgid maps get created correctly.

Once we have this we should be able to build a container starting with a non
privileged user

podman run -ti --user build --device=/dev/fuse -v ./Dockerfile:/Dockerfile:z quay.io/podman/stable podman buildd /

Addresses: #4741

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>