### PR TITLE
Tear down network when restarting containers

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1254,6 +1254,12 @@ func (c *Container) restartWithTimeout(ctx context.Context, timeout uint) (err e
 				}
 			}
 		}
+		// Ensure we tear down the container network so it will be
+		// recreated - otherwise, behavior of restart differs from stop
+		// and start
+		if err := c.cleanupNetwork(); err != nil {
+			return err
+		}
 	}
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
This makes restart a bit slower for root containers, but it does make it more consistent with `podman stop` and `podman start` on a container. Importantly, `podman restart` will now recreate firewall rules if they were somehow purged.

Fixes #5051
