### PR TITLE
[CI:DOCS] Add logo and dev statement

### DIFF
--- a/docs/source/Reference.rst
+++ b/docs/source/Reference.rst
@@ -1,4 +1,4 @@
 Reference
 =========
 
-Check out our new `API documentation <_static/api.html>`_
+Check out our new in-development `API documentation <_static/api.html>`_

--- a/pkg/api/Makefile
+++ b/pkg/api/Makefile
@@ -1,3 +1,5 @@
+export GO111MODULE=off
+
 SWAGGER_OUT ?= swagger.yaml
 
 swagger:

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -1,6 +1,8 @@
-// Package serviceapi Provides a Container compatible interface.
+// Package serviceapi Provides a Container compatible interface (EXPERIMENTAL)
 //
-// This documentation describes the HTTP LibPod interface
+// This documentation describes the HTTP LibPod interface.  It is to be consider
+// only as experimental as this point.  The endpoints, parameters, inputs, and
+// return values can all change.
 //
 //     Schemes: http, https
 //     Host: podman.io
@@ -8,6 +10,10 @@
 //     Version: 0.0.1
 //     License: Apache-2.0 https://opensource.org/licenses/Apache-2.0
 //     Contact: Podman <podman@lists.podman.io> https://podman.io/community/
+//     InfoExtensions:
+//     x-logo:
+//       - url: https://raw.githubusercontent.com/containers/libpod/master/logo/podman-logo.png
+//       - altText: "Podman logo"
 //
 //     Consumes:
 //     - application/json


### PR DESCRIPTION
Add statement to the info section stating this is experimental only for now.  Also add the podman logo to the right-hand navigation.

Signed-off-by: Brent Baude <bbaude@redhat.com>