### PR TITLE
Bump to v1.6.5

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ package version
 // NOTE: remember to bump the version at the top
 // of the top-level README.md file when this is
 // bumped.
-const Version = "1.6.4"
+const Version = "1.6.5"
 
 // RemoteAPIVersion is the version for the remote
 // client API.  It is used to determine compatibility


### PR DESCRIPTION
This is on the v1.6 long-term support branch; v1.8.0 will remain the most recent master release, and this is not intended to replace it.

With that said:
Bump to v1.6.5, including a new version of c/image with necessary fixes.