### PR TITLE
Cirrus: Fix libpod base images going stale

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -296,7 +296,7 @@ meta_task:
     timeout_in: 10m
 
     # Cirrus-CI ignores entrypoint defined in image
-    script: '/usr/local/bin/entrypoint.sh |& ${TIMESTAMP}'
+    script: '$CIRRUS_WORKING_DIR/$SCRIPT_BASE/update_meta.sh |& ${TIMESTAMP}'
 
 
 # Remove old and disused images based on labels set by meta_task

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -64,8 +64,8 @@ export PACKER_BUILDS="${PACKER_BUILDS:-ubuntu-18,ubuntu-19,fedora-30,xfedora-30,
 export UBUNTU_BASE_IMAGE="ubuntu-1904-disco-v20190724"
 export PRIOR_UBUNTU_BASE_IMAGE="ubuntu-1804-bionic-v20190722a"
 # Manually produced base-image names (see $SCRIPT_BASE/README.md)
-export FEDORA_BASE_IMAGE="fedora-cloud-base-30-1-2-1565360543"
-export PRIOR_FEDORA_BASE_IMAGE="fedora-cloud-base-29-1-2-1565360543"
+export FEDORA_BASE_IMAGE="fedora-cloud-base-30-1-2-1578586410"
+export PRIOR_FEDORA_BASE_IMAGE="fedora-cloud-base-29-1-2-1541789245"
 export BUILT_IMAGE_SUFFIX="${BUILT_IMAGE_SUFFIX:--$CIRRUS_REPO_NAME-${CIRRUS_BUILD_ID}}"
 # IN_PODMAN container image
 IN_PODMAN_IMAGE="quay.io/libpod/in_podman:latest"
@@ -428,6 +428,18 @@ remove_packaged_podman_files() {
 
     # Be super extra sure and careful vs performant and completely safe
     sync && echo 3 > /proc/sys/vm/drop_caches
+}
+
+canonicalize_image_names() {
+    req_env_var IMGNAMES
+    echo "Adding all current base images to \$IMGNAMES for timestamp update"
+    export IMGNAMES="\
+$IMGNAMES
+$UBUNTU_BASE_IMAGE
+$PRIOR_UBUNTU_BASE_IMAGE
+$FEDORA_BASE_IMAGE
+$PRIOR_FEDORA_BASE_IMAGE
+"
 }
 
 systemd_banish() {

--- a/contrib/cirrus/update_meta.sh
+++ b/contrib/cirrus/update_meta.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source $(dirname $0)/lib.sh
+
+# N/B: This script is expected to wrap $ENTRYPOINT when executing under the
+#      'meta' Cirrus task on the libpod repo.
+ENTRYPOINT=/usr/local/bin/entrypoint.sh
+
+req_env_var IMGNAMES BUILDID REPOREF GCPJSON GCPNAME GCPPROJECT CIRRUS_CI
+
+[[ -x "$ENTRYPOINT" ]] || \
+    die 2 "Expecting to find an installed entrypoint script $ENTRYPOINT."
+
+# A better way of checking isn't compatible with old but functional images
+# in-use by other repos.
+grep -q 'compute images update' "$ENTRYPOINT" || \
+    die 3 "Expecting to be running inside a specific imgts container image"
+
+canonicalize_image_names
+
+# Executing inside a container; proper hand-off for process control
+exec $ENTRYPOINT


### PR DESCRIPTION
VM Base images are used as a starting point for runtime VM images.
The in-use VM base images should never be pruned, which is an
operation that potentially occurs periodically from automation
running on the master branch of the libpod repo.

However the only place which updates timestamps (blocking pruning)
of base images, occurs during runtime VM image building.  Therefor,
if images are not regularly rebuilt, it's possible their base images
go stale and are pruned.

Changes:

* Add freshly-produced base images (old ones got pruned)
* Wrap the timestamp update script to include base image names
in the update list.

Notes:

* Regularly updating base image timestamps only needs to happen
on the libpod repo's meta task, since all base images live there.
* Using a wrapper is needed to maintain compatibility with multiple
versions of the imgts container image used by other repos / branchs.

Signed-off-by: Chris Evich <cevich@redhat.com>