### PR TITLE
Fix container filters

### DIFF
--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -56,7 +56,7 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
 		All       bool                `schema:"all"`
-		Filter    map[string][]string `schema:"filter"`
+		Filters   map[string][]string `schema:"filters"`
 		Last      int                 `schema:"last"`
 		Namespace bool                `schema:"namespace"`
 		Pod       bool                `schema:"pod"`
@@ -71,6 +71,7 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
 		return
 	}
+
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	opts := shared.PsOptions{
 		All:       query.All,
@@ -82,8 +83,8 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 		Pod:       query.Pod,
 		Sync:      query.Sync,
 	}
-	if len(query.Filter) > 0 {
-		for k, v := range query.Filter {
+	if len(query.Filters) > 0 {
+		for k, v := range query.Filters {
 			for _, val := range v {
 				generatedFunc, err := shared.GenerateContainerFilterFuncs(k, val, runtime)
 				if err != nil {

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -130,7 +130,7 @@ func (c *Connection) DoRequest(httpBody io.Reader, httpMethod, endpoint string, 
 		// if more desirable we could use url to form the encoded endpoint with params
 		r := req.URL.Query()
 		for k, v := range queryParams {
-			r.Add(k, url.QueryEscape(v))
+			r.Add(k, v)
 		}
 		req.URL.RawQuery = r.Encode()
 	}
@@ -155,18 +155,14 @@ func GetConnectionFromContext(ctx context.Context) (*Connection, error) {
 	return conn, nil
 }
 
-// FiltersToHTML converts our typical filter format of a
+// FiltersToString converts our typical filter format of a
 // map[string][]string to a query/html safe string.
-func FiltersToHTML(filters map[string][]string) (string, error) {
+func FiltersToString(filters map[string][]string) (string, error) {
 	lowerCaseKeys := make(map[string][]string)
 	for k, v := range filters {
 		lowerCaseKeys[strings.ToLower(k)] = v
 	}
-	unsafeString, err := jsoniter.MarshalToString(lowerCaseKeys)
-	if err != nil {
-		return "", err
-	}
-	return url.QueryEscape(unsafeString), nil
+	return jsoniter.MarshalToString(lowerCaseKeys)
 }
 
 // IsInformation returns true if the response code is 1xx

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -38,7 +38,7 @@ func List(ctx context.Context, all *bool, filters map[string][]string) ([]*handl
 		params["all"] = strconv.FormatBool(*all)
 	}
 	if filters != nil {
-		strFilters, err := bindings.FiltersToHTML(filters)
+		strFilters, err := bindings.FiltersToString(filters)
 		if err != nil {
 			return nil, err
 		}
@@ -155,7 +155,7 @@ func Prune(ctx context.Context, filters map[string][]string) ([]string, error) {
 	}
 	params := make(map[string]string)
 	if filters != nil {
-		stringFilter, err := bindings.FiltersToHTML(filters)
+		stringFilter, err := bindings.FiltersToString(filters)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/bindings/images/search.go
+++ b/pkg/bindings/images/search.go
@@ -26,7 +26,7 @@ func Search(ctx context.Context, term string, limit *int, filters map[string][]s
 		params["limit"] = strconv.Itoa(*limit)
 	}
 	if filters != nil {
-		stringFilter, err := bindings.FiltersToHTML(filters)
+		stringFilter, err := bindings.FiltersToString(filters)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/bindings/pods/pods.go
+++ b/pkg/bindings/pods/pods.go
@@ -97,7 +97,7 @@ func List(ctx context.Context, filters map[string][]string) (*[]libpod.PodInspec
 	}
 	params := make(map[string]string)
 	if filters != nil {
-		stringFilter, err := bindings.FiltersToHTML(filters)
+		stringFilter, err := bindings.FiltersToString(filters)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
container filters were being double encoded (maybe triple) which resulted in the wrong encoding representation of filters being sent by the go-bindings.  Also, on the server side, Filter needed to be changed to Filter to decode properly. Finally, due to the changed return type of List Containers, the go bindings return values needed to be changed.

Signed-off-by: Brent Baude <bbaude@redhat.com>