### PR TITLE
docs: replace '~' with $HOME in markdown as '~' isn't rendered properly

### DIFF
--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -633,11 +633,11 @@ $ podman build .
 
 $ podman build -f Containerfile.simple .
 
-$ cat ~/Dockerfile | podman build -f - .
+$ cat $HOME/Dockerfile | podman build -f - .
 
 $ podman build -f Dockerfile.simple -f Containerfile.notsosimple .
 
-$ podman build -f Dockerfile.in ~
+$ podman build -f Dockerfile.in $HOME
 
 $ podman build -t imageName .
 
@@ -649,7 +649,7 @@ $ podman build --runtime-flag log-format=json .
 
 $ podman build --runtime-flag debug .
 
-$ podman build --authfile /tmp/auths/myauths.json --cert-dir ~/auth --tls-verify=true --creds=username:password -t imageName -f Dockerfile.simple .
+$ podman build --authfile /tmp/auths/myauths.json --cert-dir $HOME/auth --tls-verify=true --creds=username:password -t imageName -f Dockerfile.simple .
 
 $ podman build --memory 40m --cpu-period 10000 --cpu-quota 50000 --ulimit nofile=1024:1028 -t imageName .
 

--- a/docs/source/markdown/podman-remote.1.md
+++ b/docs/source/markdown/podman-remote.1.md
@@ -135,7 +135,7 @@ the exit codes follow the `chroot` standard, see below:
 
 ## FILES
 
-**podman-remote.conf** (`~/.config/containers/podman-remote.conf`)
+**podman-remote.conf** (`$HOME/.config/containers/podman-remote.conf`)
 
     The podman-remote.conf file is the default configuration file for the podman
     remote client.  It is in the TOML format.  It is primarily used to keep track

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -108,7 +108,7 @@ Storage driver option, Default storage driver options are configured in /etc/con
 
 Output logging information to syslog as well as the console.
 
-On remote clients, logging is directed to the file ~/.config/containers/podman.log
+On remote clients, logging is directed to the file $HOME/.config/containers/podman.log
 
 **--tmpdir**
 
@@ -266,9 +266,9 @@ Currently the slirp4netns package is required to be installed to create a networ
 
 ### **NOTE:** Unsupported file systems in rootless mode
 
-The Overlay file system (OverlayFS) is not supported in rootless mode.  The fuse-overlayfs package is a tool that provides the functionality of OverlayFS in user namespace that allows mounting file systems in rootless environments.  It is recommended to install the fuse-overlayfs package and to enable it by adding `mount_program = "/usr/bin/fuse-overlayfs"` under `[storage.options]` in the `~/.config/containers/storage.conf` file.
+The Overlay file system (OverlayFS) is not supported in rootless mode.  The fuse-overlayfs package is a tool that provides the functionality of OverlayFS in user namespace that allows mounting file systems in rootless environments.  It is recommended to install the fuse-overlayfs package and to enable it by adding `mount_program = "/usr/bin/fuse-overlayfs"` under `[storage.options]` in the `$HOME/.config/containers/storage.conf` file.
 
-The Network File System (NFS) and other distributed file systems (for example: Lustre, Spectrum Scale, the General Parallel File System (GPFS)) are not supported when running in rootless mode as these file systems do not understand user namespace.  However, rootless Podman can make use of an NFS Homedir by modifying the `~/.config/containers/storage.conf` to have the `graphroot` option point to a directory stored on local (Non NFS) storage.
+The Network File System (NFS) and other distributed file systems (for example: Lustre, Spectrum Scale, the General Parallel File System (GPFS)) are not supported when running in rootless mode as these file systems do not understand user namespace.  However, rootless Podman can make use of an NFS Homedir by modifying the `$HOME/.config/containers/storage.conf` to have the `graphroot` option point to a directory stored on local (Non NFS) storage.
 
 For more information, please refer to the [Podman Troubleshooting Page](https://github.com/containers/libpod/blob/master/troubleshooting.md).
 


### PR DESCRIPTION
Apparently, a tilde is currently rendered as a single space, making
a mess of command examples that use it, so use $HOME instead.

https://github.com/mattermost/mattermost-server/issues/8228

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>