### PR TITLE
display file name of bad cni conf

### DIFF
--- a/pkg/network/files.go
+++ b/pkg/network/files.go
@@ -24,7 +24,7 @@ func LoadCNIConfsFromDir(dir string) ([]*libcni.NetworkConfigList, error) {
 	for _, confFile := range files {
 		conf, err := libcni.ConfListFromFile(confFile)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "in %s", confFile)
 		}
 		configs = append(configs, conf)
 	}
@@ -41,7 +41,7 @@ func GetCNIConfigPathByName(name string) (string, error) {
 	for _, confFile := range files {
 		conf, err := libcni.ConfListFromFile(confFile)
 		if err != nil {
-			return "", err
+			return "", errors.Wrapf(err, "in %s", confFile)
 		}
 		if conf.Name == name {
 			return confFile, nil


### PR DESCRIPTION
if one of the cni conf files is badly formatted or cannot be loaded, we now display the error as well as the filename.

Fixes: #2909
Signed-off-by: Brent Baude <bbaude@redhat.com>