### PR TITLE
Cleanup man pages exit code descriptions

### DIFF
--- a/docs/source/markdown/podman-exec.1.md
+++ b/docs/source/markdown/podman-exec.1.md
@@ -80,28 +80,28 @@ when creating the container.
 The exit code from `podman exec` gives information about why the command within the container failed to run or why it exited.  When `podman exec` exits with a
 non-zero code, the exit codes follow the `chroot` standard, see below:
 
-**_125_** if the error is with Podman **_itself_**
+  **125** The error is with Podman itself
 
     $ podman exec --foo ctrID /bin/sh; echo $?
     Error: unknown flag: --foo
     125
 
-**_126_** if the **_contained command_** cannot be invoked
+  **126** The _contained command_ cannot be invoked
 
     $ podman exec ctrID /etc; echo $?
     Error: container_linux.go:346: starting container process caused "exec: \"/etc\": permission denied": OCI runtime error
     126
 
-**_127_** if the **_contained command_** cannot be found
+  **127** The _contained command_ cannot be found
 
     $ podman exec ctrID foo; echo $?
     Error: container_linux.go:346: starting container process caused "exec: \"foo\": executable file not found in $PATH": OCI runtime error
     127
 
-**_Exit code_** of **_contained command_** otherwise
+  **Exit code** The _contained command_ exit code
 
-    $ podman exec ctrID /bin/sh -c 'exit 3'
-    # 3
+    $ podman exec ctrID /bin/sh -c 'exit 3'; echo $?
+    3
 
 ## EXAMPLES
 

--- a/docs/source/markdown/podman-remote.1.md
+++ b/docs/source/markdown/podman-remote.1.md
@@ -65,27 +65,27 @@ The exit code from `podman` gives information about why the container
 failed to run or why it exited.  When `podman` commands exit with a non-zero code,
 the exit codes follow the `chroot` standard, see below:
 
-**_125_** if the error is with podman **_itself_**
+  **125** The error is with podman itself
 
     $ podman run --foo busybox; echo $?
     Error: unknown flag: --foo
-      125
+    125
 
-**_126_** if executing a **_contained command_** and the **_command_** cannot be invoked
+  **126** Executing a _contained command_ and the _command_ cannot be invoked
 
     $ podman run busybox /etc; echo $?
     Error: container_linux.go:346: starting container process caused "exec: \"/etc\": permission denied": OCI runtime error
-      126
+    126
 
-**_127_** if executing a **_contained command_** and the **_command_** cannot be found
+  **127** Executing a _contained command_ and the _command_ cannot be found
     $ podman run busybox foo; echo $?
     Error: container_linux.go:346: starting container process caused "exec: \"foo\": executable file not found in $PATH": OCI runtime error
-      127
+    127
 
-**_Exit code_** of **_contained command_** otherwise
+  **Exit code** _contained command_ exit code
 
-    $ podman run busybox /bin/sh -c 'exit 3'
-    # 3
+    $ podman run busybox /bin/sh -c 'exit 3'; echo $?
+    3
 
 
 ## COMMANDS

--- a/docs/source/markdown/podman-rm.1.md
+++ b/docs/source/markdown/podman-rm.1.md
@@ -87,10 +87,13 @@ podman rm -f --latest
 ```
 
 ## Exit Status
-**_0_** if all specified containers removed
-**_1_** if one of the specified containers did not exist, and no other failures
-**_2_** if one of the specified containers is paused or running
-**_125_** if the command fails for a reason other than container did not exist or is paused/running
+  **0**   All specified containers removed
+
+  **1**   One of the specified containers did not exist, and no other failures
+
+  **2**   One of the specified containers is paused or running
+
+  **125** The command fails for a reason other than container did not exist or is paused/running
 
 ## SEE ALSO
 podman(1), podman-image-rm(1)

--- a/docs/source/markdown/podman-rmi.1.md
+++ b/docs/source/markdown/podman-rmi.1.md
@@ -41,10 +41,13 @@ Remove all images and containers.
 podman rmi -a -f
 ```
 ## Exit Status
-**_0_** if all specified images removed
-**_1_** if one of the specified images did not exist, and no other failures
-**_2_** if one of the specified images has child images or is being used by a container
-**_125_** if the command fails for a reason other than an image did not exist or is in use
+  **0**   All specified images removed
+
+  **1**   One of the specified images did not exist, and no other failures
+
+  **2**   One of the specified images has child images or is being used by a container
+
+  **125** The command fails for a reason other than an image did not exist or is in use
 
 ## SEE ALSO
 podman(1)

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1022,25 +1022,25 @@ The exit code from `podman run` gives information about why the container
 failed to run or why it exited.  When `podman run` exits with a non-zero code,
 the exit codes follow the `chroot` standard, see below:
 
-**_125_** if the error is with Podman **_itself_**
+  **125** The error is with Podman itself
 
     $ podman run --foo busybox; echo $?
     Error: unknown flag: --foo
     125
 
-**_126_** if the **_contained command_** cannot be invoked
+  **126** The _contained command_ cannot be invoked
 
     $ podman run busybox /etc; echo $?
     Error: container_linux.go:346: starting container process caused "exec: \"/etc\": permission denied": OCI runtime error
     126
 
-**_127_** if the **_contained command_** cannot be found
+  **127** The _contained command_ cannot be found
 
     $ podman run busybox foo; echo $?
     Error: container_linux.go:346: starting container process caused "exec: \"foo\": executable file not found in $PATH": OCI runtime error
     127
 
-**_Exit code_** of **_contained command_** otherwise
+  **Exit code** _contained command_ exit code
 
     $ podman run busybox /bin/sh -c 'exit 3'
     3

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -126,27 +126,27 @@ The exit code from `podman` gives information about why the container
 failed to run or why it exited.  When `podman` commands exit with a non-zero code,
 the exit codes follow the `chroot` standard, see below:
 
-**_125_** if the error is with podman **_itself_**
+  **125** The error is with podman **_itself_**
 
     $ podman run --foo busybox; echo $?
     Error: unknown flag: --foo
-      125
+    125
 
-**_126_** if executing a **_contained command_** and the **_command_** cannot be invoked
+  **126** Executing a _contained command_ and the _command_ cannot be invoked
 
     $ podman run busybox /etc; echo $?
     Error: container_linux.go:346: starting container process caused "exec: \"/etc\": permission denied": OCI runtime error
-      126
+    126
 
-**_127_** if executing a **_contained command_** and the **_command_** cannot be found
+  **127** Executing a _contained command_ and the _command_ cannot be found
     $ podman run busybox foo; echo $?
     Error: container_linux.go:346: starting container process caused "exec: \"foo\": executable file not found in $PATH": OCI runtime error
-      127
+    127
 
-**_Exit code_** of **_contained command_** otherwise
+  **Exit code** _contained command_ exit code
 
-    $ podman run busybox /bin/sh -c 'exit 3'
-    # 3
+    $ podman run busybox /bin/sh -c 'exit 3'; echo $?
+    3
 
 
 ## COMMANDS


### PR DESCRIPTION
The conversion of markdown to man pages is causing "_" to cover entire lines.
This PR cleans this up and fixes some of the english.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>