### PR TITLE
images --format compatible with docker

### DIFF
--- a/docs/source/markdown/podman-images.1.md
+++ b/docs/source/markdown/podman-images.1.md
@@ -51,6 +51,18 @@ Filter output based on conditions provided
 
 Change the default output format.  This can be of a supported type like 'json'
 or a Go template.
+Valid placeholders for the Go template are listed below:
+
+| **Placeholder** | **Description**                                                               |
+| --------------- | ----------------------------------------------------------------------------- |
+| .ID             | Image ID                                                                      |
+| .Repository     | Image repository                                                              |
+| .Tag            | Image tag                                                                     |
+| .Digest         | Image digest                                                                  |
+| .CreatedSince   | Elapsed time since the image was created			     					  |
+| .CreatedAt      | Time when the image was created                                               |
+| .Size           | Size of layer on disk                                                         |
+| .History        | History of the image layer                                                    |
 
 **--history**
 

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -116,7 +116,8 @@ var _ = Describe("Podman images", func() {
 	})
 
 	It("podman images in GO template format", func() {
-		session := podmanTest.Podman([]string{"images", "--format={{.ID}}"})
+		formatStr := "{{.ID}}\t{{.Created}}\t{{.CreatedAt}}\t{{.CreatedSince}}\t{{.CreatedTime}}"
+		session := podmanTest.Podman([]string{"images", fmt.Sprintf("--format=%s", formatStr)})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
@@ -280,7 +281,7 @@ RUN apk update && apk add man
 			return session.OutputToStringArray()
 		}
 
-		sortedArr := sortValueTest("created", 0, "CreatedTime")
+		sortedArr := sortValueTest("created", 0, "CreatedAt")
 		Expect(sort.SliceIsSorted(sortedArr, func(i, j int) bool { return sortedArr[i] > sortedArr[j] })).To(BeTrue())
 
 		sortedArr = sortValueTest("id", 0, "ID")


### PR DESCRIPTION
Let valid values of --format be compatible with docker. Replace CreatedTime with CreatedAt, Created with CreatedSince.
fix #5110 

Signed-off-by: Qi Wang <qiwan@redhat.com>