### PR TITLE
Review corrections pass #2

### DIFF
--- a/pkg/api/handlers/containers.go
+++ b/pkg/api/handlers/containers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"github.com/docker/docker/api/types"
 	"net/http"
 
 	"github.com/containers/libpod/libpod"
@@ -191,4 +192,56 @@ func RestartContainer(w http.ResponseWriter, r *http.Request) {
 
 	// Success
 	utils.WriteResponse(w, http.StatusNoContent, "")
+}
+
+func PruneContainers(w http.ResponseWriter, r *http.Request) {
+	var (
+		delContainers []string
+		space         int64
+	)
+	runtime := r.Context().Value("runtime").(*libpod.Runtime)
+	decoder := r.Context().Value("decoder").(*schema.Decoder)
+
+	query := struct {
+		Filters map[string][]string `schema:"filter"`
+	}{}
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		return
+	}
+
+	filterFuncs, err := utils.GenerateFilterFuncsFromMap(runtime, query.Filters)
+	if err != nil {
+		utils.InternalServerError(w, err)
+		return
+	}
+	prunedContainers, pruneErrors, err := runtime.PruneContainers(filterFuncs)
+	if err != nil {
+		utils.InternalServerError(w, err)
+		return
+	}
+
+	// Libpod response differs
+	if utils.IsLibpodRequest(r) {
+		var response []LibpodContainersPruneReport
+		for ctrID, size := range prunedContainers {
+			response = append(response, LibpodContainersPruneReport{ID: ctrID, SpaceReclaimed: size})
+		}
+		for ctrID, err := range pruneErrors {
+			response = append(response, LibpodContainersPruneReport{ID: ctrID, PruneError: err.Error()})
+		}
+		utils.WriteResponse(w, http.StatusOK, response)
+		return
+	}
+	for ctrID, size := range prunedContainers {
+		if pruneErrors[ctrID] == nil {
+			space += size
+			delContainers = append(delContainers, ctrID)
+		}
+	}
+	report := types.ContainersPruneReport{
+		ContainersDeleted: delContainers,
+		SpaceReclaimed:    uint64(space),
+	}
+	utils.WriteResponse(w, http.StatusOK, report)
 }

--- a/pkg/api/handlers/generic/containers_create.go
+++ b/pkg/api/handlers/generic/containers_create.go
@@ -40,7 +40,9 @@ func CreateContainer(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Decode()"))
 		return
 	}
-
+	if len(input.HostConfig.Links) > 0 {
+		utils.Error(w, utils.ErrLinkNotSupport.Error(), http.StatusBadRequest, errors.Wrapf(utils.ErrLinkNotSupport, "bad parameter"))
+	}
 	newImage, err := runtime.ImageRuntime().NewFromLocal(input.Image)
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "NewFromLocal()"))

--- a/pkg/api/handlers/swagger.go
+++ b/pkg/api/handlers/swagger.go
@@ -58,6 +58,13 @@ type swagContainerPruneReport struct {
 	Body []ContainersPruneReport
 }
 
+// Prune containers
+// swagger:response DocsLibpodPruneResponse
+type swagLibpodContainerPruneReport struct {
+	// in: body
+	Body []LibpodContainersPruneReport
+}
+
 // Inspect container
 // swagger:response DocsContainerInspectResponse
 type swagContainerInspectResponse struct {

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -43,6 +43,12 @@ type ContainersPruneReport struct {
 	docker.ContainersPruneReport
 }
 
+type LibpodContainersPruneReport struct {
+	ID             string `json:"id"`
+	SpaceReclaimed int64  `json:"space"`
+	PruneError     string `json:"error"`
+}
+
 type Info struct {
 	docker.Info
 	BuildahVersion     string

--- a/pkg/api/handlers/utils/handler.go
+++ b/pkg/api/handlers/utils/handler.go
@@ -51,3 +51,11 @@ func WriteJSON(w http.ResponseWriter, code int, value interface{}) {
 		logrus.Errorf("unable to write json: %q", err)
 	}
 }
+
+func FilterMapToString(filters map[string][]string) (string, error) {
+	f, err := json.Marshal(filters)
+	if err != nil {
+		return "", err
+	}
+	return string(f), nil
+}

--- a/pkg/api/server/swagger.go
+++ b/pkg/api/server/swagger.go
@@ -50,15 +50,6 @@ type swagInternalError struct {
 	}
 }
 
-// Generic error
-// swagger:response GenericError
-type swagGenericError struct {
-	// in:body
-	Body struct {
-		utils.ErrorModel
-	}
-}
-
 // Conflict error in operation
 // swagger:response ConflictError
 type swagConflictError struct {
@@ -127,21 +118,6 @@ type swagListContainers struct {
 	Body struct {
 		// This causes go-swagger to crash
 		// handlers.Container
-	}
-}
-
-// To be determined
-// swagger:response tbd
-type swagTBD struct {
-}
-
-// Success
-// swagger:response
-type swag struct {
-	// in:body
-	Body struct {
-		// example: OK
-		ok string
 	}
 }
 

--- a/pkg/bindings/bindings.go
+++ b/pkg/bindings/bindings.go
@@ -1,0 +1,9 @@
+// Package bindings provides golang-based access
+// to the Podman REST API.  Users can then interact with API endpoints
+// to manage containers, images, pods, etc.
+//
+// This package exposes a series of methods that allow users to firstly
+// create their connection with the API endpoints.  Once the connection
+// is established, users can then manage the Podman container runtime.
+
+package bindings


### PR DESCRIPTION
Add API review comments to correct documentation and endpoints.  Also, add a libpode prune method to reduce code duplication.  Only used right now for the API but when the remote client is wired, we will switch over there too.

Signed-off-by: Brent Baude <bbaude@redhat.com>