### PR TITLE
[CI:DOCS] podman system service doc fixes

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1221,8 +1221,11 @@ _podman_system() {
      subcommands="
 	df
 	info
+	migrate
 	prune
+	renumber
 	reset
+	service
      "
      __podman_subcommands "$subcommands" && return
 

--- a/docs/source/markdown/podman-system-service.1.md
+++ b/docs/source/markdown/podman-system-service.1.md
@@ -32,12 +32,12 @@ Print usage statement.
 
 Run an API listening for 5 seconds using the default socket.
 ```
-podman service --timeout 5000
+podman system service --timeout 5000
 ```
 
 Run the podman varlink service with an alternate URI and accept the default timeout.
 ```
-$ podman service --varlink unix:/tmp/io.podman
+$ podman system service --varlink unix:/tmp/io.podman
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
It took me much longer to realize that it is `podman system service` since examples were pointing me to the `podman service` and `podman system <tab>` showed there is no `service` subcommand.