### PR TITLE
Fixed build_rpm.sh script for Fedora 30

### DIFF
--- a/contrib/build_rpm.sh
+++ b/contrib/build_rpm.sh
@@ -46,8 +46,13 @@ if [[ $pkg_manager == *dnf ]]; then
         )
 fi
 
+# Package name on fedora 30 is golang-github-cpuguy83-go-md2man
+if (grep -i 'Fedora' /etc/redhat-release | grep " 30" ) ; then
+    PKGS+=(golang-github-cpuguy83-go-md2man \
+        btrfs-progs-devel \
+	)
 # btrfs-progs-devel is not available in CentOS/RHEL-8
-if ! (grep -i 'Red Hat\|CentOS' /etc/redhat-release | grep " 8" ); then
+elif ! (grep -i 'Red Hat\|CentOS' /etc/redhat-release | grep " 8" ) ; then
     PKGS+=(golang-github-cpuguy83-md2man \
         btrfs-progs-devel \
         )


### PR DESCRIPTION
golang-github-cpuguy83-go-md2man is only available in Fedora 30 and
got renamed to golang-github-cpuguy83-md2man for Fedora 31 which breaks
the user interface for building rpm on fedora 30.

It fixes the same by installing correct md2man package on Fedora 30.

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>