### PR TITLE
Only set --all when a status filter is given to ps

### DIFF
--- a/cmd/podman/ps.go
+++ b/cmd/podman/ps.go
@@ -205,9 +205,15 @@ func checkFlagsPassed(c *cliconfig.PsValues) error {
 	if c.Last >= 0 && c.Latest {
 		return errors.Errorf("last and latest are mutually exclusive")
 	}
-	// Filter forces all
+	// Filter on status forces all
 	if len(c.Filter) > 0 {
-		c.All = true
+		for _, filter := range c.Filter {
+			splitFilter := strings.SplitN(filter, "=", 2)
+			if strings.ToLower(splitFilter[0]) == "status" {
+				c.All = true
+				break
+			}
+		}
 	}
 	// Quiet conflicts with size and namespace and is overridden by a Go
 	// template.

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -243,6 +243,19 @@ var _ = Describe("Podman ps", func() {
 		Expect(psAll.OutputToString()).To(Equal(psFilter.OutputToString()))
 	})
 
+	It("podman filter without status does not find non-running", func() {
+		ctrName := "aContainerName"
+		ctr := podmanTest.Podman([]string{"create", "--name", ctrName, "-t", "-i", ALPINE, "ls", "/"})
+		ctr.WaitWithDefaultTimeout()
+		Expect(ctr.ExitCode()).To(Equal(0))
+
+		psFilter := podmanTest.Podman([]string{"ps", "--no-trunc", "--quiet", "--format", "{{.Names}}", "--filter", fmt.Sprintf("name=%s", ctrName)})
+		psFilter.WaitWithDefaultTimeout()
+		Expect(psFilter.ExitCode()).To(Equal(0))
+
+		Expect(strings.Contains(psFilter.OutputToString(), ctrName)).To(BeFalse())
+	})
+
 	It("podman ps mutually exclusive flags", func() {
 		session := podmanTest.Podman([]string{"ps", "-aqs"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
The changes in #5075 turn out to be too aggressive; we should only be setting --all if a status= filter is given. Otherwise only running containers are filtered.
