### PR TITLE
add pkg/seccomp

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containers/libpod/pkg/inspect"
 	ns "github.com/containers/libpod/pkg/namespaces"
 	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/libpod/pkg/seccomp"
 	cc "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/docker/go-connections/nat"
@@ -30,10 +31,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
-
-// seccompLabelKey is the key of the image annotation embedding a seccomp
-// profile.
-const seccompLabelKey = "io.containers.seccomp.profile"
 
 func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.Runtime) (*libpod.Container, *cc.CreateConfig, error) {
 	var (
@@ -713,11 +710,11 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 
 	// SECCOMP
 	if data != nil {
-		if value, exists := labels[seccompLabelKey]; exists {
+		if value, exists := labels[seccomp.ContainerImageLabel]; exists {
 			secConfig.SeccompProfileFromImage = value
 		}
 	}
-	if policy, err := cc.LookupSeccompPolicy(c.String("seccomp-policy")); err != nil {
+	if policy, err := seccomp.LookupPolicy(c.String("seccomp-policy")); err != nil {
 		return nil, err
 	} else {
 		secConfig.SeccompPolicy = policy

--- a/pkg/seccomp/seccomp.go
+++ b/pkg/seccomp/seccomp.go
@@ -1,0 +1,54 @@
+package seccomp
+
+import (
+	"sort"
+
+	"github.com/pkg/errors"
+)
+
+// ContianerImageLabel is the key of the image annotation embedding a seccomp
+// profile.
+const ContainerImageLabel = "io.containers.seccomp.profile"
+
+// Policy denotes a seccomp policy.
+type Policy int
+
+const (
+	// PolicyDefault - if set use SecurityConfig.SeccompProfilePath,
+	// otherwise use the default profile.  The SeccompProfilePath might be
+	// explicitly set by the user.
+	PolicyDefault Policy = iota
+	// PolicyImage - if set use SecurityConfig.SeccompProfileFromImage,
+	// otherwise follow SeccompPolicyDefault.
+	PolicyImage
+)
+
+// Map for easy lookups of supported policies.
+var supportedPolicies = map[string]Policy{
+	"":        PolicyDefault,
+	"default": PolicyDefault,
+	"image":   PolicyImage,
+}
+
+// LookupPolicy looksup the corresponding Policy for the specified
+// string. If none is found, an errors is returned including the list of
+// supported policies.
+//
+// Note that an empty string resolved to SeccompPolicyDefault.
+func LookupPolicy(s string) (Policy, error) {
+	policy, exists := supportedPolicies[s]
+	if exists {
+		return policy, nil
+	}
+
+	// Sort the keys first as maps are non-deterministic.
+	keys := []string{}
+	for k := range supportedPolicies {
+		if k != "" {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	return -1, errors.Errorf("invalid seccomp policy %q: valid policies are %+q", s, keys)
+}

--- a/pkg/spec/config_linux_cgo.go
+++ b/pkg/spec/config_linux_cgo.go
@@ -5,9 +5,10 @@ package createconfig
 import (
 	"io/ioutil"
 
+	"github.com/containers/libpod/pkg/seccomp"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-	seccomp "github.com/seccomp/containers-golang"
+	goSeccomp "github.com/seccomp/containers-golang"
 	"github.com/sirupsen/logrus"
 )
 
@@ -15,9 +16,9 @@ func getSeccompConfig(config *SecurityConfig, configSpec *spec.Spec) (*spec.Linu
 	var seccompConfig *spec.LinuxSeccomp
 	var err error
 
-	if config.SeccompPolicy == SeccompPolicyImage && config.SeccompProfileFromImage != "" {
+	if config.SeccompPolicy == seccomp.PolicyImage && config.SeccompProfileFromImage != "" {
 		logrus.Debug("Loading seccomp profile from the security config")
-		seccompConfig, err = seccomp.LoadProfile(config.SeccompProfileFromImage, configSpec)
+		seccompConfig, err = goSeccomp.LoadProfile(config.SeccompProfileFromImage, configSpec)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading seccomp profile failed")
 		}
@@ -30,13 +31,13 @@ func getSeccompConfig(config *SecurityConfig, configSpec *spec.Spec) (*spec.Linu
 		if err != nil {
 			return nil, errors.Wrapf(err, "opening seccomp profile (%s) failed", config.SeccompProfilePath)
 		}
-		seccompConfig, err = seccomp.LoadProfile(string(seccompProfile), configSpec)
+		seccompConfig, err = goSeccomp.LoadProfile(string(seccompProfile), configSpec)
 		if err != nil {
 			return nil, errors.Wrapf(err, "loading seccomp profile (%s) failed", config.SeccompProfilePath)
 		}
 	} else {
 		logrus.Debug("Loading default seccomp profile")
-		seccompConfig, err = seccomp.GetDefaultProfile(configSpec)
+		seccompConfig, err = goSeccomp.GetDefaultProfile(configSpec)
 		if err != nil {
 			return nil, errors.Wrapf(err, "loading seccomp profile (%s) failed", config.SeccompProfilePath)
 		}


### PR DESCRIPTION
Add pkg/seccomp to consolidate all seccomp-policy related code which is
currently scattered across multiple packages and complicating the
creatconfig refactoring.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@baude @mheon PTAL