### PR TITLE
Fix handler and systemd activation errors

### DIFF
--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -351,18 +351,21 @@ func ImageDataToImageInspect(ctx context.Context, l *libpodImage.Image) (*ImageI
 
 func LibpodToContainer(l *libpod.Container, infoData []define.InfoData) (*Container, error) {
 	imageId, imageName := l.Image()
-	sizeRW, err := l.RWSize()
-	if err != nil {
+
+	var (
+		err        error
+		sizeRootFs int64
+		sizeRW     int64
+		state      define.ContainerStatus
+	)
+
+	if state, err = l.State(); err != nil {
 		return nil, err
 	}
-
-	SizeRootFs, err := l.RootFsSize()
-	if err != nil {
+	if sizeRW, err = l.RWSize(); err != nil {
 		return nil, err
 	}
-
-	state, err := l.State()
-	if err != nil {
+	if sizeRootFs, err = l.RootFsSize(); err != nil {
 		return nil, err
 	}
 
@@ -375,7 +378,7 @@ func LibpodToContainer(l *libpod.Container, infoData []define.InfoData) (*Contai
 		Created:    l.CreatedTime().Unix(),
 		Ports:      nil,
 		SizeRw:     sizeRW,
-		SizeRootFs: SizeRootFs,
+		SizeRootFs: sizeRootFs,
 		Labels:     l.Labels(),
 		State:      string(state),
 		Status:     "",

--- a/pkg/api/server/handler_api.go
+++ b/pkg/api/server/handler_api.go
@@ -2,32 +2,52 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"runtime"
 
+	"github.com/containers/libpod/pkg/api/handlers/utils"
 	log "github.com/sirupsen/logrus"
 )
 
 // APIHandler is a wrapper to enhance HandlerFunc's and remove redundant code
-func APIHandler(ctx context.Context, h http.HandlerFunc) http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Debugf("APIHandler -- Method: %s URL: %s", r.Method, r.URL.String())
-		if err := r.ParseForm(); err != nil {
-			log.Infof("Failed Request: unable to parse form: %q", err)
+func (s *APIServer) APIHandler(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// http.Server hides panics, we want to see them and fix the cause.
+		defer func() {
+			err := recover()
+			if err != nil {
+				buf := make([]byte, 1<<20)
+				n := runtime.Stack(buf, true)
+				log.Warnf("Recovering from podman handler panic: %v, %s", err, buf[:n])
+				// Try to inform client things went south... won't work if handler already started writing response body
+				utils.InternalServerError(w, fmt.Errorf("%v", err))
+			}
+		}()
+
+		// Wrapper to hide some boiler plate
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			// Connection counting, ugh.  Needed to support the sliding window for idle checking.
+			s.ConnectionCh <- EnterHandler
+			defer func() { s.ConnectionCh <- ExitHandler }()
+
+			log.Debugf("APIHandler -- Method: %s URL: %s (conn %d/%d)",
+				r.Method, r.URL.String(), s.ActiveConnections, s.TotalConnections)
+
+			if err := r.ParseForm(); err != nil {
+				log.Infof("Failed Request: unable to parse form: %q", err)
+			}
+
+			// TODO: Use r.ConnContext when ported to go 1.13
+			c := context.WithValue(r.Context(), "decoder", s.Decoder)
+			c = context.WithValue(c, "runtime", s.Runtime)
+			c = context.WithValue(c, "shutdownFunc", s.Shutdown)
+			r = r.WithContext(c)
+
+			h(w, r)
 		}
-
-		// TODO: Use ConnContext when ported to go 1.13
-		c := context.WithValue(r.Context(), "decoder", ctx.Value("decoder"))
-		c = context.WithValue(c, "runtime", ctx.Value("runtime"))
-		c = context.WithValue(c, "shutdownFunc", ctx.Value("shutdownFunc"))
-		r = r.WithContext(c)
-
-		h(w, r)
-
-		shutdownFunc := r.Context().Value("shutdownFunc").(func() error)
-		if err := shutdownFunc(); err != nil {
-			log.Errorf("Failed to shutdown Server in APIHandler(): %s", err.Error())
-		}
-	})
+		fn(w, r)
+	}
 }
 
 // VersionedPath prepends the version parsing code

--- a/pkg/api/server/register_auth.go
+++ b/pkg/api/server/register_auth.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (s *APIServer) RegisterAuthHandlers(r *mux.Router) error {
-	r.Handle(VersionedPath("/auth"), APIHandler(s.Context, handlers.UnsupportedHandler))
+func (s *APIServer) registerAuthHandlers(r *mux.Router) error {
+	r.Handle(VersionedPath("/auth"), s.APIHandler(handlers.UnsupportedHandler))
 	return nil
 }

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
+func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	// swagger:operation POST /containers/create compat containerCreate
 	// ---
 	//   summary: Create a container
@@ -33,7 +33,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//       $ref: "#/responses/ConflictError"
 	//     500:
 	//       $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/create"), APIHandler(s.Context, handlers.CreateContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/create"), s.APIHandler(handlers.CreateContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /containers/json compat listContainers
 	// ---
 	// tags:
@@ -83,7 +83,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/BadParamError"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/json"), APIHandler(s.Context, generic.ListContainers)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/containers/json"), s.APIHandler(generic.ListContainers)).Methods(http.MethodGet)
 	// swagger:operation POST  /containers/prune compat pruneContainers
 	// ---
 	// tags:
@@ -105,7 +105,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/DocsContainerPruneReport"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/prune"), APIHandler(s.Context, handlers.PruneContainers)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/prune"), s.APIHandler(handlers.PruneContainers)).Methods(http.MethodPost)
 	// swagger:operation DELETE /containers/{name} compat removeContainer
 	// ---
 	// tags:
@@ -144,7 +144,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/ConflictError"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}"), APIHandler(s.Context, generic.RemoveContainer)).Methods(http.MethodDelete)
+	r.HandleFunc(VersionedPath("/containers/{name}"), s.APIHandler(generic.RemoveContainer)).Methods(http.MethodDelete)
 	// swagger:operation GET /containers/{name}/json compat getContainer
 	// ---
 	// tags:
@@ -171,7 +171,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/json"), APIHandler(s.Context, generic.GetContainer)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/containers/{name}/json"), s.APIHandler(generic.GetContainer)).Methods(http.MethodGet)
 	// swagger:operation post /containers/{name}/kill compat killcontainer
 	// ---
 	// tags:
@@ -201,7 +201,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/ConflictError"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/kill"), APIHandler(s.Context, generic.KillContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/{name}/kill"), s.APIHandler(generic.KillContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /containers/{name}/logs compat LogsFromContainer
 	// ---
 	// tags:
@@ -253,7 +253,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//      $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//      $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/logs"), APIHandler(s.Context, generic.LogsFromContainer)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/containers/{name}/logs"), s.APIHandler(generic.LogsFromContainer)).Methods(http.MethodGet)
 	// swagger:operation POST /containers/{name}/pause compat pauseContainer
 	// ---
 	// tags:
@@ -275,8 +275,8 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/pause"), APIHandler(s.Context, handlers.PauseContainer)).Methods(http.MethodPost)
-	r.HandleFunc(VersionedPath("/containers/{name}/rename"), APIHandler(s.Context, handlers.UnsupportedHandler)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/{name}/pause"), s.APIHandler(handlers.PauseContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/{name}/rename"), s.APIHandler(handlers.UnsupportedHandler)).Methods(http.MethodPost)
 	// swagger:operation POST /containers/{name}/restart compat restartContainer
 	// ---
 	// tags:
@@ -301,7 +301,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/restart"), APIHandler(s.Context, handlers.RestartContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/{name}/restart"), s.APIHandler(handlers.RestartContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /containers/{name}/start compat startContainer
 	// ---
 	// tags:
@@ -329,7 +329,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/start"), APIHandler(s.Context, handlers.StartContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/{name}/start"), s.APIHandler(handlers.StartContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /containers/{name}/stats compat statsContainer
 	// ---
 	// tags:
@@ -356,7 +356,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/stats"), APIHandler(s.Context, generic.StatsContainer)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/containers/{name}/stats"), s.APIHandler(generic.StatsContainer)).Methods(http.MethodGet)
 	// swagger:operation POST /containers/{name}/stop compat stopContainer
 	// ---
 	// tags:
@@ -384,7 +384,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/stop"), APIHandler(s.Context, handlers.StopContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/{name}/stop"), s.APIHandler(handlers.StopContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /containers/{name}/top compat topContainer
 	// ---
 	// tags:
@@ -409,7 +409,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/top"), APIHandler(s.Context, handlers.TopContainer)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/containers/{name}/top"), s.APIHandler(handlers.TopContainer)).Methods(http.MethodGet)
 	// swagger:operation POST /containers/{name}/unpause compat unpauseContainer
 	// ---
 	// tags:
@@ -431,7 +431,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/unpause"), APIHandler(s.Context, handlers.UnpauseContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/{name}/unpause"), s.APIHandler(handlers.UnpauseContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /containers/{name}/wait compat waitContainer
 	// ---
 	// tags:
@@ -457,7 +457,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/wait"), APIHandler(s.Context, generic.WaitContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/{name}/wait"), s.APIHandler(generic.WaitContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /containers/{name}/attach compat attach
 	// ---
 	// tags:
@@ -512,7 +512,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/attach"), APIHandler(s.Context, handlers.AttachContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/{name}/attach"), s.APIHandler(handlers.AttachContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /containers/{name}/resize compat resize
 	// ---
 	// tags:
@@ -544,13 +544,13 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/resize"), APIHandler(s.Context, handlers.ResizeContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/{name}/resize"), s.APIHandler(handlers.ResizeContainer)).Methods(http.MethodPost)
 
 	/*
 		libpod endpoints
 	*/
 
-	r.HandleFunc(VersionedPath("/libpod/containers/create"), APIHandler(s.Context, handlers.CreateContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/create"), s.APIHandler(handlers.CreateContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /libpod/containers/json libpod libpodListContainers
 	// ---
 	// tags:
@@ -615,7 +615,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/BadParamError"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/json"), APIHandler(s.Context, libpod.ListContainers)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/libpod/containers/json"), s.APIHandler(libpod.ListContainers)).Methods(http.MethodGet)
 	// swagger:operation POST  /libpod/containers/prune libpod libpodPruneContainers
 	// ---
 	// tags:
@@ -637,7 +637,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/DocsLibpodPruneResponse"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/prune"), APIHandler(s.Context, handlers.PruneContainers)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/prune"), s.APIHandler(handlers.PruneContainers)).Methods(http.MethodPost)
 	// swagger:operation GET /libpod/containers/showmounted libpod showMounterContainers
 	// ---
 	// tags:
@@ -655,7 +655,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//       type: string
 	//   500:
 	//      $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/showmounted"), APIHandler(s.Context, libpod.ShowMountedContainers)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/libpod/containers/showmounted"), s.APIHandler(libpod.ShowMountedContainers)).Methods(http.MethodGet)
 	// swagger:operation DELETE /libpod/containers/{name} libpod libpodRemoveContainer
 	// ---
 	// tags:
@@ -689,7 +689,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/ConflictError"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}"), APIHandler(s.Context, libpod.RemoveContainer)).Methods(http.MethodDelete)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}"), s.APIHandler(libpod.RemoveContainer)).Methods(http.MethodDelete)
 	// swagger:operation GET /libpod/containers/{name}/json libpod libpodGetContainer
 	// ---
 	// tags:
@@ -715,7 +715,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/json"), APIHandler(s.Context, libpod.GetContainer)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/json"), s.APIHandler(libpod.GetContainer)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/containers/{name}/kill libpod libpodKillContainer
 	// ---
 	// tags:
@@ -744,7 +744,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/ConflictError"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/kill"), APIHandler(s.Context, libpod.KillContainer)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/kill"), s.APIHandler(libpod.KillContainer)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/containers/{name}/mount libpod mountContainer
 	// ---
 	// tags:
@@ -770,7 +770,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/mount"), APIHandler(s.Context, libpod.MountContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/mount"), s.APIHandler(libpod.MountContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/containers/{name}/unmount libpod libpodUnmountContainer
 	// ---
 	// tags:
@@ -792,7 +792,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/unmount"), APIHandler(s.Context, libpod.UnmountContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/unmount"), s.APIHandler(libpod.UnmountContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /libpod/containers/{name}/logs libpod libpodLogsFromContainer
 	// ---
 	// tags:
@@ -844,7 +844,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//      $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//      $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/logs"), APIHandler(s.Context, generic.LogsFromContainer)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/logs"), s.APIHandler(generic.LogsFromContainer)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/containers/{name}/pause libpod libpodPauseContainer
 	// ---
 	// tags:
@@ -866,7 +866,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     "$ref": "#/responses/NoSuchContainer"
 	//   500:
 	//     "$ref": "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/pause"), APIHandler(s.Context, handlers.PauseContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name:..*}/pause"), s.APIHandler(handlers.PauseContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/containers/{name}/restart libpod libpodRestartContainer
 	// ---
 	// tags:
@@ -891,7 +891,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/restart"), APIHandler(s.Context, handlers.RestartContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/restart"), s.APIHandler(handlers.RestartContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/containers/{name}/start libpod libpodStartContainer
 	// ---
 	// tags:
@@ -919,7 +919,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/start"), APIHandler(s.Context, handlers.StartContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/start"), s.APIHandler(handlers.StartContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /libpod/containers/{name}/stats libpod libpodStatsContainer
 	// ---
 	// tags:
@@ -946,7 +946,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/stats"), APIHandler(s.Context, generic.StatsContainer)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/stats"), s.APIHandler(generic.StatsContainer)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/containers/{name}/top libpod libpodTopContainer
 	// ---
 	// tags:
@@ -980,7 +980,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/top"), APIHandler(s.Context, handlers.TopContainer)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/top"), s.APIHandler(handlers.TopContainer)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/containers/{name}/unpause libpod libpodUnpauseContainer
 	// ---
 	// tags:
@@ -1001,7 +1001,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/unpause"), APIHandler(s.Context, handlers.UnpauseContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/unpause"), s.APIHandler(handlers.UnpauseContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/containers/{name}/wait libpod libpodWaitContainer
 	// ---
 	// tags:
@@ -1022,7 +1022,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/wait"), APIHandler(s.Context, libpod.WaitContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/wait"), s.APIHandler(libpod.WaitContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/containers/{name}/exists libpod containerExists
 	// ---
 	// tags:
@@ -1044,7 +1044,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/exists"), APIHandler(s.Context, libpod.ContainerExists)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/exists"), s.APIHandler(libpod.ContainerExists)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/containers/{name}/stop libpod libpodStopContainer
 	// ---
 	// tags:
@@ -1071,7 +1071,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/stop"), APIHandler(s.Context, handlers.StopContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/stop"), s.APIHandler(handlers.StopContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/containers/{name}/attach libpod libpodAttach
 	// ---
 	// tags:
@@ -1126,7 +1126,7 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/attach"), APIHandler(s.Context, handlers.AttachContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/attach"), s.APIHandler(handlers.AttachContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/containers/{name}/resize libpod libpodResize
 	// ---
 	// tags:
@@ -1158,6 +1158,6 @@ func (s *APIServer) RegisterContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/resize"), APIHandler(s.Context, handlers.ResizeContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/resize"), s.APIHandler(handlers.ResizeContainer)).Methods(http.MethodPost)
 	return nil
 }

--- a/pkg/api/server/register_distribution.go
+++ b/pkg/api/server/register_distribution.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (s *APIServer) RegisterDistributionHandlers(r *mux.Router) error {
+func (s *APIServer) registerDistributionHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/distribution/{name}/json"), handlers.UnsupportedHandler)
 	return nil
 }

--- a/pkg/api/server/register_events.go
+++ b/pkg/api/server/register_events.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (s *APIServer) RegisterEventsHandlers(r *mux.Router) error {
+func (s *APIServer) registerEventsHandlers(r *mux.Router) error {
 	// swagger:operation GET /events system getEvents
 	// ---
 	// tags:
@@ -32,6 +32,6 @@ func (s *APIServer) RegisterEventsHandlers(r *mux.Router) error {
 	//     description: returns a string of json data describing an event
 	//   500:
 	//     "$ref": "#/responses/InternalError"
-	r.Handle(VersionedPath("/events"), APIHandler(s.Context, handlers.GetEvents))
+	r.Handle(VersionedPath("/events"), s.APIHandler(handlers.GetEvents))
 	return nil
 }

--- a/pkg/api/server/register_exec.go
+++ b/pkg/api/server/register_exec.go
@@ -74,7 +74,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//	   description: container is paused
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/containers/{name}/create"), APIHandler(s.Context, handlers.CreateExec)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/containers/{name}/create"), s.APIHandler(handlers.CreateExec)).Methods(http.MethodPost)
 	// swagger:operation POST /exec/{id}/start compat startExec
 	// ---
 	// tags:
@@ -110,7 +110,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//	   description: container is stopped or paused
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/exec/{id}/start"), APIHandler(s.Context, handlers.StartExec)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/exec/{id}/start"), s.APIHandler(handlers.StartExec)).Methods(http.MethodPost)
 	// swagger:operation POST /exec/{id}/resize compat resizeExec
 	// ---
 	// tags:
@@ -141,7 +141,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchExecInstance"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/exec/{id}/resize"), APIHandler(s.Context, handlers.ResizeExec)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/exec/{id}/resize"), s.APIHandler(handlers.ResizeExec)).Methods(http.MethodPost)
 	// swagger:operation GET /exec/{id}/inspect compat inspectExec
 	// ---
 	// tags:
@@ -163,7 +163,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchExecInstance"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/exec/{id}/json"), APIHandler(s.Context, handlers.InspectExec)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/exec/{id}/json"), s.APIHandler(handlers.InspectExec)).Methods(http.MethodGet)
 
 	/*
 		libpod api follows
@@ -235,7 +235,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//	   description: container is paused
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/containers/{name}/create"), APIHandler(s.Context, handlers.CreateExec)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/containers/{name}/create"), s.APIHandler(handlers.CreateExec)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/exec/{id}/start libpod libpodStartExec
 	// ---
 	// tags:
@@ -271,7 +271,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//	   description: container is stopped or paused
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/exec/{id}/start"), APIHandler(s.Context, handlers.StartExec)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/exec/{id}/start"), s.APIHandler(handlers.StartExec)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/exec/{id}/resize libpod libpodResizeExec
 	// ---
 	// tags:
@@ -302,7 +302,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchExecInstance"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/exec/{id}/resize"), APIHandler(s.Context, handlers.ResizeExec)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/exec/{id}/resize"), s.APIHandler(handlers.ResizeExec)).Methods(http.MethodPost)
 	// swagger:operation GET /libpod/exec/{id}/inspect libpod libpodInspectExec
 	// ---
 	// tags:
@@ -324,6 +324,6 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchExecInstance"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/exec/{id}/json"), APIHandler(s.Context, handlers.InspectExec)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/exec/{id}/json"), s.APIHandler(handlers.InspectExec)).Methods(http.MethodGet)
 	return nil
 }

--- a/pkg/api/server/register_healthcheck.go
+++ b/pkg/api/server/register_healthcheck.go
@@ -8,6 +8,6 @@ import (
 )
 
 func (s *APIServer) registerHealthCheckHandlers(r *mux.Router) error {
-	r.Handle(VersionedPath("/libpod/containers/{name}/runhealthcheck"), APIHandler(s.Context, libpod.RunHealthCheck)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/containers/{name}/runhealthcheck"), s.APIHandler(libpod.RunHealthCheck)).Methods(http.MethodGet)
 	return nil
 }

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -47,8 +47,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchImage"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/images/create"), APIHandler(s.Context, generic.CreateImageFromImage)).Methods(http.MethodPost).Queries("fromImage", "{fromImage}")
-	r.Handle(VersionedPath("/images/create"), APIHandler(s.Context, generic.CreateImageFromSrc)).Methods(http.MethodPost).Queries("fromSrc", "{fromSrc}")
+	r.Handle(VersionedPath("/images/create"), s.APIHandler(generic.CreateImageFromImage)).Methods(http.MethodPost).Queries("fromImage", "{fromImage}")
+	r.Handle(VersionedPath("/images/create"), s.APIHandler(generic.CreateImageFromSrc)).Methods(http.MethodPost).Queries("fromSrc", "{fromSrc}")
 	// swagger:operation GET /images/json compat listImages
 	// ---
 	// tags:
@@ -83,7 +83,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/DockerImageSummary"
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/images/json"), APIHandler(s.Context, generic.GetImages)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/images/json"), s.APIHandler(generic.GetImages)).Methods(http.MethodGet)
 	// swagger:operation POST /images/load compat importImage
 	// ---
 	// tags:
@@ -107,7 +107,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     description: no error
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/images/load"), APIHandler(s.Context, generic.LoadImages)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/images/load"), s.APIHandler(generic.LoadImages)).Methods(http.MethodPost)
 	// swagger:operation POST /images/prune compat pruneImages
 	// ---
 	// tags:
@@ -132,7 +132,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/DocsImageDeleteResponse"
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/images/prune"), APIHandler(s.Context, generic.PruneImages)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/images/prune"), s.APIHandler(generic.PruneImages)).Methods(http.MethodPost)
 	// swagger:operation GET /images/search compat searchImages
 	// ---
 	// tags:
@@ -163,7 +163,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/DocsSearchResponse"
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/images/search"), APIHandler(s.Context, handlers.SearchImages)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/images/search"), s.APIHandler(handlers.SearchImages)).Methods(http.MethodGet)
 	// swagger:operation DELETE /images/{name} compat removeImage
 	// ---
 	// tags:
@@ -195,7 +195,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/ConflictError'
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/images/{name}"), APIHandler(s.Context, handlers.RemoveImage)).Methods(http.MethodDelete)
+	r.Handle(VersionedPath("/images/{name}"), s.APIHandler(handlers.RemoveImage)).Methods(http.MethodDelete)
 	// swagger:operation GET /images/{name}/get compat exportImage
 	// ---
 	// tags:
@@ -218,7 +218,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//      format: binary
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/images/{name}/get"), APIHandler(s.Context, generic.ExportImage)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/images/{name}/get"), s.APIHandler(generic.ExportImage)).Methods(http.MethodGet)
 	// swagger:operation GET /images/{name}/history compat imageHistory
 	// ---
 	// tags:
@@ -240,7 +240,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchImage"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/images/{name}/history"), APIHandler(s.Context, handlers.HistoryImage)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/images/{name}/history"), s.APIHandler(handlers.HistoryImage)).Methods(http.MethodGet)
 	// swagger:operation GET /images/{name}/json compat inspectImage
 	// ---
 	// tags:
@@ -262,7 +262,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchImage"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/images/{name}/json"), APIHandler(s.Context, generic.GetImage))
+	r.Handle(VersionedPath("/images/{name}/json"), s.APIHandler(generic.GetImage))
 	// swagger:operation POST /images/{name}/tag compat tagImage
 	// ---
 	// tags:
@@ -296,7 +296,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/ConflictError'
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/images/{name}/tag"), APIHandler(s.Context, handlers.TagImage)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/images/{name}/tag"), s.APIHandler(handlers.TagImage)).Methods(http.MethodPost)
 	// swagger:operation POST /commit/ compat commitContainer
 	// ---
 	// tags:
@@ -341,7 +341,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/NoSuchImage'
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/commit"), APIHandler(s.Context, generic.CommitContainer)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/commit"), s.APIHandler(generic.CommitContainer)).Methods(http.MethodPost)
 
 	// swagger:operation POST /build images buildImage
 	// ---
@@ -551,7 +551,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/BadParamError"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/build"), APIHandler(s.Context, handlers.BuildImage)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/build"), s.APIHandler(handlers.BuildImage)).Methods(http.MethodPost)
 	/*
 		libpod endpoints
 	*/
@@ -577,7 +577,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/NoSuchImage'
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/{name}/exists"), APIHandler(s.Context, libpod.ImageExists))
+	r.Handle(VersionedPath("/libpod/images/{name}/exists"), s.APIHandler(libpod.ImageExists))
 	// swagger:operation POST /libpod/images/{name}/tree libpod libpodImageTree
 	// ---
 	// tags:
@@ -603,7 +603,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/NoSuchImage'
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/{name}/tree"), APIHandler(s.Context, libpod.ImageTree))
+	r.Handle(VersionedPath("/libpod/images/{name}/tree"), s.APIHandler(libpod.ImageTree))
 	// swagger:operation GET /libpod/images/{name}/history libpod libpodImageHistory
 	// ---
 	// tags:
@@ -625,7 +625,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/NoSuchImage'
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/{name}/history"), APIHandler(s.Context, handlers.HistoryImage)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/images/{name}/history"), s.APIHandler(handlers.HistoryImage)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/images/json libpod libpodListImages
 	// ---
 	// tags:
@@ -655,7 +655,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/DockerImageSummary"
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/json"), APIHandler(s.Context, libpod.GetImages)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/images/json"), s.APIHandler(libpod.GetImages)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/images/load libpod libpodImagesLoad
 	// ---
 	// tags:
@@ -681,7 +681,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/BadParamError"
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/load"), APIHandler(s.Context, libpod.ImagesLoad)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/images/load"), s.APIHandler(libpod.ImagesLoad)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/images/import libpod libpodImagesImport
 	// ---
 	// tags:
@@ -721,7 +721,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/BadParamError"
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/import"), APIHandler(s.Context, libpod.ImagesImport)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/images/import"), s.APIHandler(libpod.ImagesImport)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/images/pull libpod libpodImagesPull
 	// ---
 	// tags:
@@ -763,7 +763,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/BadParamError"
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/pull"), APIHandler(s.Context, libpod.ImagesPull)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/images/pull"), s.APIHandler(libpod.ImagesPull)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/images/prune libpod libpodPruneImages
 	// ---
 	// tags:
@@ -788,7 +788,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/DocsImageDeleteResponse"
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/prune"), APIHandler(s.Context, libpod.PruneImages)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/images/prune"), s.APIHandler(libpod.PruneImages)).Methods(http.MethodPost)
 	// swagger:operation GET /libpod/images/search libpod libpodSearchImages
 	// ---
 	// tags:
@@ -819,7 +819,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//      $ref: "#/responses/DocsSearchResponse"
 	//   500:
 	//      $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/search"), APIHandler(s.Context, handlers.SearchImages)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/images/search"), s.APIHandler(handlers.SearchImages)).Methods(http.MethodGet)
 	// swagger:operation DELETE /libpod/images/{name} libpod libpodRemoveImage
 	// ---
 	// tags:
@@ -849,7 +849,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/ConflictError'
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/{name}"), APIHandler(s.Context, handlers.RemoveImage)).Methods(http.MethodDelete)
+	r.Handle(VersionedPath("/libpod/images/{name}"), s.APIHandler(handlers.RemoveImage)).Methods(http.MethodDelete)
 	// swagger:operation GET /libpod/images/{name}/get libpod libpoodExportImage
 	// ---
 	// tags:
@@ -882,7 +882,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/NoSuchImage'
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/{name}/get"), APIHandler(s.Context, libpod.ExportImage)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/images/{name}/get"), s.APIHandler(libpod.ExportImage)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/images/{name}/json libpod libpodInspectImage
 	// ---
 	// tags:
@@ -904,7 +904,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/NoSuchImage'
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/{name}/json"), APIHandler(s.Context, libpod.GetImage))
+	r.Handle(VersionedPath("/libpod/images/{name}/json"), s.APIHandler(libpod.GetImage))
 	// swagger:operation POST /libpod/images/{name}/tag libpod libpodTagImage
 	// ---
 	// tags:
@@ -938,7 +938,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: '#/responses/ConflictError'
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/{name}/tag"), APIHandler(s.Context, handlers.TagImage)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/images/{name}/tag"), s.APIHandler(handlers.TagImage)).Methods(http.MethodPost)
 
 	return nil
 }

--- a/pkg/api/server/register_info.go
+++ b/pkg/api/server/register_info.go
@@ -21,6 +21,6 @@ func (s *APIServer) registerInfoHandlers(r *mux.Router) error {
 	//     description: to be determined
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/info"), APIHandler(s.Context, generic.GetInfo)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/info"), s.APIHandler(generic.GetInfo)).Methods(http.MethodGet)
 	return nil
 }

--- a/pkg/api/server/register_monitor.go
+++ b/pkg/api/server/register_monitor.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (s *APIServer) RegisterMonitorHandlers(r *mux.Router) error {
-	r.Handle(VersionedPath("/monitor"), APIHandler(s.Context, handlers.UnsupportedHandler))
+func (s *APIServer) registerMonitorHandlers(r *mux.Router) error {
+	r.Handle(VersionedPath("/monitor"), s.APIHandler(handlers.UnsupportedHandler))
 	return nil
 }

--- a/pkg/api/server/register_ping.go
+++ b/pkg/api/server/register_ping.go
@@ -9,8 +9,8 @@ import (
 
 func (s *APIServer) registerPingHandlers(r *mux.Router) error {
 
-	r.Handle("/_ping", APIHandler(s.Context, handlers.Ping)).Methods(http.MethodGet)
-	r.Handle("/_ping", APIHandler(s.Context, handlers.Ping)).Methods(http.MethodHead)
+	r.Handle("/_ping", s.APIHandler(handlers.Ping)).Methods(http.MethodGet)
+	r.Handle("/_ping", s.APIHandler(handlers.Ping)).Methods(http.MethodHead)
 
 	// swagger:operation GET /libpod/_ping libpod libpodPingGet
 	// ---
@@ -61,7 +61,7 @@ func (s *APIServer) registerPingHandlers(r *mux.Router) error {
 	//               determine if talking to Podman engine or another engine
 	//     500:
 	//       $ref: "#/responses/InternalError"
-	r.Handle("/libpod/_ping", APIHandler(s.Context, handlers.Ping)).Methods(http.MethodGet)
-	r.Handle("/libpod/_ping", APIHandler(s.Context, handlers.Ping)).Methods(http.MethodHead)
+	r.Handle("/libpod/_ping", s.APIHandler(handlers.Ping)).Methods(http.MethodGet)
+	r.Handle("/libpod/_ping", s.APIHandler(handlers.Ping)).Methods(http.MethodHead)
 	return nil
 }

--- a/pkg/api/server/register_plugins.go
+++ b/pkg/api/server/register_plugins.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (s *APIServer) RegisterPluginsHandlers(r *mux.Router) error {
-	r.Handle(VersionedPath("/plugins"), APIHandler(s.Context, handlers.UnsupportedHandler))
+func (s *APIServer) registerPluginsHandlers(r *mux.Router) error {
+	r.Handle(VersionedPath("/plugins"), s.APIHandler(handlers.UnsupportedHandler))
 	return nil
 }

--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -25,8 +25,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/BadParamError"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/pods/json"), APIHandler(s.Context, libpod.Pods)).Methods(http.MethodGet)
-	r.Handle(VersionedPath("/libpod/pods/create"), APIHandler(s.Context, libpod.PodCreate)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/pods/json"), s.APIHandler(libpod.Pods)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/pods/create"), s.APIHandler(libpod.PodCreate)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/prune pods PrunePods
 	// ---
 	// summary: Prune unused pods
@@ -45,7 +45,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     description: pod already exists
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/pods/prune"), APIHandler(s.Context, libpod.PodPrune)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/pods/prune"), s.APIHandler(libpod.PodPrune)).Methods(http.MethodPost)
 	// swagger:operation DELETE /libpod/pods/{name} pods removePod
 	// ---
 	// summary: Remove pod
@@ -70,7 +70,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchPod"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/pods/{name}"), APIHandler(s.Context, libpod.PodDelete)).Methods(http.MethodDelete)
+	r.Handle(VersionedPath("/libpod/pods/{name}"), s.APIHandler(libpod.PodDelete)).Methods(http.MethodDelete)
 	// swagger:operation GET /libpod/pods/{name}/json pods inspectPod
 	// ---
 	// summary: Inspect pod
@@ -89,7 +89,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//      $ref: "#/responses/NoSuchPod"
 	//   500:
 	//      $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/pods/{name}/json"), APIHandler(s.Context, libpod.PodInspect)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/pods/{name}/json"), s.APIHandler(libpod.PodInspect)).Methods(http.MethodGet)
 	// swagger:operation GET /libpod/pods/{name}/exists pods podExists
 	// ---
 	// summary: Pod exists
@@ -109,7 +109,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchPod"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/pods/{name}/exists"), APIHandler(s.Context, libpod.PodExists)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/pods/{name}/exists"), s.APIHandler(libpod.PodExists)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/pods/{name}/kill pods killPod
 	// ---
 	// summary: Kill a pod
@@ -137,7 +137,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/ConflictError"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/pods/{name}/kill"), APIHandler(s.Context, libpod.PodKill)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/pods/{name}/kill"), s.APIHandler(libpod.PodKill)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/{name}/pause pods pausePod
 	// ---
 	// summary: Pause a pod
@@ -157,7 +157,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchPod"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/pods/{name}/pause"), APIHandler(s.Context, libpod.PodPause)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/pods/{name}/pause"), s.APIHandler(libpod.PodPause)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/{name}/restart pods restartPod
 	// ---
 	// summary: Restart a pod
@@ -176,7 +176,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchPod"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/pods/{name}/restart"), APIHandler(s.Context, libpod.PodRestart)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/pods/{name}/restart"), s.APIHandler(libpod.PodRestart)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/{name}/start pods startPod
 	// ---
 	// summary: Start a pod
@@ -197,7 +197,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchPod"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/pods/{name}/start"), APIHandler(s.Context, libpod.PodStart)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/pods/{name}/start"), s.APIHandler(libpod.PodStart)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/{name}/stop pods stopPod
 	// ---
 	// summary: Stop a pod
@@ -224,7 +224,7 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchPod"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/pods/{name}/stop"), APIHandler(s.Context, libpod.PodStop)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/pods/{name}/stop"), s.APIHandler(libpod.PodStop)).Methods(http.MethodPost)
 	// swagger:operation POST /libpod/pods/{name}/unpause pods unpausePod
 	// ---
 	// summary: Unpause a pod
@@ -243,6 +243,6 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchPod"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/pods/{name}/unpause"), APIHandler(s.Context, libpod.PodUnpause)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/libpod/pods/{name}/unpause"), s.APIHandler(libpod.PodUnpause)).Methods(http.MethodPost)
 	return nil
 }

--- a/pkg/api/server/register_swarm.go
+++ b/pkg/api/server/register_swarm.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (s *APIServer) RegisterSwarmHandlers(r *mux.Router) error {
+func (s *APIServer) registerSwarmHandlers(r *mux.Router) error {
 	r.PathPrefix("/v{version:[0-9.]+}/configs/").HandlerFunc(noSwarm)
 	r.PathPrefix("/v{version:[0-9.]+}/nodes/").HandlerFunc(noSwarm)
 	r.PathPrefix("/v{version:[0-9.]+}/secrets/").HandlerFunc(noSwarm)

--- a/pkg/api/server/register_system.go
+++ b/pkg/api/server/register_system.go
@@ -6,6 +6,6 @@ import (
 )
 
 func (s *APIServer) registerSystemHandlers(r *mux.Router) error {
-	r.Handle(VersionedPath("/system/df"), APIHandler(s.Context, generic.GetDiskUsage))
+	r.Handle(VersionedPath("/system/df"), s.APIHandler(generic.GetDiskUsage))
 	return nil
 }

--- a/pkg/api/server/register_version.go
+++ b/pkg/api/server/register_version.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *APIServer) registerVersionHandlers(r *mux.Router) error {
-	r.Handle("/version", APIHandler(s.Context, handlers.VersionHandler))
-	r.Handle(VersionedPath("/version"), APIHandler(s.Context, handlers.VersionHandler))
+	r.Handle("/version", s.APIHandler(handlers.VersionHandler))
+	r.Handle(VersionedPath("/version"), s.APIHandler(handlers.VersionHandler))
 	return nil
 }

--- a/pkg/api/server/register_volumes.go
+++ b/pkg/api/server/register_volumes.go
@@ -18,8 +18,8 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//     description: tbd
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
-	r.Handle("/libpod/volumes/create", APIHandler(s.Context, libpod.CreateVolume)).Methods(http.MethodPost)
-	r.Handle("/libpod/volumes/json", APIHandler(s.Context, libpod.ListVolumes)).Methods(http.MethodGet)
+	r.Handle("/libpod/volumes/create", s.APIHandler(libpod.CreateVolume)).Methods(http.MethodPost)
+	r.Handle("/libpod/volumes/json", s.APIHandler(libpod.ListVolumes)).Methods(http.MethodGet)
 	// swagger:operation POST /volumes/prune volumes pruneVolumes
 	// ---
 	// summary: Prune volumes
@@ -30,7 +30,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//     description: no error
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
-	r.Handle("/libpod/volumes/prune", APIHandler(s.Context, libpod.PruneVolumes)).Methods(http.MethodPost)
+	r.Handle("/libpod/volumes/prune", s.APIHandler(libpod.PruneVolumes)).Methods(http.MethodPost)
 	// swagger:operation GET /volumes/{name}/json volumes inspectVolume
 	// ---
 	// summary: Inspect volume
@@ -49,7 +49,7 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//       "$ref": "#/responses/NoSuchVolume"
 	//   '500':
 	//      "$ref": "#/responses/InternalError"
-	r.Handle("/libpod/volumes/{name}/json", APIHandler(s.Context, libpod.InspectVolume)).Methods(http.MethodGet)
+	r.Handle("/libpod/volumes/{name}/json", s.APIHandler(libpod.InspectVolume)).Methods(http.MethodGet)
 	// swagger:operation DELETE /volumes/{name} volumes removeVolume
 	// ---
 	// summary: Remove volume
@@ -74,6 +74,6 @@ func (s *APIServer) registerVolumeHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchVolume"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle("/libpod/volumes/{name}", APIHandler(s.Context, libpod.RemoveVolume)).Methods(http.MethodDelete)
+	r.Handle("/libpod/volumes/{name}", s.APIHandler(libpod.RemoveVolume)).Methods(http.MethodDelete)
 	return nil
 }

--- a/pkg/systemd/activation.go
+++ b/pkg/systemd/activation.go
@@ -1,0 +1,40 @@
+package systemd
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// SocketActivated determine if podman is running under the socket activation protocol
+func SocketActivated() bool {
+	pid, pid_found := os.LookupEnv("LISTEN_PID")
+	fds, fds_found := os.LookupEnv("LISTEN_FDS")
+	fdnames, fdnames_found := os.LookupEnv("LISTEN_FDNAMES")
+
+	if !(pid_found && fds_found && fdnames_found) {
+		return false
+	}
+
+	p, err := strconv.Atoi(pid)
+	if err != nil || p != os.Getpid() {
+		return false
+	}
+
+	nfds, err := strconv.Atoi(fds)
+	if err != nil || nfds < 1 {
+		return false
+	}
+
+	// First available file descriptor is always 3.
+	if nfds > 1 {
+		names := strings.Split(fdnames, ":")
+		for _, n := range names {
+			if strings.Contains(n, "podman") {
+				return true
+			}
+		}
+	}
+
+	return true
+}

--- a/pkg/systemd/generate/systemdgen.go
+++ b/pkg/systemd/generate/systemdgen.go
@@ -1,4 +1,4 @@
-package systemdgen
+package generate
 
 import (
 	"bytes"

--- a/pkg/systemd/generate/systemdgen_test.go
+++ b/pkg/systemd/generate/systemdgen_test.go
@@ -1,4 +1,4 @@
-package systemdgen
+package generate
 
 import (
 	"testing"


### PR DESCRIPTION
On panic from handler: log warning and stack trace, report
InternalServerError to client

Set timeouts to allow large files to be sent to/from server.  Refactor idle window to support new timeouts.

When using `podman system service` make determining the listening endpoint deterministic.

  // When determining _*THE*_ listening endpoint --
  // 1) User input wins always
  // 2) systemd socket activation
  // 3) rootless honors XDG_RUNTIME_DIR
  // 4) if varlink -- adapter.DefaultVarlinkAddress
  // 5) lastly adapter.DefaultAPIAddress

Fixes #5150
Fixes #5151
Fixes #5224

Signed-off-by: Jhon Honce <jhonce@redhat.com>