### PR TITLE
seccomp policy: expect profile in config label

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -31,9 +31,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// seccompAnnotationKey is the key of the image annotation embedding a seccomp
+// seccompLabelKey is the key of the image annotation embedding a seccomp
 // profile.
-const seccompAnnotationKey = "io.containers.seccomp.profile"
+const seccompLabelKey = "io.containers.seccomp.profile"
 
 func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.Runtime) (*libpod.Container, *cc.CreateConfig, error) {
 	var (
@@ -709,7 +709,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 
 	// SECCOMP
 	if data != nil {
-		if value, exists := data.Annotations[seccompAnnotationKey]; exists {
+		if value, exists := labels[seccompLabelKey]; exists {
 			secConfig.SeccompProfileFromImage = value
 		}
 	}

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -679,7 +679,7 @@ of the container is assumed to be managed externally.
 
 **--seccomp-policy**=*policy*
 
-Specify the policy to select the seccomp profile. If set to *image*, Podman will look for a "io.podman.seccomp.profile" annotation in the container image and use its value as a seccomp profile. Otherwise, Podman will follow the *default* policy by applying the default profile unless specified otherwise via *--security-opt seccomp* as described below.
+Specify the policy to select the seccomp profile. If set to *image*, Podman will look for a "io.podman.seccomp.profile" label in the container-image config and use its value as a seccomp profile. Otherwise, Podman will follow the *default* policy by applying the default profile unless specified otherwise via *--security-opt seccomp* as described below.
 
 Note that this feature is experimental and may change in the future.
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -700,7 +700,7 @@ Note: On `SELinux` systems, the rootfs needs the correct label, which is by defa
 
 **--seccomp-policy**=*policy*
 
-Specify the policy to select the seccomp profile. If set to *image*, Podman will look for a "io.podman.seccomp.profile" annotation in the container image and use its value as a seccomp profile. Otherwise, Podman will follow the *default* policy by applying the default profile unless specified otherwise via *--security-opt seccomp* as described below.
+Specify the policy to select the seccomp profile. If set to *image*, Podman will look for a "io.podman.seccomp.profile" label in the container-image config and use its value as a seccomp profile. Otherwise, Podman will follow the *default* policy by applying the default profile unless specified otherwise via *--security-opt seccomp* as described below.
 
 Note that this feature is experimental and may change in the future.
 

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -19,8 +19,8 @@ var (
 	// The intention behind blocking all syscalls is to prevent
 	// regressions in the future.  The required syscalls can vary
 	// depending on which runtime we're using.
-	alpineSeccomp = "docker.io/libpod/alpine-with-seccomp:latest"
+	alpineSeccomp = "docker.io/libpod/alpine-with-seccomp:label"
 	// This image has a bogus/invalid seccomp profile which should
 	// yield a json error when being read.
-	alpineBogusSeccomp = "docker.io/libpod/alpine-with-bogus-seccomp:latest"
+	alpineBogusSeccomp = "docker.io/libpod/alpine-with-bogus-seccomp:label"
 )


### PR DESCRIPTION
Move the seccomp profile from a manifest annotation to a config label.
This way, we can support it for Docker images as well and provide an
easy way to add that data via Dockerfiles.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @nalind PTAL