### PR TITLE
Usage messages: show possible option values

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -308,7 +308,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.String(
 		"image-volume", cliconfig.DefaultImageVolume,
-		"Tells podman how to handle the builtin image volumes. The options are: 'bind', 'tmpfs', or 'ignore'",
+		`Tells podman how to handle the builtin image volumes ("bind"|"tmpfs"|"ignore")`,
 	)
 	createFlags.Bool(
 		"init", false,
@@ -431,7 +431,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.String(
 		"pull", "missing",
-		`Pull image before creating ("always"|"missing"|"never") (default "missing")`,
+		`Pull image before creating ("always"|"missing"|"never")`,
 	)
 	createFlags.BoolP(
 		"quiet", "q", false,
@@ -447,7 +447,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.String(
 		"restart", "",
-		"Restart policy to apply when a container exits",
+		`Restart policy to apply when a container exits ("always"|"no"|"on-failure")`,
 	)
 	createFlags.Bool(
 		"rm", false,
@@ -492,7 +492,7 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	)
 	createFlags.String(
 		"systemd", "true",
-		`Run container in systemd mode ("true"|"false"|"always" (default "true")`,
+		`Run container in systemd mode ("true"|"false"|"always")`,
 	)
 	createFlags.StringArray(
 		"tmpfs", []string{},

--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -33,7 +33,7 @@ const remote = false
 
 func init() {
 	cgroupManager := define.SystemdCgroupsManager
-	cgroupHelp := "Cgroup manager to use (cgroupfs or systemd)"
+	cgroupHelp := `Cgroup manager to use ("cgroupfs"|"systemd")`
 	cgroupv2, _ := cgroups.IsCgroup2UnifiedMode()
 	if rootless.IsRootless() && !cgroupv2 {
 		cgroupManager = ""
@@ -50,12 +50,12 @@ func init() {
 	if err := rootCmd.PersistentFlags().MarkHidden("default-mounts-file"); err != nil {
 		logrus.Error("unable to mark default-mounts-file flag as hidden")
 	}
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.EventsBackend, "events-backend", "", "Events backend to use")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.EventsBackend, "events-backend", "", `Events backend to use ("file"|"journald"|"none")`)
 	// Override default --help information of `--help` global flag
 	var dummyHelp bool
 	rootCmd.PersistentFlags().BoolVar(&dummyHelp, "help", false, "Help for podman")
 	rootCmd.PersistentFlags().StringSliceVar(&MainGlobalOpts.HooksDir, "hooks-dir", []string{}, "Set the OCI hooks directory path (may be set multiple times)")
-	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.LogLevel, "log-level", "error", "Log messages above specified level: debug, info, warn, error, fatal or panic")
+	rootCmd.PersistentFlags().StringVar(&MainGlobalOpts.LogLevel, "log-level", "error", `Log messages above specified level ("debug"|"info"|"warn"|"error"|"fatal"|"panic")`)
 	rootCmd.PersistentFlags().IntVar(&MainGlobalOpts.MaxWorks, "max-workers", 0, "The maximum number of workers for parallel operations")
 	if err := rootCmd.PersistentFlags().MarkHidden("max-workers"); err != nil {
 		logrus.Error("unable to mark max-workers flag as hidden")

--- a/completions/zsh/_podman
+++ b/completions/zsh/_podman
@@ -111,20 +111,13 @@ _podman_find_helper() {
     elif expr "$desc" : ".*[Pp]ath" >/dev/null; then
         optval="path"
         helper=_files
-    elif [ "$flags" = "--cgroup-manager" ]; then
-        optval="cgroup manager"
-        helper="(cgroupfs systemd)"
-    elif [ "$flags" = "--log-level" ]; then
-        optval="log level"
-        # 'Log messages above specified level: debug, ... (default "...")'
-        # Strip off the description and all 'default' strings
-        desc=${desc/Log*:/}           # debug, info, ... (default "...")
-        desc=${(S)desc//\(*\)/}       # debug, info, ... or panic
-        desc=${desc//,/}              # debug info ... or panic
-        desc=${desc// or / }          # debug info ... panic
-        desc=${desc//  / }            # collapse multiple spaces
+    # For messages like 'restart policy ("always"|"no"|"on-failure")
+    elif optlist=$(expr "$desc" : '.*(\(\"[^\\)]\+|[^\\)]\+\"\))' 2>/dev/null); then
+        optval=${${flags##--}//-/ }       # "--log-level" => "log level"
+        optlist=${optlist//\"/}           # "a"|"b"|"c"   => a|b|c
+        optlist=${optlist//\|/ }          # a|b|c         => a b c
         # FIXME: how to present values _in order_, not sorted alphabetically?
-        helper="($desc)"
+        helper="($optlist)"
     fi
     echo "$optval:$helper"
 }


### PR DESCRIPTION
...in a consistent manner: ("a"|"b"|"c")

This makes it possible (and easy) for zsh completion to
pick those out of the --help messages and offer them
as values when user hits TAB.

I chose this format because it's an already-existing
convention in cmd/podman/common.go.

Also: removed two duplicate "default: x" messages (Cobra
displays those automatically where a non-null default
is specified).

Signed-off-by: Ed Santiago <santiago@redhat.com>