### PR TITLE
Beautify podman bridge CNI config

### DIFF
--- a/cni/87-podman-bridge.conflist
+++ b/cni/87-podman-bridge.conflist
@@ -1,41 +1,37 @@
 {
-    "cniVersion": "0.4.0",
-    "name": "podman",
-    "plugins": [
-	{
-            "type": "bridge",
-            "bridge": "cni-podman0",
-            "isGateway": true,
-            "ipMasq": true,
-            "ipam": {
-		"type": "host-local",
-		"routes": [
-		    {
-			"dst": "0.0.0.0/0"
-		    }
-		],
-		"ranges": [
-		    [
-			{
-			    "subnet": "10.88.0.0/16",
-			    "gateway": "10.88.0.1"
-			}
-		    ]
-		]
+  "cniVersion": "0.4.0",
+  "name": "podman",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni-podman0",
+      "isGateway": true,
+      "ipMasq": true,
+      "ipam": {
+        "type": "host-local",
+        "routes": [{ "dst": "0.0.0.0/0" }],
+        "ranges": [
+          [
+            {
+              "subnet": "10.88.0.0/16",
+              "gateway": "10.88.0.1"
             }
-	},
-	{
-            "type": "portmap",
-            "capabilities": {
-		"portMappings": true
-            }
-	},
-	{
-            "type": "firewall",
-	    "backend": "iptables"
-	},
-	{
-            "type": "tuning"
-	}
-    ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {
+        "portMappings": true
+      }
+    },
+    {
+      "type": "firewall",
+      "backend": "iptables"
+    },
+    {
+      "type": "tuning"
+    }
+  ]
 }


### PR DESCRIPTION
Bear with me, but we vendor that file directly into the distribution and I want to provide a well-formatted JSON. :see_no_evil: 

Applying prettier to the CNI config to fix mixed indents and improve formatting.

