### PR TITLE
WIP: Swagger docs: fix inconsistencies

### DIFF
--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
-	// swagger:operation POST /containers/create compat containerCreate
+	// swagger:operation POST /containers/create compat createContainer
 	// ---
 	//   summary: Create a container
 	//   tags:
@@ -70,7 +70,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/json"), APIHandler(s.Context, generic.ListContainers)).Methods(http.MethodGet)
-	// swagger:operation POST  /containers/prune compat pruneContainers
+	// swagger:operation POST /containers/prune compat pruneContainers
 	// ---
 	//   tags:
 	//    - containers (compat)
@@ -156,7 +156,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//     "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name:..*}/json"), APIHandler(s.Context, generic.GetContainer)).Methods(http.MethodGet)
-	// swagger:operation post /containers/{nameOrID}/kill compat killcontainer
+	// swagger:operation POST /containers/{nameOrID}/kill compat killContainer
 	// ---
 	// tags:
 	//   - containers (compat)
@@ -183,7 +183,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name:..*}/kill"), APIHandler(s.Context, generic.KillContainer)).Methods(http.MethodPost)
-	// swagger:operation GET /containers/{nameOrID}/logs compat LogsFromContainer
+	// swagger:operation GET /containers/{nameOrID}/logs compat logsFromContainer
 	// ---
 	// tags:
 	//   - containers (compat)
@@ -428,7 +428,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name:..*}/wait"), APIHandler(s.Context, generic.WaitContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{nameOrID}/attach compat attach
+	// swagger:operation POST /containers/{nameOrID}/attach compat attachContainer
 	// ---
 	// tags:
 	//   - containers (compat)
@@ -482,7 +482,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//       "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name:..*}/attach"), APIHandler(s.Context, handlers.AttachContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /containers/{nameOrID}/resize compat resize
+	// swagger:operation POST /containers/{nameOrID}/resize compat resizeContainer
 	// ---
 	// tags:
 	//  - containers (compat)
@@ -518,6 +518,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 		libpod endpoints
 	*/
 
+	// swagger:operation POST /libpod/containers/create libpod libpodCreateContainer
 	r.HandleFunc(VersionedPath("/libpod/containers/create"), APIHandler(s.Context, libpod.CreateContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /libpod/containers/json libpod libpodListContainers
 	// ---
@@ -562,7 +563,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/prune"), APIHandler(s.Context, libpod.PruneContainers)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/containers/showmounted libpod showMounterContainers
+	// swagger:operation GET /libpod/containers/showmounted libpod libpodShowMountedContainers
 	// ---
 	// tags:
 	//  - containers
@@ -580,7 +581,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/showmounted"), APIHandler(s.Context, libpod.ShowMountedContainers)).Methods(http.MethodGet)
-	// swagger:operation DELETE /libpod/containers/json libpod libpodRemoveContainer
+	// swagger:operation DELETE /libpod/containers/{nameOrID} libpod libpodRemoveContainer
 	// ---
 	// tags:
 	//  - containers
@@ -637,7 +638,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/json"), APIHandler(s.Context, libpod.GetContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/containers/{nameOrID}/kill libpod libpodKillContainer
+	// swagger:operation GET /libpod/containers/{nameOrID}/kill libpod libpodKillContainer
 	// ---
 	// tags:
 	//  - containers
@@ -665,7 +666,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/kill"), APIHandler(s.Context, libpod.KillContainer)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/containers/{nameOrID}/mount libpod mountContainer
+	// swagger:operation POST /libpod/containers/{nameOrID}/mount libpod libpodMountContainer
 	// ---
 	// tags:
 	//  - containers
@@ -690,8 +691,9 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/mount"), APIHandler(s.Context, libpod.MountContainer)).Methods(http.MethodPost)
+	// swagger:operation GET /libpod/containers/{nameOrID}/logs libpod libpodLogsFromContainer
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/logs"), APIHandler(s.Context, libpod.LogsFromContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/containers/{nameOrID}/pause libpod libpodPauseContainer
+	// swagger:operation POST /libpod/containers/{nameOrID}/pause libpod pauseContainer
 	// ---
 	// tags:
 	//  - containers
@@ -712,7 +714,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/pause"), APIHandler(s.Context, handlers.PauseContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{nameOrID}/restart libpod libpodRestartContainer
+	// swagger:operation POST /libpod/containers/{nameOrID}/restart libpod restartContainer
 	// ---
 	// tags:
 	//  - containers
@@ -736,7 +738,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/restart"), APIHandler(s.Context, handlers.RestartContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{nameOrID}/start libpod libpodStartContainer
+	// swagger:operation POST /libpod/containers/{nameOrID}/start libpod startContainer
 	// ---
 	// tags:
 	//  - containers
@@ -788,7 +790,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/stats"), APIHandler(s.Context, generic.StatsContainer)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/containers/{nameOrID}/top containers topContainer
+	// swagger:operation GET /libpod/containers/{nameOrID}/top libpod topContainer
 	//
 	// List processes running inside a container. Note
 	//
@@ -817,7 +819,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/top"), APIHandler(s.Context, handlers.TopContainer)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/containers/{nameOrID}/unpause libpod libpodUnpauseContainer
+	// swagger:operation POST /libpod/containers/{nameOrID}/unpause libpod unpauseContainer
 	// ---
 	// tags:
 	//  - containers
@@ -861,7 +863,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/wait"), APIHandler(s.Context, libpod.WaitContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{nameOrID}/exists libpod containerExists
+	// swagger:operation GET /libpod/containers/{nameOrID}/exists libpod libpodContainerExists
 	// ---
 	// tags:
 	//  - containers
@@ -882,7 +884,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/exists"), APIHandler(s.Context, libpod.ContainerExists)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/containers/{nameOrID}/stop libpod libpodStopContainer
+	// swagger:operation POST /libpod/containers/{nameOrID}/stop libpod stopContainer
 	// ---
 	// tags:
 	//  - containers
@@ -908,7 +910,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/stop"), APIHandler(s.Context, handlers.StopContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{nameOrID}/attach libpod attach
+	// swagger:operation POST /libpod/containers/{nameOrID}/attach libpod attachContainer
 	// ---
 	// tags:
 	//   - containers
@@ -962,7 +964,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//   '500':
 	//       "$ref": "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/attach"), APIHandler(s.Context, handlers.AttachContainer)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/containers/{nameOrID}/resize libpod resize
+	// swagger:operation POST /libpod/containers/{nameOrID}/resize libpod resizeContainer
 	// ---
 	// tags:
 	//  - containers

--- a/pkg/api/server/register_events.go
+++ b/pkg/api/server/register_events.go
@@ -1,12 +1,14 @@
 package server
 
 import (
+	"net/http"
+
 	"github.com/containers/libpod/pkg/api/handlers"
 	"github.com/gorilla/mux"
 )
 
 func (s *APIServer) RegisterEventsHandlers(r *mux.Router) error {
-	// swagger:operation GET /events system getEvents
+	// swagger:operation GET /events compat getEvents
 	// ---
 	// summary: Returns events filtered on query parameters
 	// produces:
@@ -27,6 +29,6 @@ func (s *APIServer) RegisterEventsHandlers(r *mux.Router) error {
 	//   "500":
 	//     description: Failed
 	//     "$ref": "#/responses/InternalError"
-	r.Handle(VersionedPath("/events"), APIHandler(s.Context, handlers.GetEvents))
+	r.Handle(VersionedPath("/events"), APIHandler(s.Context, handlers.GetEvents)).Methods(http.MethodGet)
 	return nil
 }

--- a/pkg/api/server/register_healthcheck.go
+++ b/pkg/api/server/register_healthcheck.go
@@ -8,6 +8,7 @@ import (
 )
 
 func (s *APIServer) registerHealthCheckHandlers(r *mux.Router) error {
+	// swagger:operation GET /libpod/containers/{nameOrID}/runhealthcheck libpod libpodRunHealthCheck
 	r.Handle(VersionedPath("/libpod/containers/{name:..*}/runhealthcheck"), APIHandler(s.Context, libpod.RunHealthCheck)).Methods(http.MethodGet)
 	return nil
 }

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
-	// swagger:operation POST /images/create compat createImage
+	// swagger:operation POST /images/create compat createImageFromImage
 	//
 	// ---
 	// tags:
@@ -42,7 +42,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     schema:
 	//      $ref: '#/responses/GenericError'
 	r.Handle(VersionedPath("/images/create"), APIHandler(s.Context, generic.CreateImageFromImage)).Methods(http.MethodPost).Queries("fromImage", "{fromImage}")
-	// swagger:operation POST /images/create compat createImage
+	// swagger:operation POST /images/create compat createImageFromSrc
 	// ---
 	// tags:
 	//  - images (compat)
@@ -73,7 +73,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     schema:
 	//      $ref: '#/responses/GenericError'
 	r.Handle(VersionedPath("/images/create"), APIHandler(s.Context, generic.CreateImageFromSrc)).Methods(http.MethodPost).Queries("fromSrc", "{fromSrc}")
-	// swagger:operation GET /images/json compat listImages
+	// swagger:operation GET /images/json compat getImages
 	// ---
 	// tags:
 	//  - images (compat)
@@ -222,7 +222,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/images/{name:..*}/get"), APIHandler(s.Context, generic.ExportImage)).Methods(http.MethodGet)
-	// swagger:operation GET /images/{nameOrID}/history compat imageHistory
+	// swagger:operation GET /images/{nameOrID}/history compat historyImage
 	// ---
 	// tags:
 	//  - images (compat)
@@ -243,7 +243,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   '500':
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/images/{name:..*}/history"), APIHandler(s.Context, handlers.HistoryImage)).Methods(http.MethodGet)
-	// swagger:operation GET /images/{nameOrID}/json compat inspectImage
+	// swagger:operation GET /images/{nameOrID}/json compat getImage
 	// ---
 	// tags:
 	//  - images (compat)
@@ -263,7 +263,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//       $ref: "#/responses/NoSuchImage"
 	//   '500':
 	//      $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/images/{name:..*}/json"), APIHandler(s.Context, generic.GetImage))
+	r.Handle(VersionedPath("/images/{name:..*}/json"), APIHandler(s.Context, generic.GetImage)).Methods(http.MethodGet)
 	// swagger:operation POST /images/{nameOrID}/tag compat tagImage
 	// ---
 	// tags:
@@ -297,7 +297,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/images/{name:..*}/tag"), APIHandler(s.Context, handlers.TagImage)).Methods(http.MethodPost)
-	// swagger:operation POST /commit/ compat commitContainer
+	// swagger:operation POST /commit compat commitContainer
 	// ---
 	// tags:
 	//  - commit (compat)
@@ -346,7 +346,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 		libpod endpoints
 	*/
 
-	// swagger:operation POST /libpod/images/{nameOrID}/exists libpod libpodImageExists
+	// swagger:operation GET /libpod/images/{nameOrID}/exists libpod libpodImageExists
 	// ---
 	// tags:
 	//  - images
@@ -366,9 +366,10 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//       $ref: '#/responses/NoSuchImage'
 	//   '500':
 	//      $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/{name:..*}/exists"), APIHandler(s.Context, libpod.ImageExists))
-	r.Handle(VersionedPath("/libpod/images/{name:..*}/tree"), APIHandler(s.Context, libpod.ImageTree))
-	// swagger:operation GET /libpod/images/{nameOrID}/history libpod libpodImageHistory
+	r.Handle(VersionedPath("/libpod/images/{name:..*}/exists"), APIHandler(s.Context, libpod.ImageExists)).Methods(http.MethodGet)
+	// swagger:operation GET /libpod/images/{nameOrID}/tree libpod libpodImageTree
+	r.Handle(VersionedPath("/libpod/images/{name:..*}/tree"), APIHandler(s.Context, libpod.ImageTree)).Methods(http.MethodGet)
+	// swagger:operation GET /libpod/images/history libpod historyImage
 	// ---
 	// tags:
 	//  - images
@@ -391,7 +392,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/history"), APIHandler(s.Context, handlers.HistoryImage)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/images/json libpod libpodListImages
+	// swagger:operation GET /libpod/images/json libpod libpodGetImages
 	// ---
 	// tags:
 	//  - images
@@ -405,7 +406,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/json"), APIHandler(s.Context, libpod.GetImages)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/images/load libpod libpodLoadImage
+	// swagger:operation POST /libpod/images/load libpod loadImage
 	// ---
 	// tags:
 	//  - images
@@ -458,7 +459,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/prune"), APIHandler(s.Context, libpod.PruneImages)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/images/search libpod libpodSearchImages
+	// swagger:operation GET /libpod/images/search libpod searchImages
 	// ---
 	// tags:
 	//  - images
@@ -491,7 +492,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/search"), APIHandler(s.Context, handlers.SearchImages)).Methods(http.MethodGet)
-	// swagger:operation DELETE /libpod/images/{nameOrID} libpod libpodRemoveImage
+	// swagger:operation DELETE /libpod/images/{nameOrID} libpod removeImage
 	// ---
 	// tags:
 	//  - images
@@ -518,7 +519,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:..*}"), APIHandler(s.Context, handlers.RemoveImage)).Methods(http.MethodDelete)
-	// swagger:operation GET /libpod/images/{nameOrID}/get libpod libpoodExportImage
+	// swagger:operation GET /libpod/images/{nameOrID}/get libpod libpodExportImage
 	// ---
 	// tags:
 	//  - images
@@ -550,7 +551,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:..*}/get"), APIHandler(s.Context, libpod.ExportImage)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/images/{nameOrID}/json libpod libpodInspectImage
+	// swagger:operation GET /libpod/images/{nameOrID}/json libpod libpodGetImage
 	// ---
 	// tags:
 	//  - images
@@ -570,8 +571,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//       $ref: '#/responses/NoSuchImage'
 	//   '500':
 	//      $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/{name:..*}/json"), APIHandler(s.Context, libpod.GetImage))
-	// swagger:operation POST /libpod/images/{nameOrID}/tag libpod libpodTagImage
+	r.Handle(VersionedPath("/libpod/images/{name:..*}/json"), APIHandler(s.Context, libpod.GetImage)).Methods(http.MethodGet)
+	// swagger:operation POST /libpod/images/{nameOrID}/tag libpod tagImage
 	// ---
 	// tags:
 	//  - images
@@ -605,6 +606,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//      $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:..*}/tag"), APIHandler(s.Context, handlers.TagImage)).Methods(http.MethodPost)
 
+	// swagger:operation POST /build compat buildImage
 	r.Handle(VersionedPath("/build"), APIHandler(s.Context, handlers.BuildImage)).Methods(http.MethodPost)
 	return nil
 }

--- a/pkg/api/server/register_info.go
+++ b/pkg/api/server/register_info.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *APIServer) registerInfoHandlers(r *mux.Router) error {
-	// swagger:operation GET /info libpod libpodGetInfo
+	// swagger:operation GET /info compat getInfo
 	// ---
 	// summary: Get info
 	// description: Returns information on the system and libpod configuration

--- a/pkg/api/server/register_ping.go
+++ b/pkg/api/server/register_ping.go
@@ -8,9 +8,12 @@ import (
 )
 
 func (s *APIServer) registerPingHandlers(r *mux.Router) error {
+	// swagger:operation GET /_ping compat pingGET
 	r.Handle("/_ping", APIHandler(s.Context, generic.PingGET)).Methods(http.MethodGet)
+	// swagger:operation HEAD /_ping compat pingHEAD
 	r.Handle("/_ping", APIHandler(s.Context, generic.PingHEAD)).Methods("HEAD")
 
+	// swagger:operation GET /libpod/_ping libpod pingGET
 	// libpod
 	r.Handle("/libpod/_ping", APIHandler(s.Context, generic.PingGET)).Methods(http.MethodGet)
 	return nil

--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
-	// swagger:operation GET /libpod/pods/json pods ListPods
+	// swagger:operation GET /libpod/pods/json libpod libpodPods
 	// ---
 	// summary: List pods
 	// produces:
@@ -28,8 +28,9 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/json"), APIHandler(s.Context, libpod.Pods)).Methods(http.MethodGet)
+	// swagger:operation POST /libpod/pods/create libpod libpodPodCreate
 	r.Handle(VersionedPath("/libpod/pods/create"), APIHandler(s.Context, libpod.PodCreate)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/prune pods PrunePods
+	// swagger:operation POST /libpod/pods/prune libpod libpodPodPrune
 	// ---
 	// summary: Prune unused pods
 	// parameters:
@@ -48,7 +49,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/prune"), APIHandler(s.Context, libpod.PodPrune)).Methods(http.MethodPost)
-	// swagger:operation DELETE /libpod/pods/{nameOrID} pods removePod
+	// swagger:operation DELETE /libpod/pods/{nameOrID} libpod libpodPodDelete
 	// ---
 	// summary: Remove pod
 	// produces:
@@ -72,7 +73,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}"), APIHandler(s.Context, libpod.PodDelete)).Methods(http.MethodDelete)
-	// swagger:operation GET /libpod/pods/{nameOrID}/json pods inspectPod
+	// swagger:operation GET /libpod/pods/{nameOrID}/json libpod libpodPodInspect
 	// ---
 	// summary: Inspect pod
 	// produces:
@@ -90,7 +91,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/json"), APIHandler(s.Context, libpod.PodInspect)).Methods(http.MethodGet)
-	// swagger:operation GET /libpod/pods/{nameOrID}/exists pods podExists
+	// swagger:operation GET /libpod/pods/{nameOrID}/exists libpod libpodPodExists
 	// ---
 	// summary: Pod exists
 	// description: Check if a pod exists by name or ID
@@ -109,7 +110,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/exists"), APIHandler(s.Context, libpod.PodExists)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/pods/{nameOrID}/kill pods killPod
+	// swagger:operation POST /libpod/pods/{nameOrID}/kill libpod libpodPodKill
 	// ---
 	// summary: Kill a pod
 	// produces:
@@ -135,7 +136,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/kill"), APIHandler(s.Context, libpod.PodKill)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/{nameOrID}/pause pods pausePod
+	// swagger:operation POST /libpod/pods/{nameOrID}/pause libpod libpodPodPause
 	// ---
 	// summary: Pause a pod
 	// produces:
@@ -153,7 +154,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/pause"), APIHandler(s.Context, libpod.PodPause)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/{nameOrID}/restart pods restartPod
+	// swagger:operation POST /libpod/pods/{nameOrID}/restart libpod libpodPodRestart
 	// ---
 	// summary: Restart a pod
 	// produces:
@@ -171,7 +172,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/restart"), APIHandler(s.Context, libpod.PodRestart)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/{nameOrID}/start pods startPod
+	// swagger:operation POST /libpod/pods/{nameOrID}/start libpod libpodPodStart
 	// ---
 	// summary: Start a pod
 	// produces:
@@ -191,7 +192,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/start"), APIHandler(s.Context, libpod.PodStart)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/{nameOrID}/stop pods stopPod
+	// swagger:operation POST /libpod/pods/{nameOrID}/stop libpod libpodPodStop
 	// ---
 	// summary: Stop a pod
 	// produces:
@@ -217,7 +218,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//   '500':
 	//      $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/{name:..*}/stop"), APIHandler(s.Context, libpod.PodStop)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/pods/{nameOrID}/unpause pods unpausePod
+	// swagger:operation POST /libpod/pods/{nameOrID}/unpause libpod libpodPodUnpause
 	// ---
 	// summary: Unpause a pod
 	// produces:

--- a/pkg/api/server/register_system.go
+++ b/pkg/api/server/register_system.go
@@ -1,11 +1,14 @@
 package server
 
 import (
+	"net/http"
+
 	"github.com/containers/libpod/pkg/api/handlers/generic"
 	"github.com/gorilla/mux"
 )
 
 func (s *APIServer) registerSystemHandlers(r *mux.Router) error {
-	r.Handle(VersionedPath("/system/df"), APIHandler(s.Context, generic.GetDiskUsage))
+	// swagger:operation GET /system/df compat getDiskUsage
+	r.Handle(VersionedPath("/system/df"), APIHandler(s.Context, generic.GetDiskUsage)).Methods(http.MethodGet)
 	return nil
 }

--- a/pkg/api/server/register_version.go
+++ b/pkg/api/server/register_version.go
@@ -6,7 +6,9 @@ import (
 )
 
 func (s *APIServer) registerVersionHandlers(r *mux.Router) error {
+	// swagger:operation GET /version compat versionHandler
 	r.Handle("/version", APIHandler(s.Context, generic.VersionHandler))
+	// swagger:operation GET /version compat versionHandler
 	r.Handle(VersionedPath("/version"), APIHandler(s.Context, generic.VersionHandler))
 	return nil
 }

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
-	// swagger:operation POST /libpod/volumes/create volumes createVolume
+	// swagger:operation POST /libpod/volumes/create libpod libpodCreateVolume
 	// ---
 	// summary: Create a volume
 	// produces:
@@ -19,8 +19,9 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.Handle("/libpod/volumes/create", APIHandler(s.Context, libpod.CreateVolume)).Methods(http.MethodPost)
+	// swagger:operation GET /libpod/volumes/json libpod libpodListVolumes
 	r.Handle("/libpod/volumes/json", APIHandler(s.Context, libpod.ListVolumes)).Methods(http.MethodGet)
-	// swagger:operation POST /volumes/prune volumes pruneVolumes
+	// swagger:operation POST /libpod/volumes/prune libpod libpodPruneVolumes
 	// ---
 	// summary: Prune volumes
 	// produces:
@@ -31,7 +32,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.Handle("/libpod/volumes/prune", APIHandler(s.Context, libpod.PruneVolumes)).Methods(http.MethodPost)
-	// swagger:operation GET /volumes/{nameOrID}/json volumes inspectVolume
+	// swagger:operation GET /libpod/volumes/{nameOrID}/json libpod libpodInspectVolume
 	// ---
 	// summary: Inspect volume
 	// parameters:
@@ -49,7 +50,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
 	r.Handle("/libpod/volumes/{name:..*}/json", APIHandler(s.Context, libpod.InspectVolume)).Methods(http.MethodGet)
-	// swagger:operation DELETE /volumes/{nameOrID} volumes removeVolume
+	// swagger:operation DELETE /libpod/volumes/{nameOrID} libpod libpodRemoveVolume
 	// ---
 	// summary: Remove volume
 	// parameters:


### PR DESCRIPTION
The swagger doc headers are, if I may be blunt, evil.
There is far too much manual muckery; much of those
comments should be autogenerated.

I'm working on that: a script that parses the r.Handle()
registrations and autogenerates a set of swagger comments.
It's still a WIP, and I'd like to extend it much more
so the parameter descriptions can be written in a more
human-friendly way, but that's not going to happen
before devconf. ITM here are a ton of problems, some
real, some perhaps not, that my script has found and
fixed.

Some are (possibly minor, I don't know) capitalization
errors. Some are errors in the documented method (GET vs POST).
Some are errors in the endpoint. I believe that all of
them should be reviewed carefully and, as appropriate,
merged. (You do not need to merge this PR, but please
at least incorporate the necessary fixes into your trees).

Signed-off-by: Ed Santiago <santiago@redhat.com>