### PR TITLE
increase stop timeout to 30 seconds

### DIFF
--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -19,7 +19,7 @@ var (
 const (
 	// CtrRemoveTimeout is the default number of seconds to wait after stopping a container
 	// before sending the kill signal
-	CtrRemoveTimeout = 10
+	CtrRemoveTimeout = 30
 	// DefaultTransport is a prefix that we apply to an image name
 	// to check docker hub first for the image
 	DefaultTransport = "docker://"


### PR DESCRIPTION
Increase the timeout during container stop before shooting with SIGKILL.
Users have repeatedly reported that they are hitting the timeout, in
particular on small VMs with low resources.  Setting it to 30 seconds
will decrease the chance of hitting the timeout.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@mheon @giuseppe @baude @rhatdan ... this could be a controversial change as it also increases the time to stop misbehaving containers. These could still be silenced with `podman-kill` though.