### PR TITLE
APIv2: Fixed CreateImageFromImage not respecting supplied Tag parameter

### DIFF
--- a/pkg/api/handlers/generic/images.go
+++ b/pkg/api/handlers/generic/images.go
@@ -255,7 +255,7 @@ func CreateImageFromImage(w http.ResponseWriter, r *http.Request) {
 	   tag – Tag or digest. If empty when pulling an image, this causes all tags for the given image to be pulled.
 	*/
 	fromImage := query.FromImage
-	if len(query.Tag) < 1 {
+	if len(query.Tag) >= 1 {
 		fromImage = fmt.Sprintf("%s:%s", fromImage, query.Tag)
 	}
 


### PR DESCRIPTION
tag would only append if the length was below 1, this change requires at least the length of 1