### PR TITLE
Cirrus: Never run prune on other branches

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -316,8 +316,10 @@ meta_task:
 # Remove old and disused images based on labels set by meta_task
 image_prune_task:
 
-    # Do not run this frequently
-    only_if: $CIRRUS_BRANCH == $DEST_BRANCH
+    # This should ONLY ever run from the master branch, and never
+    # anywhere else so it's behavior is always consistent, even
+    # as new branches are created.
+    only_if: $CIRRUS_BRANCH == "master"
 
     depends_on:
         - "meta"


### PR DESCRIPTION
This is needed because the prune container image will be built from
other branches as they are made.  If the behavior of this or the imgts
image diverges from that of master, random VM images could be "cleaned"
unexpectedly.  By hard-coding this task to the master branch only,
it should never run anywhere else.

Signed-off-by: Chris Evich <cevich@redhat.com>