### PR TITLE
[CI:DOCS] Fix a syntax error in hack/release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -64,4 +64,4 @@ git fetch origin &&
 git checkout -b "bump-${VERSION}" origin/master &&
 release_commit &&
 git tag -s -m "version ${VERSION}" "v${VERSION}" &&
-dev_version_commit &&
+dev_version_commit


### PR DESCRIPTION
When I fixed the release script up to remove epoch changes I missed this. Oops.