### PR TITLE
add apiv2 tests for podman pause and stop

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -294,9 +295,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -530,6 +533,7 @@ github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4m
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -668,6 +672,7 @@ gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -1,0 +1,243 @@
+package test_bindings
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/containers/libpod/pkg/bindings"
+	"github.com/containers/libpod/pkg/bindings/containers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Podman containers ", func() {
+	var (
+		bt        *bindingTest
+		s         *gexec.Session
+		connText  context.Context
+		err       error
+		falseFlag bool = false
+		trueFlag  bool = true
+	)
+
+	BeforeEach(func() {
+		bt = newBindingTest()
+		bt.RestoreImagesFromCache()
+		s = bt.startAPIService()
+		time.Sleep(1 * time.Second)
+		connText, err = bindings.NewConnection(context.Background(), bt.sock)
+		Expect(err).To(BeNil())
+	})
+
+	AfterEach(func() {
+		s.Kill()
+		bt.cleanup()
+	})
+
+	It("podman pause a bogus container", func() {
+		// Pausing bogus container should return 404
+		err = containers.Pause(connText, "foobar")
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusNotFound))
+	})
+
+	It("podman unpause a bogus container", func() {
+		// Unpausing bogus container should return 404
+		err = containers.Unpause(connText, "foobar")
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusNotFound))
+	})
+
+	It("podman pause a running container by name", func() {
+		// Pausing by name should work
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		err := containers.Pause(connText, name)
+		Expect(err).To(BeNil())
+
+		// Ensure container is paused
+		data, err := containers.Inspect(connText, name, nil)
+		Expect(err).To(BeNil())
+		Expect(data.State.Status).To(Equal("paused"))
+	})
+
+	It("podman pause a running container by id", func() {
+		// Pausing by id should work
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		data, err := containers.Inspect(connText, name, nil)
+		Expect(err).To(BeNil())
+		err = containers.Pause(connText, data.ID)
+		Expect(err).To(BeNil())
+
+		// Ensure container is paused
+		data, err = containers.Inspect(connText, data.ID, nil)
+		Expect(data.State.Status).To(Equal("paused"))
+	})
+
+	It("podman unpause a running container by name", func() {
+		// Unpausing by name should work
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		err := containers.Pause(connText, name)
+		Expect(err).To(BeNil())
+		err = containers.Unpause(connText, name)
+		Expect(err).To(BeNil())
+
+		// Ensure container is unpaused
+		data, err := containers.Inspect(connText, name, nil)
+		Expect(data.State.Status).To(Equal("running"))
+	})
+
+	It("podman unpause a running container by ID", func() {
+		// Unpausing by ID should work
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		// Pause by name
+		err := containers.Pause(connText, name)
+		data, err := containers.Inspect(connText, name, nil)
+		Expect(err).To(BeNil())
+		err = containers.Unpause(connText, data.ID)
+		Expect(err).To(BeNil())
+
+		// Ensure container is unpaused
+		data, err = containers.Inspect(connText, name, nil)
+		Expect(data.State.Status).To(Equal("running"))
+	})
+
+	It("podman pause a paused container by name", func() {
+		// Pausing a paused container by name should fail
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		err := containers.Pause(connText, name)
+		Expect(err).To(BeNil())
+		err = containers.Pause(connText, name)
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
+	})
+
+	It("podman pause a paused container by id", func() {
+		// Pausing a paused container by id should fail
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		data, err := containers.Inspect(connText, name, nil)
+		Expect(err).To(BeNil())
+		err = containers.Pause(connText, data.ID)
+		Expect(err).To(BeNil())
+		err = containers.Pause(connText, data.ID)
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
+	})
+
+	It("podman pause a stopped container by name", func() {
+		// Pausing a stopped container by name should fail
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		err := containers.Stop(connText, name, nil)
+		Expect(err).To(BeNil())
+		err = containers.Pause(connText, name)
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
+	})
+
+	It("podman pause a stopped container by id", func() {
+		// Pausing a stopped container by id should fail
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		data, err := containers.Inspect(connText, name, nil)
+		err = containers.Stop(connText, data.ID, nil)
+		Expect(err).To(BeNil())
+		err = containers.Pause(connText, data.ID)
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
+	})
+
+	It("podman remove a paused container by id without force", func() {
+		// Removing a paused container without force should fail
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		data, err := containers.Inspect(connText, name, nil)
+		Expect(err).To(BeNil())
+		err = containers.Pause(connText, data.ID)
+		Expect(err).To(BeNil())
+		err = containers.Remove(connText, data.ID, &falseFlag, &falseFlag)
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
+	})
+
+	It("podman remove a paused container by id with force", func() {
+		// Removing a paused container with force should work
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		data, err := containers.Inspect(connText, name, nil)
+		Expect(err).To(BeNil())
+		err = containers.Pause(connText, data.ID)
+		Expect(err).To(BeNil())
+		err = containers.Remove(connText, data.ID, &trueFlag, &falseFlag)
+		Expect(err).To(BeNil())
+	})
+
+	It("podman stop a paused container by name", func() {
+		// Stopping a paused container by name should fail
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		err := containers.Pause(connText, name)
+		Expect(err).To(BeNil())
+		err = containers.Stop(connText, name, nil)
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
+	})
+
+	It("podman stop a paused container by id", func() {
+		// Stopping a paused container by id should fail
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		data, err := containers.Inspect(connText, name, nil)
+		Expect(err).To(BeNil())
+		err = containers.Pause(connText, data.ID)
+		Expect(err).To(BeNil())
+		err = containers.Stop(connText, data.ID, nil)
+		Expect(err).ToNot(BeNil())
+		code, _ := bindings.CheckResponseCode(err)
+		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
+	})
+
+	It("podman stop a running container by name", func() {
+		// Stopping a running container by name should work
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		err := containers.Stop(connText, name, nil)
+		Expect(err).To(BeNil())
+
+		// Ensure container is stopped
+		data, err := containers.Inspect(connText, name, nil)
+		Expect(err).To(BeNil())
+		Expect(data.State.Status).To(Equal("exited"))
+	})
+
+	It("podman stop a running container by ID)", func() {
+		// Stopping a running container by ID should work
+		var name = "top"
+		bt.RunTopContainer(&name, &falseFlag, nil)
+		data, err := containers.Inspect(connText, name, nil)
+		Expect(err).To(BeNil())
+		err = containers.Stop(connText, data.ID, nil)
+		Expect(err).To(BeNil())
+
+		// Ensure container is stopped
+		data, err = containers.Inspect(connText, name, nil)
+		Expect(err).To(BeNil())
+		Expect(data.State.Status).To(Equal("exited"))
+	})
+
+})


### PR DESCRIPTION
Initial ginkgo setup credit to Brent Baude <bbaude@redhat.com>

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@baude PTAL. This has your breaking changes from last week pulled in as well.

Also, removing a paused container with force is failing currently. It passed last time I checked yesterday, maybe a rebase earlier today broke it. Looking into it.