### PR TITLE
add epoch for specfile

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -43,6 +43,11 @@
 %global shortcommit_conmon %(c=%{commit_conmon}; echo ${c:0:7})
 
 Name: podman
+%if 0%{?fedora}
+Epoch: 99
+%else
+Epoch: 0
+%endif
 Version: 1.8.1
 Release: #COMMITDATE#.git%{shortcommit0}%{?dist}
 Summary: Manage Pods, Containers and Container Images


### PR DESCRIPTION
to get the copr rpms to jive better with the fedora rpms, we need to set an epoch.

Signed-off-by: Brent Baude <bbaude@redhat.com>