### PR TITLE
docs: mention that "podman version" prints out Remote API Version

### DIFF
--- a/docs/source/markdown/podman-version.1.md
+++ b/docs/source/markdown/podman-version.1.md
@@ -7,7 +7,7 @@ podman\-version - Display the Podman version information
 **podman version** [*options*]
 
 ## DESCRIPTION
-Shows the following information: Version, Go Version, Git Commit, Build Time,
+Shows the following information: Remote API Version, Version, Go Version, Git Commit, Build Time,
 OS, and Architecture.
 
 ## OPTIONS


### PR DESCRIPTION
Since "man podman-version" seems to want to list everything printed
about the current version, add a reference to Remote API Version
for completeness.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>