### PR TITLE
Add --no-healthcheck command to create/run

### DIFF
--- a/cmd/podman/common.go
+++ b/cmd/podman/common.go
@@ -396,6 +396,10 @@ func getCreateFlags(c *cliconfig.PodmanCommand) {
 		"Assign a name to the container",
 	)
 	createFlags.Bool(
+		"no-healthcheck", false,
+		"Disable healthchecks on container",
+	)
+	createFlags.Bool(
 		"oom-kill-disable", false,
 		"Disable OOM Killer",
 	)

--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -120,12 +120,13 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 			imageName = newImage.ID()
 		}
 
-		// if the user disabled the healthcheck with "none", we skip adding it
+		// if the user disabled the healthcheck with "none" or the no-healthcheck
+		// options is provided, we skip adding it
 		healthCheckCommandInput := c.String("healthcheck-command")
 
 		// the user didn't disable the healthcheck but did pass in a healthcheck command
 		// now we need to make a healthcheck from the commandline input
-		if healthCheckCommandInput != "none" {
+		if healthCheckCommandInput != "none" && !c.Bool("no-healthcheck") {
 			if len(healthCheckCommandInput) > 0 {
 				healthCheck, err = makeHealthCheckFromCli(c)
 				if err != nil {

--- a/cmd/podman/shared/intermediate.go
+++ b/cmd/podman/shared/intermediate.go
@@ -425,6 +425,7 @@ func NewIntermediateLayer(c *cliconfig.PodmanCommand, remote bool) GenericCLIRes
 	m["memory-swappiness"] = newCRInt64(c, "memory-swappiness")
 	m["name"] = newCRString(c, "name")
 	m["network"] = newCRString(c, "network")
+	m["no-healthcheck"] = newCRBool(c, "no-healthcheck")
 	m["no-hosts"] = newCRBool(c, "no-hosts")
 	m["oom-kill-disable"] = newCRBool(c, "oom-kill-disable")
 	m["oom-score-adj"] = newCRInt(c, "oom-score-adj")

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1888,6 +1888,11 @@ _podman_container_run() {
 		--expose
 		--gidmap
 		--group-add
+		--health-cmd
+		--health-interval
+		--health-retries
+		--health-start-period
+		--health-timeout
 		--hostname -h
 		--http-proxy
 		--image-volume
@@ -1906,6 +1911,7 @@ _podman_container_run() {
 		--memory-reservation
 		--name
 		--network
+		--no-healthcheck
 		--no-hosts
 		--oom-score-adj
 		--pid

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -557,6 +557,10 @@ Valid values are:
 
 Not implemented
 
+**--no-healthcheck**=*true|false*
+
+Disable any defined healthchecks for container.
+
 **--no-hosts**=*true|false*
 
 Do not create /etc/hosts for the container.

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -560,6 +560,10 @@ Valid _mode_ values are:
 
 Not implemented.
 
+**--no-healthcheck**=*true|false*
+
+Disable any defined healthchecks for container.
+
 **--no-hosts**=**true**|**false**
 
 Do not create _/etc/hosts_ for the container.

--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -41,6 +41,26 @@ var _ = Describe("Podman healthcheck run", func() {
 		Expect(session).To(ExitWithError())
 	})
 
+	It("podman disable healthcheck with --no-healthcheck on valid container", func() {
+		SkipIfRemote()
+		session := podmanTest.Podman([]string{"run", "-dt", "--no-healthcheck", "--name", "hc", healthcheck})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(125))
+	})
+
+	It("podman disable healthcheck with --health-cmd=none on valid container", func() {
+		SkipIfRemote()
+		session := podmanTest.Podman([]string{"run", "-dt", "--health-cmd", "none", "--name", "hc", healthcheck})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		hc := podmanTest.Podman([]string{"healthcheck", "run", "hc"})
+		hc.WaitWithDefaultTimeout()
+		Expect(hc.ExitCode()).To(Equal(125))
+	})
+
 	It("podman healthcheck on valid container", func() {
 		Skip("Extremely consistent flake - re-enable on debugging")
 		session := podmanTest.Podman([]string{"run", "-dt", "--name", "hc", healthcheck})


### PR DESCRIPTION
Now support --no-healthcheck option to disable defined healthchecks in a container image.  --health-cmd=none remains supported as well.

Fixes: #5299

Signed-off-by: Brent Baude <bbaude@redhat.com>