### PR TITLE
Fix make package-install on fedora31

### DIFF
--- a/contrib/build_rpm.sh
+++ b/contrib/build_rpm.sh
@@ -48,7 +48,7 @@ fi
 
 # btrfs-progs-devel is not available in CentOS/RHEL-8
 if ! (grep -i 'Red Hat\|CentOS' /etc/redhat-release | grep " 8" ); then
-    PKGS+=(golang-github-cpuguy83-go-md2man \
+    PKGS+=(golang-github-cpuguy83-md2man \
         btrfs-progs-devel \
         )
 fi


### PR DESCRIPTION

**Description**

After cloning the repository on Fedora 31, I tried to execute `make package-install` but it failed.
After [some research](https://src.fedoraproject.org/rpms/golang-github-cpuguy83-go-md2man/c/2a410118e7fedd9541a324f142d9e818bf1223a1?branch=master), seems like the package has been renamed from `golang-github-cpuguy83-go-md2man` to `golang-github-cpuguy83-md2man`.

This PR fixes the broken behavior for f31 but maintains compatibility with older fedora versions (tested on f31, f30, and f29).


**Steps to reproduce the issue:**

1. Setup a fresh fedora31 

2. Follow [contributing instructions](https://github.com/containers/libpod/blob/master/CONTRIBUTING.md#fork-and-clone-libpod) and clone the repository

3. Run `make package-install`

**Describe the results you received:**
```
[...]
+ sudo /usr/bin/dnf install -y createrepo device-mapper-devel git glib2-devel glibc-static go-compilers-golang-compiler golang gpgme-devel libassuan-devel libseccomp-devel libselinux-devel make redhat-rpm-config rpm-build rpmdevtools systemd-devel python3-devel python3-varlink golang-github-cpuguy83-go-md2man btrfs-progs-devel
Last metadata expiration check: 2:49:06 ago on Sun Feb 16 18:21:13 2020.
Package git-2.24.1-1.fc31.x86_64 is already installed.
Package golang-1.13.6-1.fc31.x86_64 is already installed.
Package make-1:4.2.1-15.fc31.x86_64 is already installed.
Package redhat-rpm-config-142-1.fc31.noarch is already installed.
No match for argument: golang-github-cpuguy83-go-md2man
Error: Unable to find a match: golang-github-cpuguy83-go-md2man
make: *** [Makefile:626: package] Error 1
```

**Additional environment details (AWS, VirtualBox, physical, etc.):**

Physical + Virtualbox + as a Container

```
NAME=Fedora
VERSION="31 (Workstation Edition)"
ID=fedora
VERSION_ID=31
PLATFORM_ID="platform:f31"
PRETTY_NAME="Fedora 31 (Workstation Edition)"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=31
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=31
VARIANT="Workstation Edition"
VARIANT_ID=workstation
```