### PR TITLE
Force --all when --filter is passed to podman ps

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -205,6 +205,10 @@ func checkFlagsPassed(c *cliconfig.PsValues) error {
 	if c.Last >= 0 && c.Latest {
 		return errors.Errorf("last and latest are mutually exclusive")
 	}
+	// Filter forces all
+	if len(c.Filter) > 0 {
+		c.All = true
+	}
 	// Quiet conflicts with size and namespace and is overridden by a Go
 	// template.
 	if c.Quiet {

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -96,6 +96,7 @@ Display namespace information
 Filter what containers are shown in the output.
 Multiple filters can be given with multiple uses of the --filter flag.
 If multiple filters are given, only containers which match all of the given filters will be shown.
+Results will be drawn from all containers, regardless of whether --all was given.
 
 Valid filters are listed below:
 

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -227,6 +227,22 @@ var _ = Describe("Podman ps", func() {
 		Expect(output[0]).To(Equal(fullCid))
 	})
 
+	It("podman ps filter by exited does not need all", func() {
+		ctr := podmanTest.Podman([]string{"run", "-t", "-i", ALPINE, "ls", "/"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr.ExitCode()).To(Equal(0))
+
+		psAll := podmanTest.Podman([]string{"ps", "-aq", "--no-trunc"})
+		psAll.WaitWithDefaultTimeout()
+		Expect(psAll.ExitCode()).To(Equal(0))
+
+		psFilter := podmanTest.Podman([]string{"ps", "--no-trunc", "--quiet", "--filter", "status=exited"})
+		psFilter.WaitWithDefaultTimeout()
+		Expect(psFilter.ExitCode()).To(Equal(0))
+
+		Expect(psAll.OutputToString()).To(Equal(psFilter.OutputToString()))
+	})
+
 	It("podman ps mutually exclusive flags", func() {
 		session := podmanTest.Podman([]string{"ps", "-aqs"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
When we filter, it should be out of all containers, not just running ones, by default - this is necessary to ensure Docker compatability.

Fixes #5050
