### PR TITLE
podman-ps: support image IDs

### DIFF
--- a/cmd/podman/shared/container.go
+++ b/cmd/podman/shared/container.go
@@ -30,6 +30,7 @@ import (
 const (
 	cidTruncLength = 12
 	podTruncLength = 12
+	iidTruncLength = 12
 	cmdTruncLength = 17
 )
 
@@ -66,6 +67,7 @@ type BatchContainerStruct struct {
 type PsContainerOutput struct {
 	ID        string
 	Image     string
+	ImageID   string
 	Command   string
 	Created   string
 	Ports     string
@@ -203,7 +205,7 @@ func NewBatchContainer(r *libpod.Runtime, ctr *libpod.Container, opts PsOptions)
 		status = "Error"
 	}
 
-	_, imageName := ctr.Image()
+	imageID, imageName := ctr.Image()
 	cid := ctr.ID()
 	podID := ctr.PodID()
 	if !opts.NoTrunc {
@@ -214,6 +216,9 @@ func NewBatchContainer(r *libpod.Runtime, ctr *libpod.Container, opts PsOptions)
 		if len(command) > cmdTruncLength {
 			command = command[0:cmdTruncLength] + "..."
 		}
+		if len(imageID) > iidTruncLength {
+			imageID = imageID[0:iidTruncLength]
+		}
 	}
 
 	ports, err := ctr.PortMappings()
@@ -223,6 +228,7 @@ func NewBatchContainer(r *libpod.Runtime, ctr *libpod.Container, opts PsOptions)
 
 	pso.ID = cid
 	pso.Image = imageName
+	pso.ImageID = imageID
 	pso.Command = command
 	pso.Created = created
 	pso.Ports = portsToString(ports)

--- a/docs/source/markdown/podman-ps.1.md
+++ b/docs/source/markdown/podman-ps.1.md
@@ -55,7 +55,8 @@ Valid placeholders for the Go template are listed below:
 | **Placeholder** | **Description**                                  |
 | --------------- | ------------------------------------------------ |
 | .ID             | Container ID                                     |
-| .Image          | Image ID/Name                                    |
+| .Image          | Image Name/ID                                    |
+| .ImageID        | Image ID                                         |
 | .Command        | Quoted command used                              |
 | .CreatedAt      | Creation time for container                      |
 | .RunningFor     | Time elapsed since container was started         |

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -170,10 +170,11 @@ var _ = Describe("Podman ps", func() {
 		_, ec, _ := podmanTest.RunLsContainer("test1")
 		Expect(ec).To(Equal(0))
 
-		result := podmanTest.Podman([]string{"ps", "-a", "--format", "table {{.ID}} {{.Image}} {{.Labels}}"})
+		result := podmanTest.Podman([]string{"ps", "-a", "--format", "table {{.ID}} {{.Image}} {{.ImageID}} {{.Labels}}"})
 		result.WaitWithDefaultTimeout()
 		Expect(strings.Contains(result.OutputToStringArray()[0], "table")).To(BeFalse())
 		Expect(strings.Contains(result.OutputToStringArray()[0], "ID")).To(BeTrue())
+		Expect(strings.Contains(result.OutputToStringArray()[0], "ImageID")).To(BeTrue())
 		Expect(strings.Contains(result.OutputToStringArray()[1], "alpine:latest")).To(BeTrue())
 		Expect(result.ExitCode()).To(Equal(0))
 	})


### PR DESCRIPTION
Support printing image IDs via `--format "{{.ImageID}}"`.

Fixes: #5160
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>