### PR TITLE
spec: allow container alias name in lookup

### DIFF
--- a/pkg/spec/namespaces.go
+++ b/pkg/spec/namespaces.go
@@ -422,7 +422,7 @@ func (c *UtsConfig) ConfigureGenerator(g *generate.Generator, net *NetworkConfig
 	if hostname == "" {
 		switch {
 		case utsCtrID != "":
-			utsCtr, err := runtime.GetContainer(utsCtrID)
+			utsCtr, err := runtime.LookupContainer(utsCtrID)
 			if err != nil {
 				return errors.Wrapf(err, "unable to retrieve hostname from dependency container %s", utsCtrID)
 			}

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -276,7 +276,7 @@ func (s *SpecGenerator) utsConfigureGenerator(g *generate.Generator, runtime *li
 	if hostname == "" {
 		switch {
 		case s.UtsNS.IsContainer():
-			utsCtr, err := runtime.GetContainer(s.UtsNS.Value)
+			utsCtr, err := runtime.LookupContainer(s.UtsNS.Value)
 			if err != nil {
 				return errors.Wrapf(err, "unable to retrieve hostname from dependency container %s", s.UtsNS.Value)
 			}

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -146,6 +146,17 @@ var _ = Describe("Podman run networking", func() {
 		Expect(match).Should(BeTrue())
 	})
 
+	It("podman run --net container: and --uts container:", func() {
+		ctrName := "ctrToJoin"
+		ctr1 := podmanTest.RunTopContainer(ctrName)
+		ctr1.WaitWithDefaultTimeout()
+		Expect(ctr1.ExitCode()).To(Equal(0))
+
+		ctr2 := podmanTest.Podman([]string{"run", "-d", "--net=container:" + ctrName, "--uts=container:" + ctrName, ALPINE, "true"})
+		ctr2.WaitWithDefaultTimeout()
+		Expect(ctr2.ExitCode()).To(Equal(0))
+	})
+
 	It("podman run --net container: copies hosts and resolv", func() {
 		SkipIfRootless()
 		ctrName := "ctr1"


### PR DESCRIPTION
Previously --uts=container: expected the full container ID.

Closes: https://github.com/containers/libpod/issues/5289

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>