### PR TITLE
[CI:DOCS] swagger: v2: libpod/images/{import,load,pull}

### DIFF
--- a/pkg/api/handlers/generic/images.go
+++ b/pkg/api/handlers/generic/images.go
@@ -3,6 +3,7 @@ package generic
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -314,4 +315,48 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 		summaries[j] = is
 	}
 	utils.WriteResponse(w, http.StatusOK, summaries)
+}
+
+func LoadImages(w http.ResponseWriter, r *http.Request) {
+	// TODO this is basically wrong
+	decoder := r.Context().Value("decoder").(*schema.Decoder)
+	runtime := r.Context().Value("runtime").(*libpod.Runtime)
+
+	query := struct {
+		Changes map[string]string `json:"changes"`
+		Message string            `json:"message"`
+		Quiet   bool              `json:"quiet"`
+	}{
+		// This is where you can override the golang default value for one of fields
+	}
+
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		return
+	}
+
+	var (
+		err    error
+		writer io.Writer
+	)
+	f, err := ioutil.TempFile("", "api_load.tar")
+	if err != nil {
+		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to create tempfile"))
+		return
+	}
+	if err := handlers.SaveFromBody(f, r); err != nil {
+		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to write temporary file"))
+		return
+	}
+	id, err := runtime.LoadImage(r.Context(), "", f.Name(), writer, "")
+	//id, err := runtime.Import(r.Context())
+	if err != nil {
+		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to load image"))
+		return
+	}
+	utils.WriteResponse(w, http.StatusOK, struct {
+		Stream string `json:"stream"`
+	}{
+		Stream: fmt.Sprintf("Loaded image: %s\n", id),
+	})
 }

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -2,7 +2,6 @@ package libpod
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -176,46 +175,17 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 	utils.WriteResponse(w, http.StatusOK, rdr)
 }
 
-func ImportImage(w http.ResponseWriter, r *http.Request) {
-	// TODO this is basically wrong
-	decoder := r.Context().Value("decoder").(*schema.Decoder)
-	runtime := r.Context().Value("runtime").(*libpod.Runtime)
+func ImagesLoad(w http.ResponseWriter, r *http.Request) {
+	//TODO ...
+	utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.New("/libpod/images/load is not yet implemented"))
+}
 
-	query := struct {
-		Changes map[string]string `json:"changes"`
-		Message string            `json:"message"`
-		Quiet   bool              `json:"quiet"`
-	}{
-		// This is where you can override the golang default value for one of fields
-	}
+func ImagesImport(w http.ResponseWriter, r *http.Request) {
+	//TODO ...
+	utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.New("/libpod/images/import is not yet implemented"))
+}
 
-	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
-		return
-	}
-
-	var (
-		err    error
-		writer io.Writer
-	)
-	f, err := ioutil.TempFile("", "api_load.tar")
-	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to create tempfile"))
-		return
-	}
-	if err := handlers.SaveFromBody(f, r); err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to write temporary file"))
-		return
-	}
-	id, err := runtime.LoadImage(r.Context(), "", f.Name(), writer, "")
-	//id, err := runtime.Import(r.Context())
-	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "failed to load image"))
-		return
-	}
-	utils.WriteResponse(w, http.StatusOK, struct {
-		Stream string `json:"stream"`
-	}{
-		Stream: fmt.Sprintf("Loaded image: %s\n", id),
-	})
+func ImagesPull(w http.ResponseWriter, r *http.Request) {
+	//TODO ...
+	utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.New("/libpod/images/pull is not yet implemented"))
 }

--- a/pkg/api/handlers/swagger.go
+++ b/pkg/api/handlers/swagger.go
@@ -26,6 +26,27 @@ type swagImageInspect struct {
 	}
 }
 
+// Load response
+// swagger:response DocsLibpodImagesLoadResponse
+type swagLibpodImagesLoadResponse struct {
+	// in:body
+	Body []LibpodImagesLoadReport
+}
+
+// Import response
+// swagger:response DocsLibpodImagesImportResponse
+type swagLibpodImagesImportResponse struct {
+	// in:body
+	Body LibpodImagesImportReport
+}
+
+// Pull response
+// swagger:response DocsLibpodImagesPullResponse
+type swagLibpodImagesPullResponse struct {
+	// in:body
+	Body LibpodImagesPullReport
+}
+
 // Delete response
 // swagger:response DocsImageDeleteResponse
 type swagImageDeleteResponse struct {

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -49,6 +49,21 @@ type LibpodContainersPruneReport struct {
 	PruneError     string `json:"error"`
 }
 
+type LibpodImagesLoadReport struct {
+	ID       string   `json:"id"`
+	RepoTags []string `json:"repoTags"`
+}
+
+type LibpodImagesImportReport struct {
+	ID       string   `json:"id"`
+	RepoTags []string `json:"repoTags"`
+}
+
+type LibpodImagesPullReport struct {
+	ID       string   `json:"id"`
+	RepoTags []string `json:"repoTags"`
+}
+
 type Info struct {
 	docker.Info
 	BuildahVersion     string

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -107,7 +107,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     description: no error
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/images/load"), APIHandler(s.Context, libpod.ImportImage)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/images/load"), APIHandler(s.Context, generic.LoadImages)).Methods(http.MethodPost)
 	// swagger:operation POST /images/prune compat pruneImages
 	// ---
 	// tags:
@@ -631,17 +631,13 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/json"), APIHandler(s.Context, libpod.GetImages)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/images/load libpod libpodImportImage
+	// swagger:operation POST /libpod/images/load libpod libpodImagesLoad
 	// ---
 	// tags:
 	//  - images
-	// summary: Import image
-	// description: Load a set of images and tags into a repository.
+	// summary: Load image
+	// description: Load an image (oci-archive or docker-archive) stream.
 	// parameters:
-	//  - in: query
-	//    name: quiet
-	//    type: boolean
-	//    description: not supported
 	//  - in: query
 	//    name: change
 	//    description: "Apply the following possible instructions to the created image (default []): CMD | ENTRYPOINT | ENV | EXPOSE | LABEL | STOPSIGNAL | USER | VOLUME | WORKDIR.  JSON encoded string"
@@ -660,10 +656,71 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// - application/json
 	// responses:
 	//   200:
-	//     description: no error
+	//     $ref: "#/response/LibpodImagesLoadResponse"
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/load"), APIHandler(s.Context, libpod.ImportImage)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/images/load"), APIHandler(s.Context, libpod.ImagesLoad)).Methods(http.MethodPost)
+	// swagger:operation POST /libpod/images/import libpod libpodImagesImport
+	// ---
+	// tags:
+	//  - images
+	// summary: Import image
+	// description: Import a previosly exported tarball as an image.
+	// parameters:
+	//  - in: query
+	//    name: change
+	//    description: "Apply the following possible instructions to the created image (default []): CMD | ENTRYPOINT | ENV | EXPOSE | LABEL | STOPSIGNAL | USER | VOLUME | WORKDIR.  JSON encoded string"
+	//    type: string
+	//  - in: query
+	//    name: message
+	//    description: Set commit message for imported image
+	//    type: string
+	//  - in: query
+	//    name: url
+	//    description: Specify a URL instead of a tarball
+	//    type: bool
+	//  - in: body
+	//    name: request
+	//    description: Tarball of (or URL to) container image
+	//    required: true
+	//    schema:
+	//      type: string
+	// produces:
+	// - application/json
+	// responses:
+	//   200:
+	//     $ref: "#/response/LibpodImagesImportResponse"
+	//   500:
+	//     $ref: '#/responses/InternalError'
+	r.Handle(VersionedPath("/libpod/images/import"), APIHandler(s.Context, libpod.ImagesImport)).Methods(http.MethodPost)
+	// swagger:operation GET /libpod/images/pull libpod libpodImagesPull
+	// ---
+	// tags:
+	//  - images
+	// summary: Import image
+	// description: Import a previosly exported image as a tarball.
+	// parameters:
+	//  - in: query
+	//    name: reference
+	//    description: Mandatory reference to the image (e.g., quay.io/image/name:tag)/
+	//    type: string
+	//  - in: query
+	//    name: credentials
+	//    description: username:password for the registry.
+	//    type: string
+	//  - in: query
+	//    name: tls-verify
+	//    description: Require TLS verification.
+	//    type: bool
+	//    default: true
+	// produces:
+	// - application/json
+	// responses:
+	//   200:
+	//     $ref: "#/response/LibpodImagesPullResponse"
+	//   500:
+	//     $ref: '#/responses/InternalError'
+	r.Handle(VersionedPath("/libpod/images/pull"), APIHandler(s.Context, libpod.ImagesPull)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/images/prune libpod libpodPruneImages
 	// ---
 	// tags:


### PR DESCRIPTION
Note: this commit is merely adding swagger documentation and the golang
stubs and types for the proposed endpoints.  The implementation will
follow in separate individual changes in the future.

The ultimate goal is to prevent the libpod API from exposing the rather
complex /images/create endpoint from Docker and split it into easier to
implement, use and comprehend endpoints with a more narrow focus.

 # Import

Add the v2 swagger documentation for the libpod/images/import endpoint.
Note that we have intend to have separate backend and not mix it up with
load since import allows for specifying a URL instead of a local
tarball.

 # Load

Complete the v2 swagger documentation for the libpod/images/load
endpoint.  Note that we are accounting for future plans to be able to
load multiple images from one oci/docker archive by returning an array
of image-load responses.

Also move the (incomplete) implementation of the generic endpoint to the
corresponding package and create a stub for the libpod handler, which
will be implemented once there's an agreement on the proposed API.

 # Pull

Add the v2 swagger documentation for the libpod/images/pull endpoint.
Similar to the load endpoint, we return an array since more than one
image can be pulled when the `all-tags` parameter is set.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>