### PR TITLE
Make: s/uname -o/uname -s/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,7 +582,7 @@ install.libseccomp.sudo:
 
 
 cmd/podman/varlink/iopodman.go: .gopathok cmd/podman/varlink/io.podman.varlink
-ifneq (,$(findstring Linux,$(shell uname -o)))
+ifneq (,$(findstring Linux,$(shell uname -s)))
 	# Only generate the varlink code on Linux (see issue #4814).
 	GO111MODULE=off $(GO) generate ./cmd/podman/varlink/...
 endif


### PR DESCRIPTION
uname -o doesn't seem to work on Mac OS.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>