### PR TITLE
Add cmd flag to show container name in log

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -260,7 +260,7 @@ type LogsValues struct {
 	Tail       int64
 	Timestamps bool
 	Latest     bool
-	UseNames   bool
+	UseName    bool
 }
 
 type MountValues struct {

--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -260,6 +260,7 @@ type LogsValues struct {
 	Tail       int64
 	Timestamps bool
 	Latest     bool
+	UseNames   bool
 }
 
 type MountValues struct {

--- a/cmd/podman/logs.go
+++ b/cmd/podman/logs.go
@@ -37,6 +37,7 @@ var (
 			return nil
 		},
 		Example: `podman logs ctrID
+  podman logs --names ctrID1 ctrID2
   podman logs --tail 2 mywebserver
   podman logs --follow=true --since 10m ctrID
   podman logs mywebserver mydbserver`,
@@ -54,6 +55,7 @@ func init() {
 	flags.StringVar(&logsCommand.Since, "since", "", "Show logs since TIMESTAMP")
 	flags.Int64Var(&logsCommand.Tail, "tail", -1, "Output the specified number of LINES at the end of the logs.  Defaults to -1, which prints all lines")
 	flags.BoolVarP(&logsCommand.Timestamps, "timestamps", "t", false, "Output the timestamps in the log")
+	flags.BoolVarP(&logsCommand.UseNames, "names", "n", false, "Output the container name in the log")
 	markFlagHidden(flags, "details")
 	flags.SetInterspersed(false)
 
@@ -85,6 +87,7 @@ func logsCmd(c *cliconfig.LogsValues) error {
 		Since:      sinceTime,
 		Tail:       c.Tail,
 		Timestamps: c.Timestamps,
+		UseNames:   c.UseNames,
 	}
 	return runtime.Log(c, options)
 }

--- a/cmd/podman/logs.go
+++ b/cmd/podman/logs.go
@@ -55,7 +55,7 @@ func init() {
 	flags.StringVar(&logsCommand.Since, "since", "", "Show logs since TIMESTAMP")
 	flags.Int64Var(&logsCommand.Tail, "tail", -1, "Output the specified number of LINES at the end of the logs.  Defaults to -1, which prints all lines")
 	flags.BoolVarP(&logsCommand.Timestamps, "timestamps", "t", false, "Output the timestamps in the log")
-	flags.BoolVarP(&logsCommand.UseNames, "names", "n", false, "Output the container name in the log")
+	flags.BoolVarP(&logsCommand.UseName, "names", "n", false, "Output the container name in the log")
 	markFlagHidden(flags, "details")
 	flags.SetInterspersed(false)
 
@@ -87,7 +87,7 @@ func logsCmd(c *cliconfig.LogsValues) error {
 		Since:      sinceTime,
 		Tail:       c.Tail,
 		Timestamps: c.Timestamps,
-		UseNames:   c.UseNames,
+		UseName:    c.UseName,
 	}
 	return runtime.Log(c, options)
 }

--- a/libpod/container.log.go
+++ b/libpod/container.log.go
@@ -41,6 +41,7 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 	if len(tailLog) > 0 {
 		for _, nll := range tailLog {
 			nll.CID = c.ID()
+			nll.CName = c.Name()
 			if nll.Since(options.Since) {
 				logChannel <- nll
 			}
@@ -63,6 +64,7 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 				partial = ""
 			}
 			nll.CID = c.ID()
+			nll.CName = c.Name()
 			if nll.Since(options.Since) {
 				logChannel <- nll
 			}

--- a/libpod/logs/log.go
+++ b/libpod/logs/log.go
@@ -35,6 +35,7 @@ type LogOptions struct {
 	Timestamps bool
 	Multi      bool
 	WaitGroup  *sync.WaitGroup
+	UseNames   bool
 }
 
 // LogLine describes the information for each line of a log
@@ -44,6 +45,7 @@ type LogLine struct {
 	Time         time.Time
 	Msg          string
 	CID          string
+	CName        string
 }
 
 // GetLogFile returns an hp tail for a container given options
@@ -120,11 +122,16 @@ func getTailLog(path string, tail int) ([]*LogLine, error) {
 func (l *LogLine) String(options *LogOptions) string {
 	var out string
 	if options.Multi {
-		cid := l.CID
-		if len(cid) > 12 {
-			cid = cid[:12]
+		if options.UseNames {
+			cname := l.CName
+			out = fmt.Sprintf("%s ", cname)
+		} else {
+			cid := l.CID
+			if len(cid) > 12 {
+				cid = cid[:12]
+			}
+			out = fmt.Sprintf("%s ", cid)
 		}
-		out = fmt.Sprintf("%s ", cid)
 	}
 	if options.Timestamps {
 		out += fmt.Sprintf("%s ", l.Time.Format(LogTimeFormat))

--- a/libpod/logs/log.go
+++ b/libpod/logs/log.go
@@ -35,7 +35,7 @@ type LogOptions struct {
 	Timestamps bool
 	Multi      bool
 	WaitGroup  *sync.WaitGroup
-	UseNames   bool
+	UseName    bool
 }
 
 // LogLine describes the information for each line of a log
@@ -122,7 +122,7 @@ func getTailLog(path string, tail int) ([]*LogLine, error) {
 func (l *LogLine) String(options *LogOptions) string {
 	var out string
 	if options.Multi {
-		if options.UseNames {
+		if options.UseName {
 			cname := l.CName
 			out = fmt.Sprintf("%s ", cname)
 		} else {


### PR DESCRIPTION
This flag allows user to show container name in podman log command

Fixes: #4962

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>