### PR TITLE
Use cgroupv2 super magic from golang.org/x/sys/unix

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -97,8 +97,7 @@ type controllerHandler interface {
 }
 
 const (
-	cgroupRoot         = "/sys/fs/cgroup"
-	_cgroup2SuperMagic = 0x63677270
+	cgroupRoot = "/sys/fs/cgroup"
 	// CPU is the cpu controller
 	CPU = "cpu"
 	// CPUAcct is the cpuacct controller

--- a/pkg/cgroups/cgroups_supported.go
+++ b/pkg/cgroups/cgroups_supported.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 var (
@@ -27,7 +28,7 @@ func IsCgroup2UnifiedMode() (bool, error) {
 		if err := syscall.Statfs("/sys/fs/cgroup", &st); err != nil {
 			isUnified, isUnifiedErr = false, err
 		} else {
-			isUnified, isUnifiedErr = st.Type == _cgroup2SuperMagic, nil
+			isUnified, isUnifiedErr = st.Type == unix.CGROUP2_SUPER_MAGIC, nil
 		}
 	})
 	return isUnified, isUnifiedErr


### PR DESCRIPTION
We can use this constant from the already existing sys/unix package
instead of defining it by our own.