### PR TITLE
CI: add API v2 tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -398,6 +398,7 @@ testing_task:
     unit_test_script: '$SCRIPT_BASE/unit_test.sh |& ${TIMESTAMP}'
     integration_test_script: '$SCRIPT_BASE/integration_test.sh |& ${TIMESTAMP}'
     system_test_script: '$SCRIPT_BASE/system_test.sh |& ${TIMESTAMP}'
+    apiv2_test_script: '$SCRIPT_BASE/apiv2_test.sh |& ${TIMESTAMP}'
     build_release_script: '$SCRIPT_BASE/build_release.sh |& ${TIMESTAMP}'
     # For PRs this confirms uploading releases after merge, is functional.
     upload_release_archive_script: '$SCRIPT_BASE/upload_release_archive.sh |& ${TIMESTAMP}'
@@ -447,6 +448,7 @@ special_testing_rootless_task:
     setup_environment_script: '$SCRIPT_BASE/setup_environment.sh |& ${TIMESTAMP}'
     integration_test_script: '$SCRIPT_BASE/integration_test.sh |& ${TIMESTAMP}'
     system_test_script: '$SCRIPT_BASE/system_test.sh |& ${TIMESTAMP}'
+    apiv2_test_script: '$SCRIPT_BASE/apiv2_test.sh |& ${TIMESTAMP}'
 
     on_failure:
         failed_branch_script: '$CIRRUS_WORKING_DIR/$SCRIPT_BASE/notice_branch_failure.sh'

--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,14 @@ remotesystem:
 	fi;\
 	exit $$rc
 
+.PHONY: localapiv2
+localapiv2:
+	env PODMAN=./bin/podman ./test/apiv2/test-apiv2
+
+.PHONY: remoteapiv2
+remoteapiv2:
+	true
+
 .PHONY: system.test-binary
 system.test-binary: .install.ginkgo
 	$(GO) test -c ./test/system

--- a/contrib/cirrus/apiv2_test.sh
+++ b/contrib/cirrus/apiv2_test.sh
@@ -1,0 +1,1 @@
+integration_test.sh

--- a/test/apiv2/01-basic.at
+++ b/test/apiv2/01-basic.at
@@ -41,10 +41,16 @@ t GET    libpod/containers/create  405
 #
 # system info
 #
+# Some day perhaps it will always be runc; for now, cgroupsv2 requires crun
+#
 # FIXME: run 'podman info --format=json', and compare select fields
-t GET info 200           \
-  .OSType=linux          \
-  .DefaultRuntime=runc   \
+runtime=runc
+if have_cgroupsv2; then
+    runtime=crun
+fi
+t GET info 200                \
+  .OSType=linux               \
+  .DefaultRuntime~.*$runtime  \
   .MemTotal~[0-9]\\+
 
 # Timing: make sure server stays responsive

--- a/test/apiv2/40-pods.at
+++ b/test/apiv2/40-pods.at
@@ -23,9 +23,10 @@ t POST libpod/pods/create name=foo 409 .cause="pod already exists"
 
 #t POST libpod/pods/create a=b 400 .cause='bad parameter'  # FIXME: unimplemented
 
-if root; then
+if root || have_cgroupsv2; then
     t POST libpod/pods/foo/pause   '' 204
 else
+    # Rootless cgroupsv1 : unsupported
     t POST libpod/pods/foo/pause '' 500 \
       .cause="this container does not have a cgroup" \
       .message~".*pause pods containing rootless containers with cgroup V1"

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -290,6 +290,12 @@ function rootless() {
     test "$ROOTLESS" = "true"
 }
 
+# True if cgroups v2 are enabled
+function have_cgroupsv2() {
+    cgroup_type=$(stat -f -c %T /sys/fs/cgroup)
+    test "$cgroup_type" = "cgroup2fs"
+}
+
 # END   infrastructure code
 ###############################################################################
 # BEGIN sanity checks


### PR DESCRIPTION
API v2 has been quiet for a few days, and the test script is
actually passing. Let's take advantage of this opportunity
to get them running in CI.

Signed-off-by: Ed Santiago <santiago@redhat.com>