### PR TITLE
Remove c.String(net)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1587,8 +1587,6 @@ memorySwappiness [?int](#?int)
 
 name [?string](#?string)
 
-net [?string](#?string)
-
 network [?string](#?string)
 
 noHosts [?bool](#?bool)

--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -376,10 +376,6 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"Assign a name to the container",
 	)
 	createFlags.String(
-		"net", getDefaultNetwork(),
-		"Connect a container to a network",
-	)
-	createFlags.String(
 		"network", getDefaultNetwork(),
 		"Connect a container to a network",
 	)

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -85,13 +85,7 @@ func createInit(c *cliconfig.PodmanCommand) error {
 		logrus.Warn("setting security options with --privileged has no effect")
 	}
 
-	var setNet string
-	if c.IsSet("network") {
-		setNet = c.String("network")
-	} else if c.IsSet("net") {
-		setNet = c.String("net")
-	}
-	if (c.IsSet("dns") || c.IsSet("dns-opt") || c.IsSet("dns-search")) && (setNet == "none" || strings.HasPrefix(setNet, "container:")) {
+	if (c.IsSet("dns") || c.IsSet("dns-opt") || c.IsSet("dns-search")) && (c.String("network") == "none" || strings.HasPrefix(c.String("network"), "container:")) {
 		return errors.Errorf("conflicting options: dns and the network mode.")
 	}
 

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -25,7 +25,7 @@ var (
 			return runCmd(&runCommand)
 		},
 		Example: `podman run imageID ls -alF /etc
-  podman run --net=host imageID dnf -y install java
+  podman run --network=host imageID dnf -y install java
   podman run --volume /var/hostdir:/var/ctrdir -i -t fedora /bin/bash`,
 	}
 )

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -355,14 +355,10 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 	// Instead of integrating here, should be done in libpod
 	// However, that also involves setting up security opts
 	// when the pod's namespace is integrated
-	namespaceNet := c.String("network")
-	if c.Changed("net") {
-		namespaceNet = c.String("net")
-	}
 	namespaces = map[string]string{
 		"cgroup": c.String("cgroupns"),
 		"pid":    c.String("pid"),
-		"net":    namespaceNet,
+		"net":    c.String("network"),
 		"ipc":    c.String("ipc"),
 		"user":   c.String("userns"),
 		"uts":    c.String("uts"),
@@ -636,11 +632,6 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 	}
 	// This is done because cobra cannot have two aliased flags. So we have to check
 	// both
-	network := c.String("network")
-	if c.Changed("net") {
-		network = c.String("net")
-	}
-
 	memorySwappiness := c.Int64("memory-swappiness")
 
 	logDriver := libpod.KubernetesLogging
@@ -687,7 +678,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		DNSServers:   c.StringSlice("dns"),
 		HTTPProxy:    c.Bool("http-proxy"),
 		MacAddress:   c.String("mac-address"),
-		Network:      network,
+		Network:      c.String("network"),
 		NetMode:      netMode,
 		IPAddress:    c.String("ip"),
 		Publish:      c.StringSlice("publish"),

--- a/cmd/podman/shared/intermediate.go
+++ b/cmd/podman/shared/intermediate.go
@@ -423,7 +423,6 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIRes
 	m["memory-swap"] = newCRString(c, "memory-swap")
 	m["memory-swappiness"] = newCRInt64(c, "memory-swappiness")
 	m["name"] = newCRString(c, "name")
-	m["net"] = newCRString(c, "net")
 	m["network"] = newCRString(c, "network")
 	m["no-hosts"] = newCRBool(c, "no-hosts")
 	m["oom-kill-disable"] = newCRBool(c, "oom-kill-disable")

--- a/cmd/podman/shared/intermediate_varlink.go
+++ b/cmd/podman/shared/intermediate_varlink.go
@@ -127,7 +127,6 @@ func (g GenericCLIResults) MakeVarlink() iopodman.Create {
 		MemorySwap:             StringToPtr(g.Find("memory-swap")),
 		MemorySwappiness:       AnyIntToInt64Ptr(g.Find("memory-swappiness")),
 		Name:                   StringToPtr(g.Find("name")),
-		Net:                    StringToPtr(g.Find("net")),
 		Network:                StringToPtr(g.Find("network")),
 		OomKillDisable:         BoolToPtr(g.Find("oom-kill-disable")),
 		OomScoreAdj:            AnyIntToInt64Ptr(g.Find("oom-score-adj")),
@@ -386,7 +385,6 @@ func VarlinkCreateToGeneric(opts iopodman.Create) GenericCLIResults {
 	m["memory-swap"] = stringFromVarlink(opts.MemorySwap, "memory-swap", nil)
 	m["memory-swappiness"] = int64FromVarlink(opts.MemorySwappiness, "memory-swappiness", &memSwapDefault)
 	m["name"] = stringFromVarlink(opts.Name, "name", nil)
-	m["net"] = stringFromVarlink(opts.Net, "net", &netModeDefault)
 	m["network"] = stringFromVarlink(opts.Network, "network", &netModeDefault)
 	m["no-hosts"] = boolFromVarlink(opts.NoHosts, "no-hosts", false)
 	m["oom-kill-disable"] = boolFromVarlink(opts.OomKillDisable, "oon-kill-disable", false)

--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -61,6 +61,8 @@ func aliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "health-start-period"
 	case "healthcheck-timeout":
 		name = "health-timeout"
+	case "net":
+		name = "network"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -350,7 +350,6 @@ type Create (
     memorySwap: ?string,
     memorySwappiness: ?int,
     name: ?string,
-    net: ?string,
     network: ?string,
     noHosts: ?bool,
     oomKillDisable: ?bool,

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1014,7 +1014,7 @@ In order for users to run rootless, there must be an entry for their username in
 Rootless Podman works better if the fuse-overlayfs and slirp4netns packages are installed.
 The fuse-overlay package provides a userspace overlay storage driver, otherwise users need to use
 the vfs storage driver, which is diskspace expensive and does not perform well. slirp4netns is
-required for VPN, without it containers need to be run with the --net=host flag.
+required for VPN, without it containers need to be run with the --network=host flag.
 
 ## ENVIRONMENT
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1310,7 +1310,7 @@ In order for users to run rootless, there must be an entry for their username in
 Rootless Podman works better if the fuse-overlayfs and slirp4netns packages are installed.
 The fuse-overlay package provides a userspace overlay storage driver, otherwise users need to use
 the vfs storage driver, which is diskspace expensive and does not perform well. slirp4netns is
-required for VPN, without it containers need to be run with the --net=host flag.
+required for VPN, without it containers need to be run with the --network=host flag.
 
 ## ENVIRONMENT
 


### PR DESCRIPTION
We have a lot of cludgy code trying to make --net and --network equivalent.
This will allow --net to still exists but will eliminate the help and confusion.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>