### PR TITLE
Fix example format in system df man

### DIFF
--- a/docs/source/markdown/podman-system-df.1.md
+++ b/docs/source/markdown/podman-system-df.1.md
@@ -18,7 +18,7 @@ Pretty-print images using a Go template
 Show detailed information on space usage
 
 ## EXAMPLE
-
+```
 $ podman system df
 TYPE            TOTAL   ACTIVE   SIZE    RECLAIMABLE
 Images          6       2        281MB   168MB (59%)
@@ -49,7 +49,7 @@ $ podman system df --format "{{.Type}}\t{{.Total}}"
 Images          1
 Containers      5
 Local Volumes   1
-
+```
 ## SEE ALSO
 podman-system(1)
 


### PR DESCRIPTION
Fix the formatting of the examples in the
podman system df man page.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>