### PR TITLE
Fixed a bug about bash automatically complete

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -104,7 +104,7 @@ __podman_complete_containers_running() {
 }
 
 __podman_complete_containers_stopped() {
-	__podman_complete_containers "$@" --filter status=exited
+	__podman_complete_containers "$@" --all --filter status=exited
 }
 
 __podman_complete_containers_unpauseable() {
@@ -2448,7 +2448,7 @@ _podman_start() {
 	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
 	    ;;
 	*)
-	    __podman_complete_container_names
+	    __podman_complete_containers_stopped
 	    ;;
     esac
 }


### PR DESCRIPTION
When I input podman start in bash , and then type tab ,  cannot automatically complete container name , this pr will fix the bug .