### PR TITLE
cp: drop check for rootless

### DIFF
--- a/cmd/podman/cp.go
+++ b/cmd/podman/cp.go
@@ -101,18 +101,7 @@ func copyBetweenHostAndContainer(runtime *libpod.Runtime, src string, dest strin
 		}
 	}()
 
-	// We can't pause rootless containers.
-	if pause && rootless.IsRootless() {
-		state, err := ctr.State()
-		if err != nil {
-			return err
-		}
-		if state == define.ContainerStateRunning {
-			return errors.Errorf("cannot copy into running rootless container with pause set - pass --pause=false to force copying")
-		}
-	}
-
-	if pause && !rootless.IsRootless() {
+	if pause {
 		if err := ctr.Pause(); err != nil {
 			// An invalid state error is fine.
 			// The container isn't running or is already paused.


### PR DESCRIPTION
rootless containers can use pause on cgroups v2.

Whether it is possible or not to use pause depends from multiple
conditions, such as:

- be on a cgroup v2 unified hierarchy,
- using systemd cgroup manager,
- the kernel has the freezer controller,

The last one may fail for root as well.

Instead of trying to catch all the possible conditions in Podman, let
the OCI runtime complain if pause cannot be performed.

Closes: https://github.com/containers/libpod/issues/4813

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>