### PR TITLE
revert accidental change from codespell pr.

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -19,7 +19,7 @@
 %endif
 
 # %if ! 0% {?gobuild:1}
-%define gobuild(o:) go build -tags="$BUILDTAGS" -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|of -An -tx1|tr -d ' \\n')" -a -v -x %{?**};
+%define gobuild(o:) go build -tags="$BUILDTAGS" -ldflags "${LDFLAGS:-} -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n')" -a -v -x %{?**};
 #% endif
 
 # libpod hack directory


### PR DESCRIPTION
This should use `od` not `of`

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>