### PR TITLE
markdown: fix formatting of commands at bottom of podman-exec

### DIFF
--- a/docs/source/markdown/podman-exec.1.md
+++ b/docs/source/markdown/podman-exec.1.md
@@ -105,9 +105,11 @@ non-zero code, the exit codes follow the `chroot` standard, see below:
 
 ## EXAMPLES
 
+```
 $ podman exec -it ctrID ls
 $ podman exec -it -w /tmp myCtr pwd
 $ podman exec --user root ctrID ls
+```
 
 ## SEE ALSO
 podman(1), podman-run(1)


### PR DESCRIPTION
Current (lack of) formatting crunches first two lines together.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>