### PR TITLE
more BATS tests

### DIFF
--- a/test/system/075-exec.bats
+++ b/test/system/075-exec.bats
@@ -49,4 +49,20 @@ load helpers
     run_podman rm -f $cid
 }
 
+# Issue #4785 - piping to exec statement - fixed in #4818
+@test "podman exec - cat from stdin" {
+    skip_if_remote
+
+    run_podman run -d $IMAGE sh -c 'while [ ! -e /stop ]; do sleep 0.1;done'
+    cid="$output"
+
+    echo_string=$(random_string 20)
+    run_podman exec -i $cid cat < <(echo $echo_string)
+    is "$output" "$echo_string" "output read back from 'exec cat'"
+
+    run_podman exec $cid touch /stop
+    run_podman wait $cid
+    run_podman rm $cid
+}
+
 # vim: filetype=sh

--- a/test/system/140-diff.bats
+++ b/test/system/140-diff.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# Tests for podman diff
+#
+
+load helpers
+
+@test "podman diff" {
+    rand_file=$(random_string 10)
+    run_podman run $IMAGE sh -c "touch /$rand_file;rm /etc/services"
+    run_podman diff --format json -l
+
+    # Expected results for each type of diff
+    declare -A expect=(
+        [added]="/$rand_file"
+        [changed]="/etc"
+        [deleted]="/etc/services"
+    )
+
+    for field in ${!expect[@]}; do
+        result=$(jq -r -c ".${field}[]" <<<"$output")
+        is "$result" "${expect[$field]}" "$field"
+    done
+
+    run_podman rm -l
+}
+
+# vim: filetype=sh

--- a/test/system/410-selinux.bats
+++ b/test/system/410-selinux.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# 410-selinux - podman selinux tests
+#
+
+load helpers
+
+
+function check_label() {
+    if [ ! -e /usr/sbin/selinuxenabled ] || ! /usr/sbin/selinuxenabled; then
+        skip "selinux disabled or not available"
+    fi
+
+    local args="$1"; shift        # command-line args for run
+
+    # FIXME: it'd be nice to specify the command to run, e.g. 'ls -dZ /',
+    # but alpine ls (from busybox) doesn't support -Z
+    run_podman run --rm $args $IMAGE cat -v /proc/self/attr/current
+
+    # FIXME: on some CI systems, 'run --privileged' emits a spurious
+    # warning line about dup devices. Ignore it.
+    local context="$output"
+    if [ ${#lines[@]} -gt 1 ]; then
+        if expr "${lines[0]}" : "WARNING: .* type, major" >/dev/null; then
+            echo "# ${lines[0]} [ignored]" >&3
+            context="${lines[1]}"
+        else
+            die "FAILED: too much output, expected one single line"
+        fi
+    fi
+
+    is "$context" ".*_u:system_r:.*" "SELinux role should always be system_r"
+
+    # e.g. system_u:system_r:container_t:s0:c45,c745 -> "container_t"
+    type=$(cut -d: -f3 <<<"$context")
+    is "$type" "$1" "SELinux type"
+
+    if [ -n "$2" ]; then
+        # e.g. from the above example -> "s0:c45,c745"
+        range=$(cut -d: -f4,5 <<<"$context")
+        is "$range" "$2" "SELinux range"
+    fi
+}
+
+
+@test "podman selinux: confined container" {
+    check_label "" "container_t"
+}
+
+@test "podman selinux: container with label=disable" {
+    skip_if_rootless
+
+    check_label "--security-opt label=disable" "spc_t"
+}
+
+@test "podman selinux: privileged container" {
+    skip_if_rootless
+
+    check_label "--privileged --userns=host" "spc_t"
+}
+
+@test "podman selinux: container with overridden range" {
+    check_label "--security-opt label=level:s0:c1,c2" "container_t" "s0:c1,c2"
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
- run: --name (includes 'podman container exists' tests)
- run: --pull (always, never, missing)
- build: new test for ADD URL (#4420)
- exec: new test for issue #4785 (pipe getting lost)
- diff: new test
- selinux (mostly copied from docker-autotest)

Plus a bug fix: the wait_for_output() helper would continue
checking, eventually timing out, even if the container had
already exited (probably because of an error). Fix: as
part of the loop, run 'podman inspect' and bail out if
container is not running. Include exit code and logs.

Signed-off-by: Ed Santiago <santiago@redhat.com>