### PR TITLE
Add mirroring dockerfiles

### DIFF
--- a/contrib/fedora-minimal/Dockerfile
+++ b/contrib/fedora-minimal/Dockerfile
@@ -1,0 +1,1 @@
+FROM fedora-minimal:latest

--- a/contrib/fedora-minimal/README.md
+++ b/contrib/fedora-minimal/README.md
@@ -1,0 +1,4 @@
+This dockerfile exists so that the container image can be "mirrored"
+onto quay.io automatically, so automated testing can be more resilient.
+
+https://quay.io/repository/libpod/fedora-minimal?tab=builds


### PR DESCRIPTION
These are built on quay.io in leu of an image-clone service.

Signed-off-by: Chris Evich <cevich@redhat.com>