### PR TITLE
Cirrus: remove workaround for cleaning /go/bin

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -102,8 +102,6 @@ gating_task:
     networking_script: '${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/networking.sh'
 
     gate_script:
-        # TODO: remove once the image doesn't ship with pre-installed tools
-        # - rm /go/bin/*
         # N/B: entrypoint.sh resets $GOSRC (same as make clean)
         - '/usr/local/bin/entrypoint.sh install.tools |& ${TIMESTAMP}'
         - '/usr/local/bin/entrypoint.sh validate |& ${TIMESTAMP}'


### PR DESCRIPTION
Remove the temporary workaround for cleaning /go/bin in the gating task.
The workaround was added to make sure that we're always installing the
latest tools in `make install.tools`.  The gating image does not ship
with these pre-installed tools anymore which is now causing errors in
the gating task as the `rm` is missing the `--force` flag.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>