### PR TITLE
Makefile cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,6 @@ endif
 
 GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
 
-BOX="fedora_atomic"
-
 CROSS_BUILD_TARGETS := \
 	bin/podman.cross.darwin.amd64 \
 	bin/podman.cross.linux.amd64
@@ -317,9 +315,6 @@ remotesystem:
 
 system.test-binary: .install.ginkgo
 	$(GO) test -c ./test/system
-
-vagrant-check:
-	BOX=$(BOX) sh ./vagrant.sh
 
 binaries: varlink_generate podman podman-remote ## Build podman
 

--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,7 @@ release.txt:
 		echo -n " $$field"; done >> "$@"
 	echo "" >> "$@"
 
-podman-v$(RELEASE_NUMBER).tar.gz: binaries docs release.txt
+podman-release.tar.gz: binaries docs release.txt
 	$(eval TMPDIR := $(shell mktemp -d -p '' podman_XXXX))
 	$(eval SUBDIR := podman-v$(RELEASE_NUMBER))
 	mkdir -p "$(TMPDIR)/$(SUBDIR)"
@@ -404,8 +404,8 @@ podman-v$(RELEASE_NUMBER).tar.gz: binaries docs release.txt
 	tar -czvf $@ --xattrs -C "$(TMPDIR)" "./release.txt" "./$(SUBDIR)"
 	-rm -rf "$(TMPDIR)"
 
-# Must call make in-line: Dependency-spec. w/ wild-card also consumes variable value.
-podman-remote-v$(RELEASE_NUMBER)-%.zip:
+# Must call make in-line: Dependency-spec. w/ wild-card.
+podman-remote-release-%.zip:
 	$(MAKE) podman-remote-$* install-podman-remote-$*-docs release.txt \
 		RELEASE_BASENAME=$(shell hack/get_release_info.sh REMOTENAME) \
 		RELEASE_DIST=$* RELEASE_DIST_VER="-"
@@ -424,12 +424,12 @@ podman-remote-v$(RELEASE_NUMBER)-%.zip:
 .PHONY: podman-release
 podman-release:
 	rm -f release.txt
-	$(MAKE) podman-v$(RELEASE_NUMBER).tar.gz
+	$(MAKE) podman-release.tar.gz
 
 .PHONY: podman-remote-%-release
 podman-remote-%-release:
 	rm -f release.txt
-	$(MAKE) podman-remote-v$(RELEASE_NUMBER)-$*.zip
+	$(MAKE) podman-remote-release-$*.zip
 
 .PHONY: docker-docs
 docker-docs: docs

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ ETCDIR ?= /etc
 TMPFILESDIR ?= ${PREFIX}/lib/tmpfiles.d
 SYSTEMDDIR ?= ${PREFIX}/lib/systemd/system
 USERSYSTEMDDIR ?= ${PREFIX}/lib/systemd/user
-BUILDFLAGS ?=
 BUILDTAGS ?= \
 	$(shell hack/apparmor_tag.sh) \
 	$(shell hack/btrfs_installed_tag.sh) \

--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,8 @@ test/goecho/goecho: .gopathok $(wildcard test/goecho/*.go)
 bin/podman: .gopathok $(SOURCES) go.mod go.sum $(PODMAN_VARLINK_DEPENDENCIES) ## Build with podman
 # Make sure to warn in case we're building without the systemd buildtag.
 ifeq (,$(findstring systemd,$(BUILDTAGS)))
-$(warning \
-	Podman is being compiled without the systemd build tag.\
-	Install libsystemd on Ubuntu or systemd-devel on rpm based distro for journald support)
+	@echo "Podman is being compiled without the systemd build tag. Install libsystemd on \
+		Ubuntu or systemd-devel on rpm based distro for journald support."
 endif
 	$(GO_BUILD) $(BUILDFLAGS) -gcflags '$(GCFLAGS)' -asmflags '$(ASMFLAGS)' -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/podman
 

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,10 @@ CROSS_BUILD_TARGETS := \
 	bin/podman.cross.darwin.amd64 \
 	bin/podman.cross.linux.amd64
 
+.PHONY: all
 all: binaries docs
 
+.PHONY: default
 default: help
 
 define PRINT_HELP_PYSCRIPT
@@ -131,6 +133,7 @@ for cmd in sorted(cmds):
 endef
 export PRINT_HELP_PYSCRIPT
 
+.PHONY: help
 help:
 	@$(PYTHON) -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
@@ -142,6 +145,7 @@ ifeq ("$(wildcard $(GOPKGDIR))","")
 endif
 	touch $@
 
+.PHONY: lint
 lint: golangci-lint
 ifeq ($(PRE_COMMIT),)
 	@echo "FATAL: pre-commit was not found, check https://pre-commit.com/ about installing it." >&2
@@ -149,20 +153,25 @@ ifeq ($(PRE_COMMIT),)
 endif
 	$(PRE_COMMIT) run -a
 
+.PHONY: golangci-lint
 golangci-lint: .gopathok varlink_generate .install.golangci-lint
 	$(GOBIN)/golangci-lint run
 
+.PHONY: gofmt
 gofmt: ## Verify the source code gofmt
 	find . -name '*.go' ! -path './vendor/*' -exec gofmt -s -w {} \+
 	git diff --exit-code
 
+.PHONY: test/checkseccomp/checkseccomp
 test/checkseccomp/checkseccomp: .gopathok $(wildcard test/checkseccomp/*.go)
 	$(GO_BUILD) -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/test/checkseccomp
 
+.PHONY: test/goecho/goechoe
 test/goecho/goecho: .gopathok $(wildcard test/goecho/*.go)
 	$(GO_BUILD) -ldflags '$(LDFLAGS_PODMAN)' -o $@ $(PROJECT)/test/goecho
 
 
+.PHONY: bin/podman
 bin/podman: .gopathok $(SOURCES) go.mod go.sum $(PODMAN_VARLINK_DEPENDENCIES) ## Build with podman
 # Make sure to warn in case we're building without the systemd buildtag.
 ifeq (,$(findstring systemd,$(BUILDTAGS)))
@@ -172,11 +181,14 @@ $(warning \
 endif
 	$(GO_BUILD) $(BUILDFLAGS) -gcflags '$(GCFLAGS)' -asmflags '$(ASMFLAGS)' -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS)" -o $@ $(PROJECT)/cmd/podman
 
+.PHONY: podman
 podman: bin/podman
 
+.PHONY: bin/podman-remote
 bin/podman-remote: .gopathok $(SOURCES) go.mod go.sum $(PODMAN_VARLINK_DEPENDENCIES) ## Build with podman on remote environment
 	$(GO_BUILD) $(BUILDFLAGS) -gcflags '$(GCFLAGS)' -asmflags '$(ASMFLAGS)' -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS) remoteclient" -o $@ $(PROJECT)/cmd/podman
 
+.PHONY: podman-remote
 podman-remote: bin/podman-remote
 
 .PHONY: podman.msi
@@ -209,6 +221,7 @@ pkg/api/swagger.yaml: .gopathok release.txt
 .PHONY: swagger
 swagger: pkg/api/swagger.yaml
 
+.PHONY: clean
 clean: ## Clean artifacts
 	rm -rf \
 		.gopathok \
@@ -228,36 +241,47 @@ clean: ## Clean artifacts
 		libpod/pod_easyjson.go \
 		docs/build
 
+.PHONY: libpodimage
 libpodimage: ## Build the libpod image
 	${CONTAINER_RUNTIME} build -t ${LIBPOD_IMAGE} .
 
+.PHONY: dbuild
 dbuild: libpodimage
 	${CONTAINER_RUNTIME} run --name=${LIBPOD_INSTANCE} --privileged -v ${PWD}:/go/src/${PROJECT} --rm ${LIBPOD_IMAGE} make all
 
+.PHONY: dbuild-podman-remote
 dbuild-podman-remote: libpodimage
 	${CONTAINER_RUNTIME} run --name=${LIBPOD_INSTANCE} --privileged -v ${PWD}:/go/src/${PROJECT} --rm ${LIBPOD_IMAGE} go build -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS) remoteclient" -o bin/podman-remote $(PROJECT)/cmd/podman
 
+.PHONY: dbuild-podman-remote-darwin
 dbuild-podman-remote-darwin: libpodimage
 	${CONTAINER_RUNTIME} run --name=${LIBPOD_INSTANCE} --privileged -v ${PWD}:/go/src/${PROJECT} --rm ${LIBPOD_IMAGE} env GOOS=darwin go build -ldflags '$(LDFLAGS_PODMAN)' -tags "remoteclient containers_image_openpgp exclude_graphdriver_devicemapper" -o bin/podman-remote-darwin $(PROJECT)/cmd/podman
 
+.PHONY: test
 test: libpodimage ## Run tests on built image
 	${CONTAINER_RUNTIME} run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e OCI_RUNTIME -e CGROUP_MANAGER=cgroupfs -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make clean all localunit install.catatonit localintegration
 
+.PHONY: integration
 integration: libpodimage ## Execute integration tests
 	${CONTAINER_RUNTIME} run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e OCI_RUNTIME -e CGROUP_MANAGER=cgroupfs -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make clean all install.catatonit localintegration
 
+.PHONY: integration.fedora
 integration.fedora:
 	DIST=Fedora sh .papr_prepare.sh
 
+.PHONY: integration.centos
 integration.centos:
 	DIST=CentOS sh .papr_prepare.sh
 
+.PHONY: shell
 shell: libpodimage ## Run the built image and attach a shell
 	${CONTAINER_RUNTIME} run -e STORAGE_OPTIONS="--storage-driver=vfs" -e CGROUP_MANAGER=cgroupfs -e TESTFLAGS -e OCI_RUNTIME -e TRAVIS -it --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} sh
 
+.PHONY: testunit
 testunit: libpodimage ## Run unittest on the built image
 	${CONTAINER_RUNTIME} run -e STORAGE_OPTIONS="--storage-driver=vfs" -e TESTFLAGS -e CGROUP_MANAGER=cgroupfs -e OCI_RUNTIME -e TRAVIS -t --privileged --rm -v ${CURDIR}:/go/src/${PROJECT} ${LIBPOD_IMAGE} make localunit
 
+.PHONY: localunit
 localunit: test/goecho/goecho varlink_generate
 	ginkgo \
 		-r \
@@ -268,24 +292,31 @@ localunit: test/goecho/goecho varlink_generate
 		--tags "$(BUILDTAGS)" \
 		--succinct
 
+.PHONY: ginkgo
 ginkgo:
 	ginkgo -v $(TESTFLAGS) -tags "$(BUILDTAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes 3 -debug test/e2e/.
 
+.PHONY: ginkgo-remote
 ginkgo-remote:
 	ginkgo -v $(TESTFLAGS) -tags "$(BUILDTAGS) remoteclient" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor test/e2e/.
 
+.PHONY: endpoint
 endpoint:
 	ginkgo -v $(TESTFLAGS) -tags "$(BUILDTAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -debug test/endpoint/.
 
+.PHONY: localintegration
 localintegration: varlink_generate test-binaries ginkgo
 
+.PHONY: remoteintegration
 remoteintegration: varlink_generate test-binaries ginkgo-remote
 
+.PHONY: localsystem
 localsystem:
 	# Wipe existing config, database, and cache: start with clean slate.
 	$(RM) -rf ${HOME}/.local/share/containers ${HOME}/.config/containers
 	if timeout -v 1 true; then PODMAN=./bin/podman bats test/system/; else echo "Skipping $@: 'timeout -v' unavailable'"; fi
 
+.PHONY: remotesystem
 remotesystem:
 	# Wipe existing config, database, and cache: start with clean slate.
 	$(RM) -rf ${HOME}/.local/share/containers ${HOME}/.config/containers
@@ -313,14 +344,18 @@ remotesystem:
 	fi;\
 	exit $$rc
 
+.PHONY: system.test-binary
 system.test-binary: .install.ginkgo
 	$(GO) test -c ./test/system
 
+.PHONY: binaries
 binaries: varlink_generate podman podman-remote ## Build podman
 
+.PHONY: install.catatonit
 install.catatonit:
 	./hack/install_catatonit.sh
 
+.PHONY: test-binaries
 test-binaries: test/checkseccomp/checkseccomp test/goecho/goecho install.catatonit
 
 MANPAGES_MD ?= $(wildcard docs/source/markdown/*.md pkg/*/docs/*.md)
@@ -330,9 +365,11 @@ MANPAGES_DEST ?= $(subst markdown,man, $(subst source,build,$(MANPAGES)))
 $(MANPAGES): %: %.md .gopathok
 	@sed -e 's/\((podman.*\.md)\)//' -e 's/\[\(podman.*\)\]/\1/' $<  | $(GOMD2MAN) -in /dev/stdin -out $(subst source/markdown,build/man,$@)
 
+.PHONY: docs
 docdir:
 	mkdir -p docs/build/man
 
+.PHONY: docs
 docs: .install.md2man docdir $(MANPAGES) ## Generate documentation
 
 install-podman-remote-%-docs: podman-remote docs $(MANPAGES)
@@ -341,9 +378,11 @@ install-podman-remote-%-docs: podman-remote docs $(MANPAGES)
 	ln -sf $(shell pwd)/docs/source/markdown/links docs/build/man/
 	docs/remote-docs.sh $* docs/build/remote/$* $(if $(findstring windows,$*),docs/source/markdown,docs/build/man)
 
+.PHONY: man-page-check
 man-page-check:
 	hack/man-page-checker
 
+.PHONY: codespell
 codespell:
 	codespell -S bin,vendor,.git,go.sum,changelog.txt,seccomp.json,.cirrus.yml,"*.xz,*.gz,*.tar,*.tgz,bin2img,*ico,*.png,*.1,*.5,copyimg,*.orig,apidoc.go" -L uint,iff,od,seeked
 
@@ -394,9 +433,11 @@ podman-remote-%-release:
 	rm -f release.txt
 	$(MAKE) podman-remote-v$(RELEASE_NUMBER)-$*.zip
 
+.PHONY: docker-docs
 docker-docs: docs
 	(cd docs; ./dckrman.sh ./build/man/*.1)
 
+.PHONY: changelog
 changelog: ## Generate changelog
 	@echo "Creating changelog from $(CHANGELOG_BASE) to $(CHANGELOG_TARGET)"
 	$(eval TMPFILE := $(shell mktemp))
@@ -407,13 +448,16 @@ changelog: ## Generate changelog
 	$(shell cat $(TMPFILE) >> changelog.txt)
 	$(shell rm $(TMPFILE))
 
+.PHONY: install
 install: .gopathok install.bin install.remote install.man install.cni install.systemd  ## Install binaries to system locations
 
+.PHONY: install.remote
 install.remote: podman-remote
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 bin/podman-remote $(DESTDIR)$(BINDIR)/podman-remote
 	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(DESTDIR)$(BINDIR)/podman bin/podman-remote
 
+.PHONY: install.bin
 install.bin: podman
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 bin/podman $(DESTDIR)$(BINDIR)/podman
@@ -426,24 +470,30 @@ install.man: docs
 	install ${SELINUXOPT} -m 644 $(filter %.5,$(MANPAGES_DEST)) -t $(DESTDIR)$(MANDIR)/man5
 	install ${SELINUXOPT} -m 644 docs/source/markdown/links/*1 -t $(DESTDIR)$(MANDIR)/man1
 
+.PHONY: install.config
 install.config:
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(SHAREDIR_CONTAINERS)
 	install ${SELINUXOPT} -m 644 libpod.conf $(DESTDIR)$(SHAREDIR_CONTAINERS)/libpod.conf
 
+.PHONY: install.seccomp
 install.seccomp:
+	# TODO: we should really be using the upstream one from github.com/seccomp
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(SHAREDIR_CONTAINERS)
 	install ${SELINUXOPT} -m 644 seccomp.json $(DESTDIR)$(SHAREDIR_CONTAINERS)/seccomp.json
 
+.PHONY: install.completions
 install.completions:
 	install ${SELINUXOPT} -d -m 755 ${DESTDIR}${BASHINSTALLDIR}
 	install ${SELINUXOPT} -m 644 completions/bash/podman ${DESTDIR}${BASHINSTALLDIR}
 	install ${SELINUXOPT} -d -m 755 ${DESTDIR}${ZSHINSTALLDIR}
 	install ${SELINUXOPT} -m 644 completions/zsh/_podman ${DESTDIR}${ZSHINSTALLDIR}
 
+.PHONY: install.cni
 install.cni:
 	install ${SELINUXOPT} -d -m 755 ${DESTDIR}${ETCDIR}/cni/net.d/
 	install ${SELINUXOPT} -m 644 cni/87-podman-bridge.conflist ${DESTDIR}${ETCDIR}/cni/net.d/87-podman-bridge.conflist
 
+.PHONY: install.docker
 install.docker: docker-docs
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man1
 	install ${SELINUXOPT} -m 755 docker $(DESTDIR)$(BINDIR)/docker
@@ -451,6 +501,7 @@ install.docker: docker-docs
 	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR}  ${DESTDIR}${USERSYSTEMDDIR} ${DESTDIR}${TMPFILESDIR}
 	install ${SELINUXOPT} -m 644 contrib/systemd/system/podman-docker.conf -t ${DESTDIR}${TMPFILESDIR}
 
+.PHONY: install.systemd
 install.systemd:
 	install ${SELINUXOPT} -m 755 -d ${DESTDIR}${SYSTEMDDIR}  ${DESTDIR}${USERSYSTEMDDIR} ${DESTDIR}${TMPFILESDIR}
 	install ${SELINUXOPT} -m 644 contrib/varlink/io.podman.socket ${DESTDIR}${SYSTEMDDIR}/io.podman.socket
@@ -462,6 +513,7 @@ install.systemd:
 	sed -e 's,^WantedBy=.*,WantedBy=default.target,' < contrib/varlink/io.podman.service > ${DESTDIR}${USERSYSTEMDDIR}/io.podman.service
 	install ${SELINUXOPT} -m 644 contrib/varlink/podman.conf ${DESTDIR}${TMPFILESDIR}/podman.conf
 
+.PHONY: uninstall
 uninstall:
 	for i in $(filter %.1,$(MANPAGES_DEST)); do \
 		rm -f $(DESTDIR)$(MANDIR)/man1/$$(basename $${i}); \
@@ -491,25 +543,32 @@ define go-get
 		$(GO) get -u ${1}
 endef
 
+.PHONY: .install.ginkgo
 .install.ginkgo: .gopathok
 	if [ ! -x "$(GOBIN)/ginkgo" ]; then \
 		$(GO_BUILD) -o ${GOPATH}/bin/ginkgo ./vendor/github.com/onsi/ginkgo/ginkgo ; \
 	fi
 
+.PHONY: .install.gitvalidation
 .install.gitvalidation: .gopathok
 	if [ ! -x "$(GOBIN)/git-validation" ]; then \
 		$(call go-get,github.com/vbatts/git-validation); \
 	fi
 
+.PHONY: .install.golangci-lint
 .install.golangci-lint: .gopathok
 	VERSION=1.18.0 GOBIN=$(GOBIN) sh ./hack/install_golangci.sh
 
+.PHONY: .install.md2man
 .install.md2man: .gopathok
 	if [ ! -x "$(GOMD2MAN)" ]; then \
 		$(call go-get,github.com/cpuguy83/go-md2man); \
 	fi
 
+.PHONY: varlink_generate
 varlink_generate: .gopathok cmd/podman/varlink/iopodman.go ## Generate varlink
+
+.PHONY: varlink_api_generate
 varlink_api_generate: .gopathok API.md
 
 .PHONY: install.libseccomp.sudo
@@ -528,49 +587,35 @@ endif
 API.md: cmd/podman/varlink/io.podman.varlink
 	$(GO) generate ./docs/...
 
+.PHONY: validate.completions
 validate.completions: completions/bash/podman
 	. completions/bash/podman
 	if [ -x /bin/zsh ]; then /bin/zsh completions/zsh/_podman; fi
 
+.PHONY: validate
 validate: gofmt .gitvalidation validate.completions golangci-lint man-page-check
 
+.PHONY: build-all-new-commits
 build-all-new-commits:
 	# Validate that all the commits build on top of $(GIT_BASE_BRANCH)
 	git rebase $(GIT_BASE_BRANCH) -x make
 
+.PHONY: build-no-cgo
 build-no-cgo:
 	env BUILDTAGS="containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_disk_quota" CGO_ENABLED=0 $(MAKE)
 
+.PHONY: vendor
 vendor:
 	export GO111MODULE=on \
 		$(GO) mod tidy && \
 		$(GO) mod vendor && \
 		$(GO) mod verify
 
+.PHONY: vendor-in-container
 vendor-in-container:
 	podman run --privileged --rm --env HOME=/root -v `pwd`:/src -w /src docker.io/library/golang:1.13 make vendor
 
-.PHONY: \
-	binaries \
-	changelog \
-	clean \
-	default \
-	docs \
-	gofmt \
-	golangci-lint \
-	help \
-	install \
-	install.libseccomp.sudo \
-	lint \
-	pause \
-	package \
-	package-install \
-	shell \
-	uninstall \
-	validate \
-	validate.completions \
-	vendor
-
+.PHONY: package
 package:  ## Build rpm packages
 	## TODO(ssbarnea): make version number predictable, it should not change
 	## on each execution, producing duplicates.
@@ -580,6 +625,7 @@ package:  ## Build rpm packages
 # Remember that rpms install exec to /usr/bin/podman while a `make install`
 # installs them to /usr/local/bin/podman which is likely before. Always use
 # a full path to test installed podman or you risk to call another executable.
+.PHONY: package-install
 package-install: package  ## Install rpm packages
 	sudo ${PKG_MANAGER} -y install ${HOME}/rpmbuild/RPMS/*/*.rpm
 	/usr/bin/podman version

--- a/go.mod
+++ b/go.mod
@@ -26,12 +26,14 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
+	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 // indirect
 	github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20190911111923-ecfe977594f1 // indirect
 	github.com/etcd-io/bbolt v1.3.3
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-ini/ini v1.51.1 // indirect
 	github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/google/uuid v1.1.1
@@ -41,7 +43,9 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hpcloud/tail v1.0.0
 	github.com/json-iterator/go v1.1.9
+	github.com/mrtazz/checkmake v0.0.0-20191009095831-03dd76b964dd // indirect
 	github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618
+	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/opencontainers/go-digest v1.0.0-rc1

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNE
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c h1:ZfSZ3P3BedhKGUhzj7BQlPSU4OvT6tfOKe3DVHzOA7s=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f h1:8GDPb0tCY8LQ+OJ3dbHb5sA6YZWXFORQYZx5sdsTlMs=
 github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
@@ -190,6 +192,8 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v0.0.0-20161207003320-04f313413ffd/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-ini/ini v1.51.1 h1:/QG3cj23k5V8mOl4JnNzUNhc1kr/jzMiNsNuWKcx8gM=
+github.com/go-ini/ini v1.51.1/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
@@ -328,6 +332,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.5 h1:JhhFTIOslh5ZsPrpa3Wdg8bF0WI3b44EMblmU9wIsXc=
 github.com/mattn/go-shellwords v1.0.5/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
@@ -352,6 +358,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/mrtazz/checkmake v0.0.0-20191009095831-03dd76b964dd h1:3k5dpxjeXlUuz8STW9BE2WsvPnaMcmlfGKAbe3J5v+0=
+github.com/mrtazz/checkmake v0.0.0-20191009095831-03dd76b964dd/go.mod h1:YBPKCT1PrhoFU743gPdtJNp+LmM0QlGMWME1J+FJtQI=
 github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618 h1:7InQ7/zrOh6SlFjaXFubv0xX0HsuC9qJsdqm7bNQpYM=
 github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618/go.mod h1:x8F1gnqOkIEiO4rqoeEEEqQbo7HjGMTvyoq3gej4iT0=
 github.com/mtrmac/gpgme v0.0.0-20170102180018-b2432428689c h1:xa+eQWKuJ9MbB9FBL/eoNvDFvveAkz2LQoz8PzX7Q/4=
@@ -359,6 +367,8 @@ github.com/mtrmac/gpgme v0.0.0-20170102180018-b2432428689c/go.mod h1:GhAqVMEWnTc
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
+github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
A set of cleanups for the Makefile. I'm ultimately aiming at making it faster (and fix #4829) since it got _very_ slow over time.

I bisected the performance and found that the release targets are responsible:
https://github.com/containers/libpod/blob/master/Makefile#L364-L372

@cevich, are `podman-v$(RELEASE_NUMBER).tar.gz:` and the remote counterpart used in the CI? Generating `RELEASE_NUMBER` for each invocation of the Makefile is burning most of the time. Commenting the two targets renders a `make tab tab` completion fast again. If needed, any chance we could not embed that in the target name?