### PR TITLE
Swagger: fix one incorrect comment

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -822,7 +822,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//      $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/search"), s.APIHandler(handlers.SearchImages)).Methods(http.MethodGet)
-	// swagger:operation DELETE /libpod/images/{name} libpod libpodRemoveImage
+	// swagger:operation DELETE /libpod/images/{name:.*} libpod libpodRemoveImage
 	// ---
 	// tags:
 	//  - images
@@ -830,7 +830,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// description: Delete an image from local store
 	// parameters:
 	//  - in: path
-	//    name: name
+	//    name: name:.*
 	//    type: string
 	//    required: true
 	//    description: name or ID of image to delete


### PR DESCRIPTION
PR #5235 updated a bunch of entrypoints from {name} to {name:.*},
requiring matching changes to swagger comments. Looks like one
got missed due to the manual nature of this work.

Have I mentioned lately that manual maintenance of duplicate
information is not a great idea?

Discrepancy caught by my script, which I would really like to
look into getting into CI, but is gating on #5238. (I would
actually not like to get this script into CI, I would prefer
to have the duplicate information be autogenerated from
the function calls themselves, but I seem to have lost
that battle)

Signed-off-by: Ed Santiago <santiago@redhat.com>