### PR TITLE
Support host networking with podma play kube

### DIFF
--- a/pkg/adapter/pods.go
+++ b/pkg/adapter/pods.go
@@ -538,6 +538,9 @@ func (r *LocalRuntime) PlayKubeYAML(ctx context.Context, c *cliconfig.KubePlayVa
 	if hasUserns {
 		namespaces["user"] = fmt.Sprintf("container:%s", podInfraID)
 	}
+	if podYAML.Spec.HostNetwork {
+		namespaces["net"] = "host"
+	}
 	if !c.Quiet {
 		writer = os.Stderr
 	}


### PR DESCRIPTION
If the hostNetwork boolean is set in the kubernetes yaml file,
set the networking to host.


Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>