### PR TITLE
Remove ImageVolumes from database

### DIFF
--- a/libpod/common_test.go
+++ b/libpod/common_test.go
@@ -23,7 +23,6 @@ func getTestContainer(id, name string, manager lock.Manager) (*Container, error)
 			Name:            name,
 			RootfsImageID:   id,
 			RootfsImageName: "testimg",
-			ImageVolumes:    true,
 			StaticDir:       "/does/not/exist/",
 			LogPath:         "/does/not/exist/",
 			Stdin:           true,

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -249,8 +249,6 @@ type ContainerConfig struct {
 	RootfsImageName string `json:"rootfsImageName,omitempty"`
 	// Rootfs to use for the container, this conflicts with RootfsImageID
 	Rootfs string `json:"rootfs,omitempty"`
-	// Whether to mount volumes specified in the image.
-	ImageVolumes bool `json:"imageVolumes"`
 	// Src path to be mounted on /dev/shm in container.
 	ShmDir string `json:"ShmDir,omitempty"`
 	// Size of the container's SHM.
@@ -508,12 +506,6 @@ func (c *Container) Namespace() string {
 // Image returns the ID and name of the image used as the container's rootfs
 func (c *Container) Image() (string, string) {
 	return c.config.RootfsImageID, c.config.RootfsImageName
-}
-
-// ImageVolumes returns whether the container is configured to create
-// persistent volumes requested by the image
-func (c *Container) ImageVolumes() bool {
-	return c.config.ImageVolumes
 }
 
 // ShmDir returns the sources path to be mounted on /dev/shm in container

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -593,7 +593,7 @@ func WithUser(user string) CtrCreateOption {
 // other configuration from the image will be added to the config.
 // TODO: Replace image name and ID with a libpod.Image struct when that is
 // finished.
-func WithRootFSFromImage(imageID string, imageName string, useImageVolumes bool) CtrCreateOption {
+func WithRootFSFromImage(imageID string, imageName string) CtrCreateOption {
 	return func(ctr *Container) error {
 		if ctr.valid {
 			return define.ErrCtrFinalized
@@ -608,7 +608,6 @@ func WithRootFSFromImage(imageID string, imageName string, useImageVolumes bool)
 
 		ctr.config.RootfsImageID = imageID
 		ctr.config.RootfsImageName = imageName
-		ctr.config.ImageVolumes = useImageVolumes
 
 		return nil
 	}

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -127,7 +127,7 @@ func (r *Runtime) makeInfraContainer(ctx context.Context, p *Pod, imgName, imgID
 
 	containerName := p.ID()[:IDTruncLength] + "-infra"
 	options = append(options, r.WithPod(p))
-	options = append(options, WithRootFSFromImage(imgID, imgName, false))
+	options = append(options, WithRootFSFromImage(imgID, imgName))
 	options = append(options, WithName(containerName))
 	options = append(options, withIsInfra())
 

--- a/libpod/util_test.go
+++ b/libpod/util_test.go
@@ -1,8 +1,9 @@
 package libpod
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRemoveScientificNotationFromFloat(t *testing.T) {

--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -341,9 +341,8 @@ func (c *CreateConfig) getContainerCreateOptions(runtime *libpod.Runtime, pod *l
 	}
 	options = append(options, nsOpts...)
 
-	useImageVolumes := c.ImageVolumeType == TypeBind
 	// Gather up the options for NewContainer which consist of With... funcs
-	options = append(options, libpod.WithRootFSFromImage(c.ImageID, c.Image, useImageVolumes))
+	options = append(options, libpod.WithRootFSFromImage(c.ImageID, c.Image))
 	options = append(options, libpod.WithConmonPidFile(c.ConmonPidFile))
 	options = append(options, libpod.WithLabels(c.Labels))
 	options = append(options, libpod.WithShmSize(c.Resources.ShmSize))

--- a/pkg/specgen/create.go
+++ b/pkg/specgen/create.go
@@ -36,9 +36,7 @@ func (s *SpecGenerator) MakeContainer(rt *libpod.Runtime) (*libpod.Container, er
 		return nil, err
 	}
 
-	// TODO mheon wants to talk with Dan about this
-	useImageVolumes := s.ImageVolumeMode == "bind"
-	options = append(options, libpod.WithRootFSFromImage(newImage.ID(), s.Image, useImageVolumes))
+	options = append(options, libpod.WithRootFSFromImage(newImage.ID(), s.Image))
 
 	runtimeSpec, err := s.toOCISpec(rt, newImage)
 	if err != nil {


### PR DESCRIPTION
Before Libpod supported named volumes, we approximated image volumes by bind-mounting in per-container temporary directories. This was handled by Libpod, and had a corresponding database entry to enable/disable it.

However, when we enabled named volumes, we completely rewrote the old implementation; none of the old bind mount implementation still exists, save one flag in the database. With nothing remaining to use it, it has no further purpose.
