### PR TITLE
docs: remove reference to "sudo" in "podman exists" examples

### DIFF
--- a/docs/source/markdown/podman-container-exists.1.md
+++ b/docs/source/markdown/podman-container-exists.1.md
@@ -21,7 +21,7 @@ Print usage statement
 
 Check if an container called `webclient` exists in local storage (the container does actually exist).
 ```
-$ sudo podman container exists webclient
+$ podman container exists webclient
 $ echo $?
 0
 $
@@ -29,7 +29,7 @@ $
 
 Check if an container called `webbackend` exists in local storage (the container does not actually exist).
 ```
-$ sudo podman container exists webbackend
+$ podman container exists webbackend
 $ echo $?
 1
 $

--- a/docs/source/markdown/podman-image-exists.1.md
+++ b/docs/source/markdown/podman-image-exists.1.md
@@ -22,7 +22,7 @@ Print usage statement
 
 Check if an image called `webclient` exists in local storage (the image does actually exist).
 ```
-$ sudo podman image exists webclient
+$ podman image exists webclient
 $ echo $?
 0
 $
@@ -30,7 +30,7 @@ $
 
 Check if an image called `webbackend` exists in local storage (the image does not actually exist).
 ```
-$ sudo podman image exists webbackend
+$ podman image exists webbackend
 $ echo $?
 1
 $


### PR DESCRIPTION
In both of "podman {container,image} exists" man pages, there
are superfluous uses of "sudo" in examples -- get rid of them.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>