### PR TITLE
podman images: add --filter=since=XX

### DIFF
--- a/docs/source/markdown/podman-images.1.md
+++ b/docs/source/markdown/podman-images.1.md
@@ -29,11 +29,11 @@ Filter output based on conditions provided
 
   Filters:
 
-  **after==TIMESTRING**
-    Filter on images created after the given time.Time.
+  **since=IMAGE**
+    Filter on images created after the given IMAGE (name or tag).
 
-  **before==TIMESTRING**
-    Filter on images created before the given time.Time.
+  **before=IMAGE**
+    Filter on images created before the given IMAGE (name or tag).
 
   **dangling=true|false**
     Show dangling images. Dangling images are a file system layer that was used in a previous build of an image and is no longer referenced by any active images. They are denoted with the <none> tag, consume disk space and serve no active purpose.

--- a/libpod/image/filters.go
+++ b/libpod/image/filters.go
@@ -141,7 +141,7 @@ func (ir *Runtime) createFilterFuncs(filters []string, img *Image) ([]ResultFilt
 				return nil, errors.Wrapf(err, "unable to find image %s in local stores", splitFilter[1])
 			}
 			filterFuncs = append(filterFuncs, CreatedBeforeFilter(before.Created()))
-		case "after":
+		case "since", "after":
 			after, err := ir.NewFromLocal(splitFilter[1])
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to find image %s in local stores", splitFilter[1])


### PR DESCRIPTION
Looks like a bit of a misunderstanding from early on.

Docker implements --filter=since=IMAGE. Podman implements 'after'
instead of 'since'. Add an equivalent case statement to handle
both, keeping 'after' because we have no way of knowing if it
is used in the field.

Update documentation ... and fix what looks like a complete
misinterpretation of what the code actually does: the man page
claimed that these were time fields, but I don't see any
possible incantation in which a time value works or could
work. Updated docs to reflect IMAGE usage. Also changed
nonworking '==' to single '='.

Added tests.

Fixes: #5040

Signed-off-by: Ed Santiago <santiago@redhat.com>