### PR TITLE
Do not configure CNI when slirp4netns is requested

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -148,7 +148,7 @@ func (r *Runtime) createNetNS(ctr *Container) (n ns.NetNS, q []*cnitypes.Result,
 	logrus.Debugf("Made network namespace at %s for container %s", ctrNS.Path(), ctr.ID())
 
 	networkStatus := []*cnitypes.Result{}
-	if !rootless.IsRootless() {
+	if !rootless.IsRootless() && ctr.config.NetMode != "slirp4netns" {
 		networkStatus, err = r.configureNetNS(ctr, ctrNS)
 	}
 	return ctrNS, networkStatus, err
@@ -462,7 +462,7 @@ func (r *Runtime) teardownNetNS(ctr *Container) error {
 	logrus.Debugf("Tearing down network namespace at %s for container %s", ctr.state.NetNS.Path(), ctr.ID())
 
 	// rootless containers do not use the CNI plugin
-	if !rootless.IsRootless() {
+	if !rootless.IsRootless() && ctr.config.NetMode != "slirp4netns" {
 		var requestedIP net.IP
 		if ctr.requestedIP != nil {
 			requestedIP = ctr.requestedIP


### PR DESCRIPTION
Our networking code bakes in a lot of assumptions about how networking should work - that CNI is *always* used with root, and that slirp4netns is *always* used only with rootless. These are not safe assumptions. This fixes one particular issue, which would cause CNI to also be run when slirp4netns was requested as root.

Fixes: #4687
