### PR TITLE
build: specify input fd to buildah

### DIFF
--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -352,6 +352,7 @@ func buildCmd(c *cliconfig.BuildValues) error {
 		ContextDirectory:        contextDir,
 		DefaultMountsFilePath:   c.GlobalFlags.DefaultMountsFile,
 		Err:                     stderr,
+		In:                      os.Stdin,
 		ForceRmIntermediateCtrs: c.ForceRm,
 		IIDFile:                 c.Iidfile,
 		Labels:                  c.Label,


### PR DESCRIPTION
It solves a tight loop with poll as stdin will be initialized to
/dev/null in buildah/imagebuildah/StageExecutor.Run.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>