### PR TITLE
markdown: reword 'podman-inspect' to properly explain '--size'

### DIFF
--- a/docs/source/markdown/podman-inspect.1.md
+++ b/docs/source/markdown/podman-inspect.1.md
@@ -36,7 +36,7 @@ The latest option is not supported on the remote client or when invoked as *podm
 
 **--size**, **-s**
 
-Display the total file size if the type is a container
+In addition to normal output, display the total file size if the type is a container.
 
 
 ## EXAMPLE


### PR DESCRIPTION
Reword the man page to clarify that the '--size' option displays
the container size in addition to the normal outout.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>