### PR TITLE
Fix upstream dockerfile and add 'by hand' ctrfile

### DIFF
--- a/contrib/podmanimage/README.md
+++ b/contrib/podmanimage/README.md
@@ -10,10 +10,10 @@ the images live are public and can be pulled without credentials.  These contain
 resulting containers can run safely with privileges within the container.  The container images are built
 using the latest Fedora and then Podman is installed into them:
 
-  * quay.io/podman/stable - This image is built using the latest stable version of Podman in a Fedora based container.  Built with podman/stable/Dockerfile.
-  * quay.io/podman/upstream - This image is built using the latest code found in this GitHub repository.  When someone creates a commit and pushes it, the image is created.  Due to that the image changes frequently and is not guaranteed to be stable.  Built with podmanimage/upstream/Dockerfile.
-  * quay.io/podman/testing - This image is built using the latest version of Podman that is or was in updates testing for Fedora.  At times this may be the same as the stable image.  This container image will primarily be used by the development teams for verification testing when a new package is created.  Built with podmanimage/testing/Dockerfile.
-
+  * quay.io/podman/stable - This image is built using the latest stable version of Podman in a Fedora based container.  Built with [podmanimage/stable/Dockerfile](stable/Dockerfile).
+  * quay.io/podman/upstream - This image is built using the latest code found in this GitHub repository.  When someone creates a commit and pushes it, the image is created.  Due to that the image changes frequently and is not guaranteed to be stable.  Built with [podmanimage/upstream/Dockerfile](upstream/Dockerfile).
+  * quay.io/podman/testing - This image is built using the latest version of Podman that is or was in updates testing for Fedora.  At times this may be the same as the stable image.  This container image will primarily be used by the development teams for verification testing when a new package is created.  Built with [podmanimage/testing/Dockerfile](testing/Dockerfile).
+  * quay.io/podman/stable:version - This image is built manually using a Fedora based container.  An RPM is first pulled from the [Fedora Updates System](https://bodhi.fedoraproject.org/) and the image is built from there.  For more details, see the Containerfile used to build it, [podmanimage/stable/manual/Containerfile](stable/manual/Containerfile).
 ## Sample Usage
 
 

--- a/contrib/podmanimage/stable/manual/Containerfile
+++ b/contrib/podmanimage/stable/manual/Containerfile
@@ -1,0 +1,39 @@
+# stable/manual/Containerfile
+#
+# Build a Podman container image from the latest
+# stable version of Podman on the Fedora Updates System.
+# https://bodhi.fedoraproject.org/updates/?search=podman
+# This image can be used to create a secured container
+# that runs safely with privileges within the container.
+# This Containerfile builds version 1.7.0, the version and
+# the RPM name would need to be adjusted before a run as
+# appropriate.
+#
+# To use, first copy an rpm file from bohdi to `/root/tmp`
+# and then run:
+#   'podman build -f ./Containerfile -t quay.io/podman/stable:v1.7.0 .'
+#
+# Once complete run:
+#   `podman push quay.io/stable:v1.7.0 docker://quay.io/podman/stable:v1.7.0`
+#
+# Start Build Process using the latest Fedora
+FROM fedora:latest
+
+# Don't include container-selinux and remove
+# directories used by dnf that are just taking
+# up space.
+#
+COPY /tmp/podman-1.7.0-3.fc30.x86_64.rpm /tmp
+RUN yum -y install /tmp/podman-1.7.0-3.fc30.x86_64.rpm fuse-overlayfs --exclude container-selinux; rm -rf /var/cache /var/log/dnf* /var/log/yum.* /tmp/podman*.rpm
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' /etc/containers/storage.conf
+RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+
+# Adjust libpod.conf to write logging to a file
+RUN sed -i 's/events_logger = "journald"/events_logger = "file"/g' /usr/share/containers/libpod.conf; mkdir -p /run/systemd/journal
+
+# Set up environment variables to note that this is
+# not starting with usernamespace and default to
+# isolate the filesystem with chroot.
+ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot

--- a/contrib/podmanimage/upstream/Dockerfile
+++ b/contrib/podmanimage/upstream/Dockerfile
@@ -19,16 +19,16 @@ ENV GOPATH=/root/podman
 # that are needed for building but not running Podman
 RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install --exclude container-selinux \
      --enablerepo=updates-testing \
-     atomic-registries \
      btrfs-progs-devel \
      containernetworking-cni \
+     conmon \
      device-mapper-devel \
      git \
      glib2-devel \
      glibc-devel \
      glibc-static \
      go \
-     golang-github-cpuguy83-go-md2man \
+     golang-github-cpuguy83-md2man \
      gpgme-devel \
      iptables \
      libassuan-devel \


### PR DESCRIPTION
The podmanimage/upstream/Dockerfile had two rpms in its
build procedure that are no longer available.  The atomic-registries
has been removed and the md2man has been renamed.  In addtion
conmon was not being installed and I've added that.

I've been using a Containerfile to build or rebuild a
specific version of the podmanimage stored in the stable
repository with a version tag.  As the other Containerfiles
have been updated by others, and in case anyone else needs
to build it, I've added it to the repo and have also updated
the readme.md.

FWIW, the builds in the quay.io/podman/upstream have been failing for a while due to missing rpms.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>