### PR TITLE
add default network for apiv2 create

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -138,6 +138,7 @@ func before(cmd *cobra.Command, args []string) error {
 		logrus.Info("running as rootless")
 	}
 	setUMask()
+
 	return profileOn(cmd)
 }
 

--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -18,7 +18,7 @@ exithandler() {
     echo "$(basename $0) exit status: $RET"
     [[ "$RET" -eq "0" ]] && date +%s >> "$SETUP_MARKER_FILEPATH"
     show_env_vars
-    [ "$RET" -eq "0" ]] || warn "Non-zero exit caused by error ABOVE env. var. display."
+    [[ "$RET" -eq "0" ]] || warn "Non-zero exit caused by error ABOVE env. var. display."
 }
 trap exithandler EXIT
 

--- a/pkg/api/handlers/containers.go
+++ b/pkg/api/handlers/containers.go
@@ -72,7 +72,6 @@ func UnpauseContainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// the api does not error if the Container is already paused, so just into it
 	if err := con.Unpause(); err != nil {
 		utils.InternalServerError(w, err)
 		return

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -942,6 +942,50 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:.*}/tag"), s.APIHandler(handlers.TagImage)).Methods(http.MethodPost)
-
+	// swagger:operation POST /commit libpod libpodCommitContainer
+	// ---
+	// tags:
+	//  - containers
+	// summary: Commit
+	// description: Create a new image from a container
+	// parameters:
+	//  - in: query
+	//    name: container
+	//    type: string
+	//    description: the name or ID of a container
+	//  - in: query
+	//    name: repo
+	//    type: string
+	//    description: the repository name for the created image
+	//  - in: query
+	//    name: tag
+	//    type: string
+	//    description: tag name for the created image
+	//  - in: query
+	//    name: comment
+	//    type: string
+	//    description: commit message
+	//  - in: query
+	//    name: author
+	//    type: string
+	//    description: author of the image
+	//  - in: query
+	//    name: pause
+	//    type: boolean
+	//    description: pause the container before committing it
+	//  - in: query
+	//    name: changes
+	//    type: string
+	//    description: instructions to apply while committing in Dockerfile format
+	// produces:
+	// - application/json
+	// responses:
+	//   201:
+	//     description: no error
+	//   404:
+	//     $ref: '#/responses/NoSuchImage'
+	//   500:
+	//     $ref: '#/responses/InternalError'
+	r.Handle(VersionedPath("/commit"), s.APIHandler(generic.CommitContainer)).Methods(http.MethodPost)
 	return nil
 }

--- a/pkg/bindings/containers/create.go
+++ b/pkg/bindings/containers/create.go
@@ -11,7 +11,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 )
 
-func CreateWithSpec(ctx context.Context, s specgen.SpecGenerator) (utils.ContainerCreateResponse, error) {
+func CreateWithSpec(ctx context.Context, s *specgen.SpecGenerator) (utils.ContainerCreateResponse, error) {
 	var ccr utils.ContainerCreateResponse
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {

--- a/pkg/bindings/test/create_test.go
+++ b/pkg/bindings/test/create_test.go
@@ -1,0 +1,50 @@
+package test_bindings
+
+import (
+	"time"
+
+	"github.com/containers/libpod/pkg/bindings/containers"
+	"github.com/containers/libpod/pkg/specgen"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Create containers ", func() {
+	var (
+		bt *bindingTest
+		s  *gexec.Session
+	)
+
+	BeforeEach(func() {
+		bt = newBindingTest()
+		bt.RestoreImagesFromCache()
+		s = bt.startAPIService()
+		time.Sleep(1 * time.Second)
+		err := bt.NewConnection()
+		Expect(err).To(BeNil())
+	})
+
+	AfterEach(func() {
+		s.Kill()
+		bt.cleanup()
+	})
+
+	It("create a container running top", func() {
+		s := specgen.NewSpecGenerator(alpine.name)
+		s.Command = []string{"top"}
+		s.Terminal = true
+		s.Name = "top"
+		ctr, err := containers.CreateWithSpec(bt.conn, s)
+		Expect(err).To(BeNil())
+		data, err := containers.Inspect(bt.conn, ctr.ID, nil)
+		Expect(err).To(BeNil())
+		Expect(data.Name).To(Equal("top"))
+		err = containers.Start(bt.conn, ctr.ID, nil)
+		Expect(err).To(BeNil())
+		data, err = containers.Inspect(bt.conn, ctr.ID, nil)
+		Expect(err).To(BeNil())
+		Expect(data.State.Status).To(Equal("running"))
+	})
+
+})

--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -70,9 +70,7 @@ func (n *Namespace) IsPrivate() bool {
 	return n.NSMode == Private
 }
 
-// validate perform simple validation on the namespace to make sure it is not
-// invalid from the get-go
-func (n *Namespace) validate() error {
+func validateNetNS(n *Namespace) error {
 	if n == nil {
 		return nil
 	}
@@ -81,6 +79,15 @@ func (n *Namespace) validate() error {
 		break
 	default:
 		return errors.Errorf("invalid network %q", n.NSMode)
+	}
+	return nil
+}
+
+// validate perform simple validation on the namespace to make sure it is not
+// invalid from the get-go
+func (n *Namespace) validate() error {
+	if n == nil {
+		return nil
 	}
 	// Path and From Container MUST have a string value set
 	if n.NSMode == Path || n.NSMode == FromContainer {

--- a/pkg/specgen/validate.go
+++ b/pkg/specgen/validate.go
@@ -138,7 +138,7 @@ func (s *SpecGenerator) validate(rt *libpod.Runtime) error {
 	if err := s.IpcNS.validate(); err != nil {
 		return err
 	}
-	if err := s.NetNS.validate(); err != nil {
+	if err := validateNetNS(&s.NetNS); err != nil {
 		return err
 	}
 	if err := s.PidNS.validate(); err != nil {


### PR DESCRIPTION
during container creation, if no network is provided, we need to add a default value so the container can be later started.

use apiv2 container creation for RunTopContainer instead of an exec to the system podman. RunTopContainer now also returns the container id and an error.

also, changed the use of the connections and bindings slightly to make it more convenient to write tests.

Fixes: #5366 

Signed-off-by: Brent Baude <bbaude@redhat.com>