### PR TITLE
pod: honor --infra-command

### DIFF
--- a/cmd/podman/libpodruntime/runtime.go
+++ b/cmd/podman/libpodruntime/runtime.go
@@ -169,7 +169,7 @@ func getRuntime(ctx context.Context, c *cliconfig.PodmanCommand, renumber, migra
 	}
 
 	infraCommandFlag := c.Flags().Lookup("infra-command")
-	if infraCommandFlag != nil && infraImageFlag.Changed {
+	if infraCommandFlag != nil && infraCommandFlag.Changed {
 		infraCommand, _ := c.Flags().GetString("infra-command")
 		options = append(options, libpod.WithDefaultInfraCommand(infraCommand))
 	}

--- a/docs/source/markdown/podman-pod-create.1.md
+++ b/docs/source/markdown/podman-pod-create.1.md
@@ -29,7 +29,7 @@ Create an infra container and associate it with the pod. An infra container is a
 
 **--infra-command**=*command*
 
-The command that will be run to start the infra container. Default: "/pause"
+The command that will be run to start the infra container. Default: ""
 
 **--infra-image**=*image*
 

--- a/libpod.conf
+++ b/libpod.conf
@@ -77,7 +77,7 @@ cni_default_network = "podman"
 infra_image = "k8s.gcr.io/pause:3.1"
 
 # Default command to run the infra container
-infra_command = "/pause"
+infra_command = ""
 
 # Determines whether libpod will reserve ports on the host when they are
 # forwarded to containers. When enabled, when ports are forwarded to containers,

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -6,7 +6,7 @@ var (
 	// DefaultInfraImage to use for infra container
 	DefaultInfraImage = "k8s.gcr.io/pause:3.1"
 	// DefaultInfraCommand to be run in an infra container
-	DefaultInfraCommand = "/pause"
+	DefaultInfraCommand = ""
 	// DefaultSHMLockPath is the default path for SHM locks
 	DefaultSHMLockPath = "/libpod_lock"
 	// DefaultRootlessSHMLockPath is the default path for rootless SHM locks


### PR DESCRIPTION
if --infra-command is specified, it must have a higher precedence over
the command specified in the image.

If the image specifies an entrypoint, it must be used also with
--infra-command.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>