### PR TITLE
Add support for multiple CNI networks in podman inspect

### DIFF
--- a/libpod/networking_unsupported.go
+++ b/libpod/networking_unsupported.go
@@ -20,6 +20,6 @@ func (r *Runtime) createNetNS(ctr *Container) (err error) {
 	return define.ErrNotImplemented
 }
 
-func (c *Container) getContainerNetworkInfo(data *InspectContainerData) *InspectContainerData {
-	return nil
+func (c *Container) getContainerNetworkInfo() (*InspectNetworkSettings, error) {
+	return nil, define.ErrNotImplemented
 }


### PR DESCRIPTION
When inspecting containers, info on CNI networks added to the container by name (e.g. --net=name1) should be displayed separately from the configuration of the default network, in a separate map called Networks.

This patch adds this separation, improving our Docker compatibility and also adding the ability to see if a container has more than one IPv4 and IPv6 address and more than one MAC address.