### PR TITLE
exec: get the exit code from sync pipe instead of file

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -297,7 +297,9 @@ func (c *Container) Exec(tty, privileged bool, env map[string]string, cmd []stri
 		// Conmon will pass a non-zero exit code from the runtime as a pid here.
 		// we differentiate a pid with an exit code by sending it as negative, so reverse
 		// that change and return the exit code the runtime failed with.
-		if pid < 0 {
+		// Make sure the value is not ErrorConmonRead, as that is a podman set bogus value
+		// and not sent by conmon (and thus has no special meaning)
+		if pid < 0 && pid != define.ErrorConmonRead {
 			ec = -1 * pid
 		}
 		return ec, err

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -206,28 +206,6 @@ func (c *Container) execOCILog(sessionID string) string {
 	return filepath.Join(c.execBundlePath(sessionID), "oci-log")
 }
 
-// readExecExitCode reads the exit file for an exec session and returns
-// the exit code
-func (c *Container) readExecExitCode(sessionID string) (int, error) {
-	exitFile := filepath.Join(c.execExitFileDir(sessionID), c.ID())
-	chWait := make(chan error)
-	defer close(chWait)
-
-	_, err := WaitForFile(exitFile, chWait, time.Second*5)
-	if err != nil {
-		return -1, err
-	}
-	ec, err := ioutil.ReadFile(exitFile)
-	if err != nil {
-		return -1, err
-	}
-	ecInt, err := strconv.Atoi(string(ec))
-	if err != nil {
-		return -1, err
-	}
-	return ecInt, nil
-}
-
 // Wait for the container's exit file to appear.
 // When it does, update our state based on it.
 func (c *Container) waitForExitFileAndSync() error {

--- a/libpod/define/exec_codes.go
+++ b/libpod/define/exec_codes.go
@@ -1,6 +1,7 @@
 package define
 
 import (
+	"math"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -17,6 +18,11 @@ const (
 	ExecErrorCodeCannotInvoke = 126
 	// ExecErrorCodeNotFound is the error code to return when a command cannot be found
 	ExecErrorCodeNotFound = 127
+	// ErrorConmonRead is a bogus value that can neither be a valid PID or exit code. It is
+	// used because conmon will send a negative value when sending a PID back over a pipe FD
+	// to signify something went wrong in the runtime. We need to differentiate between that
+	// value and a failure on the podman side of reading that value. Thus, we use ErrorConmonRead
+	ErrorConmonRead = math.MinInt32 - 1
 )
 
 // TranslateExecErrorToExitCode takes an error and checks whether it

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -70,7 +70,7 @@ type OCIRuntime interface {
 	// ExecContainer executes a command in a running container.
 	// Returns an int (exit code), error channel (errors from attach), and
 	// error (errors that occurred attempting to start the exec session).
-	ExecContainer(ctr *Container, sessionID string, options *ExecOptions) (int, chan error, error)
+	ExecContainer(ctr *Container, sessionID string, options *ExecOptions) (chan DataAndErr, chan error, error)
 	// ExecStopContainer stops a given exec session in a running container.
 	// SIGTERM with be sent initially, then SIGKILL after the given timeout.
 	// If timeout is 0, SIGKILL will be sent immediately, and SIGTERM will
@@ -158,4 +158,11 @@ type HTTPAttachStreams struct {
 	Stdin  bool
 	Stdout bool
 	Stderr bool
+}
+
+// DataAndErr is a generic structure for passing around an int and an error
+// it is especially useful for getting information from conmon
+type DataAndErr struct {
+	data int
+	err  error
 }

--- a/libpod/oci_attach_linux.go
+++ b/libpod/oci_attach_linux.go
@@ -119,8 +119,8 @@ func (c *Container) attachToExec(streams *AttachStreams, keys string, resize <-c
 	socketPath := buildSocketPath(sockPath)
 
 	// 2: read from attachFd that the parent process has set up the console socket
-	if _, err := readConmonPipeData(attachFd, ""); err != nil {
-		return err
+	if pipeData := readConmonPipeData(attachFd, ""); pipeData.err != nil {
+		return pipeData.err
 	}
 
 	// 2: then attach

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1557,7 +1557,7 @@ func readConmonPipeData(pipe *os.File, ociLog string) DataAndErr {
 		ch <- syncStruct{si: si}
 	}()
 
-	data := -1
+	data := define.ErrorConmonRead
 	select {
 	case ss := <-ch:
 		if ss.err != nil {
@@ -1567,14 +1567,14 @@ func readConmonPipeData(pipe *os.File, ociLog string) DataAndErr {
 					var ociErr ociError
 					if err := json.Unmarshal(ociLogData, &ociErr); err == nil {
 						return DataAndErr{
-							data: -1,
+							data: data,
 							err:  getOCIRuntimeError(ociErr.Msg),
 						}
 					}
 				}
 			}
 			return DataAndErr{
-				data: -1,
+				data: data,
 				err:  errors.Wrapf(ss.err, "container create failed (no logs from conmon)"),
 			}
 		}
@@ -1607,7 +1607,7 @@ func readConmonPipeData(pipe *os.File, ociLog string) DataAndErr {
 		data = ss.si.Data
 	case <-time.After(define.ContainerCreateTimeout):
 		return DataAndErr{
-			data: -1,
+			data: data,
 			err:  errors.Wrapf(define.ErrInternal, "container creation timeout"),
 		}
 	}

--- a/libpod/oci_missing.go
+++ b/libpod/oci_missing.go
@@ -121,8 +121,8 @@ func (r *MissingRuntime) AttachResize(ctr *Container, newSize remotecommand.Term
 }
 
 // ExecContainer is not available as the runtime is missing
-func (r *MissingRuntime) ExecContainer(ctr *Container, sessionID string, options *ExecOptions) (int, chan error, error) {
-	return -1, nil, r.printError()
+func (r *MissingRuntime) ExecContainer(ctr *Container, sessionID string, options *ExecOptions) (chan DataAndErr, chan error, error) {
+	return nil, nil, r.printError()
 }
 
 // ExecStopContainer is not available as the runtime is missing.


### PR DESCRIPTION
Before, we were getting the exit code from the file, in which we waited an arbitrary amount of time (5 seconds) for the file, and segfaulted if we didn't find it. instead, we should be a bit more certain conmon has sent the exit code. Luckily, it sends the exit code along the sync pipe fd, so we can read it from there

Adapt the ExecContainer interface to pass along a channel to get the pid and exit code from conmon, to be able to read both from the pipe

Also slightly change the way we report a bogus value when failing to read from the conmon pipe. we now set it to a value that cannot be a valid pid * -1, to make sure we correctly report the place an error comes from

Signed-off-by: Peter Hunt <pehunt@redhat.com>