### PR TITLE
Add /swagger/ endpoint to serve swagger yaml to clients

### DIFF
--- a/pkg/api/server/register_swagger.go
+++ b/pkg/api/server/register_swagger.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/gorilla/mux"
+)
+
+// DefaultPodmanSwaggerSpec provides the default path to the podman swagger spec file
+const DefaultPodmanSwaggerSpec = "/usr/share/containers/podman/swagger.yaml"
+
+// RegisterSwaggerHandlers maps the swagger endpoint for the server
+func (s *APIServer) RegisterSwaggerHandlers(r *mux.Router) error {
+	// This handler does _*NOT*_ provide an UI rather just a swagger spec that an UI could render
+	r.PathPrefix("/swagger/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := DefaultPodmanSwaggerSpec
+		if p, found := os.LookupEnv("PODMAN_SWAGGER_SPEC"); found {
+			path = p
+		}
+		w.Header().Set("Content-Type", "text/yaml")
+
+		http.ServeFile(w, r, path)
+	})
+	return nil
+}

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -113,6 +113,7 @@ func newServer(runtime *libpod.Runtime, duration time.Duration, listener *net.Li
 		server.registerPingHandlers,
 		server.RegisterPluginsHandlers,
 		server.registerPodsHandlers,
+		server.RegisterSwaggerHandlers,
 		server.RegisterSwarmHandlers,
 		server.registerSystemHandlers,
 		server.registerVersionHandlers,


### PR DESCRIPTION
The provided yaml file will describe the current Podman REST API.

Signed-off-by: Jhon Honce <jhonce@redhat.com>