### PR TITLE
seperate container create network options

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -16,6 +16,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -116,14 +117,49 @@ func getDefaultNetwork() string {
 	return "bridge"
 }
 
-func getCreateFlags(c *cliconfig.PodmanCommand) {
-
-	createFlags := c.Flags()
-
-	createFlags.StringSlice(
+func getNetFlags() *pflag.FlagSet {
+	netFlags := pflag.FlagSet{}
+	netFlags.StringSlice(
 		"add-host", []string{},
 		"Add a custom host-to-IP mapping (host:ip) (default [])",
 	)
+	netFlags.StringSlice(
+		"dns", []string{},
+		"Set custom DNS servers",
+	)
+	netFlags.StringSlice(
+		"dns-opt", []string{},
+		"Set custom DNS options",
+	)
+	netFlags.StringSlice(
+		"dns-search", []string{},
+		"Set custom DNS search domains",
+	)
+	netFlags.String(
+		"ip", "",
+		"Specify a static IPv4 address for the container",
+	)
+	netFlags.String(
+		"mac-address", "",
+		"Container MAC address (e.g. 92:d0:c6:0a:29:33)",
+	)
+	netFlags.String(
+		"network", getDefaultNetwork(),
+		"Connect a container to a network",
+	)
+	netFlags.StringSliceP(
+		"publish", "p", []string{},
+		"Publish a container's port, or a range of ports, to the host (default [])",
+	)
+	netFlags.Bool(
+		"no-hosts", false,
+		"Do not create /etc/hosts within the container, instead use the version from the image",
+	)
+	return &netFlags
+}
+
+func getCreateFlags(c *cliconfig.PodmanCommand) {
+	createFlags := c.Flags()
 	createFlags.StringSlice(
 		"annotation", []string{},
 		"Add annotations to container (key:value) (default [])",
@@ -236,18 +272,6 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"device-write-iops", []string{},
 		"Limit write rate (IO per second) to a device (e.g. --device-write-iops=/dev/sda:1000)",
 	)
-	createFlags.StringSlice(
-		"dns", []string{},
-		"Set custom DNS servers",
-	)
-	createFlags.StringSlice(
-		"dns-opt", []string{},
-		"Set custom DNS options",
-	)
-	createFlags.StringSlice(
-		"dns-search", []string{},
-		"Set custom DNS search domains",
-	)
 	createFlags.String(
 		"entrypoint", "",
 		"Overwrite the default ENTRYPOINT of the image",
@@ -324,10 +348,6 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"Keep STDIN open even if not attached",
 	)
 	createFlags.String(
-		"ip", "",
-		"Specify a static IPv4 address for the container",
-	)
-	createFlags.String(
 		"ipc", "",
 		"IPC namespace to use",
 	)
@@ -351,10 +371,6 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"log-opt", []string{},
 		"Logging driver options (default [])",
 	)
-	createFlags.String(
-		"mac-address", "",
-		"Container MAC address (e.g. 92:d0:c6:0a:29:33)",
-	)
 	createFlags.StringP(
 		"memory", "m", "",
 		"Memory limit "+sizeWithUnitFormat,
@@ -374,14 +390,6 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	createFlags.String(
 		"name", "",
 		"Assign a name to the container",
-	)
-	createFlags.String(
-		"network", getDefaultNetwork(),
-		"Connect a container to a network",
-	)
-	createFlags.Bool(
-		"no-hosts", false,
-		"Do not create /etc/hosts within the container, instead use the version from the image",
 	)
 	createFlags.Bool(
 		"oom-kill-disable", false,
@@ -416,10 +424,6 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 	createFlags.Bool(
 		"privileged", false,
 		"Give extended privileges to container",
-	)
-	createFlags.StringSliceP(
-		"publish", "p", []string{},
-		"Publish a container's port, or a range of ports, to the host (default [])",
 	)
 	createFlags.BoolP(
 		"publish-all", "P", false,

--- a/cmd/podman/create.go
+++ b/cmd/podman/create.go
@@ -41,6 +41,7 @@ func init() {
 
 	getCreateFlags(&createCommand.PodmanCommand)
 	flags := createCommand.Flags()
+	flags.AddFlagSet(getNetFlags())
 	flags.SetInterspersed(false)
 	flags.SetNormalizeFunc(aliasFlags)
 }

--- a/cmd/podman/pod_create.go
+++ b/cmd/podman/pod_create.go
@@ -44,6 +44,18 @@ func init() {
 	podCreateCommand.SetUsageTemplate(UsageTemplate())
 	flags := podCreateCommand.Flags()
 	flags.SetInterspersed(false)
+	// When we are ready to add the network options to the create commmand, we need to uncomment
+	// the following
+
+	//flags.AddFlagSet(getNetFlags())
+
+	// Once this is uncommented, then the publish option below needs to be removed because it
+	// conflicts with the publish in getNetFlags.  Upon removal, the c.Publish will not work
+	// anymore and needs to be cleaned up. I suggest starting with removing the Publish attribute
+	// from PodCreateValues structure. Running make should then expose all areas that need to be
+	// addressed.  To get the value of publish (and other flags in getNetFlags, use the syntax:
+	// c.<type>("<flag_name") or c.Bool("publish")
+	// Remember to do this safely by checking len, etc.
 
 	flags.StringVar(&podCreateCommand.CgroupParent, "cgroup-parent", "", "Set parent cgroup for the pod")
 	flags.BoolVar(&podCreateCommand.Infra, "infra", true, "Create an infra container associated with the pod to share namespaces with")

--- a/cmd/podman/run.go
+++ b/cmd/podman/run.go
@@ -38,6 +38,7 @@ func init() {
 	flags.SetInterspersed(false)
 	flags.SetNormalizeFunc(aliasFlags)
 	flags.Bool("sig-proxy", true, "Proxy received signals to the process")
+	flags.AddFlagSet(getNetFlags())
 	getCreateFlags(&runCommand.PodmanCommand)
 	markFlagHiddenForRemoteClient("authfile", flags)
 }


### PR DESCRIPTION
this pr splits off some of the network container create options into a different flag set.  the options in question are:

--add-host
--dns
--dns-opt
--dns-search
--ip
--mac-address
--network
--no-hosts
--publish

in the future, these options are going to be added to the pod create flags.  this makes that transition easier and provides for less code duplication.

Signed-off-by: Brent Baude <bbaude@redhat.com>