### PR TITLE
Move podman-service to podman-system-service

### DIFF
--- a/cmd/podman/commands.go
+++ b/cmd/podman/commands.go
@@ -26,9 +26,6 @@ func getMainCommands() []*cobra.Command {
 	if len(_varlinkCommand.Use) > 0 {
 		rootCommands = append(rootCommands, _varlinkCommand)
 	}
-	if len(_serviceCommand.Use) > 0 {
-		rootCommands = append(rootCommands, _serviceCommand)
-	}
 	return rootCommands
 }
 
@@ -71,9 +68,15 @@ func getTrustSubCommands() []*cobra.Command {
 
 // Commands that the local client implements
 func getSystemSubCommands() []*cobra.Command {
-	return []*cobra.Command{
+	systemCommands := []*cobra.Command{
 		_renumberCommand,
 		_dfSystemCommand,
 		_migrateCommand,
 	}
+
+	if len(_serviceCommand.Use) > 0 {
+		systemCommands = append(systemCommands, _serviceCommand)
+	}
+
+	return systemCommands
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1200,6 +1200,19 @@ _podman_system_prune() {
     esac
 }
 
+_podman_system_service() {
+	local options_with_args="
+	-t
+	--timeout
+	"
+	local boolean_options="
+	      --help
+	      -h
+	      --varlink
+	"
+	_complete_ "$options_with_args" "$boolean_options"
+}
+
 _podman_system() {
     local boolean_options="
 	--help
@@ -1751,19 +1764,6 @@ _podman_search() {
 	      --help
 	      -h
 	      --no-trunc
-	"
-	_complete_ "$options_with_args" "$boolean_options"
-}
-
-_podman_service() {
-	local options_with_args="
-	-t
-	--timeout
-	"
-	local boolean_options="
-	      --help
-	      -h
-	      --varlink
 	"
 	_complete_ "$options_with_args" "$boolean_options"
 }

--- a/docs/source/markdown/podman-system-service.1.md
+++ b/docs/source/markdown/podman-system-service.1.md
@@ -1,13 +1,13 @@
 % podman-service(1)
 
 ## NAME
-podman\-service - Run an API service
+podman\-system\-service - Run an API service
 
 ## SYNOPSIS
-**podman service** [*options*]
+**podman system service** [*options*]
 
 ## DESCRIPTION
-The **podman service** command creates a listening service that will answer API calls for Podman.  You may
+The **podman system service** command creates a listening service that will answer API calls for Podman.  You may
 optionally provide an endpoint for the API in URI form.  For example, *unix://tmp/foobar.sock* or *tcp:localhost:8080*.
 If no endpoint is provided, defaults will be used.  The default endpoint for a rootfull
 service is *unix:/run/podman/podman.sock* and rootless is *unix:/$XDG_RUNTIME_DIR/podman/podman.sock* (for

--- a/docs/source/markdown/podman-system.1.md
+++ b/docs/source/markdown/podman-system.1.md
@@ -19,6 +19,8 @@ The system command allows you to manage the podman systems
 | prune    | [podman-system-prune(1)](podman-system-prune.1.md)  | Remove all unused container, image and volume data.                          |
 | renumber | [podman-system-renumber(1)](podman-system-renumber.1.md)| Migrate lock numbers to handle a change in maximum number of locks.      |
 | reset    | [podman-system-reset(1)](podman-system-reset.1.md)  | Reset storage back to initial state.                                         |
+| service  | [podman-service(1)](podman-system-service.1.md)     | Run an API service                                                           |
+
 
 ## SEE ALSO
 podman(1)

--- a/docs/source/markdown/podman.1.md
+++ b/docs/source/markdown/podman.1.md
@@ -191,7 +191,6 @@ the exit codes follow the `chroot` standard, see below:
 | [podman-rmi(1)](podman-rmi.1.md)                 | Removes one or more locally stored images.                                  |
 | [podman-run(1)](podman-run.1.md)                 | Run a command in a new container.                                           |
 | [podman-save(1)](podman-save.1.md)               | Save an image to a container archive.                                       |
-| [podman-service(1)](podman-service.1.md)           |  Run an API service                                          |
 | [podman-search(1)](podman-search.1.md)           | Search a registry for an image.                                             |
 | [podman-start(1)](podman-start.1.md)             | Start one or more containers.                                               |
 | [podman-stats(1)](podman-stats.1.md)             | Display a live stream of one or more container's resource usage statistics. |


### PR DESCRIPTION
Alleviates a conflict with the unrelated `docker service` command

Fixes #5108
