### PR TITLE
Force using runc in F30

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ###
-    _BUILT_IMAGE_SUFFIX: "libpod-5874660151656448"
+    _BUILT_IMAGE_SUFFIX: "libpod-5940307564953600"
     FEDORA_CACHE_IMAGE_NAME: "fedora-31-${_BUILT_IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-30-${_BUILT_IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-19-${_BUILT_IMAGE_SUFFIX}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,8 +48,9 @@ env:
     #### Default to NOT operating in any special-case testing mode
     ####
     SPECIALMODE: "none"  # don't do anything special
-    TEST_REMOTE_CLIENT: false  # don't test remote client by default
-    ADD_SECOND_PARTITION: false  # will certainly fail inside containers
+    TEST_REMOTE_CLIENT: 'false'  # don't test remote client by default
+    ADD_SECOND_PARTITION: 'false'  # will certainly fail inside containers
+    MOD_LIBPOD_CONF: 'true'  # Update libpod.conf runtime if required by OS environment
 
     ####
     #### Credentials and other secret-sauces, decrypted at runtime when authorized.
@@ -253,6 +254,9 @@ build_each_commit_task:
         cpu: 8
         memory: "8Gb"
 
+    env:
+        MOD_LIBPOD_CONF: 'false'
+
     timeout_in: 30m
 
     setup_environment_script: '$SCRIPT_BASE/setup_environment.sh |& ${TIMESTAMP}'
@@ -281,6 +285,9 @@ build_without_cgo_task:
     gce_instance:
         cpu: 8
         memory: "8Gb"
+
+    env:
+        MOD_LIBPOD_CONF: 'false'
 
     timeout_in: 30m
 
@@ -381,10 +388,10 @@ testing_task:
     timeout_in: 120m
 
     env:
-        ADD_SECOND_PARTITION: true
+        ADD_SECOND_PARTITION: 'true'
         matrix:
-            TEST_REMOTE_CLIENT: true
-            TEST_REMOTE_CLIENT: false
+            TEST_REMOTE_CLIENT: 'true'
+            TEST_REMOTE_CLIENT: 'false'
 
     networking_script: '${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/networking.sh'
     setup_environment_script: '$SCRIPT_BASE/setup_environment.sh |& ${TIMESTAMP}'
@@ -428,11 +435,11 @@ special_testing_rootless_task:
         $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
 
     env:
-        ADD_SECOND_PARTITION: true
+        ADD_SECOND_PARTITION: 'true'
         SPECIALMODE: 'rootless'  # See docs
         matrix:
-            TEST_REMOTE_CLIENT: true
-            TEST_REMOTE_CLIENT: false
+            TEST_REMOTE_CLIENT: 'true'
+            TEST_REMOTE_CLIENT: 'false'
 
     timeout_in: 60m
 
@@ -469,7 +476,8 @@ special_testing_in_podman_task:
             image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
 
     env:
-        ADD_SECOND_PARTITION: true
+        ADD_SECOND_PARTITION: 'true'
+        MOD_LIBPOD_CONF: 'false'  # Use existing/native setup
         SPECIALMODE: 'in_podman'  # See docs
         # TODO: Support both runc and crun (cgroups v1 and v2 container images)
         # matrix:
@@ -628,10 +636,10 @@ verify_test_built_images_task:
         image_name: "${PACKER_BUILDER_NAME}${BUILT_IMAGE_SUFFIX}"
 
     env:
-        ADD_SECOND_PARTITION: true
+        ADD_SECOND_PARTITION: 'true'
         matrix:
-            TEST_REMOTE_CLIENT: true
-            TEST_REMOTE_CLIENT: false
+            TEST_REMOTE_CLIENT: 'true'
+            TEST_REMOTE_CLIENT: 'false'
         matrix:
             # Required env. var. by check_image_script
             PACKER_BUILDER_NAME: "fedora-30"

--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -16,16 +16,6 @@ fi
 
 cd "$GOSRC"
 
-# Transition workaround: runc is still the default for upstream development
-handle_crun() {
-    # For systems with crun installed, assume CgroupsV2 and use it
-    if type -P crun &> /dev/null
-    then
-        warn "Replacing runc -> crun in libpod.conf"
-        sed -i -r -e 's/^runtime = "runc"/runtime = "crun"/' /usr/share/containers/libpod.conf
-    fi
-}
-
 case "$SPECIALMODE" in
     in_podman)
         ${CONTAINER_RUNTIME} run --rm --privileged --net=host \
@@ -49,7 +39,6 @@ case "$SPECIALMODE" in
     endpoint)
         make
         make install PREFIX=/usr ETCDIR=/etc
-        #handle_crun
         make test-binaries
         make endpoint
         ;;
@@ -63,7 +52,6 @@ case "$SPECIALMODE" in
         make install PREFIX=/usr ETCDIR=/etc
         make install.config PREFIX=/usr
         make test-binaries
-        handle_crun
         if [[ "$TEST_REMOTE_CLIENT" == "true" ]]
         then
             make remote${TESTSUITE} VARLINK_LOG=$VARLINK_LOG

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -88,6 +88,7 @@ ROOTLESS_ENV_RE='(CIRRUS_.+)|(ROOTLESS_.+)|(.+_IMAGE.*)|(.+_BASE)|(.*DIRPATH)|(.
 SECRET_ENV_RE='(IRCID)|(ACCOUNT)|(GC[EP]..+)|(SSH)'
 
 SPECIALMODE="${SPECIALMODE:-none}"
+MOD_LIBPOD_CONF="${MOD_LIBPOD_CONF:false}"
 TEST_REMOTE_CLIENT="${TEST_REMOTE_CLIENT:-false}"
 export CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-podman}
 
@@ -105,6 +106,8 @@ OS_RELEASE_ID="$(source /etc/os-release; echo $ID)"
 OS_RELEASE_VER="$(source /etc/os-release; echo $VERSION_ID | cut -d '.' -f 1)"
 # Combined to ease soe usage
 OS_REL_VER="${OS_RELEASE_ID}-${OS_RELEASE_VER}"
+# Type of filesystem used for cgroups
+CG_FS_TYPE="$(stat -f -c %T /sys/fs/cgroup)"
 
 # Installed into cache-images, supports overrides
 # by user-data in case of breakage or for debugging.

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -46,7 +46,8 @@ case "${OS_RELEASE_ID}" in
         # All SELinux distros need this for systemd-in-a-container
         setsebool container_manage_cgroup true
         if [[ "$ADD_SECOND_PARTITION" == "true" ]]; then
-            bash "$SCRIPT_BASE/add_second_partition.sh"; fi
+            bash "$SCRIPT_BASE/add_second_partition.sh"
+        fi
 
         if [[ "$OS_RELEASE_VER" == "31" ]]; then
             warn "Switching io schedular to deadline to avoid RHBZ 1767539"

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -6,15 +6,19 @@ source $(dirname $0)/lib.sh
 
 req_env_var USER HOME GOSRC SCRIPT_BASE SETUP_MARKER_FILEPATH
 
-show_env_vars
-
 # Ensure this script only executes successfully once and always logs ending timestamp
-[[ ! -e "$SETUP_MARKER_FILEPATH" ]] || exit 0
+if [[ -e "$SETUP_MARKER_FILEPATH" ]]; then
+    show_env_vars
+    exit 0
+fi
+
 exithandler() {
     RET=$?
     echo "."
     echo "$(basename $0) exit status: $RET"
     [[ "$RET" -eq "0" ]] && date +%s >> "$SETUP_MARKER_FILEPATH"
+    show_env_vars
+    [ "$RET" -eq "0" ]] || warn "Non-zero exit caused by error ABOVE env. var. display."
 }
 trap exithandler EXIT
 

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -96,7 +96,7 @@ env=yaml.load(open(".cirrus.yml"), Loader=yaml.SafeLoader)["env"]
 keys=[k for k in env if "ENCRYPTED" not in str(env[k])]
 for k,v in env.items():
     v=str(v)
-    if "ENCRYPTED" not in v:
+    if "ENCRYPTED" not in v and "ADD_SECOND_PARTITION" not in v:
         print("{0}=\"{1}\"".format(k, v)),
     '
 }
@@ -181,7 +181,7 @@ parse_args(){
     [[ -z "$ROOTLESS_USER" ]] || \
         ENVS="$ENVS ROOTLESS_USER=$ROOTLESS_USER"
 
-    SETUP_CMD="env $ENVS $GOSRC/contrib/cirrus/setup_environment.sh"
+    SETUP_CMD="env $ENVS ADD_SECOND_PARTITIO=True $GOSRC/contrib/cirrus/setup_environment.sh"
     VMNAME="${VMNAME:-${USER}-${IMAGE_NAME}}"
 
     CREATE_CMD="$PGCLOUD compute instances create --zone=$ZONE --image=${IMAGE_NAME} --custom-cpu=$CPUS --custom-memory=$MEMORY --boot-disk-size=$DISK --labels=in-use-by=$USER $IBI_ARGS $VMNAME"

--- a/pkg/bindings/test/common_test.go
+++ b/pkg/bindings/test/common_test.go
@@ -240,3 +240,7 @@ func createCache() {
 	}
 	b.cleanup()
 }
+
+func isStopped(state string) bool {
+	return state == "exited" || state == "stopped"
+}

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Podman containers ", func() {
 		// Ensure container is stopped
 		data, err := containers.Inspect(connText, name, nil)
 		Expect(err).To(BeNil())
-		Expect(data.State.Status).To(Equal("exited"))
+		Expect(isStopped(data.State.Status)).To(BeTrue())
 	})
 
 	It("podman stop a running container by ID", func() {
@@ -247,7 +247,7 @@ var _ = Describe("Podman containers ", func() {
 		// Ensure container is stopped
 		data, err = containers.Inspect(connText, name, nil)
 		Expect(err).To(BeNil())
-		Expect(data.State.Status).To(Equal("exited"))
+		Expect(isStopped(data.State.Status)).To(BeTrue())
 	})
 
 })


### PR DESCRIPTION
Suspect crun is being pulled in by installing podman RPM at F30 VM build time.  Attempting to fix that, and also force use of runc for Fedora < 31 at runtime.

Ref: https://github.com/containers/libpod/pull/5333#issuecomment-592048270