### PR TITLE
swagger documentation updates

### DIFF
--- a/pkg/api/handlers/generic/config.go
+++ b/pkg/api/handlers/generic/config.go
@@ -1,0 +1,9 @@
+package generic
+
+// ContainerCreateResponse is the response struct for creating a container
+type ContainerCreateResponse struct {
+	// ID of the container created
+	Id string `json:"Id"`
+	// Warnings during container creation
+	Warnings []string `json:"Warnings"`
+}

--- a/pkg/api/handlers/generic/containers_create.go
+++ b/pkg/api/handlers/generic/containers_create.go
@@ -71,11 +71,7 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	type ctrCreateResponse struct {
-		Id       string   `json:"Id"`
-		Warnings []string `json:"Warnings"`
-	}
-	response := ctrCreateResponse{
+	response := ContainerCreateResponse{
 		Id:       ctr.ID(),
 		Warnings: []string{}}
 

--- a/pkg/api/handlers/generic/swagger.go
+++ b/pkg/api/handlers/generic/swagger.go
@@ -1,0 +1,24 @@
+package generic
+
+// Create container
+// swagger:response ContainerCreateResponse
+type swagCtrCreateResponse struct {
+	// in:body
+	Body struct {
+		ContainerCreateResponse
+	}
+}
+
+// Wait container
+// swagger:response ContainerWaitResponse
+type swagCtrWaitResponse struct {
+	// in:body
+	Body struct {
+		// container exit code
+		StatusCode int
+		error      message
+		Error      struct {
+			Message string
+		}
+	}
+}

--- a/pkg/api/server/register_events.go
+++ b/pkg/api/server/register_events.go
@@ -26,7 +26,7 @@ func (s *APIServer) RegisterEventsHandlers(r *mux.Router) error {
 	//     description: OK
 	//   "500":
 	//     description: Failed
-	//     "$ref": "#/types/errorModel"
+	//     "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/events"), APIHandler(s.Context, handlers.GetEvents))
 	return nil
 }

--- a/pkg/api/server/register_info.go
+++ b/pkg/api/server/register_info.go
@@ -8,21 +8,17 @@ import (
 )
 
 func (s *APIServer) registerInfoHandlers(r *mux.Router) error {
-	// swagger:operation GET /info libpod getInfo
-	//
-	// Returns information on the system and libpod configuration
-	//
+	// swagger:operation GET /info libpod libpodGetInfo
 	// ---
+	// summary: Get info
+	// description: Returns information on the system and libpod configuration
 	// produces:
 	// - application/json
 	// responses:
 	//   '200':
-	//     schema:
-	//       "$ref": "#/types/Info"
+	//     description: to be determined
 	//   '500':
-	//     description: unexpected error
-	//     schema:
-	//      "$ref": "#/types/ErrorModel"
+	//      "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/info"), APIHandler(s.Context, generic.GetInfo)).Methods(http.MethodGet)
 	return nil
 }

--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -9,10 +9,8 @@ import (
 
 func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	// swagger:operation GET /libpod/pods/json pods ListPods
-	//
-	// List Pods
-	//
 	// ---
+	// summary: List pods
 	// produces:
 	// - application/json
 	// parameters:
@@ -29,15 +27,14 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/libpod/pods/json"), APIHandler(s.Context, libpod.Pods)).Methods(http.MethodGet)
 	r.Handle(VersionedPath("/libpod/pods/create"), APIHandler(s.Context, libpod.PodCreate)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/prune pods PrunePods
-	//
-	// Prune unused pods
-	//
 	// ---
+	// summary: Prune unused pods
 	// parameters:
 	//  - in: query
 	//    name: force
 	//    description: force delete
 	//    type: bool
+	//    default: false
 	// produces:
 	// - application/json
 	// responses:
@@ -49,10 +46,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//      $ref: "#responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/prune"), APIHandler(s.Context, libpod.PodPrune)).Methods(http.MethodPost)
 	// swagger:operation DELETE /libpod/pods/{nameOrID} pods removePod
-	//
-	// Remove Pod
-	//
 	// ---
+	// summary: Remove pod
 	// produces:
 	// - application/json
 	// parameters:
@@ -75,10 +70,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//      $ref: "#responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}"), APIHandler(s.Context, libpod.PodDelete)).Methods(http.MethodDelete)
 	// swagger:operation GET /libpod/pods/{nameOrID}/json pods inspectPod
-	//
-	// Inspect Pod
-	//
 	// ---
+	// summary: Inspect pod
 	// produces:
 	// - application/json
 	// parameters:
@@ -95,10 +88,9 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//      $ref: "#responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/json"), APIHandler(s.Context, libpod.PodInspect)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/pods/{nameOrID}/exists pods podExists
-	//
-	// Inspect Pod
-	//
 	// ---
+	// summary: Pod exists
+	// description: Check if a pod exists by name or ID
 	// produces:
 	// - application/json
 	// parameters:
@@ -115,10 +107,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//      $ref: "#responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/exists"), APIHandler(s.Context, libpod.PodExists)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/pods/{nameOrID}/kill pods killPod
-	//
-	// Kill a pod
-	//
 	// ---
+	// summary: Kill a pod
 	// produces:
 	// - application/json
 	// parameters:
@@ -143,10 +133,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//      $ref: "#responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/kill"), APIHandler(s.Context, libpod.PodKill)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/{nameOrID}/pause pods pausePod
-	//
-	// Pause a pod
-	//
 	// ---
+	// summary: Pause a pod
 	// produces:
 	// - application/json
 	// parameters:
@@ -163,10 +151,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//      $ref: "#responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/pause"), APIHandler(s.Context, libpod.PodPause)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/{nameOrID}/restart pods restartPod
-	//
-	// Restart a pod
-	//
 	// ---
+	// summary: Restart a pod
 	// produces:
 	// - application/json
 	// parameters:
@@ -183,10 +169,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//      $ref: "#responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/restart"), APIHandler(s.Context, libpod.PodRestart)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/{nameOrID}/start pods startPod
-	//
-	// Start a pod
-	//
 	// ---
+	// summary: Start a pod
 	// produces:
 	// - application/json
 	// parameters:
@@ -205,10 +189,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//      $ref: "#responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/start"), APIHandler(s.Context, libpod.PodStart)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/{nameOrID}/stop pods stopPod
-	//
-	// Stop a pod
-	//
 	// ---
+	// summary: Stop a pod
 	// produces:
 	// - application/json
 	// parameters:
@@ -233,10 +215,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//      $ref: "#responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/stop"), APIHandler(s.Context, libpod.PodStop)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/{nameOrID}/unpause pods unpausePod
-	//
-	// Unpause a pod
-	//
 	// ---
+	// summary: Unpause a pod
 	// produces:
 	// - application/json
 	// parameters:

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -9,10 +9,8 @@ import (
 
 func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	// swagger:operation POST /libpod/volumes/create volumes createVolume
-	//
-	//  Create a volume
-	//
 	// ---
+	// summary: Create a volume
 	// produces:
 	// - application/json
 	// responses:
@@ -23,10 +21,8 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	r.Handle("/libpod/volumes/create", APIHandler(s.Context, libpod.CreateVolume)).Methods(http.MethodPost)
 	r.Handle("/libpod/volumes/json", APIHandler(s.Context, libpod.ListVolumes)).Methods(http.MethodGet)
 	// swagger:operation POST /volumes/prune volumes pruneVolumes
-	//
-	//  Prune volumes
-	//
 	// ---
+	// summary: Prune volumes
 	// produces:
 	// - application/json
 	// responses:
@@ -36,10 +32,8 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//      "$ref": "#/responses/InternalError"
 	r.Handle("/libpod/volumes/prune", APIHandler(s.Context, libpod.PruneVolumes)).Methods(http.MethodPost)
 	// swagger:operation GET /volumes/{nameOrID}/json volumes inspectVolume
-	//
-	//  Inspect volume
-	//
 	// ---
+	// summary: Inspect volume
 	// parameters:
 	//  - in: path
 	//    name: nameOrID
@@ -56,10 +50,8 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//      "$ref": "#/responses/InternalError"
 	r.Handle("/libpod/volumes/{name:..*}/json", APIHandler(s.Context, libpod.InspectVolume)).Methods(http.MethodGet)
 	// swagger:operation DELETE /volumes/{nameOrID} volumes removeVolume
-	//
-	//  Inspect volume
-	//
 	// ---
+	// summary: Remove volume
 	// parameters:
 	//  - in: path
 	//    name: nameOrID

--- a/pkg/api/server/swagger.go
+++ b/pkg/api/server/swagger.go
@@ -131,3 +131,8 @@ type swagListContainers struct {
 		//handlers.Container
 	}
 }
+
+// To be determined
+// swagger:response tbd
+type swagTBD struct {
+}


### PR DESCRIPTION
adhere closer to the spec by using description and summary fields and
also ensuring that the id is unique to avoid collision between generic
and libpod endpoints.

also, make swagger output work with redoc which seems to display our
information better for our needs.

Signed-off-by: baude <bbaude@redhat.com>