### PR TITLE
Remove 1 sec delay

### DIFF
--- a/cmd/podman/service.go
+++ b/cmd/podman/service.go
@@ -143,7 +143,6 @@ func runREST(r *libpod.Runtime, uri string, timeout time.Duration) error {
 		if err != nil {
 			return errors.Wrapf(err, "unable to create socket %s", uri)
 		}
-		defer l.Close()
 		listener = &l
 	}
 	server, err := api.NewServerWithSettings(r, timeout, listener)


### PR DESCRIPTION
 * Stop closing net.Listener() twice on interrupt
 * Do not report error if closing server twice
 * Refactor reading channel to make golangci-lint happy

Fixes #5311

Signed-off-by: Jhon Honce <jhonce@redhat.com>