### PR TITLE
e2e/run_signal_test.go: make it more robust

### DIFF
--- a/test/e2e/run_signal_test.go
+++ b/test/e2e/run_signal_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Podman run with --sig-proxy", func() {
 		Expect(killSession.ExitCode()).To(Equal(0))
 
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(137))
+		Expect(session.ExitCode()).ToNot(Equal(0))
 		ok, _ = session.GrepString("Received")
 		Expect(ok).To(BeFalse())
 	})


### PR DESCRIPTION
Make the signal test more robust by just checking that the container's
exit code is non-zero.  There are two possible exit codes (i.e., 130 and
137) depending on how the container is being killed, which is likely
responsible for CI flakes.

Fixes: #4886
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>