### PR TITLE
Fixed typo in KillContainer

### DIFF
--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -15,7 +15,7 @@ import (
 
 func KillContainer(w http.ResponseWriter, r *http.Request) (*libpod.Container, error) {
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
-	decoder := r.Context().Value("decorder").(*schema.Decoder)
+	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
 		Signal syscall.Signal `schema:"signal"`
 	}{


### PR DESCRIPTION
fixes panic

```
WARN[0060] Recovering from podman handler panic: interface conversion: interface {} is nil, not *schema.Decoder, goroutine 198 [running]:
github.com/containers/libpod/pkg/api/server.(*APIServer).APIHandler.func1.1(0x1e99420, 0xc0007bb420)
	pkg/api/server/handler_api.go:21 +0xb5
panic(0x1904020, 0xc0005a0bd0)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/containers/libpod/pkg/api/handlers/utils.KillContainer(0x1e99420, 0xc0007bb420, 0xc000772500, 0xc0002a0e00, 0x7f68a024f6d0, 0x0)
	pkg/api/handlers/utils/containers.go:18 +0x862
github.com/containers/libpod/pkg/api/handlers/generic.KillContainer(0x1e99420, 0xc0007bb420, 0xc000772500)
	pkg/api/handlers/generic/containers.go:118 +0x5a
github.com/containers/libpod/pkg/api/server.(*APIServer).APIHandler.func1.2(0x1e99420, 0xc0007bb420, 0xc000772400)
	pkg/api/server/handler_api.go:47 +0x4a9
github.com/containers/libpod/pkg/api/server.(*APIServer).APIHandler.func1(0x1e99420, 0xc0007bb420, 0xc000772400)
	pkg/api/server/handler_api.go:49 +0xbd
net/http.HandlerFunc.ServeHTTP(0xc000349440, 0x1e99420, 0xc0007bb420, 0xc000772400)
	/usr/local/go/src/net/http/server.go:1995 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00018c0c0, 0x1e99420, 0xc0007bb420, 0xc000a78900)
	vendor/github.com/gorilla/mux/mux.go:210 +0xe3
net/http.serverHandler.ServeHTTP(0xc00046a000, 0x1e99420, 0xc0007bb420, 0xc000a78900)
	/usr/local/go/src/net/http/server.go:2774 +0xa8
net/http.(*conn).serve(0xc000449360, 0x1ea25a0, 0xc0004556c0)
	/usr/local/go/src/net/http/server.go:1878 +0x851
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2884 +0x2f4
....
```
