### PR TITLE
Add test to validate the pod bindings api

### DIFF
--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -121,7 +121,7 @@ func Pods(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, found := r.URL.Query()["filters"]; found {
+	if len(query.Filters) > 0 {
 		utils.Error(w, "filters are not implemented yet", http.StatusInternalServerError, define.ErrNotImplemented)
 		return
 	}

--- a/pkg/bindings/pods/pods.go
+++ b/pkg/bindings/pods/pods.go
@@ -87,9 +87,9 @@ func Prune(ctx context.Context) error {
 
 // List returns all pods in local storage.  The optional filters parameter can
 // be used to refine which pods should be listed.
-func List(ctx context.Context, filters map[string][]string) (*[]libpod.PodInspect, error) {
+func List(ctx context.Context, filters map[string][]string) ([]*libpod.PodInspect, error) {
 	var (
-		inspect []libpod.PodInspect
+		inspect []*libpod.PodInspect
 	)
 	conn, err := bindings.GetConnectionFromContext(ctx)
 	if err != nil {
@@ -103,11 +103,11 @@ func List(ctx context.Context, filters map[string][]string) (*[]libpod.PodInspec
 		}
 		params["filters"] = stringFilter
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/pods/json", params)
+	response, err := conn.DoRequest(nil, http.MethodGet, "/pods/json", params)
 	if err != nil {
-		return &inspect, err
+		return inspect, err
 	}
-	return &inspect, response.Process(&inspect)
+	return inspect, response.Process(&inspect)
 }
 
 // Restart restarts all containers in a pod.
@@ -147,7 +147,7 @@ func Start(ctx context.Context, nameOrID string) error {
 	if err != nil {
 		return err
 	}
-	response, err := conn.DoRequest(nil, http.MethodDelete, "/pods/%s/start", nil, nameOrID)
+	response, err := conn.DoRequest(nil, http.MethodPost, "/pods/%s/start", nil, nameOrID)
 	if err != nil {
 		return err
 	}

--- a/pkg/bindings/test/common_test.go
+++ b/pkg/bindings/test/common_test.go
@@ -162,16 +162,30 @@ func (b *bindingTest) restoreImageFromCache(i testImage) {
 	p.Wait(45)
 }
 
-// Run a container and add append the alpine image to it
-func (b *bindingTest) RunTopContainer(name *string) {
+// Run a container within or without a pod
+// and add or append the alpine image to it
+func (b *bindingTest) RunTopContainer(containerName *string, insidePod *bool, podName *string) {
 	cmd := []string{"run", "-dt"}
-	if name != nil {
-		containerName := *name
-		cmd = append(cmd, "--name", containerName)
+	if *insidePod && podName != nil {
+		pName := *podName
+		cmd = append(cmd, "--pod", pName)
+	} else if containerName != nil {
+		cName := *containerName
+		cmd = append(cmd, "--name", cName)
 	}
 	cmd = append(cmd, alpine.name, "top")
-	p := b.runPodman(cmd)
-	p.Wait(45)
+	b.runPodman(cmd).Wait(45)
+}
+
+// This method creates a pod with the given pod name.
+// Podname is an optional parameter
+func (b *bindingTest) Podcreate(name *string) {
+	if name != nil {
+		podname := *name
+		b.runPodman([]string{"pod", "create", "--name", podname}).Wait(45)
+	} else {
+		b.runPodman([]string{"pod", "create"}).Wait(45)
+	}
 }
 
 //  StringInSlice returns a boolean based on whether a given

--- a/pkg/bindings/test/images_test.go
+++ b/pkg/bindings/test/images_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Podman images", func() {
 
 		// Start a container with alpine image
 		var top string = "top"
-		bt.RunTopContainer(&top)
+		bt.RunTopContainer(&top, &falseFlag, nil)
 		// we should now have a container called "top" running
 		containerResponse, err := containers.Inspect(connText, "top", &falseFlag)
 		Expect(err).To(BeNil())

--- a/pkg/bindings/test/pods_test.go
+++ b/pkg/bindings/test/pods_test.go
@@ -1,0 +1,202 @@
+package test_bindings
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/containers/libpod/libpod/define"
+	"github.com/containers/libpod/pkg/bindings"
+	"github.com/containers/libpod/pkg/bindings/pods"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Podman images", func() {
+	var (
+		bt       *bindingTest
+		s        *gexec.Session
+		connText context.Context
+		newpod   string
+		err      error
+		trueFlag bool = true
+	)
+
+	BeforeEach(func() {
+		bt = newBindingTest()
+		newpod = "newpod"
+		bt.RestoreImagesFromCache()
+		bt.Podcreate(&newpod)
+		s = bt.startAPIService()
+		time.Sleep(1 * time.Second)
+		connText, err = bindings.NewConnection(bt.sock)
+		Expect(err).To(BeNil())
+	})
+
+	AfterEach(func() {
+		s.Kill()
+		bt.cleanup()
+	})
+
+	It("inspect pod", func() {
+		//Inspect an invalid pod name
+		_, err := pods.Inspect(connText, "dummyname")
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusNotFound))
+
+		//Inspect an valid pod name
+		response, err := pods.Inspect(connText, newpod)
+		Expect(err).To(BeNil())
+		Expect(response.Config.Name).To(Equal(newpod))
+	})
+
+	// Test validates the list all api returns
+	It("list pod", func() {
+		//List all the pods in the current instance
+		podSummary, err := pods.List(connText, nil)
+		Expect(err).To(BeNil())
+		Expect(len(podSummary)).To(Equal(1))
+		// Adding an alpine container to the existing pod
+		bt.RunTopContainer(nil, &trueFlag, &newpod)
+		podSummary, err = pods.List(connText, nil)
+		// Verify no errors.
+		Expect(err).To(BeNil())
+		// Verify number of containers in the pod.
+		Expect(len(podSummary[0].Containers)).To(Equal(2))
+
+		// Add multiple pods and verify them by name and size.
+		var newpod2 string = "newpod2"
+		bt.Podcreate(&newpod2)
+		podSummary, err = pods.List(connText, nil)
+		Expect(len(podSummary)).To(Equal(2))
+		var names []string
+		for _, i := range podSummary {
+			names = append(names, i.Config.Name)
+		}
+		Expect(StringInSlice(newpod, names)).To(BeTrue())
+		Expect(StringInSlice("newpod2", names)).To(BeTrue())
+
+		// Not working  Because: code to list based on filter
+		// "not yet implemented",
+		// Validate list pod with filters
+		filters := make(map[string][]string)
+		filters["name"] = []string{newpod}
+		filteredPods, err := pods.List(connText, filters)
+		Expect(err).To(BeNil())
+		Expect(len(filteredPods)).To(BeNumerically("==", 1))
+	})
+
+	// The test validates if the exists responds
+	It("exists pod", func() {
+		response, err := pods.Exists(connText, "dummyName")
+		Expect(err).To(BeNil())
+		Expect(response).To(BeFalse())
+
+		// Should exit with no error and response should be true
+		response, err = pods.Exists(connText, "newpod")
+		Expect(err).To(BeNil())
+		Expect(response).To(BeTrue())
+	})
+
+	// This test validates if All running containers within
+	// each specified pod are paused and unpaused
+	It("pause upause pod", func() {
+		// Pause invalid container
+		err := pods.Pause(connText, "dummyName")
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusNotFound))
+
+		// Adding an alpine container to the existing pod
+		bt.RunTopContainer(nil, &trueFlag, &newpod)
+		response, err := pods.Inspect(connText, newpod)
+		Expect(err).To(BeNil())
+
+		// Binding needs to be modified to inspect the pod state.
+		// Since we dont have a pod state we inspect the states of the containers within the pod.
+		// Pause a valid container
+		err = pods.Pause(connText, newpod)
+		Expect(err).To(BeNil())
+		response, err = pods.Inspect(connText, newpod)
+		for _, i := range response.Containers {
+			Expect(define.StringToContainerStatus(i.State)).
+				To(Equal(define.ContainerStatePaused))
+		}
+
+		// Unpause a valid container
+		err = pods.Unpause(connText, newpod)
+		Expect(err).To(BeNil())
+		response, err = pods.Inspect(connText, newpod)
+		for _, i := range response.Containers {
+			Expect(define.StringToContainerStatus(i.State)).
+				To(Equal(define.ContainerStateRunning))
+		}
+	})
+
+	It("start stop restart pod", func() {
+		// Start an invalid pod
+		err = pods.Start(connText, "dummyName")
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusNotFound))
+
+		// Stop an invalid pod
+		err = pods.Stop(connText, "dummyName", nil)
+		Expect(err).ToNot(BeNil())
+		code, _ = bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusNotFound))
+
+		// Restart an invalid pod
+		err = pods.Restart(connText, "dummyName")
+		Expect(err).ToNot(BeNil())
+		code, _ = bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusNotFound))
+
+		// Start a valid pod and inspect status of each container
+		err = pods.Start(connText, newpod)
+		Expect(err).To(BeNil())
+
+		response, err := pods.Inspect(connText, newpod)
+		for _, i := range response.Containers {
+			Expect(define.StringToContainerStatus(i.State)).
+				To(Equal(define.ContainerStateRunning))
+		}
+
+		// Start a already running container
+		// (Test fails for now needs to be fixed)
+		err = pods.Start(connText, newpod)
+		Expect(err).ToNot(BeNil())
+		code, _ = bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusNotModified))
+
+		// Stop the running pods
+		err = pods.Stop(connText, newpod, nil)
+		Expect(err).To(BeNil())
+		response, _ = pods.Inspect(connText, newpod)
+		for _, i := range response.Containers {
+			Expect(define.StringToContainerStatus(i.State)).
+				To(Equal(define.ContainerStateStopped))
+		}
+
+		// Stop a already running pod
+		// (Test fails for now needs to be fixed)
+		err = pods.Stop(connText, newpod, nil)
+		Expect(err).ToNot(BeNil())
+		code, _ = bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusNotModified))
+
+		err = pods.Restart(connText, newpod)
+		Expect(err).To(BeNil())
+		response, _ = pods.Inspect(connText, newpod)
+		for _, i := range response.Containers {
+			Expect(define.StringToContainerStatus(i.State)).
+				To(Equal(define.ContainerStateRunning))
+		}
+	})
+
+	// Remove all stopped pods and their container to be implemented.
+	It("prune pod", func() {
+	})
+})


### PR DESCRIPTION
Include test to validate pod create, start, stop, restart,
pause, unpause, list, and inspect api bindings.
Also includes bug fixes that resulted in invalid api responses.

Signed-off-by: Sujil02 <sushah@redhat.com>