### PR TITLE
Feature/ubuntu doc adjustment

### DIFF
--- a/install.md
+++ b/install.md
@@ -124,9 +124,8 @@ The Kubic project provides packages for Ubuntu 18.04, 19.04 and 19.10.
 
 ```bash
 . /etc/os-release
-sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
-sudo apt-key add - < Release.key
+sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+wget -q https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key -O- | sudo apt-key add -
 sudo apt-get update -qq
 sudo apt-get -qq -y install podman
 ```

--- a/install.md
+++ b/install.md
@@ -129,8 +129,6 @@ wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:st
 sudo apt-key add - < Release.key
 sudo apt-get update -qq
 sudo apt-get -qq -y install podman
-sudo mkdir -p /etc/containers
-echo -e "[registries.search]\nregistries = ['docker.io', 'quay.io']" | sudo tee /etc/containers/registries.conf
 ```
 
 There are many [packages](https://packages.ubuntu.com/search?keywords=libpod&searchon=names&suite=eoan&section=all)


### PR DESCRIPTION
Adjusts install.md (Ubuntu): 
- registries.conf setup is now in containers-image package
- replaces ${NAME} with hard-encoded Ubuntu to support all *buntu flavors
- combines downloading and registering of the apt-secure key into a piped oneliner
