### PR TITLE
Simplify image object creation

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -120,7 +120,7 @@ func (ir *Runtime) newImage(inputName string, img *storage.Image) *Image {
 	}
 }
 
-// newFromStorage creates a new image object from a storage.Image
+// newFromStorage creates a new image object from a storage.Image. Its "input name" will be its ID.
 func (ir *Runtime) newFromStorage(img *storage.Image) *Image {
 	return ir.newImage(img.ID, img)
 }

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -218,7 +218,7 @@ func (i *Image) reloadImage() error {
 	if err != nil {
 		return errors.Wrapf(err, "unable to reload image")
 	}
-	i.image = newImage.image
+	i.image = newImage
 	return nil
 }
 
@@ -245,7 +245,7 @@ func (ir *Runtime) getLocalImage(inputName string) (string, *storage.Image, erro
 
 	img, err := ir.getImage(stripSha256(inputName))
 	if err == nil {
-		return inputName, img.image, err
+		return inputName, img, err
 	}
 
 	// container-storage wasn't able to find it in its current form
@@ -269,7 +269,7 @@ func (ir *Runtime) getLocalImage(inputName string) (string, *storage.Image, erro
 	}
 	img, err = ir.getImage(ref.String())
 	if err == nil {
-		return inputName, img.image, err
+		return inputName, img, err
 	}
 
 	// grab all the local images
@@ -444,7 +444,7 @@ func (i *Image) Remove(ctx context.Context, force bool) error {
 // getImage retrieves an image matching the given name or hash from system
 // storage
 // If no matching image can be found, an error is returned
-func (ir *Runtime) getImage(image string) (*Image, error) {
+func (ir *Runtime) getImage(image string) (*storage.Image, error) {
 	var img *storage.Image
 	ref, err := is.Transport.ParseStoreReference(ir.store, image)
 	if err == nil {
@@ -460,8 +460,7 @@ func (ir *Runtime) getImage(image string) (*Image, error) {
 		}
 		img = img2
 	}
-	newImage := ir.newFromStorage(img)
-	return newImage, nil
+	return img, nil
 }
 
 // GetImages retrieves all images present in storage

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -111,14 +111,18 @@ func setStore(options storage.StoreOptions) (storage.Store, error) {
 	return store, nil
 }
 
-// newFromStorage creates a new image object from a storage.Image
-func (ir *Runtime) newFromStorage(img *storage.Image) *Image {
-	image := Image{
-		InputName:    img.ID,
+// newImage creates a new image object given an "input name" and a storage.Image
+func (ir *Runtime) newImage(inputName string, img *storage.Image) *Image {
+	return &Image{
+		InputName:    inputName,
 		imageruntime: ir,
 		image:        img,
 	}
-	return &image
+}
+
+// newFromStorage creates a new image object from a storage.Image
+func (ir *Runtime) newFromStorage(img *storage.Image) *Image {
+	return ir.newImage(img.ID, img)
 }
 
 // NewFromLocal creates a new image object that is intended
@@ -129,11 +133,7 @@ func (ir *Runtime) NewFromLocal(name string) (*Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Image{
-		InputName:    updatedInputName,
-		imageruntime: ir,
-		image:        localImage,
-	}, nil
+	return ir.newImage(updatedInputName, localImage), nil
 }
 
 // New creates a new image object where the image could be local

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -145,11 +145,11 @@ func (ir *Runtime) New(ctx context.Context, name, signaturePolicyPath, authfile 
 	defer span.Finish()
 
 	// We don't know if the image is local or not ... check local first
-	newImage := Image{
-		InputName:    name,
-		imageruntime: ir,
-	}
 	if pullType != util.PullImageAlways {
+		newImage := Image{
+			InputName:    name,
+			imageruntime: ir,
+		}
 		localImage, err := newImage.getLocalImage()
 		if err == nil {
 			newImage.image = localImage
@@ -168,6 +168,10 @@ func (ir *Runtime) New(ctx context.Context, name, signaturePolicyPath, authfile 
 		return nil, errors.Wrapf(err, "unable to pull %s", name)
 	}
 
+	newImage := Image{
+		InputName:    name,
+		imageruntime: ir,
+	}
 	newImage.InputName = imageName[0]
 	img, err := newImage.getLocalImage()
 	if err != nil {

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -146,14 +146,9 @@ func (ir *Runtime) New(ctx context.Context, name, signaturePolicyPath, authfile 
 
 	// We don't know if the image is local or not ... check local first
 	if pullType != util.PullImageAlways {
-		newImage := Image{
-			InputName:    name,
-			imageruntime: ir,
-		}
-		localImage, err := newImage.getLocalImage()
+		newImage, err := ir.NewFromLocal(name)
 		if err == nil {
-			newImage.image = localImage
-			return &newImage, nil
+			return newImage, nil
 		} else if pullType == util.PullImageNever {
 			return nil, err
 		}
@@ -168,16 +163,11 @@ func (ir *Runtime) New(ctx context.Context, name, signaturePolicyPath, authfile 
 		return nil, errors.Wrapf(err, "unable to pull %s", name)
 	}
 
-	newImage := Image{
-		InputName:    imageName[0],
-		imageruntime: ir,
-	}
-	img, err := newImage.getLocalImage()
+	newImage, err := ir.NewFromLocal(imageName[0])
 	if err != nil {
 		return nil, errors.Wrapf(err, "error retrieving local image after pulling %s", name)
 	}
-	newImage.image = img
-	return &newImage, nil
+	return newImage, nil
 }
 
 // LoadFromArchiveReference creates a new image object for images pulled from a tar archive and the like (podman load)
@@ -194,16 +184,11 @@ func (ir *Runtime) LoadFromArchiveReference(ctx context.Context, srcRef types.Im
 	}
 
 	for _, name := range imageNames {
-		newImage := Image{
-			InputName:    name,
-			imageruntime: ir,
-		}
-		img, err := newImage.getLocalImage()
+		newImage, err := ir.NewFromLocal(name)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error retrieving local image after pulling %s", name)
 		}
-		newImage.image = img
-		newImages = append(newImages, &newImage)
+		newImages = append(newImages, newImage)
 	}
 	ir.newImageEvent(events.LoadFromArchive, "")
 	return newImages, nil

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -169,10 +169,9 @@ func (ir *Runtime) New(ctx context.Context, name, signaturePolicyPath, authfile 
 	}
 
 	newImage := Image{
-		InputName:    name,
+		InputName:    imageName[0],
 		imageruntime: ir,
 	}
-	newImage.InputName = imageName[0]
 	img, err := newImage.getLocalImage()
 	if err != nil {
 		return nil, errors.Wrapf(err, "error retrieving local image after pulling %s", name)

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -687,13 +687,6 @@ func (i *Image) toImageSourceRef(ctx context.Context) (types.ImageSource, error)
 
 //Size returns the size of the image
 func (i *Image) Size(ctx context.Context) (*uint64, error) {
-	if i.image == nil {
-		localImage, err := i.getLocalImage()
-		if err != nil {
-			return nil, err
-		}
-		i.image = localImage
-	}
 	sum, err := i.imageruntime.store.ImageSize(i.ID())
 	if err == nil && sum >= 0 {
 		usum := uint64(sum)

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -99,10 +99,7 @@ func NewImageRuntimeFromOptions(options storage.StoreOptions) (*Runtime, error) 
 	if err != nil {
 		return nil, err
 	}
-
-	return &Runtime{
-		store: store,
-	}, nil
+	return NewImageRuntimeFromStore(store), nil
 }
 
 func setStore(options storage.StoreOptions) (storage.Store, error) {


### PR DESCRIPTION
This is a refactoring that should not change behavior.  Originally created primarily so that both `image.Runtime` and `image.Image` have a single constructor where I can hook the WIP new API, this:
- Simplifies creation of `Image` by name, so that each caller doesn’t have to create it manually, call `getLocalImage` which modifies one member, and then modify another member manually
- Modifies `Runtime.getImage` to return a `storage.Image` instead of wrapping it in an `image.Image` that every caller discards.
- Removes dead code in `Image.Size`

See the individual commit messages for details.