### PR TITLE
markdown: remove extraneous backquote from "podman rmi"

### DIFF
--- a/docs/source/markdown/podman-rmi.1.md
+++ b/docs/source/markdown/podman-rmi.1.md
@@ -29,7 +29,7 @@ podman rmi c0ed59d05ff7
 Remove an image and its associated containers.
 ```
 podman rmi --force imageID
-````
+```
 
 Remove multiple images by their shortened IDs.
 ```


### PR DESCRIPTION
Extraneous backquote messes up rendering of "man podman-rmi".

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>