### PR TITLE
search test on fedora registry: retry 5 times

### DIFF
--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"text/template"
+	"time"
 
 	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
@@ -165,8 +166,16 @@ registries = ['{{.Host}}:{{.Port}}']`
 	})
 
 	It("podman search v2 registry with empty query", func() {
-		search := podmanTest.Podman([]string{"search", "registry.fedoraproject.org/"})
-		search.WaitWithDefaultTimeout()
+		var search *PodmanSessionIntegration
+		for i := 0; i < 5; i++ {
+			search = podmanTest.Podman([]string{"search", "registry.fedoraproject.org/"})
+			search.WaitWithDefaultTimeout()
+			if search.ExitCode() == 0 {
+				break
+			}
+			fmt.Println("Search failed; sleeping & retrying...")
+			time.Sleep(2 * time.Second)
+		}
 		Expect(search.ExitCode()).To(Equal(0))
 		Expect(len(search.OutputToStringArray())).To(BeNumerically(">=", 1))
 	})


### PR DESCRIPTION
...to try to compensate for flaky host.

registry.fedoraproject.org is just not reliable. It's flaking
with 503 errors, causing massive amounts of wasted CI time
and developer effort.

There is exactly one instance of that registry in these tests.
We can't replace it with quay.io, because "search quay.io/"
(trailing slash) fails with some sort of authentication error.
So let's just try a sleep/retry cycle instead.

Signed-off-by: Ed Santiago <santiago@redhat.com>