### PR TITLE
v2 api: top improvements

### DIFF
--- a/libpod/container_top_linux.go
+++ b/libpod/container_top_linux.go
@@ -3,6 +3,8 @@
 package libpod
 
 import (
+	"bufio"
+	"os"
 	"strconv"
 	"strings"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/psgo"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // Top gathers statistics about the running processes in a container. It returns a
@@ -36,7 +39,34 @@ func (c *Container) Top(descriptors []string) ([]string, error) {
 			}
 		}
 	}
-	return c.GetContainerPidInformation(psgoDescriptors)
+
+	// If we encountered an ErrUnknownDescriptor error, fallback to executing
+	// ps(1). This ensures backwards compatibility to users depending on ps(1)
+	// and makes sure we're ~compatible with docker.
+	output, psgoErr := c.GetContainerPidInformation(psgoDescriptors)
+	if psgoErr == nil {
+		return output, nil
+	}
+	if errors.Cause(psgoErr) != psgo.ErrUnknownDescriptor {
+		return nil, psgoErr
+	}
+
+	output, err = c.execPS(descriptors)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error executing ps(1) in the container")
+	}
+
+	// Trick: filter the ps command from the output instead of
+	// checking/requiring PIDs in the output.
+	filtered := []string{}
+	cmd := strings.Join(descriptors, " ")
+	for _, line := range output {
+		if !strings.Contains(line, cmd) {
+			filtered = append(filtered, line)
+		}
+	}
+
+	return filtered, nil
 }
 
 // GetContainerPidInformation returns process-related data of all processes in
@@ -64,4 +94,60 @@ func (c *Container) GetContainerPidInformation(descriptors []string) ([]string, 
 		res = append(res, strings.Join(out, "\t"))
 	}
 	return res, nil
+}
+
+// execPS executes ps(1) with the specified args in the container.
+func (c *Container) execPS(args []string) ([]string, error) {
+	rPipe, wPipe, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	defer wPipe.Close()
+	defer rPipe.Close()
+
+	rErrPipe, wErrPipe, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	defer wErrPipe.Close()
+	defer rErrPipe.Close()
+
+	streams := new(AttachStreams)
+	streams.OutputStream = wPipe
+	streams.ErrorStream = wErrPipe
+	streams.AttachOutput = true
+	streams.AttachError = true
+
+	stdout := []string{}
+	go func() {
+		scanner := bufio.NewScanner(rPipe)
+		for scanner.Scan() {
+			stdout = append(stdout, scanner.Text())
+		}
+	}()
+	stderr := []string{}
+	go func() {
+		scanner := bufio.NewScanner(rErrPipe)
+		for scanner.Scan() {
+			stderr = append(stderr, scanner.Text())
+		}
+	}()
+
+	cmd := append([]string{"ps"}, args...)
+	ec, err := c.Exec(false, false, map[string]string{}, cmd, "", "", streams, 0, nil, "")
+	if err != nil {
+		return nil, err
+	} else if ec != 0 {
+		return nil, errors.Errorf("Runtime failed with exit status: %d and output: %s", ec, strings.Join(stderr, " "))
+	}
+
+	if logrus.GetLevel() >= logrus.DebugLevel {
+		// If we're running in debug mode or higher, we might want to have a
+		// look at stderr which includes debug logs from conmon.
+		for _, log := range stderr {
+			logrus.Debugf("%s", log)
+		}
+	}
+
+	return stdout, nil
 }

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -927,9 +927,7 @@ func (r *LocalRuntime) Top(cli *cliconfig.TopValues) ([]string, error) {
 
 	output, err = r.execPS(container, descriptors)
 	if err != nil {
-		// Note: return psgoErr to guide users into using the AIX descriptors
-		// instead of using ps(1).
-		return nil, psgoErr
+		return nil, errors.Wrapf(err, "error executing ps(1) in the container")
 	}
 
 	// Trick: filter the ps command from the output instead of
@@ -956,10 +954,8 @@ func (r *LocalRuntime) execPS(c *libpod.Container, args []string) ([]string, err
 	streams := new(libpod.AttachStreams)
 	streams.OutputStream = wPipe
 	streams.ErrorStream = wPipe
-	streams.InputStream = bufio.NewReader(os.Stdin)
 	streams.AttachOutput = true
 	streams.AttachError = true
-	streams.AttachInput = true
 
 	psOutput := []string{}
 	go func() {

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -27,7 +27,6 @@ import (
 	"github.com/containers/libpod/libpod/logs"
 	"github.com/containers/libpod/pkg/adapter/shortcuts"
 	"github.com/containers/libpod/pkg/systemdgen"
-	"github.com/containers/psgo"
 	"github.com/containers/storage"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -913,89 +912,7 @@ func (r *LocalRuntime) Top(cli *cliconfig.TopValues) ([]string, error) {
 		return nil, errors.Wrapf(err, "unable to lookup requested container")
 	}
 
-	output, psgoErr := container.Top(descriptors)
-	if psgoErr == nil {
-		return output, nil
-	}
-
-	// If we encountered an ErrUnknownDescriptor error, fallback to executing
-	// ps(1). This ensures backwards compatibility to users depending on ps(1)
-	// and makes sure we're ~compatible with docker.
-	if errors.Cause(psgoErr) != psgo.ErrUnknownDescriptor {
-		return nil, psgoErr
-	}
-
-	output, err = r.execPS(container, descriptors)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error executing ps(1) in the container")
-	}
-
-	// Trick: filter the ps command from the output instead of
-	// checking/requiring PIDs in the output.
-	filtered := []string{}
-	cmd := strings.Join(descriptors, " ")
-	for _, line := range output {
-		if !strings.Contains(line, cmd) {
-			filtered = append(filtered, line)
-		}
-	}
-
-	return filtered, nil
-}
-
-func (r *LocalRuntime) execPS(c *libpod.Container, args []string) ([]string, error) {
-	rPipe, wPipe, err := os.Pipe()
-	if err != nil {
-		return nil, err
-	}
-	defer wPipe.Close()
-	defer rPipe.Close()
-
-	rErrPipe, wErrPipe, err := os.Pipe()
-	if err != nil {
-		return nil, err
-	}
-	defer wErrPipe.Close()
-	defer rErrPipe.Close()
-
-	streams := new(libpod.AttachStreams)
-	streams.OutputStream = wPipe
-	streams.ErrorStream = wErrPipe
-	streams.AttachOutput = true
-	streams.AttachError = true
-
-	stdout := []string{}
-	go func() {
-		scanner := bufio.NewScanner(rPipe)
-		for scanner.Scan() {
-			stdout = append(stdout, scanner.Text())
-		}
-	}()
-	stderr := []string{}
-	go func() {
-		scanner := bufio.NewScanner(rErrPipe)
-		for scanner.Scan() {
-			stderr = append(stderr, scanner.Text())
-		}
-	}()
-
-	cmd := append([]string{"ps"}, args...)
-	ec, err := c.Exec(false, false, map[string]string{}, cmd, "", "", streams, 0, nil, "")
-	if err != nil {
-		return nil, err
-	} else if ec != 0 {
-		return nil, errors.Errorf("Runtime failed with exit status: %d and output: %s", ec, strings.Join(stderr, " "))
-	}
-
-	if logrus.GetLevel() >= logrus.DebugLevel {
-		// If we're running in debug mode or higher, we might want to have a
-		// look at stderr which includes debug logs from conmon.
-		for _, log := range stderr {
-			logrus.Debugf("%s", log)
-		}
-	}
-
-	return stdout, nil
+	return container.Top(descriptors)
 }
 
 // ExecContainer executes a command in the container

--- a/pkg/api/handlers/containers_top.go
+++ b/pkg/api/handlers/containers_top.go
@@ -4,10 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod"
-	"github.com/containers/libpod/libpod/define"
-	"github.com/containers/libpod/pkg/adapter"
 	"github.com/containers/libpod/pkg/api/handlers/utils"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/schema"
@@ -30,19 +27,14 @@ func TopContainer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	name := mux.Vars(r)["name"]
-
-	adapterRuntime := adapter.LocalRuntime{}
-	adapterRuntime.Runtime = runtime
-
-	topValues := cliconfig.TopValues{}
-	topValues.InputArgs = []string{name, query.PsArgs}
-
-	output, err := adapterRuntime.Top(&topValues)
+	c, err := runtime.LookupContainer(name)
 	if err != nil {
-		if errors.Cause(err) == define.ErrNoSuchCtr {
-			utils.ContainerNotFound(w, name, err)
-			return
-		}
+		utils.ContainerNotFound(w, name, err)
+		return
+	}
+
+	output, err := c.Top([]string{query.PsArgs})
+	if err != nil {
 		utils.InternalServerError(w, err)
 		return
 	}

--- a/pkg/api/handlers/containers_top.go
+++ b/pkg/api/handlers/containers_top.go
@@ -15,10 +15,14 @@ func TopContainer(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 
+	defaultValue := "-ef"
+	if utils.IsLibpodRequest(r) {
+		defaultValue = ""
+	}
 	query := struct {
 		PsArgs string `schema:"ps_args"`
 	}{
-		PsArgs: "-ef",
+		PsArgs: defaultValue,
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,

--- a/pkg/api/handlers/generic/containers_stats.go
+++ b/pkg/api/handlers/generic/containers_stats.go
@@ -43,7 +43,7 @@ func StatsContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If the container isn't returning, then let's not bother and return
+	// If the container isn't running, then let's not bother and return
 	// immediately.
 	state, err := ctnr.State()
 	if err != nil {

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -135,7 +135,6 @@ type Stats struct {
 
 type ContainerTopOKBody struct {
 	dockerContainer.ContainerTopOKBody
-	ID string `json:"Id"`
 }
 
 type PodCreateConfig struct {

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -345,7 +345,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//  - in: query
 	//    name: ps_args
 	//    type: string
-	//    description: arguments to pass to ps such as aux
+	//    description: arguments to pass to ps such as aux. Requires ps(1) to be installed in the container if no ps(1) compatible AIX descriptors are used.
 	// produces:
 	// - application/json
 	// responses:
@@ -653,6 +653,34 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/stats"), APIHandler(s.Context, generic.StatsContainer)).Methods(http.MethodGet)
+	// swagger:operation GET /libpod/containers/{nameOrID}/top containers topContainer
+	//
+	// List processes running inside a container. Note
+	//
+	// ---
+	// parameters:
+	//  - in: path
+	//    name: nameOrID
+	//    required: true
+	//    description: the name or ID of the container
+	//  - in: query
+	//    name: stream
+	//    type: bool
+	//    default: true
+	//    description: Stream the output
+	//    name: ps_args
+	//    type: string
+	//    description: arguments to pass to ps such as aux. Requires ps(1) to be installed in the container if no ps(1) compatible AIX descriptors are used.
+	// produces:
+	// - application/json
+	// responses:
+	//   '200':
+	//     description: no error
+	//       "ref": "#/responses/DockerTopResponse"
+	//   '404':
+	//       "$ref": "#/responses/NoSuchContainer"
+	//   '500':
+	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/top"), APIHandler(s.Context, handlers.TopContainer)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/containers/{nameOrID}/unpause containers libpodUnpauseContainer
 	// ---


### PR DESCRIPTION
* Use `pkg/adapter` to increase code reuse and reduce code redundancy.
* Extend swagger docs to mention AIX descriptors.
* Document the libpod endpoint which shares the same handler.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@baude @jwhonce PTAL