### PR TITLE
sigproxy: return after closing the channel

### DIFF
--- a/pkg/adapter/sigproxy_linux.go
+++ b/pkg/adapter/sigproxy_linux.go
@@ -25,11 +25,17 @@ func ProxySignals(ctr *libpod.Container) {
 			}
 
 			if err := ctr.Kill(uint(s.(syscall.Signal))); err != nil {
+				// If the container dies, and we find out here,
+				// we need to forward that one signal to
+				// ourselves so that it is not lost, and then
+				// we terminate the proxy and let the defaults
+				// play out.
 				logrus.Errorf("Error forwarding signal %d to container %s: %v", s, ctr.ID(), err)
 				signal.StopCatch(sigBuffer)
 				if err := syscall.Kill(syscall.Getpid(), s.(syscall.Signal)); err != nil {
 					logrus.Errorf("failed to kill pid %d", syscall.Getpid())
 				}
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
When stopping signal handling (e.g., to properly handle ^C) we are also
closing the signal channel.  We should really return from the go-routine
instead of continuing and risking double-closing the channel which leads
to a panic.

Fixes: #5034
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>