### PR TITLE
env: set "container" to current binary

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -477,7 +477,9 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 	//
 	// Precedence order (higher index wins):
 	//  1) env-host, 2) image data, 3) env-file, 4) env
-	var env map[string]string
+	env := map[string]string{
+		"container": "podman",
+	}
 
 	// Start with env-host
 	if c.Bool("env-host") {
@@ -485,7 +487,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		if err != nil {
 			return nil, errors.Wrap(err, "error parsing host environment variables")
 		}
-		env = osEnv
+		env = envLib.Join(env, osEnv)
 	}
 
 	// Image data overrides any previous variables

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -12,11 +12,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-// DefaultEnvVariables set $PATH, $TERM and $container.
+// DefaultEnvVariables sets $PATH and $TERM.
 var DefaultEnvVariables = map[string]string{
-	"PATH":      "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-	"TERM":      "xterm",
-	"container": "podman",
+	"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	"TERM": "xterm",
 }
 
 const whiteSpaces = " \t"


### PR DESCRIPTION
Instead of hard-coding "podman" as the "container" environment variable
set it to the current binary.  This way the package isn't tied to podman
and can be used by others (e.g., cri-o).

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan PTAL