### PR TITLE
make image reference for commit optional

### DIFF
--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -56,12 +56,15 @@ func commitCmd(c *cliconfig.CommitValues) error {
 	defer runtime.DeferredShutdown(false)
 
 	args := c.InputArgs
-	if len(args) != 2 {
-		return errors.Errorf("you must provide a container name or ID and a target image name")
+	if len(args) < 1 {
+		return errors.Errorf("you must provide a container name or ID and optionally a target image name")
 	}
 
 	container := args[0]
-	reference := args[1]
+	reference := ""
+	if len(args) > 1 {
+		reference = args[1]
+	}
 	if c.Flag("change").Changed {
 		for _, change := range c.Change {
 			splitChange := strings.Split(strings.ToUpper(change), "=")

--- a/docs/source/markdown/podman-commit.1.md
+++ b/docs/source/markdown/podman-commit.1.md
@@ -6,7 +6,7 @@ podman\-commit - Create new image based on the changed container
 ## SYNOPSIS
 **podman commit** [*options*] *container* *image*
 
-**podman container commit** [*options*] *container* *image*
+**podman container commit** [*options*] *container* [*image*]
 
 ## DESCRIPTION
 **podman commit** creates an image based on a changed container. The author of the


### PR DESCRIPTION
to match docker compat, the image tag should be optional.

Fixes: #5027

Signed-off-by: Brent Baude <bbaude@redhat.com>