### PR TITLE
apiv2 tests: add more pod tests, timing check

### DIFF
--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -47,4 +47,19 @@ t GET info 200           \
   .DefaultRuntime=runc   \
   .MemTotal~[0-9]\\+
 
+# Timing: make sure server stays responsive
+t0=$SECONDS
+for i in $(seq 1 10); do
+    # FIXME: someday: refactor t(), separate out the 'curl' logic so we
+    #        can call it directly. Then we won't get ten annoying 'ok' lines.
+    t GET info 200
+done
+t1=$SECONDS
+delta_t=$((t1 - t2))
+if [ $delta_t -le 5 ]; then
+    _show_ok 1 "Time for ten /info requests ($delta_t seconds) <= 5s"
+else
+    _show_ok 0 "Time for ten /info requests" "<= 5 seconds" "$delta_t seconds"
+fi
+
 # vim: filetype=sh

--- a/test/apiv2/40-pods.at
+++ b/test/apiv2/40-pods.at
@@ -3,18 +3,20 @@
 # test pod-related endpoints
 #
 
-# FIXME! Shouldn't /create give an actual pod ID?
-expected_id='machine.slice'
-if rootless; then
-    expected_id=/libpod_parent
-fi
-
 t GET  libpod/pods/json            200 null
-t POST libpod/pods/create name=foo 201 .id=$expected_id
+t POST libpod/pods/create name=foo 201 .id~[0-9a-f]\\{64\\}
+pod_id=$(jq -r .id <<<"$output")
 t GET  libpod/pods/foo/exists      204
+t GET  libpod/pods/$pod_id/exists  204
 t GET  libpod/pods/notfoo/exists   404
-t GET  libpod/pods/foo/json        200     .Config.name=foo     .Containers=null
-t GET  libpod/pods/json            200 .[0].Config.name=foo .[0].Containers=null
+t GET  libpod/pods/foo/json        200 \
+  .Config.name=foo  \
+  .Config.id=$pod_id \
+  .Containers=null
+t GET  libpod/pods/json            200 \
+  .[0].Config.name=foo \
+  .[0].Config.id=$pod_id \
+  .[0].Containers=null
 
 # Cannot create a dup pod with the same name
 t POST libpod/pods/create name=foo 409 .cause="pod already exists"
@@ -35,8 +37,10 @@ t POST libpod/pods/foo/restart '' 500 .cause="no such container"
 
 t POST libpod/pods/bar/restart '' 404
 
-#t POST libpod/pods/prune ''    200     # FIXME: unimplemented, returns 500
-#t POST libpod/pods/prune 'a=b' 400     # FIXME: unimplemented, returns 500
+# FIXME: I'm not sure what 'prune' is supposed to do; as of 20200224 it
+# just returns 200 (ok) with empty result list.
+#t POST libpod/pods/prune ''    200     # FIXME: 2020-02-24 returns 200 {}
+#t POST libpod/pods/prune 'a=b' 400     # FIXME: 2020-02-24 returns 200
 
 # Clean up; and try twice, making sure that the second time fails
 t DELETE libpod/pods/foo 204

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -253,7 +253,7 @@ function start_service() {
         die "Cannot start service on non-localhost ($HOST)"
     fi
 
-    $PODMAN_BIN --root $WORKDIR system service --timeout 15000 tcp:127.0.0.1:$PORT \
+    $PODMAN_BIN --root $WORKDIR system service --timeout 15 tcp:127.0.0.1:$PORT \
         &> $WORKDIR/server.log &
     service_pid=$!
 


### PR DESCRIPTION
Looks like /libpod/pods/create has been fixed to return an
actual pod ID. Extend those tests.

Also, update timeout in the server command: it's now seconds,
not milliseconds.

Also, update FIXME comments in /pods/prune . Still doesn't
work, but clarify what we're seeing.

Also, add a new test that runs ten /info requests and
barfs if it takes more than 5 seconds.

Signed-off-by: Ed Santiago <santiago@redhat.com>