### PR TITLE
Use cleaned destination path for indexing image volumes

### DIFF
--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -739,6 +739,7 @@ func (config *CreateConfig) getImageVolumes() (map[string]spec.Mount, map[string
 
 	for vol := range config.BuiltinImgVolumes {
 		cleanDest := filepath.Clean(vol)
+		logrus.Debugf("Adding image volume at %s", cleanDest)
 		if config.ImageVolumeType == "tmpfs" {
 			// Tmpfs image volumes are handled as mounts
 			mount := spec.Mount{
@@ -747,13 +748,13 @@ func (config *CreateConfig) getImageVolumes() (map[string]spec.Mount, map[string
 				Type:        TypeTmpfs,
 				Options:     []string{"rprivate", "rw", "nodev", "exec"},
 			}
-			mounts[vol] = mount
+			mounts[cleanDest] = mount
 		} else {
 			// Anonymous volumes have no name.
 			namedVolume := new(libpod.ContainerNamedVolume)
 			namedVolume.Options = []string{"rprivate", "rw", "nodev", "exec"}
 			namedVolume.Dest = cleanDest
-			volumes[vol] = namedVolume
+			volumes[cleanDest] = namedVolume
 		}
 	}
 


### PR DESCRIPTION
We use filepath.Clean() to remove trailing slashes to ensure that when we supercede image mounts with mounts from --volume and --mount, paths are consistent when we compare. Unfortunately, while we used the cleaned path for the destination in the mount, it was accidentally not used to index the maps that we use to identify what to supercede, so our comparisons might be thrown off by trailing slashes and similar.

Fixes #5219