### PR TITLE
markdown: fix grammar/formatting, standardize on markdown

### DIFF
--- a/docs/source/markdown/podman-unshare.1.md
+++ b/docs/source/markdown/podman-unshare.1.md
@@ -10,19 +10,19 @@ podman\-unshare - Run a command inside of a modified user namespace
 Launches a process (by default, *$SHELL*) in a new user namespace. The user
 namespace is configured so that the invoking user's UID and primary GID appear
 to be UID 0 and GID 0, respectively.  Any ranges which match that user and
-group in /etc/subuid and /etc/subgid are also mapped in as themselves with the
+group in `/etc/subuid` and `/etc/subgid` are also mapped in as themselves with the
 help of the *newuidmap(1)* and *newgidmap(1)* helpers.
 
-podman unshare is useful for troubleshooting unprivileged operations and for
+**podman unshare** is useful for troubleshooting unprivileged operations and for
 manually clearing storage and other data related to images and containers.
 
-It is also useful if you want to use the `podman mount` command.  If an unprivileged users wants to mount and work with a container, then they need to execute
-podman unshare.  Executing `podman mount` fails for unprivileged users unless the user is running inside a `podman unshare` session.
+It is also useful if you want to use the **podman mount** command.  If an unprivileged user wants to mount and work with a container, then they need to execute
+**podman unshare**.  Executing **podman mount** fails for unprivileged users unless the user is running inside a **podman unshare** session.
 
 The unshare session defines two environment variables:
 
-**CONTAINERS_GRAPHROOT** the path to the persistent containers data.
-**CONTAINERS_RUNROOT** the path to the volatile containers data.
+- **CONTAINERS_GRAPHROOT**: the path to the persistent container's data.
+- **CONTAINERS_RUNROOT**: the path to the volatile container's data.
 
 ## EXAMPLE
 


### PR DESCRIPTION
While fixing grammar and list formatting issues, standardize on
markdown as follows:

  - commands are marked by '**'
  - files are marked by backquotes
  - list items are marked with leading '-'

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>