### PR TITLE
Minor: Bugfix in upload image

### DIFF
--- a/contrib/upldrel/entrypoint.sh
+++ b/contrib/upldrel/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 source /usr/local/bin/lib_entrypoint.sh
 
-req_env_var GCPJSON_FILEPATH GCPNAME GCPPROJECT BUCKET FROM_FILEPATH TO_FILENAME ALSO_FILENAME
+req_env_var GCPJSON_FILEPATH GCPNAME GCPPROJECT BUCKET FROM_FILEPATH TO_FILENAME
 
 [[ -r "$FROM_FILEPATH" ]] || \
     die 2 ERROR Cannot read release archive file: "$FROM_FILEPATH"


### PR DESCRIPTION
The release upload process always involves two filenames, however the
second filename might (someday) be optional.  The code allowed for this,
however input validation did not.  This change fixes the validation.

Signed-off-by: Chris Evich <cevich@redhat.com>