### PR TITLE
inspect image healthchecks

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -1012,6 +1012,15 @@ func (i *Image) Inspect(ctx context.Context) (*inspect.ImageData, error) {
 		History:      ociv1Img.History,
 		NamesHistory: i.NamesHistory(),
 	}
+	if manifestType == manifest.DockerV2Schema2MediaType {
+		hc, err := i.GetHealthCheck(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if hc != nil {
+			data.HealthCheck = hc
+		}
+	}
 	return data, nil
 }
 

--- a/pkg/inspect/inspect.go
+++ b/pkg/inspect/inspect.go
@@ -3,6 +3,7 @@ package inspect
 import (
 	"time"
 
+	"github.com/containers/image/v5/manifest"
 	"github.com/containers/libpod/libpod/driver"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go/v1"
@@ -10,28 +11,29 @@ import (
 
 // ImageData holds the inspect information of an image
 type ImageData struct {
-	ID           string            `json:"Id"`
-	Digest       digest.Digest     `json:"Digest"`
-	RepoTags     []string          `json:"RepoTags"`
-	RepoDigests  []string          `json:"RepoDigests"`
-	Parent       string            `json:"Parent"`
-	Comment      string            `json:"Comment"`
-	Created      *time.Time        `json:"Created"`
-	Config       *v1.ImageConfig   `json:"Config"`
-	Version      string            `json:"Version"`
-	Author       string            `json:"Author"`
-	Architecture string            `json:"Architecture"`
-	Os           string            `json:"Os"`
-	Size         int64             `json:"Size"`
-	VirtualSize  int64             `json:"VirtualSize"`
-	GraphDriver  *driver.Data      `json:"GraphDriver"`
-	RootFS       *RootFS           `json:"RootFS"`
-	Labels       map[string]string `json:"Labels"`
-	Annotations  map[string]string `json:"Annotations"`
-	ManifestType string            `json:"ManifestType"`
-	User         string            `json:"User"`
-	History      []v1.History      `json:"History"`
-	NamesHistory []string          `json:"NamesHistory"`
+	ID           string                        `json:"Id"`
+	Digest       digest.Digest                 `json:"Digest"`
+	RepoTags     []string                      `json:"RepoTags"`
+	RepoDigests  []string                      `json:"RepoDigests"`
+	Parent       string                        `json:"Parent"`
+	Comment      string                        `json:"Comment"`
+	Created      *time.Time                    `json:"Created"`
+	Config       *v1.ImageConfig               `json:"Config"`
+	Version      string                        `json:"Version"`
+	Author       string                        `json:"Author"`
+	Architecture string                        `json:"Architecture"`
+	Os           string                        `json:"Os"`
+	Size         int64                         `json:"Size"`
+	VirtualSize  int64                         `json:"VirtualSize"`
+	GraphDriver  *driver.Data                  `json:"GraphDriver"`
+	RootFS       *RootFS                       `json:"RootFS"`
+	Labels       map[string]string             `json:"Labels"`
+	Annotations  map[string]string             `json:"Annotations"`
+	ManifestType string                        `json:"ManifestType"`
+	User         string                        `json:"User"`
+	History      []v1.History                  `json:"History"`
+	NamesHistory []string                      `json:"NamesHistory"`
+	HealthCheck  *manifest.Schema2HealthConfig `json:"Healthcheck,omitempty"`
 }
 
 // RootFS holds the root fs information of an image

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -164,4 +164,17 @@ var _ = Describe("Podman inspect", func() {
 		Expect(inspectDst.ExitCode()).To(Equal(0))
 		Expect(inspectDst.OutputToString()).To(Equal("/test1"))
 	})
+
+	It("podman inspect shows healthcheck on docker image", func() {
+		pull := podmanTest.Podman([]string{"pull", healthcheck})
+		pull.WaitWithDefaultTimeout()
+		Expect(pull.ExitCode()).To(BeZero())
+
+		session := podmanTest.Podman([]string{"inspect", "--format=json", healthcheck})
+		session.WaitWithDefaultTimeout()
+		imageData := session.InspectImageJSON()
+		Expect(imageData[0].HealthCheck.Timeout).To(BeNumerically("==", 3000000000))
+		Expect(imageData[0].HealthCheck.Interval).To(BeNumerically("==", 60000000000))
+		Expect(imageData[0].HealthCheck.Test).To(Equal([]string{"CMD-SHELL", "curl -f http://localhost/ || exit 1"}))
+	})
 })


### PR DESCRIPTION
when a docker image has a defined healthcheck, it should be displayed with inspect.  this is only valid for docker images as oci images are not aware of healthchecks.

Fixes: #4799
Signed-off-by: Brent Baude <bbaude@redhat.com>