### PR TITLE
{CI:DOCS] run gofmt before lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -596,7 +596,7 @@ validate.completions: completions/bash/podman
 	if [ -x /bin/zsh ]; then /bin/zsh completions/zsh/_podman; fi
 
 .PHONY: validate
-validate: lint gofmt .gitvalidation validate.completions man-page-check
+validate: gofmt lint .gitvalidation validate.completions man-page-check
 
 .PHONY: build-all-new-commits
 build-all-new-commits:


### PR DESCRIPTION
the linting task identifies gofmt issues; therefore it makes more sense to run our make gofmt first, which actually fixes the gofmt issues.

Signed-off-by: Brent Baude <bbaude@redhat.com>