### PR TITLE
always run the docs task on post-merge

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -729,10 +729,6 @@ verify_test_built_images_task:
 
 docs_task:
 
-    # Only run this for PRs on mention, and after merge
-    only_if: >-
-        $CIRRUS_BRANCH != $DEST_BRANCH
-
     depends_on:
         - "gating"
 


### PR DESCRIPTION
Signed-off-by: Brent Baude <bbaude@redhat.com>