### PR TITLE
Hidden remote flags can be nil

### DIFF
--- a/cmd/podman/push.go
+++ b/cmd/podman/push.go
@@ -100,7 +100,8 @@ func pushCmd(c *cliconfig.PushValues) error {
 
 	// --compress and --format can only be used for the "dir" transport
 	splitArg := strings.SplitN(destName, ":", 2)
-	if c.Flag("compress").Changed || c.Flag("format").Changed {
+
+	if c.IsSet("compress") || c.Flag("format").Changed {
 		if splitArg[0] != directory.Transport.Name() {
 			return errors.Errorf("--compress and --format can be set only when pushing to a directory using the 'dir' transport")
 		}
@@ -141,7 +142,7 @@ func pushCmd(c *cliconfig.PushValues) error {
 		DockerRegistryCreds: registryCreds,
 		DockerCertPath:      certPath,
 	}
-	if c.Flag("tls-verify").Changed {
+	if c.IsSet("tls-verify") {
 		dockerRegistryOptions.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!c.TlsVerify)
 	}
 


### PR DESCRIPTION
The pull command has several options that are hidden for the remote client.  In that case, when checking to see if the flag has been flipped with .Changed, we get a nil pointer error.  Using IsSet is tolerant of this.

Fixes: #4706

Signed-off-by: Brent Baude <bbaude@redhat.com>