### PR TITLE
[Makefile] Ensure .gopathok dependency is met for varlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -532,7 +532,7 @@ install.libseccomp.sudo:
 	cd ../../seccomp/libseccomp && git checkout --detach $(LIBSECCOMP_COMMIT) && ./autogen.sh && ./configure --prefix=/usr && make all && make install
 
 
-cmd/podman/varlink/iopodman.go: cmd/podman/varlink/io.podman.varlink
+cmd/podman/varlink/iopodman.go: .gopathok cmd/podman/varlink/io.podman.varlink
 	GO111MODULE=off $(GO) generate ./cmd/podman/varlink/...
 
 API.md: cmd/podman/varlink/io.podman.varlink


### PR DESCRIPTION
When executing make in parallel, e.g `make -j8`, there is a chance steps are
executed at the same time. There is a chance .gopathok and the actual varlink
generation happening at the same time, causing a race and ultimately failing the
build.

Ensuring the .gopathok dependency is met at the actual step fixes the problem.

Signed-off-by: Morten Linderud <morten@linderud.pw>