### PR TITLE
Login test: use --password-stdin

### DIFF
--- a/test/system/150-login.bats
+++ b/test/system/150-login.bats
@@ -108,8 +108,8 @@ function setup() {
 @test "podman login - basic test" {
     run_podman login --tls-verify=false \
                --username ${PODMAN_LOGIN_USER} \
-               --password ${PODMAN_LOGIN_PASS} \
-               localhost:${PODMAN_LOGIN_REGISTRY_PORT}
+               --password-stdin \
+               localhost:${PODMAN_LOGIN_REGISTRY_PORT} <<<"${PODMAN_LOGIN_PASS}"
     is "$output" "Login Succeeded!" "output from podman login"
 
     # Now log out
@@ -123,8 +123,8 @@ function setup() {
 
     run_podman 125 login --tls-verify=false \
                --username ${PODMAN_LOGIN_USER} \
-               --password "x${PODMAN_LOGIN_PASS}" \
-               $registry
+               --password-stdin \
+               $registry <<< "x${PODMAN_LOGIN_PASS}"
     is "$output" \
        "Error: error logging into \"$registry\": invalid username/password" \
        'output from podman login'


### PR DESCRIPTION
Great timing: this new test collided against #5268, which added
a warning about using command-line --password. CI is now going
to fail all over.

Fix: rework test to use --password-stdin. Am doing so only
in the places where output string is checked; other instances
can keep using '--password xxx' because it's simpler.

Signed-off-by: Ed Santiago <santiago@redhat.com>