### PR TITLE
build: move initialization after SetXdgDirs

### DIFF
--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -53,13 +53,12 @@ var (
 	}
 )
 
-func init() {
+func initBuild() {
 	buildCommand.Command = _buildCommand
 	buildCommand.SetHelpTemplate(HelpTemplate())
 	buildCommand.SetUsageTemplate(UsageTemplate())
 	flags := buildCommand.Flags()
 	flags.SetInterspersed(true)
-
 	budFlags := buildahcli.GetBudFlags(&budFlagsValues)
 	flag := budFlags.Lookup("pull")
 	if err := flag.Value.Set("true"); err != nil {

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -83,7 +83,7 @@ var rootCmd = &cobra.Command{
 
 var MainGlobalOpts cliconfig.MainFlags
 
-func init() {
+func initCobra() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.TraverseChildren = true
 	rootCmd.Version = version.Version
@@ -94,16 +94,20 @@ func init() {
 	rootCmd.AddCommand(getMainCommands()...)
 }
 
+func init() {
+	if err := libpod.SetXdgDirs(); err != nil {
+		logrus.Errorf(err.Error())
+		os.Exit(1)
+	}
+	initBuild()
+	initCobra()
+}
+
 func initConfig() {
 	//	we can do more stuff in here.
 }
 
 func before(cmd *cobra.Command, args []string) error {
-	if err := libpod.SetXdgDirs(); err != nil {
-		logrus.Errorf(err.Error())
-		os.Exit(1)
-	}
-
 	//	Set log level; if not log-level is provided, default to error
 	logLevel := MainGlobalOpts.LogLevel
 	if logLevel == "" {

--- a/pkg/util/utils_supported.go
+++ b/pkg/util/utils_supported.go
@@ -33,7 +33,7 @@ func GetRuntimeDir() (string, error) {
 				logrus.Debugf("unable to make temp dir %s", tmpDir)
 			}
 			st, err := os.Stat(tmpDir)
-			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && st.Mode().Perm() == 0700 {
+			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && (st.Mode().Perm()&0700 == 0700) {
 				runtimeDir = tmpDir
 			}
 		}
@@ -43,7 +43,7 @@ func GetRuntimeDir() (string, error) {
 				logrus.Debugf("unable to make temp dir %s", tmpDir)
 			}
 			st, err := os.Stat(tmpDir)
-			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && st.Mode().Perm() == 0700 {
+			if err == nil && int(st.Sys().(*syscall.Stat_t).Uid) == os.Geteuid() && (st.Mode().Perm()&0700 == 0700) {
 				runtimeDir = tmpDir
 			}
 		}


### PR DESCRIPTION
otherwise it triggers the config file initialization from vendor/github.com/containers/common/pkg/config before the init() in main.go can set correctly XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS when they are missing.

commit 96de762eedd1470dfbe73cf424eea848589268d7 introduced the regression.

Closes: https://github.com/containers/libpod/issues/5314

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
