### PR TITLE
support device-cgroup-rule

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -257,6 +257,10 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"Add a host device to the container (default [])",
 	)
 	createFlags.StringSlice(
+		"device-cgroup-rule", []string{},
+		"Add a rule to the cgroup allowed devices list",
+	)
+	createFlags.StringSlice(
 		"device-read-bps", []string{},
 		"Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)",
 	)

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -761,6 +761,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 			CPURtPeriod:       c.Uint64("cpu-rt-period"),
 			CPURtRuntime:      c.Int64("cpu-rt-runtime"),
 			CPUs:              c.Float64("cpus"),
+			DeviceCgroupRules: c.StringSlice("device-cgroup-rule"),
 			DeviceReadBps:     c.StringSlice("device-read-bps"),
 			DeviceReadIOps:    c.StringSlice("device-read-iops"),
 			DeviceWriteBps:    c.StringSlice("device-write-bps"),

--- a/cmd/podman/shared/intermediate.go
+++ b/cmd/podman/shared/intermediate.go
@@ -386,6 +386,7 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIRes
 	m["detach"] = newCRBool(c, "detach")
 	m["detach-keys"] = newCRString(c, "detach-keys")
 	m["device"] = newCRStringSlice(c, "device")
+	m["device-cgroup-rule"] = newCRStringSlice(c, "device-cgroup-rule")
 	m["device-read-bps"] = newCRStringSlice(c, "device-read-bps")
 	m["device-read-iops"] = newCRStringSlice(c, "device-read-iops")
 	m["device-write-bps"] = newCRStringSlice(c, "device-write-bps")

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1870,6 +1870,7 @@ _podman_container_run() {
 		--cpuset-mems
 		--cpu-shares -c
 		--device
+		--device-cgroup-rule
 		--device-read-bps
 		--device-read-iops
 		--device-write-bps

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -209,6 +209,13 @@ Note: if the user only has access rights via a group then accessing the device
 from inside a rootless container will fail. The `crun` runtime offers a
 workaround for this by adding the option `--annotation run.oci.keep_original_groups=1`.
 
+**--device-cgroup-rule**="type major:minor mode"
+
+Add a rule to the cgroup allowed devices list. The rule is expected to be in the format specified in the Linux kernel documentation (Documentation/cgroup-v1/devices.txt):
+       - type: a (all), c (char), or b (block);
+       - major and minor: either a number, or * for all;
+       - mode: a composition of r (read), w (write), and m (mknod(2)).
+
 **--device-read-bps**=*path*
 
 Limit read rate (bytes per second) from a device (e.g. --device-read-bps=/dev/sda:1mb)

--- a/pkg/spec/config_unsupported.go
+++ b/pkg/spec/config_unsupported.go
@@ -30,3 +30,7 @@ func makeThrottleArray(throttleInput []string, rateType int) ([]spec.LinuxThrott
 func devicesFromPath(g *generate.Generator, devicePath string) error {
 	return errors.New("function not implemented")
 }
+
+func deviceCgroupRules(g *generate.Generator, deviceCgroupRules []string) error {
+	return errors.New("function not implemented")
+}

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -38,6 +38,7 @@ type CreateResourceConfig struct {
 	CPUs              float64  // cpus
 	CPUsetCPUs        string
 	CPUsetMems        string   // cpuset-mems
+	DeviceCgroupRules []string //device-cgroup-rule
 	DeviceReadBps     []string // device-read-bps
 	DeviceReadIOps    []string // device-read-iops
 	DeviceWriteBps    []string // device-write-bps

--- a/pkg/spec/parse.go
+++ b/pkg/spec/parse.go
@@ -2,11 +2,16 @@ package createconfig
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/docker/go-units"
+	"github.com/pkg/errors"
 )
+
+// deviceCgroupRulegex defines the valid format of device-cgroup-rule
+var deviceCgroupRuleRegex = regexp.MustCompile(`^([acb]) ([0-9]+|\*):([0-9]+|\*) ([rwm]{1,3})$`)
 
 // Pod signifies a kernel namespace is being shared
 // by a container with the pod it is associated with
@@ -204,4 +209,17 @@ func IsValidDeviceMode(mode string) bool {
 		legalDeviceMode[c] = false
 	}
 	return true
+}
+
+// validateDeviceCgroupRule validates the format of deviceCgroupRule
+func validateDeviceCgroupRule(deviceCgroupRule string) error {
+	if !deviceCgroupRuleRegex.MatchString(deviceCgroupRule) {
+		return errors.Errorf("invalid device cgroup rule format: '%s'", deviceCgroupRule)
+	}
+	return nil
+}
+
+// parseDeviceCgroupRule matches and parses the deviceCgroupRule into slice
+func parseDeviceCgroupRule(deviceCgroupRule string) [][]string {
+	return deviceCgroupRuleRegex.FindAllStringSubmatch(deviceCgroupRule, -1)
 }

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -232,6 +232,12 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 				return nil, err
 			}
 		}
+		if len(config.Resources.DeviceCgroupRules) != 0 {
+			if err := deviceCgroupRules(&g, config.Resources.DeviceCgroupRules); err != nil {
+				return nil, err
+			}
+			addedResources = true
+		}
 	}
 
 	// SECURITY OPTS

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -999,4 +999,16 @@ USER mail`
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
+
+	It("podman run --device-cgroup-rule", func() {
+		SkipIfRemote()
+		SkipIfRootless()
+		deviceCgroupRule := "c 42:* rwm"
+		session := podmanTest.Podman([]string{"run", "--name", "test", "-d", "--device-cgroup-rule", deviceCgroupRule, ALPINE, "top"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"exec", "test", "mknod", "newDev", "c", "42", "1"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
fix #4876
Add `--device-cgroup-rule` to podman create and run. This enables to add device rules after the container has been created.

Signed-off-by: Qi Wang <qiwan@redhat.com>