### PR TITLE
rootless: raise error if the process is not found

### DIFF
--- a/pkg/rootless/rootless_linux.go
+++ b/pkg/rootless/rootless_linux.go
@@ -510,7 +510,7 @@ func TryJoinFromFilePaths(pausePidPath string, needNewNamespace bool, paths []st
 			}
 		}
 	}
-	if !foundProcess {
+	if !foundProcess && pausePidPath != "" {
 		return BecomeRootInUserNS(pausePidPath)
 	}
 	if lastErr != nil {


### PR DESCRIPTION
we need to store the pause process PID file so that it can be re-used later.
    
commit e9dc2120925d9bc32b87ed3c4122aa40f7413db5 introduced this regression.

Closes: https://github.com/containers/libpod/issues/5246

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
