### PR TITLE
Fix Makefile ref libseccomp branch as a commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ LDFLAGS_PODMAN ?= \
 	  -X $(LIBPOD)/config._etcDir=$(ETCDIR) \
 	  -extldflags "$(LDFLAGS)"
 #Update to LIBSECCOMP_COMMIT should reflect in Dockerfile too.
-LIBSECCOMP_COMMIT := release-2.3
+LIBSECCOMP_COMMIT := v2.3.3
 # Rarely if ever should integration tests take more than 50min,
 # caller may override in special circumstances if needed.
 GINKGOTIMEOUT ?= -timeout=90m


### PR DESCRIPTION
Commit a824186ac9 mistakenly updated LIBSECCOMP_COMMIT with a branch
name instead of a commit reference.  This breaks on Ubuntu's git with
the `--detach` option, causing it to throw this error:

```
fatal: '--detach' cannot be used with '-b/-B/--orphan'
```

Fix this by using the tag `v2.3.3` which at the time of this commit, is
the current HEAD of the release-2.3 branch.

Thanks to Ed Santiago <santiago@redhat.com> for helping figure
out the error and the fix.

Signed-off-by: Chris Evich <cevich@redhat.com>