### PR TITLE
rootlessport: remove state dir on exit + honor ctr.runtime.config.TmpDir

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -344,6 +344,7 @@ func (r *Runtime) setupRootlessPortMapping(ctr *Container, netnsPath string) (er
 		NetNSPath: netnsPath,
 		ExitFD:    3,
 		ReadyFD:   4,
+		TmpDir:    ctr.runtime.config.TmpDir,
 	}
 	cfgJSON, err := json.Marshal(cfg)
 	if err != nil {

--- a/pkg/rootlessport/rootlessport_linux.go
+++ b/pkg/rootlessport/rootlessport_linux.go
@@ -46,6 +46,7 @@ type Config struct {
 	NetNSPath string
 	ExitFD    int
 	ReadyFD   int
+	TmpDir    string
 }
 
 func init() {
@@ -101,7 +102,7 @@ func parent() error {
 	}
 
 	// create the parent driver
-	stateDir, err := ioutil.TempDir("", "rootlessport")
+	stateDir, err := ioutil.TempDir(cfg.TmpDir, "rootlessport")
 	if err != nil {
 		return err
 	}

--- a/pkg/rootlessport/rootlessport_linux.go
+++ b/pkg/rootlessport/rootlessport_linux.go
@@ -105,6 +105,7 @@ func parent() error {
 	if err != nil {
 		return err
 	}
+	defer os.RemoveAll(stateDir)
 	driver, err := rkbuiltin.NewParentDriver(&logrusWriter{prefix: "parent: "}, stateDir)
 	if err != nil {
 		return err


### PR DESCRIPTION
* rootlessport: remove state dir on exit 
* rootlessport: honor `ctr.runtime.config.TmpDir`.  Previously, rootlessport was using `/var/tmp` as the tmp dir.