### PR TITLE
Cirrus: Set EPOCH_TEST_COMMIT during gate task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,10 +85,15 @@ gce_instance:
 # quick format, lint, and unit tests on the standard platform.
 gating_task:
 
+    # Only run this on PRs, never during post-merge testing.  This is also required
+    # for proper setting of EPOCH_TEST_COMMIT value, required by validation tools.
+    only_if: $CIRRUS_BRANCH != $DEST_BRANCH
+
     env:
         CIRRUS_WORKING_DIR: "/usr/src/libpod"
         GOPATH: "/go"
         GOSRC: "/go/src/github.com/containers/libpod"
+        EPOCH_TEST_COMMIT: "${CIRRUS_BASE_SHA}"
 
     # Runs within Cirrus's "community cluster"
     container:


### PR DESCRIPTION
For whatever reason, this required variable is not set when `make` is
doing validation within automation.  Fix this by establishing the
value based on data provided from the CI system.  Since this data
is specific to automation executing against a PR, limit this specific
job to not run during testing of branches (post-merge).  This is safe
since we can assume the PR would not have been merged, if the basics
checked during gating did not pass.

Signed-off-by: Chris Evich <cevich@redhat.com>