### PR TITLE
markdown: fix erroneous asterisk markup for options

### DIFF
--- a/docs/source/markdown/podman-login.1.md
+++ b/docs/source/markdown/podman-login.1.md
@@ -29,7 +29,7 @@ Password for registry
 
 Take the password from stdin
 
-**--username**, **-u=***username*
+**--username**, **-u**=*username*
 
 Username for registry
 

--- a/docs/source/markdown/podman-pod-ps.1.md
+++ b/docs/source/markdown/podman-pod-ps.1.md
@@ -75,7 +75,7 @@ Sort by created, ID, name, status, or number of containers
 
 Default: created
 
-**--filter**, **-f=***filter*
+**--filter**, **-f**=*filter*
 
 Filter output based on conditions given
 

--- a/docs/source/markdown/podman-system-df.1.md
+++ b/docs/source/markdown/podman-system-df.1.md
@@ -10,7 +10,7 @@ podman\-system\-df - Show podman disk usage
 Show podman disk usage
 
 ## OPTIONS
-**--format=***format*
+**--format**=*format*
 
 Pretty-print images using a Go template
 

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -79,7 +79,7 @@ When namespace is set, created containers and pods will join the given namespace
 **--network-cmd-path**=*path*
 Path to the command binary to use for setting up a network.  It is currently only used for setting up a slirp4netns network.  If "" is used then the binary is looked up using the $PATH environment variable.
 
-**--root=***value*
+**--root**=*value*
 
 Storage root dir in which data, including images, is stored (default: "/var/lib/containers/storage" for UID 0, "$HOME/.local/share/containers/storage" for other users).
 Default root dir is configured in `/etc/containers/storage.conf`.


### PR DESCRIPTION
Fix option markup in a number of man pages so it renders
properly when viewing online.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>