### PR TITLE
Revert "libpod, rootless: create cgroup for conmon"

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1255,6 +1255,14 @@ func (r *ConmonOCIRuntime) moveConmonToCgroupAndSignal(ctr *Container, cmd *exec
 		mustCreateCgroup = false
 	}
 
+	if rootless.IsRootless() {
+		ownsCgroup, err := cgroups.UserOwnsCurrentSystemdCgroup()
+		if err != nil {
+			return err
+		}
+		mustCreateCgroup = !ownsCgroup
+	}
+
 	if mustCreateCgroup {
 		cgroupParent := ctr.CgroupParent()
 		if r.cgroupManager == define.SystemdCgroupsManager {


### PR DESCRIPTION
This reverts commit 78e2a31943ddab6efcbc14388532dfb410780299.

Fixes: #4833
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@giuseppe PTAL