### PR TITLE
Update documentation of commit command to show image reference is optional

### DIFF
--- a/cmd/podman/commit.go
+++ b/cmd/podman/commit.go
@@ -15,7 +15,7 @@ var (
 	commitDescription = `Create an image from a container's changes. Optionally tag the image created, set the author with the --author flag, set the commit message with the --message flag, and make changes to the instructions with the --change flag.`
 
 	_commitCommand = &cobra.Command{
-		Use:   "commit [flags] CONTAINER IMAGE",
+		Use:   "commit [flags] CONTAINER [IMAGE]",
 		Short: "Create new image based on the changed container",
 		Long:  commitDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -26,7 +26,8 @@ var (
 		},
 		Example: `podman commit -q --message "committing container to image" reverent_golick image-committed
   podman commit -q --author "firstName lastName" reverent_golick image-committed
-  podman commit -q --pause=false containerID image-committed`,
+  podman commit -q --pause=false containerID image-committed
+  podman commit containerID`,
 	}
 
 	// ChangeCmds is the list of valid Changes commands to passed to the Commit call

--- a/docs/source/markdown/podman-commit.1.md
+++ b/docs/source/markdown/podman-commit.1.md
@@ -4,7 +4,7 @@
 podman\-commit - Create new image based on the changed container
 
 ## SYNOPSIS
-**podman commit** [*options*] *container* *image*
+**podman commit** [*options*] *container* [*image*]
 
 **podman container commit** [*options*] *container* [*image*]
 
@@ -18,6 +18,7 @@ image. If this is not desired, the `--pause` flag can be set to false. When the 
 is complete, Podman will print out the ID of the new image.
 
 If *image* does not begin with a registry name component, `localhost` will be added to the name.
+If *image* is not provided, the values for the `REPOSITORY` and `TAG` values of the created image will each be set to `<none>`.
 
 ## OPTIONS
 
@@ -83,6 +84,11 @@ e3ce4d93051ceea088d1c242624d659be32cf1667ef62f1d16d6b60193e2c7a8
 
 ```
 $ podman commit -q --pause=false containerID image-committed
+e3ce4d93051ceea088d1c242624d659be32cf1667ef62f1d16d6b60193e2c7a8
+```
+
+```
+$ podman commit containerID
 e3ce4d93051ceea088d1c242624d659be32cf1667ef62f1d16d6b60193e2c7a8
 ```
 


### PR DESCRIPTION
Following
Commit ba1d1304a67b ("make image reference for commit optional")

Updates usage text used by cobra and markdown document used to generate MAN page.

Closes #5145

Signed-off-by: Allan Jacquet-Cretides <allan.jacquet@gmail.com>