### PR TITLE
rootless: check if the conmon process is valid

### DIFF
--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -452,6 +452,7 @@ func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []st
 
 	var lastErr error
 	var pausePid int
+	foundProcess := false
 
 	for _, path := range paths {
 		if !needNewNamespace {
@@ -502,11 +503,15 @@ func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []st
 			}
 
 			pausePid, err = strconv.Atoi(string(b[:n]))
-			if err == nil {
+			if err == nil && unix.Kill(pausePid, 0) == nil {
+				foundProcess = true
 				lastErr = nil
 				break
 			}
 		}
+	}
+	if !foundProcess {
+		return BecomeRootInUserNS(pausePidPath)
 	}
 	if lastErr != nil {
 		return false, 0, lastErr


### PR DESCRIPTION
if the pause process doesn't exist and  we try to join a conmon
namespace, make sure the process still exists.  Otherwise re-create
the user namespace.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>