### PR TITLE
honor pull policy in play kube

### DIFF
--- a/libpod/image/config.go
+++ b/libpod/image/config.go
@@ -1,5 +1,11 @@
 package image
 
+const (
+	// LatestTag describes the tag used to refer to the latest version
+	// of an image
+	LatestTag = "latest"
+)
+
 // ImageDeleteResponse is the response for removing an image from storage and containers
 // what was untagged vs actually removed
 type ImageDeleteResponse struct { //nolint

--- a/libpod/image/parts.go
+++ b/libpod/image/parts.go
@@ -67,7 +67,7 @@ func (ip *imageParts) suspiciousRefNameTagValuesForSearch() (string, string, str
 	} else if _, hasDigest := ip.unnormalizedRef.(reference.Digested); hasDigest {
 		tag = "none"
 	} else {
-		tag = "latest"
+		tag = LatestTag
 	}
 	return registry, imageName, tag
 }


### PR DESCRIPTION
When a container specification has a pull policy, we should honor it when recreating the pods/containers from yaml.

Fixes: #4880

Signed-off-by: Brent Baude <bbaude@redhat.com>