### PR TITLE
container create: relax os/arch checks

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -109,11 +109,11 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		}
 
 		if overrideOS == "" && imageData.Os != goruntime.GOOS {
-			return nil, nil, errors.Errorf("incompatible image OS %q on %q host", imageData.Os, goruntime.GOOS)
+			logrus.Infof("Using %q (OS) image on %q host", imageData.Os, goruntime.GOOS)
 		}
 
 		if overrideArch == "" && imageData.Architecture != goruntime.GOARCH {
-			return nil, nil, errors.Errorf("incompatible image architecture %q on %q host", imageData.Architecture, goruntime.GOARCH)
+			logrus.Infof("Using %q (architecture) on %q host", imageData.Architecture, goruntime.GOARCH)
 		}
 
 		names := newImage.Names()


### PR DESCRIPTION
Relax the os/arch checks when creating a container and only info-log
mismatches instead of erroring out.  There are too many images used
in the wild which do not set their arch correctly correctly.  Erroring
out has hit users sufficiently enough to justify relaxing the errors
and only log to at least inform the users and image vendors.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>