### PR TITLE
Make it easier to override git variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ CHANGELOG_BASE ?= HEAD~
 CHANGELOG_TARGET ?= HEAD
 PROJECT := github.com/containers/libpod
 GIT_BASE_BRANCH ?= origin/master
+VERSION ?= $(shell git describe HEAD 2>/dev/null)
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 GIT_BRANCH_CLEAN ?= $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 LIBPOD_IMAGE ?= libpod_dev$(if $(GIT_BRANCH_CLEAN),:$(GIT_BRANCH_CLEAN))
@@ -89,7 +90,7 @@ LIBSECCOMP_COMMIT := v2.3.3
 GINKGOTIMEOUT ?= -timeout=90m
 
 RELEASE_VERSION ?= $(shell hack/get_release_info.sh VERSION)
-RELEASE_NUMBER ?= $(shell hack/get_release_info.sh NUMBER|sed -e 's/^v\(.*\)/\1/')
+RELEASE_NUMBER ?= $(shell hack/get_release_info.sh NUMBER)
 RELEASE_DIST ?= $(shell hack/get_release_info.sh DIST)
 RELEASE_DIST_VER ?= $(shell hack/get_release_info.sh DIST_VER)
 RELEASE_ARCH ?= $(shell hack/get_release_info.sh ARCH)

--- a/hack/get_release_info.sh
+++ b/hack/get_release_info.sh
@@ -19,10 +19,16 @@ unset OUTPUT
 case "$1" in
     # Wild-card suffix needed by valid_args() e.g. possible bad grep of "$(echo $FOO)"
     VERSION*)
-        OUTPUT="${CIRRUS_TAG:-$(git fetch --tags && git describe HEAD 2> /dev/null)}"
+        # v1.7.0-152-g9be6430
+        OUTPUT="${CIRRUS_TAG:-$VERSION}"
+        ;;
+    TAG*)
+        # v1.7.0
+        OUTPUT="$($0 VERSION | sed 's/-.*//')"
         ;;
     NUMBER*)
-        OUTPUT="$($0 VERSION | sed 's/-.*//')"
+        # 1.7.0
+        OUTPUT="$($0 TAG | sed -e 's/^v\(.*\)/\1/')"
         ;;
     DIST_VER*)
         OUTPUT="$(source /etc/os-release; echo $VERSION_ID | cut -d '.' -f 1)"


### PR DESCRIPTION
Use $VERSION instead of the "$CIRRUS_TAG".
(the other variable to set is $GIT_COMMIT)

Avoid doing an unnecessary `git fetch --tags`.
Move the NUMBER sed hacks to the shell script.

Allows building from e.g. tarball, without git.

Also allows building within a _different_ git.

Example use:

```shell
make VERSION=v1.7.0 GIT_COMMIT=b7ce1157b00af09f4a09e39b377aa3abff46ee05
```

Closes #4787
