### PR TITLE
add more image tests for go bindings

### DIFF
--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -206,7 +206,7 @@ func unixClient(_url *url.URL) (*http.Client, error) {
 }
 
 // DoRequest assembles the http request and returns the response
-func (c *Connection) DoRequest(httpBody io.Reader, httpMethod, endpoint string, queryParams map[string]string, pathValues ...string) (*APIResponse, error) {
+func (c *Connection) DoRequest(httpBody io.Reader, httpMethod, endpoint string, queryParams url.Values, pathValues ...string) (*APIResponse, error) {
 	var (
 		err      error
 		response *http.Response
@@ -225,12 +225,7 @@ func (c *Connection) DoRequest(httpBody io.Reader, httpMethod, endpoint string, 
 		return nil, err
 	}
 	if len(queryParams) > 0 {
-		// if more desirable we could use url to form the encoded endpoint with params
-		r := req.URL.Query()
-		for k, v := range queryParams {
-			r.Add(k, v)
-		}
-		req.URL.RawQuery = r.Encode()
+		req.URL.RawQuery = queryParams.Encode()
 	}
 	// Give the Do three chances in the case of a comm/service hiccup
 	for i := 0; i < 3; i++ {

--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -3,6 +3,7 @@ package containers
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/containers/libpod/libpod"
@@ -21,28 +22,28 @@ func List(ctx context.Context, filters map[string][]string, all *bool, last *int
 		return nil, err
 	}
 	var containers []lpapiv2.ListContainer
-	params := make(map[string]string)
+	params := url.Values{}
 	if all != nil {
-		params["all"] = strconv.FormatBool(*all)
+		params.Set("all", strconv.FormatBool(*all))
 	}
 	if last != nil {
-		params["last"] = strconv.Itoa(*last)
+		params.Set("last", strconv.Itoa(*last))
 	}
 	if pod != nil {
-		params["pod"] = strconv.FormatBool(*pod)
+		params.Set("pod", strconv.FormatBool(*pod))
 	}
 	if size != nil {
-		params["size"] = strconv.FormatBool(*size)
+		params.Set("size", strconv.FormatBool(*size))
 	}
 	if sync != nil {
-		params["sync"] = strconv.FormatBool(*sync)
+		params.Set("sync", strconv.FormatBool(*sync))
 	}
 	if filters != nil {
 		filterString, err := bindings.FiltersToString(filters)
 		if err != nil {
 			return nil, err
 		}
-		params["filters"] = filterString
+		params.Set("filters", filterString)
 	}
 	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/json", params)
 	if err != nil {
@@ -63,13 +64,13 @@ func Prune(ctx context.Context, filters map[string][]string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	params := make(map[string]string)
+	params := url.Values{}
 	if filters != nil {
 		filterString, err := bindings.FiltersToString(filters)
 		if err != nil {
 			return nil, err
 		}
-		params["filters"] = filterString
+		params.Set("filters", filterString)
 	}
 	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/prune", params)
 	if err != nil {
@@ -86,12 +87,12 @@ func Remove(ctx context.Context, nameOrID string, force, volumes *bool) error {
 	if err != nil {
 		return err
 	}
-	params := make(map[string]string)
+	params := url.Values{}
 	if force != nil {
-		params["force"] = strconv.FormatBool(*force)
+		params.Set("force", strconv.FormatBool(*force))
 	}
 	if volumes != nil {
-		params["vols"] = strconv.FormatBool(*volumes)
+		params.Set("vols", strconv.FormatBool(*volumes))
 	}
 	response, err := conn.DoRequest(nil, http.MethodDelete, "/containers/%s", params, nameOrID)
 	if err != nil {
@@ -109,9 +110,9 @@ func Inspect(ctx context.Context, nameOrID string, size *bool) (*libpod.InspectC
 	if err != nil {
 		return nil, err
 	}
-	params := make(map[string]string)
+	params := url.Values{}
 	if size != nil {
-		params["size"] = strconv.FormatBool(*size)
+		params.Set("size", strconv.FormatBool(*size))
 	}
 	response, err := conn.DoRequest(nil, http.MethodGet, "/containers/%s/json", params, nameOrID)
 	if err != nil {
@@ -129,8 +130,8 @@ func Kill(ctx context.Context, nameOrID string, signal string) error {
 	if err != nil {
 		return err
 	}
-	params := make(map[string]string)
-	params["signal"] = signal
+	params := url.Values{}
+	params.Set("signal", signal)
 	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/kill", params, nameOrID)
 	if err != nil {
 		return err
@@ -162,9 +163,9 @@ func Restart(ctx context.Context, nameOrID string, timeout *int) error {
 	if err != nil {
 		return err
 	}
-	params := make(map[string]string)
+	params := url.Values{}
 	if timeout != nil {
-		params["t"] = strconv.Itoa(*timeout)
+		params.Set("t", strconv.Itoa(*timeout))
 	}
 	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/restart", params, nameOrID)
 	if err != nil {
@@ -181,9 +182,9 @@ func Start(ctx context.Context, nameOrID string, detachKeys *string) error {
 	if err != nil {
 		return err
 	}
-	params := make(map[string]string)
+	params := url.Values{}
 	if detachKeys != nil {
-		params["detachKeys"] = *detachKeys
+		params.Set("detachKeys", *detachKeys)
 	}
 	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/start", params, nameOrID)
 	if err != nil {
@@ -242,13 +243,13 @@ func Exists(ctx context.Context, nameOrID string) (bool, error) {
 // Stop stops a running container.  The timeout is optional. The nameOrID can be a container name
 // or a partial/full ID
 func Stop(ctx context.Context, nameOrID string, timeout *int) error {
-	params := make(map[string]string)
+	params := url.Values{}
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return err
 	}
 	if timeout != nil {
-		params["t"] = strconv.Itoa(*timeout)
+		params.Set("t", strconv.Itoa(*timeout))
 	}
 	response, err := conn.DoRequest(nil, http.MethodPost, "/containers/%s/stop", params, nameOrID)
 	if err != nil {

--- a/pkg/bindings/images/search.go
+++ b/pkg/bindings/images/search.go
@@ -3,6 +3,7 @@ package images
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/containers/libpod/libpod/image"
@@ -20,17 +21,17 @@ func Search(ctx context.Context, term string, limit *int, filters map[string][]s
 	if err != nil {
 		return nil, err
 	}
-	params := make(map[string]string)
-	params["term"] = term
+	params := url.Values{}
+	params.Set("term", term)
 	if limit != nil {
-		params["limit"] = strconv.Itoa(*limit)
+		params.Set("limit", strconv.Itoa(*limit))
 	}
 	if filters != nil {
 		stringFilter, err := bindings.FiltersToString(filters)
 		if err != nil {
 			return nil, err
 		}
-		params["filters"] = stringFilter
+		params.Set("filters", stringFilter)
 	}
 	response, err := conn.DoRequest(nil, http.MethodGet, "/images/search", params)
 	if err != nil {

--- a/pkg/bindings/pods/pods.go
+++ b/pkg/bindings/pods/pods.go
@@ -3,6 +3,7 @@ package pods
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/containers/libpod/libpod"
@@ -48,9 +49,9 @@ func Kill(ctx context.Context, nameOrID string, signal *string) error {
 	if err != nil {
 		return err
 	}
-	params := make(map[string]string)
+	params := url.Values{}
 	if signal != nil {
-		params["signal"] = *signal
+		params.Set("signal", *signal)
 	}
 	response, err := conn.DoRequest(nil, http.MethodPost, "/pods/%s/kill", params, nameOrID)
 	if err != nil {
@@ -95,13 +96,13 @@ func List(ctx context.Context, filters map[string][]string) ([]*libpod.PodInspec
 	if err != nil {
 		return nil, err
 	}
-	params := make(map[string]string)
+	params := url.Values{}
 	if filters != nil {
 		stringFilter, err := bindings.FiltersToString(filters)
 		if err != nil {
 			return nil, err
 		}
-		params["filters"] = stringFilter
+		params.Set("filters", stringFilter)
 	}
 	response, err := conn.DoRequest(nil, http.MethodGet, "/pods/json", params)
 	if err != nil {
@@ -130,9 +131,9 @@ func Remove(ctx context.Context, nameOrID string, force *bool) error {
 	if err != nil {
 		return err
 	}
-	params := make(map[string]string)
+	params := url.Values{}
 	if force != nil {
-		params["force"] = strconv.FormatBool(*force)
+		params.Set("force", strconv.FormatBool(*force))
 	}
 	response, err := conn.DoRequest(nil, http.MethodDelete, "/pods/%s", params, nameOrID)
 	if err != nil {
@@ -166,9 +167,9 @@ func Stop(ctx context.Context, nameOrID string, timeout *int) error {
 	if err != nil {
 		return err
 	}
-	params := make(map[string]string)
+	params := url.Values{}
 	if timeout != nil {
-		params["t"] = strconv.Itoa(*timeout)
+		params.Set("t", strconv.Itoa(*timeout))
 	}
 	response, err := conn.DoRequest(nil, http.MethodPost, "/pods/%s/stop", params, nameOrID)
 	if err != nil {

--- a/pkg/bindings/test/common_test.go
+++ b/pkg/bindings/test/common_test.go
@@ -20,8 +20,17 @@ type testImage struct {
 }
 
 const (
+	devPodmanBinaryLocation     string = "../../../bin/podman"
 	defaultPodmanBinaryLocation string = "/usr/bin/podman"
 )
+
+func getPodmanBinary() string {
+	_, err := os.Stat(devPodmanBinaryLocation)
+	if os.IsNotExist(err) {
+		return defaultPodmanBinaryLocation
+	}
+	return devPodmanBinaryLocation
+}
 
 var (
 	ImageCacheDir = "/tmp/podman/imagecachedir"
@@ -50,7 +59,7 @@ type bindingTest struct {
 
 func (b *bindingTest) runPodman(command []string) *gexec.Session {
 	var cmd []string
-	podmanBinary := defaultPodmanBinaryLocation
+	podmanBinary := getPodmanBinary()
 	val, ok := os.LookupEnv("PODMAN_BINARY")
 	if ok {
 		podmanBinary = val
@@ -166,7 +175,7 @@ func (b *bindingTest) restoreImageFromCache(i testImage) {
 // and add or append the alpine image to it
 func (b *bindingTest) RunTopContainer(containerName *string, insidePod *bool, podName *string) {
 	cmd := []string{"run", "-dt"}
-	if *insidePod && podName != nil {
+	if insidePod != nil && podName != nil {
 		pName := *podName
 		cmd = append(cmd, "--pod", pName)
 	} else if containerName != nil {

--- a/pkg/bindings/volumes/volumes.go
+++ b/pkg/bindings/volumes/volumes.go
@@ -3,6 +3,7 @@ package volumes
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/containers/libpod/libpod"
@@ -73,9 +74,9 @@ func Remove(ctx context.Context, nameOrID string, force *bool) error {
 	if err != nil {
 		return err
 	}
-	params := make(map[string]string)
+	params := url.Values{}
 	if force != nil {
-		params["force"] = strconv.FormatBool(*force)
+		params.Set("force", strconv.FormatBool(*force))
 	}
 	response, err := conn.DoRequest(nil, http.MethodPost, "/volumes/%s/prune", params, nameOrID)
 	if err != nil {


### PR DESCRIPTION
adding more image tests for go bindings.  one big change is that the params were converted from map[string]string to url.values to account for the ability to send []string as query params

Signed-off-by: Brent Baude <bbaude@redhat.com>