### PR TITLE
lint: activate bashate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,22 @@ repos:
       - id: check-byte-order-marker
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
+  - repo: https://github.com/openstack-dev/bashate.git
+    rev: "0.6.0"
+    hooks:
+      - id: bashate
+        entry: bashate --error . --ignore=E003,E002,E006,E011,E020,E041,E042
+        # Run bashate check for all bash scripts
+        # Ignores the following rules:
+        # E006: Line longer than 79 columns (as many scripts use jinja
+        #       templating, this is very difficult)
+        # E040: Syntax error determined using `bash -n` (as many scripts
+        #       use jinja templating, this will often fail and the syntax
+        #       error will be discovered in execution anyway)
+        # TODO(ssbarnea): remove temporary skips made during adoption:
+        # E002 Tab indents
+        # E010 The "do" should be on same line as for
+        # E011 Then keyword is not on same line as if or elif keyword
+        # E020 Function declaration not in format ^function name {$
+        # E041 Arithmetic expansion using $[ is deprecated for $((
+        # E042 local declaration hides errors

--- a/Makefile
+++ b/Makefile
@@ -536,7 +536,7 @@ validate.completions: completions/bash/podman
 	. completions/bash/podman
 	if [ -x /bin/zsh ]; then /bin/zsh completions/zsh/_podman; fi
 
-validate: gofmt .gitvalidation validate.completions golangci-lint man-page-check
+validate: lint gofmt .gitvalidation validate.completions golangci-lint man-page-check
 
 build-all-new-commits:
 	# Validate that all the commits build on top of $(GIT_BASE_BRANCH)

--- a/contrib/cirrus/build_vm_images.sh
+++ b/contrib/cirrus/build_vm_images.sh
@@ -28,8 +28,7 @@ cd "$GOSRC/$PACKER_BASE"
 # Add/update labels on base-images used in this build to prevent premature deletion
 ARGS="
 "
-for base_image_var in $BASE_IMAGE_VARS
-do
+for base_image_var in $BASE_IMAGE_VARS; do
     # See entrypoint.sh in contrib/imgts and contrib/imgprune
     # These updates can take a while, run them in the background, check later
     gcloud compute images update \

--- a/contrib/cirrus/check_image.sh
+++ b/contrib/cirrus/check_image.sh
@@ -43,8 +43,7 @@ do
         "$(systemctl list-unit-files --no-legend $REQ_UNIT)" = "$REQ_UNIT enabled" || let "NFAILS+=1"
 done
 
-for evil_unit in $EVIL_UNITS
-do
+for evil_unit in $EVIL_UNITS; do
     # Exits zero if any unit matching pattern is running
     unit_status=$(systemctl is-active $evil_unit &> /dev/null; echo $?)
     item_test "No $evil_unit unit is present or active:" "$unit_status" -ne "0" || let "NFAILS+=1"

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -163,8 +163,7 @@ show_env_vars() {
     _ENV_VAR_NAMES=$(awk 'BEGIN{for(v in ENVIRON) print v}' | \
         egrep -v "(^PATH$)|(^BASH_FUNC)|(^[[:punct:][:space:]]+)|$SECRET_ENV_RE" | \
         sort -u)
-    for _env_var_name in $_ENV_VAR_NAMES
-    do
+    for _env_var_name in $_ENV_VAR_NAMES; do
         # Supports older BASH versions
         printf "    ${_env_var_name}=%q\n" "$(printenv $_env_var_name)"
     done
@@ -199,8 +198,7 @@ timeout_attempt_delay_command() {
     STDOUTERR=$(mktemp -p '' $(basename $0)_XXXXX)
     req_env_var ATTEMPTS DELAY
     echo "Retrying $ATTEMPTS times with a $DELAY delay, and $TIMEOUT timeout for command: $@"
-    for (( COUNT=1 ; COUNT <= $ATTEMPTS ; COUNT++ ))
-    do
+    for (( COUNT=1 ; COUNT <= $ATTEMPTS ; COUNT++ )); do
         echo "##### (attempt #$COUNT)" &>> "$STDOUTERR"
         if timeout --foreground $TIMEOUT "$@" &>> "$STDOUTERR"
         then
@@ -326,8 +324,7 @@ setup_rootless() {
         egrep -v "(^PATH$)|(^BASH_FUNC)|(^[[:punct:][:space:]]+)|$SECRET_ENV_RE" | \
         egrep "$ROOTLESS_ENV_RE" | \
         sort -u)
-    for _env_var_name in $_ENV_VAR_NAMES
-    do
+    for _env_var_name in $_ENV_VAR_NAMES; do
         # Works with older versions of bash
         printf "${_env_var_name}=%q\n" "$(printenv $_env_var_name)" >> "/home/$ROOTLESS_USER/.bashrc"
     done
@@ -336,8 +333,7 @@ setup_rootless() {
     systemctl start sshd
     NOW=$(date +%s)
     TIMEOUT=$(date --date '+5 minutes' +%s)
-    while [[ "$(date +%s)" -lt "$TIMEOUT" ]]
-    do
+    while [[ "$(date +%s)" -lt "$TIMEOUT" ]]; do
         if timeout --foreground -k 1s 1s \
             ssh $ROOTLESS_USER@localhost \
             -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o CheckHostIP=no \
@@ -398,10 +394,8 @@ remove_packaged_podman_files() {
     req_env_var OS_RELEASE_ID
 
     # If any binaries are resident they could cause unexpected pollution
-    for unit in io.podman.service io.podman.socket
-    do
-        for state in enabled active
-        do
+    for unit in io.podman.service io.podman.socket; do
+        for state in enabled active; do
             if systemctl --quiet is-$state $unit
             then
                 echo "Warning: $unit found $state prior to packaged-file removal"

--- a/contrib/cirrus/networking.sh
+++ b/contrib/cirrus/networking.sh
@@ -6,8 +6,7 @@
 
 source $(dirname $0)/lib.sh
 
-while read host port
-do
+while read host port; do
     if [[ "$port" -eq "443" ]]
     then
         item_test "SSL/TLS to $host:$port" "$(echo -n '' | openssl s_client -quiet -no_ign_eof -connect $host:$port &> /dev/null; echo $?)" -eq "0"

--- a/contrib/cirrus/packer/systemd_banish.sh
+++ b/contrib/cirrus/packer/systemd_banish.sh
@@ -15,8 +15,7 @@ then
 fi
 
 echo "Disabling periodic services that could destabilize testing:"
-for unit in $EVIL_UNITS
-do
+for unit in $EVIL_UNITS; do
     echo "Banishing $unit (ignoring errors)"
     (
         sudo systemctl stop $unit

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -19,8 +19,7 @@ exithandler() {
 trap exithandler EXIT
 
 # Verify basic dependencies
-for depbin in go rsync unzip sha256sum curl make python3 git
-do
+for depbin in go rsync unzip sha256sum curl make python3 git; do
     if ! type -P "$depbin" &> /dev/null
     then
         echo "***** WARNING: $depbin binary not found in $PATH *****"

--- a/contrib/cirrus/success.sh
+++ b/contrib/cirrus/success.sh
@@ -30,8 +30,7 @@ then
                          sort -u | \
                          tail -$MAX_NICKS)
 
-        for c_email in $COMMIT_AUTHORS
-        do
+        for c_email in $COMMIT_AUTHORS; do
             c_email=$(echo "$c_email" | tr --delete --complement "$EMAILCSET")
             echo -e "\tExamining $c_email"
             NICK=$(echo "$AUTHOR_NICKS" | grep -m 1 "$c_email" | \

--- a/contrib/cirrus/upload_release_archive.sh
+++ b/contrib/cirrus/upload_release_archive.sh
@@ -64,8 +64,7 @@ echo "$RELEASE_GCPJSON" > "$TMPF"
 unset RELEASE_GCPJSON
 
 cd $GOSRC
-for filename in $(ls -1 *.tar.gz *.zip *.msi $SWAGGER_FILEPATH)
-do
+for filename in $(ls -1 *.tar.gz *.zip *.msi $SWAGGER_FILEPATH); do
     unset EXT
     EXT=$(echo "$filename" | sed -r -e 's/.+\.(.+$)/\1/g')
     if [[ -z "$EXT" ]] || [[ "$EXT" == "$filename" ]]

--- a/contrib/imgprune/entrypoint.sh
+++ b/contrib/imgprune/entrypoint.sh
@@ -12,8 +12,7 @@ LIB="$CIRRUS_WORKING_DIR/$SCRIPT_BASE/lib.sh"
 if [[ "$CI" == "true" ]] && [[ -r "$LIB" ]]
 then
     # Avoid importing anything that might conflict
-    for env in $(sed -ne 's/^[^#]\+_BASE_IMAGE=/img=/p' "$LIB")
-    do
+    for env in $(sed -ne 's/^[^#]\+_BASE_IMAGE=/img=/p' "$LIB"); do
         eval $env
         BASE_IMAGES="$BASE_IMAGES $img"
     done
@@ -50,8 +49,7 @@ count_image() {
 echo "Using filter: $FILTER"
 echo "Searching images for pruning candidates older than $TOO_OLD ($(date --date="$TOO_OLD" --iso-8601=date)):"
 $GCLOUD compute images list --format="$FORMAT" --filter="$FILTER" | \
-    while read name selfLink creationTimestamp labels
-    do
+    while read name selfLink creationTimestamp labels; do
         count_image
         created_ymd=$(date --date=$creationTimestamp --iso-8601=date)
         last_used=$(egrep --only-matching --max-count=1 'last-used=[[:digit:]]+' <<< $labels || true)
@@ -92,8 +90,7 @@ then
     exit 0
 fi
 
-for image_name in $(sort --random-sort $TODELETE | tail -$PRUNE_LIMIT)
-do
+for image_name in $(sort --random-sort $TODELETE | tail -$PRUNE_LIMIT); do
     if echo "$IMGNAMES $BASE_IMAGES" | grep -q "$image_name"
     then
         # double-verify in-use images were filtered out in search loop above

--- a/contrib/imgts/entrypoint.sh
+++ b/contrib/imgts/entrypoint.sh
@@ -15,8 +15,7 @@ ARGS="
     --update-labels=project=$GCPPROJECT
 "
 
-for image in $IMGNAMES
-do
+for image in $IMGNAMES; do
     $GCLOUD compute images update "$image" $ARGS &
 done
 

--- a/contrib/systemd/README.md
+++ b/contrib/systemd/README.md
@@ -5,15 +5,15 @@
 The following unit file examples assume:
  1. copied the `service` executable into `/usr/local/bin`
  1. `chcon system_u:object_r:container_runtime_exec_t:s0 /usr/local/bin/service`
- 
+
 then:
  1. copy the `podman.service` and `podman.socket` files into `/etc/systemd/system`
  1. `systemctl daemon-reload`
  1. `systemctl enable podman.socket`
  1. `systemctl start podman.socket`
  1. `systemctl status podman.socket podman.service`
- 
-Assuming the status messages show no errors, the libpod service is ready to respond to the APIv2 on the unix domain socket `/run/podman/podman.sock` 
+
+Assuming the status messages show no errors, the libpod service is ready to respond to the APIv2 on the unix domain socket `/run/podman/podman.sock`
 
 ### podman.service
 ```toml
@@ -55,15 +55,15 @@ The following unit file examples assume:
  1. you have a created a directory `~/bin`
  1. copied the `service` executable into `~/bin`
  1. `chcon system_u:object_r:container_runtime_exec_t:s0 ~/bin/service`
- 
+
 then:
  1. `mkdir -p ~/.config/systemd/user`
  1. copy the `podman.service` and `podman.socket` files into `~/.config/systemd/user`
  1. `systemctl --user enable podman.socket`
  1. `systemctl --user start podman.socket`
  1. `systemctl --user status podman.socket podman.service`
- 
-Assuming the status messages show no errors, the libpod service is ready to respond to the APIv2 on the unix domain socket `/run/user/$(id -u)/podman/podman.sock` 
+
+Assuming the status messages show no errors, the libpod service is ready to respond to the APIv2 on the unix domain socket `/run/user/$(id -u)/podman/podman.sock`
 
 ### podman.service
 

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -90,15 +90,15 @@ show_usage() {
 }
 
 get_env_vars() {
-    python -c '
+    python - <<END
 import yaml
 env=yaml.load(open(".cirrus.yml"), Loader=yaml.SafeLoader)["env"]
 keys=[k for k in env if "ENCRYPTED" not in str(env[k])]
 for k,v in env.items():
     v=str(v)
     if "ENCRYPTED" not in v:
-        print "{0}=\"{1}\"".format(k, v),
-    '
+        print("{0}=\"{1}\"".format(k, v),)
+END
 }
 
 parse_args(){
@@ -116,8 +116,7 @@ parse_args(){
     IMAGE_NAME=""
     ROOTLESS_USER=""
     SPECIALMODE="none"
-    for arg
-    do
+    for arg; do
         if [[ "$SPECIALMODE" == "GRABNEXT" ]] && [[ "${arg:0:1}" != "-" ]]
         then
             SPECIALMODE="$arg"
@@ -252,8 +251,7 @@ trap delvm EXIT
 echo -e "\n${YEL}Waiting up to 30s for ssh port to open${NOR}"
 trap 'COUNT=9999' INT
 ATTEMPTS=10
-for (( COUNT=1 ; COUNT <= $ATTEMPTS ; COUNT++ ))
-do
+for (( COUNT=1 ; COUNT <= $ATTEMPTS ; COUNT++ )); do
     if $SSH_CMD --command "true"; then break; else sleep 3s; fi
 done
 if (( COUNT > $ATTEMPTS ))

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -64,4 +64,4 @@ git fetch origin &&
 git checkout -b "bump-${VERSION}" origin/master &&
 release_commit &&
 git tag -s -m "version ${VERSION}" "v${VERSION}" &&
-dev_version_commit &&
+dev_version_commit

--- a/install.md
+++ b/install.md
@@ -90,7 +90,7 @@ Built-in, no need to install
 #### [Raspbian](https://raspbian.org)
 
 The Kubic project provides packages for Raspbian 10.
- 
+
 ```bash
 # Raspbian 10
 echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Raspbian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
@@ -187,7 +187,7 @@ with our [COPR repository](https://copr.fedorainfracloud.org/coprs/baude/Upstrea
 #### [Raspbian](https://raspbian.org)
 
 The Kubic project provides RC/testing packages for Raspbian 10.
- 
+
 ```bash
 # Raspbian 10
 echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/Raspbian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list

--- a/pkg/api/Makefile
+++ b/pkg/api/Makefile
@@ -10,4 +10,3 @@ ${SWAGGER_OUT}:
 	# generate doesn't remove file on error
 	rm -f ${SWAGGER_OUT}
 	swagger generate spec -o ${SWAGGER_OUT} -i tags.yaml -w ./
-

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -1,3 +1,4 @@
+#!/usr/bin/env false
 # -*- bash -*-
 
 # Podman command to run; may be podman-remote

--- a/test/test_podman_baseline.sh
+++ b/test/test_podman_baseline.sh
@@ -111,8 +111,8 @@ podman rm myweb
 ########
 prun_test_failed=0
 podman rmi docker.io/library/busybox:latest > /dev/null || :
-for i in `seq 10`
-do ( podman run -d --name b$i docker.io/library/busybox:latest busybox httpd -f -p 80 )&
+for i in `seq 10`; do
+    ( podman run -d --name b$i docker.io/library/busybox:latest busybox httpd -f -p 80 )&
 done
 echo -e "\nwaiting for creation...\n"
 wait
@@ -126,7 +126,9 @@ count=$( podman ps -q  | wc -l )
 }
 
 prun_test_failed=0
-for i in `seq 10`; do ( podman stop -t=1 b$i; podman rm b$i )& done
+for i in `seq 10`; do
+    ( podman stop -t=1 b$i; podman rm b$i )&
+done
 echo -e "\nwaiting for deletion...\n"
 wait
 echo -e "\ndone\n"
@@ -145,8 +147,8 @@ count=$( podman ps -q  | wc -l )
 ########
 prun_test_failed=0
 podman pull docker.io/library/busybox:latest > /dev/null || :
-for i in `seq 10`
-do ( podman run -d --name c$i docker.io/library/busybox:latest busybox httpd -f -p 80 )&
+for i in `seq 10`; do
+    ( podman run -d --name c$i docker.io/library/busybox:latest busybox httpd -f -p 80 )&
 done
 echo -e "\nwaiting for creation...\n"
 wait
@@ -160,7 +162,9 @@ count=$( podman ps -q  | wc -l )
 }
 
 
-for i in `seq 10`; do ( podman stop -t=1 c$i; podman rm c$i )& done
+for i in `seq 10`; do
+    ( podman stop -t=1 c$i; podman rm c$i )&
+done
 echo -e "\nwaiting for deletion...\n"
 wait
 echo -e "\ndone\n"


### PR DESCRIPTION
- Activate bashate and resolves rule `E010`.
- Temporary disable other non-conforming rules, as they will be
  addressed in follow-ups
- Fixes python2 bug in embedded get_env_vars()
- Includes newline auto-fixed introduced by a previous merge