### PR TITLE
HTTP 304 (NotModified) is not an error!

### DIFF
--- a/pkg/api/handlers/containers.go
+++ b/pkg/api/handlers/containers.go
@@ -41,10 +41,9 @@ func StopContainer(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, errors.Wrapf(err, "unable to get state for Container %s", name))
 		return
 	}
-	// If the Container is stopped already, send a 302
+	// If the Container is stopped already, send a 304
 	if state == define.ContainerStateStopped || state == define.ContainerStateExited {
-		utils.Error(w, http.StatusText(http.StatusNotModified), http.StatusNotModified,
-			errors.Errorf("Container %s is already stopped ", name))
+		utils.WriteResponse(w, http.StatusNotModified, "")
 		return
 	}
 
@@ -134,8 +133,7 @@ func StartContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if state == define.ContainerStateRunning {
-		msg := fmt.Sprintf("Container %s is already running", name)
-		utils.Error(w, msg, http.StatusNotModified, errors.New(msg))
+		utils.WriteResponse(w, http.StatusNotModified, "")
 		return
 	}
 	if err := con.Start(r.Context(), false); err != nil {

--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -202,8 +202,7 @@ func PodStop(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if allContainersStopped {
-		alreadyStopped := errors.Errorf("pod %s is already stopped", pod.ID())
-		utils.Error(w, "Something went wrong", http.StatusNotModified, alreadyStopped)
+		utils.WriteResponse(w, http.StatusNotModified, "")
 		return
 	}
 
@@ -249,8 +248,7 @@ func PodStart(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if allContainersRunning {
-		alreadyRunning := errors.Errorf("pod %s is already running", pod.ID())
-		utils.Error(w, "Something went wrong", http.StatusNotModified, alreadyRunning)
+		utils.WriteResponse(w, http.StatusNotModified, "")
 		return
 	}
 	if _, err := pod.Start(r.Context()); err != nil {


### PR DESCRIPTION
Even after #5169, my test logs kept showing:

   ERRO[0004] unable to write json: "http: request method or response status code does not allow body"

Cause: overly-helpful code trying to treat condition as an
error and include a diagnostic message. This is forbidden
per rfc2616.

This PR fixes the faulty response, as well as three others
found via:

    $ ack 'Error.*NotMod'  (4 hits total)
    $ ack 'Error.*NoCont'  (no hits)

Signed-off-by: Ed Santiago <santiago@redhat.com>