### PR TITLE
Add backend code for pod network options

### DIFF
--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"net"
 	"time"
 
 	"github.com/containers/libpod/libpod/define"
@@ -97,8 +98,17 @@ type PodContainerInfo struct {
 
 // InfraContainerConfig is the configuration for the pod's infra container
 type InfraContainerConfig struct {
-	HasInfraContainer bool                 `json:"makeInfraContainer"`
-	PortBindings      []ocicni.PortMapping `json:"infraPortBindings"`
+	HasInfraContainer  bool                 `json:"makeInfraContainer"`
+	PortBindings       []ocicni.PortMapping `json:"infraPortBindings"`
+	StaticIP           net.IP               `json:"staticIP,omitempty"`
+	StaticMAC          net.HardwareAddr     `json:"staticMAC,omitempty"`
+	UseImageResolvConf bool                 `json:"useImageResolvConf,omitempty"`
+	DNSServer          []string             `json:"dnsServer,omitempty"`
+	DNSSearch          []string             `json:"dnsSearch,omitempty"`
+	DNSOption          []string             `json:"dnsOption,omitempty"`
+	UseImageHosts      bool                 `json:"useImageHosts,omitempty"`
+	HostAdd            []string             `json:"hostsAdd,omitempty"`
+	Networks           []string             `json:"networks,omitempty"`
 }
 
 // ID retrieves the pod's ID

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -94,14 +94,38 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, imgID
 	options = append(options, withIsInfra())
 
 	// Since user namespace sharing is not implemented, we only need to check if it's rootless
-	networks := make([]string, 0)
 	netmode := "bridge"
 	if isRootless {
 		netmode = "slirp4netns"
 	}
 	// PostConfigureNetNS should not be set since user namespace sharing is not implemented
 	// and rootless networking no longer supports post configuration setup
-	options = append(options, WithNetNS(p.config.InfraContainer.PortBindings, false, netmode, networks))
+	options = append(options, WithNetNS(p.config.InfraContainer.PortBindings, false, netmode, p.config.InfraContainer.Networks))
+
+	if p.config.InfraContainer.StaticIP != nil {
+		options = append(options, WithStaticIP(p.config.InfraContainer.StaticIP))
+	}
+	if p.config.InfraContainer.StaticMAC != nil {
+		options = append(options, WithStaticMAC(p.config.InfraContainer.StaticMAC))
+	}
+	if p.config.InfraContainer.UseImageResolvConf {
+		options = append(options, WithUseImageResolvConf())
+	}
+	if len(p.config.InfraContainer.DNSServer) > 0 {
+		options = append(options, WithDNS(p.config.InfraContainer.DNSServer))
+	}
+	if len(p.config.InfraContainer.DNSSearch) > 0 {
+		options = append(options, WithDNSSearch(p.config.InfraContainer.DNSSearch))
+	}
+	if len(p.config.InfraContainer.DNSOption) > 0 {
+		options = append(options, WithDNSOption(p.config.InfraContainer.DNSOption))
+	}
+	if p.config.InfraContainer.UseImageHosts {
+		options = append(options, WithUseImageHosts())
+	}
+	if len(p.config.InfraContainer.HostAdd) > 0 {
+		options = append(options, WithHosts(p.config.InfraContainer.HostAdd))
+	}
 
 	return r.newContainer(ctx, g.Config, options...)
 }


### PR DESCRIPTION
This adds network-related options to the pod in the database. We are going to add the CLI frontend in further patches.

In short, this should greatly improve the ability of pods to configure networking, once the CLI parsing is added.