### PR TITLE
search endpoint failure correction

### DIFF
--- a/pkg/api/handlers/images.go
+++ b/pkg/api/handlers/images.go
@@ -156,6 +156,7 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 	results, err := image.SearchImages(query.Term, options)
 	if err != nil {
 		utils.BadRequest(w, "term", query.Term, err)
+		return
 	}
 	utils.WriteResponse(w, http.StatusOK, results)
 }


### PR DESCRIPTION
when returning an invalid search, a return was omitted triggering a null on the consumer end.

Fixes: #5228

Signed-off-by: Brent Baude <bbaude@redhat.com>