### PR TITLE
Warn user about --password cli option in login

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -82,6 +82,10 @@ func loginCmd(c *cliconfig.LoginValues) error {
 		server = registryFromFullName(scrubServer(args[0]))
 	}
 
+	if c.Flag("password").Changed {
+		fmt.Fprintf(os.Stderr, "WARNING! Using --password via the cli is insecure. Please consider using --password-stdin\n")
+	}
+
 	sc := image.GetSystemContext("", c.Authfile, false)
 	if c.Flag("tls-verify").Changed {
 		sc.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!c.TlsVerify)


### PR DESCRIPTION
Using command line parameter --password may reveal registry password. Better to warn user about this.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>