### PR TITLE
Fix SELinux labels of volumes

### DIFF
--- a/libpod/runtime_volume_linux.go
+++ b/libpod/runtime_volume_linux.go
@@ -85,7 +85,7 @@ func (r *Runtime) newVolume(ctx context.Context, options ...VolumeCreateOption) 
 	if err := os.Chown(fullVolPath, volume.config.UID, volume.config.GID); err != nil {
 		return nil, errors.Wrapf(err, "error chowning volume directory %q to %d:%d", fullVolPath, volume.config.UID, volume.config.GID)
 	}
-	if err := LabelVolumePath(fullVolPath, true); err != nil {
+	if err := LabelVolumePath(fullVolPath); err != nil {
 		return nil, err
 	}
 	volume.config.MountPoint = fullVolPath

--- a/libpod/util_linux.go
+++ b/libpod/util_linux.go
@@ -92,7 +92,7 @@ func assembleSystemdCgroupName(baseSlice, newSlice string) (string, error) {
 
 // LabelVolumePath takes a mount path for a volume and gives it an
 // selinux label of either shared or not
-func LabelVolumePath(path string, shared bool) error {
+func LabelVolumePath(path string) error {
 	_, mountLabel, err := label.InitLabels([]string{})
 	if err != nil {
 		return errors.Wrapf(err, "error getting default mountlabels")
@@ -100,12 +100,13 @@ func LabelVolumePath(path string, shared bool) error {
 	if err := label.ReleaseLabel(mountLabel); err != nil {
 		return errors.Wrapf(err, "error releasing label %q", mountLabel)
 	}
-	if err := label.Relabel(path, mountLabel, shared); err != nil {
-		permString := "private"
-		if shared {
-			permString = "shared"
+
+	if err := label.Relabel(path, mountLabel, true); err != nil {
+		if err != syscall.ENOTSUP {
+			logrus.Debugf("Labeling not supported on %q", path)
+		} else {
+			return errors.Wrapf(err, "error setting selinux label for %s to %q as shared", path, mountLabel)
 		}
-		return errors.Wrapf(err, "error setting selinux label for %s to %q as %s", path, mountLabel, permString)
 	}
 	return nil
 }

--- a/pkg/adapter/pods.go
+++ b/pkg/adapter/pods.go
@@ -565,8 +565,8 @@ func (r *LocalRuntime) PlayKubeYAML(ctx context.Context, c *cliconfig.KubePlayVa
 						return nil, errors.Errorf("Error creating HostPath %s at %s", volume.Name, hostPath.Path)
 					}
 				}
-				// unconditionally label a newly created volume as private
-				if err := libpod.LabelVolumePath(hostPath.Path, false); err != nil {
+				// Label a newly created volume
+				if err := libpod.LabelVolumePath(hostPath.Path); err != nil {
 					return nil, errors.Wrapf(err, "Error giving %s a label", hostPath.Path)
 				}
 			case v1.HostPathFileOrCreate:
@@ -579,8 +579,8 @@ func (r *LocalRuntime) PlayKubeYAML(ctx context.Context, c *cliconfig.KubePlayVa
 						logrus.Warnf("Error in closing newly created HostPath file: %v", err)
 					}
 				}
-				// unconditionally label a newly created volume as private
-				if err := libpod.LabelVolumePath(hostPath.Path, false); err != nil {
+				// unconditionally label a newly created volume
+				if err := libpod.LabelVolumePath(hostPath.Path); err != nil {
 					return nil, errors.Wrapf(err, "Error giving %s a label", hostPath.Path)
 				}
 			case v1.HostPathDirectory:


### PR DESCRIPTION
If we attempt to label a volume and the file system
does not support labeling, then just warn.  SELinux
may or may not work, on the volume.

There is no way to setup a private label on a newly
created volume without using the container mountlabel.

If we don't have a mount label at the time of creation of
the volume, the only option we have is to create a shared
label.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>