### PR TITLE
Special case memory-swap=-1

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -309,9 +309,13 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		}
 	}
 	if c.String("memory-swap") != "" {
-		memorySwap, err = units.RAMInBytes(c.String("memory-swap"))
-		if err != nil {
-			return nil, errors.Wrapf(err, "invalid value for memory-swap")
+		if c.String("memory-swap") == "-1" {
+			memorySwap = -1
+		} else {
+			memorySwap, err = units.RAMInBytes(c.String("memory-swap"))
+			if err != nil {
+				return nil, errors.Wrapf(err, "invalid value for memory-swap")
+			}
 		}
 	}
 	if c.String("kernel-memory") != "" {


### PR DESCRIPTION
We document that memory-swap==-1 means unlimited, but currently we
won't allow the user to specify the -1 value.

Fixes: https://github.com/containers/libpod/issues/5091

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>