### PR TITLE
disable generation of cni firewall plugin

### DIFF
--- a/cni/87-podman-bridge.conflist
+++ b/cni/87-podman-bridge.conflist
@@ -27,10 +27,6 @@
       }
     },
     {
-      "type": "firewall",
-      "backend": "iptables"
-    },
-    {
       "type": "tuning"
     }
   ]

--- a/pkg/adapter/network.go
+++ b/pkg/adapter/network.go
@@ -209,7 +209,6 @@ func (r *LocalRuntime) NetworkCreateBridge(cli *cliconfig.NetworkCreateValues) (
 	bridge := network.NewHostLocalBridge(bridgeDeviceName, isGateway, false, ipMasq, ipamConfig)
 	plugins = append(plugins, bridge)
 	plugins = append(plugins, network.NewPortMapPlugin())
-	plugins = append(plugins, network.NewFirewallPlugin())
 	// if we find the dnsname plugin, we add configuration for it
 	if network.HasDNSNamePlugin(runtimeConfig.CNIPluginDir) && !cli.DisableDNS {
 		// Note: in the future we might like to allow for dynamic domain names


### PR DESCRIPTION
it turns out that when the firewall plugin is not provided as part of the configuration, then the firewall cni plugin will dynamically figure out if it should use firewalld or iptables.

also removing this from the default configuration file

Signed-off-by: Brent Baude <bbaude@redhat.com>