### PR TITLE
Fix wrong Containerfile location on build

### DIFF
--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -234,10 +234,6 @@ func buildCmd(c *cliconfig.BuildValues) error {
 				return errors.Wrapf(err, "error determining path to file %q", containerfiles[i])
 			}
 			contextDir = filepath.Dir(absFile)
-			containerfiles[i], err = filepath.Rel(contextDir, absFile)
-			if err != nil {
-				return errors.Wrapf(err, "error determining path to file %q", containerfiles[i])
-			}
 			break
 		}
 	}


### PR DESCRIPTION
Podman does select the wrong Containerfile if the current working
directory contains a Containerfile but we specify one from a different
location.

Reproducer:
```
> mkdir 1
> echo FROM scratch > Containerfile
> echo FROM golang > 1/Containerfile
> podman build -f 1/Containerfile -t test
STEP 1: FROM scratch
```
