### PR TITLE
[CI:DOCS]rootless exec cannot join root namespace

### DIFF
--- a/rootless.md
+++ b/rootless.md
@@ -44,3 +44,4 @@ can easily fail
   * If a build is attempting to use a UID that is not mapped into the user namespace mapping for a container, then builds will not be able to put the UID in an image.
 * Making device nodes within a container fails, even when running --privileged.
   * The kernel does not allow non root user processes (processes without CAP_MKNOD) to create device nodes.  If a container needs to create device nodes, it must be run as root.
+* When using --net=host with rootless containers, subsequent podman execs to that container will not join the host network namespace because it is owned by root.


### PR DESCRIPTION
add a quick note in the rootless.md about usage of --net=host as rootless and subsequent podman execs.

Fixes: #4473

Signed-off-by: Brent Baude <bbaude@redhat.com>