### PR TITLE
[CI:DOCS] Add query parameter converters for complex types

### DIFF
--- a/pkg/api/handlers/decoder.go
+++ b/pkg/api/handlers/decoder.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"encoding/json"
+	"reflect"
+	"time"
+
+	"github.com/gorilla/schema"
+	"github.com/sirupsen/logrus"
+)
+
+// NewAPIDecoder returns a configured schema.Decoder
+func NewAPIDecoder() *schema.Decoder {
+	d := schema.NewDecoder()
+	d.IgnoreUnknownKeys(true)
+	d.RegisterConverter(map[string][]string{}, convertUrlValuesString)
+	d.RegisterConverter(time.Time{}, convertTimeString)
+	return d
+}
+
+// On client:
+// 	v := map[string][]string{
+//		"dangling": {"true"},
+//	}
+//
+//	payload, err := jsoniter.MarshalToString(v)
+//	if err != nil {
+//		panic(err)
+//	}
+//	payload = url.QueryEscape(payload)
+func convertUrlValuesString(query string) reflect.Value {
+	f := map[string][]string{}
+
+	err := json.Unmarshal([]byte(query), &f)
+	if err != nil {
+		logrus.Infof("convertUrlValuesString: Failed to Unmarshal %s: %s", query, err.Error())
+	}
+
+	return reflect.ValueOf(f)
+}
+
+func convertTimeString(query string) reflect.Value {
+	t, err := time.Parse(time.RFC3339, query)
+	if err != nil {
+		logrus.Infof("convertTimeString: Failed to Unmarshal %s: %s", query, err.Error())
+
+		return reflect.ValueOf(time.Time{})
+	}
+	return reflect.ValueOf(t)
+}

--- a/pkg/api/handlers/handler.go
+++ b/pkg/api/handlers/handler.go
@@ -15,10 +15,11 @@ func getVar(r *http.Request, k string) string {
 	return mux.Vars(r)[k]
 }
 
-func hasVar(r *http.Request, k string) bool {
-	_, found := mux.Vars(r)[k]
-	return found
-}
+// func hasVar(r *http.Request, k string) bool {
+// 	_, found := mux.Vars(r)[k]
+// 	return found
+// }
+
 func getName(r *http.Request) string {
 	return getVar(r, "name")
 }

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -108,7 +108,7 @@ func Pods(w http.ResponseWriter, r *http.Request) {
 	)
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
-		filters []string `schema:"filters"`
+		Filters map[string][]string `schema:"filters"`
 	}{
 		// override any golang type defaults
 	}
@@ -117,10 +117,12 @@ func Pods(w http.ResponseWriter, r *http.Request) {
 			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
 		return
 	}
-	if len(query.filters) > 0 {
+
+	if _, found := r.URL.Query()["filters"]; found {
 		utils.Error(w, "filters are not implemented yet", http.StatusInternalServerError, define.ErrNotImplemented)
 		return
 	}
+
 	pods, err := runtime.GetAllPods()
 	if err != nil {
 		utils.Error(w, "Something went wrong", http.StatusInternalServerError, err)
@@ -164,7 +166,7 @@ func PodStop(w http.ResponseWriter, r *http.Request) {
 		decoder   = r.Context().Value("decoder").(*schema.Decoder)
 	)
 	query := struct {
-		timeout int `schema:"t"`
+		Timeout int `schema:"t"`
 	}{
 		// override any golang type defaults
 	}
@@ -207,8 +209,8 @@ func PodStop(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if query.timeout > 0 {
-		_, stopError = pod.StopWithTimeout(r.Context(), false, query.timeout)
+	if query.Timeout > 0 {
+		_, stopError = pod.StopWithTimeout(r.Context(), false, query.Timeout)
 	} else {
 		_, stopError = pod.Stop(r.Context(), false)
 	}

--- a/pkg/api/handlers/utils/images.go
+++ b/pkg/api/handlers/utils/images.go
@@ -15,17 +15,18 @@ func GetImages(w http.ResponseWriter, r *http.Request) ([]*image.Image, error) {
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	query := struct {
-		//all     bool # all is currently unused
-		filters []string
-		//digests bool # digests is currently unused
+		// all     bool # all is currently unused
+		Filters map[string][]string `schema:"filters"`
+		// digests bool # digests is currently unused
 	}{
 		// This is where you can override the golang default value for one of fields
 	}
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		return nil, err
 	}
-	filters := query.filters
-	if len(filters) < 1 {
+
+	var filters = []string{}
+	if _, found := r.URL.Query()["filters"]; found {
 		filters = append(filters, fmt.Sprintf("reference=%s", ""))
 	}
 	return runtime.ImageRuntime().GetImagesWithFilters(filters)


### PR DESCRIPTION
* Add converter for URL query parameters of type map[string][]string
* Add converter for URL query parameters of type time.Time
* Added function to allocate and configure schema.Decoder for API use
* Updated API handlers to leverage new converters, and correct handler
  code for filter type

An encoding example for a client using filters:
```go
  v := map[string][]string{
      "dangling": {"true"},
  }
  payload, err := jsoniter.MarshalToString(v)
  if err != nil {
    panic(err)
  }
  payload = "?filters=" + url.QueryEscape(payload)
```

Signed-off-by: Jhon Honce <jhonce@redhat.com>