### PR TITLE
run `varlink_generate` on Linux only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -524,7 +524,10 @@ install.libseccomp.sudo:
 
 
 cmd/podman/varlink/iopodman.go: .gopathok cmd/podman/varlink/io.podman.varlink
+ifeq ("$(shell uname -o)", "GNU/Linux")
+	# Only generate the varlink code on Linux (see issue #4814).
 	GO111MODULE=off $(GO) generate ./cmd/podman/varlink/...
+endif
 
 API.md: cmd/podman/varlink/io.podman.varlink
 	$(GO) generate ./docs/...


### PR DESCRIPTION
Running the `varlink_generate` make target on non-Linux machines is not
supported, so restrict it to Linux only.

Fixes: #4814
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>