### PR TITLE
fix mandatory parameter in login/logout

### DIFF
--- a/docs/source/markdown/podman-login.1.md
+++ b/docs/source/markdown/podman-login.1.md
@@ -4,11 +4,12 @@
 podman\-login - Login to a container registry
 
 ## SYNOPSIS
-**podman login** [*options*] *registry*
+**podman login** [*options*] [*registry*]
 
 ## DESCRIPTION
 **podman login** logs into a specified registry server with the correct username
-and password. **podman login** reads in the username and password from STDIN.
+and password. If the registry is not specified, the first registry under [registries.search]
+from registries.conf will be used. **podman login** reads in the username and password from STDIN.
 The username and password can also be set using the **username** and **password** flags.
 The path of the authentication file can be specified by the user by setting the **authfile**
 flag. The default path used is **${XDG\_RUNTIME\_DIR}/containers/auth.json**.
@@ -17,7 +18,7 @@ flag. The default path used is **${XDG\_RUNTIME\_DIR}/containers/auth.json**.
 
 **podman login [GLOBAL OPTIONS]**
 
-**podman login [OPTIONS] REGISTRY [GLOBAL OPTIONS]**
+**podman login [OPTIONS] [REGISTRY] [GLOBAL OPTIONS]**
 
 ## OPTIONS
 

--- a/docs/source/markdown/podman-logout.1.md
+++ b/docs/source/markdown/podman-logout.1.md
@@ -8,7 +8,8 @@ podman\-logout - Logout of a container registry
 
 ## DESCRIPTION
 **podman logout** logs out of a specified registry server by deleting the cached credentials
-stored in the **auth.json** file. The path of the authentication file can be overridden by the user by setting the **authfile** flag.
+stored in the **auth.json** file. If the registry is not specified, the first registry under [registries.search]
+from registries.conf will be used. The path of the authentication file can be overridden by the user by setting the **authfile** flag.
 The default path used is **${XDG\_RUNTIME\_DIR}/containers/auth.json**.
 All the cached credentials can be removed by setting the **all** flag.
 


### PR DESCRIPTION
fix #5146
Insted of using a registry as mandatory parameter, this path allows podman to use the first registry from registries.conf.

Signed-off-by: Qi Wang <qiwan@redhat.com>