### PR TITLE
history: fix size computing

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -831,7 +831,8 @@ func (i *Image) History(ctx context.Context) ([]*History, error) {
 		id := "<missing>"
 		if x == numHistories {
 			id = i.ID()
-		} else if layer != nil {
+		}
+		if layer != nil {
 			if !oci.History[x].EmptyLayer {
 				size = layer.UncompressedSize
 			}


### PR DESCRIPTION
Get the layer's size whether it relates to the first history entry or
not.  This fixes issues where the first entry would always be shown
to be of size 0.

Fixes: #4916
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>