### PR TITLE
Fix varlink code generation target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,7 +582,7 @@ install.libseccomp.sudo:
 
 
 cmd/podman/varlink/iopodman.go: .gopathok cmd/podman/varlink/io.podman.varlink
-ifeq ("$(shell uname -o)", "GNU/Linux")
+ifneq (,$(findstring Linux,$(shell uname -o)))
 	# Only generate the varlink code on Linux (see issue #4814).
 	GO111MODULE=off $(GO) generate ./cmd/podman/varlink/...
 endif


### PR DESCRIPTION
Fixes #5130.

varlink code generation was skipped when `uname -o` did not print "GNU/Linux".
However on some Linux systems (e.g. alpine) only "Linux" is printed
which results in cmd/podman/varlink/iopodman.go not being generated.
Thus the Makefile target condition has been changed to match "Linux".

Signed-off-by: Max Goltzsche <max.goltzsche@gmail.com>