### PR TITLE
Default CPUShares in Inspect are 1024

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -1014,6 +1014,9 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 	hostConfig.ShmSize = c.config.ShmSize
 	hostConfig.Runtime = "oci"
 
+	// Default CPUShares is 1024, but we may overwrite below.
+	hostConfig.CpuShares = 1024
+
 	// This is very expensive to initialize.
 	// So we don't want to initialize it unless we absolutely have to - IE,
 	// there are things that require a major:minor to path translation.


### PR DESCRIPTION
This is purely a display change - we weren't initializing the default value to display for the CPUShares field, which defaults to 1024. Instead, it was displaying as 0 unless the user set a CPU limit.

Fixes #4822
