### PR TITLE
docs: add workaround for --device with rootless containers (II)

### DIFF
--- a/docs/source/markdown/podman-build.1.md
+++ b/docs/source/markdown/podman-build.1.md
@@ -178,7 +178,7 @@ Add a host device to the container. The format is `<device-on-host>[:<device-on-
 
 Note: if the user only has access rights via a group then accessing the device
 from inside a rootless container will fail. The `crun` runtime offers a
-workaround for this by adding the option `--annotation io.crun.keep_original_groups=1`.
+workaround for this by adding the option `--annotation run.oci.keep_original_groups=1`.
 
 **--disable-compression, -D**
 

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -207,7 +207,7 @@ Add a host device to the container. The format is `<device-on-host>[:<device-on-
 
 Note: if the user only has access rights via a group then accessing the device
 from inside a rootless container will fail. The `crun` runtime offers a
-workaround for this by adding the option `--annotation io.crun.keep_original_groups=1`.
+workaround for this by adding the option `--annotation run.oci.keep_original_groups=1`.
 
 **--device-read-bps**=*path*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -213,7 +213,7 @@ Add a host device to the container. The format is `<device-on-host>[:<device-on-
 
 Note: if the user only has access rights via a group then accessing the device
 from inside a rootless container will fail. The `crun` runtime offers a
-workaround for this by adding the option `--annotation io.crun.keep_original_groups=1`.
+workaround for this by adding the option `--annotation run.oci.keep_original_groups=1`.
 
 **--device-read-bps**=*path*
 


### PR DESCRIPTION
Update documentation for crun >= 0.11.

See https://github.com/containers/crun/commit/6df930821d80a8e151674f0fda1321fba93bb92d

Fixes #4477

Signed-off-by: Stefan Becker <chemobejk@gmail.com>