### PR TITLE
API v2: pods: fix two incorrect return codes

### DIFF
--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -91,7 +91,11 @@ func PodCreate(w http.ResponseWriter, r *http.Request) {
 
 	pod, err := runtime.NewPod(r.Context(), options...)
 	if err != nil {
-		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)
+		http_code := http.StatusInternalServerError
+		if errors.Cause(err) == define.ErrPodExists {
+			http_code = http.StatusConflict
+		}
+		utils.Error(w, "Something went wrong.", http_code, err)
 		return
 	}
 	utils.WriteResponse(w, http.StatusCreated, handlers.IDResponse{ID: pod.CgroupParent()})
@@ -409,5 +413,5 @@ func PodExists(w http.ResponseWriter, r *http.Request) {
 		utils.PodNotFound(w, name, err)
 		return
 	}
-	utils.WriteResponse(w, http.StatusOK, "")
+	utils.WriteResponse(w, http.StatusNoContent, "")
 }

--- a/pkg/api/handlers/utils/handler.go
+++ b/pkg/api/handlers/utils/handler.go
@@ -23,6 +23,14 @@ func IsLibpodRequest(r *http.Request) bool {
 
 // WriteResponse encodes the given value as JSON or string and renders it for http client
 func WriteResponse(w http.ResponseWriter, code int, value interface{}) {
+	// RFC2616 explicitly states that the following status codes "MUST NOT
+	// include a message-body":
+	switch code {
+	case http.StatusNoContent, http.StatusNotModified: // 204, 304
+		w.WriteHeader(code)
+		return
+	}
+
 	switch v := value.(type) {
 	case string:
 		w.Header().Set("Content-Type", "text/plain; charset=us-ascii")

--- a/pkg/api/server/register_pods.go
+++ b/pkg/api/server/register_pods.go
@@ -41,6 +41,8 @@ func (s *APIServer) registerPodsHandlers(r *mux.Router) error {
 	//         type: string
 	//   400:
 	//     $ref: "#/responses/BadParamError"
+	//   409:
+	//     description: pod already exists
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/pods/prune"), APIHandler(s.Context, libpod.PodPrune)).Methods(http.MethodPost)


### PR DESCRIPTION
 1) /pods/\<X\>/exists - is documented to return 204, and that's
    the correct value, but until now it has been returning 200.

 2) /pods/create - return 409 (conflict), not 500, when pod
    already exists

Also: in WriteResponse(), if code is 204 (No Content), emit
the status code only but no content-type headers nor content.

Signed-off-by: Ed Santiago <santiago@redhat.com>