### PR TITLE
add caching for binding tests

### DIFF
--- a/pkg/api/handlers/utils/images.go
+++ b/pkg/api/handlers/utils/images.go
@@ -31,9 +31,12 @@ func GetImages(w http.ResponseWriter, r *http.Request) ([]*image.Image, error) {
 	if _, found := mux.Vars(r)["digests"]; found && query.Digests {
 		UnSupportedParameter("digests")
 	}
-
-	if _, found := r.URL.Query()["filters"]; found {
-		filters = append(filters, fmt.Sprintf("reference=%s", ""))
+	if len(query.Filters) > 0 {
+		for k, v := range query.Filters {
+			for _, val := range v {
+				filters = append(filters, fmt.Sprintf("%s=%s", k, val))
+			}
+		}
 	}
 	return runtime.ImageRuntime().GetImagesWithFilters(filters)
 }


### PR DESCRIPTION
add the ability to cache images instead of pull them.  makes tests faster and less network use when we flip on CI.

Also added list images with filter test

Signed-off-by: Brent Baude <bbaude@redhat.com>