### PR TITLE
WIP: Cirrus: More Ubuntu 19 + Fedora 31

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -394,8 +394,9 @@ testing_task:
         - name: "test ${PRIOR_FEDORA_NAME}"
           gce_instance:
               image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
-        # Multiple test failures on Ubuntu 19 - Fixes TBD in future PR
-        # TODO: image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
+        - name: "test ${UBUNTU_CACHE_IMAGE_NAME}"
+          gce_instance:
+              image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
         - name: "test ${PRIOR_UBUNTU_NAME}"
           gce_instance:
               image_name: "${PRIOR_UBUNTU_CACHE_IMAGE_NAME}"
@@ -494,12 +495,12 @@ special_testing_in_podman_task:
         $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
 
     matrix:
-        # FIXME: Integration testing currently broken for F31 hosts
-        # Error: container_linux.go:345: starting container process caused "process_linux.go:281: applying cgroup configuration for process caused \"mountpoint for cgroup not found\"": OCI runtime error
-        # image_name: "${FEDORA_CACHE_IMAGE_NAME}"
         - name: "in-podman ${PRIOR_FEDORA_NAME}"
           gce_instance:
               image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
+        - name: "in-podman ${FEDORA_CACHE_IMAGE_NAME}"
+          gce_instance:
+              image_name: "${FEDORA_CACHE_IMAGE_NAME}"
 
     env:
         ADD_SECOND_PARTITION: 'true'
@@ -695,47 +696,6 @@ verify_test_built_images_task:
 
     always:
         <<: *standardlogs
-
-
-#test_building_snap_task:
-#
-#    depends_on:
-#        - "gating"
-#
-#    only_if: >-
-#        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-#        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
-#
-#    container:
-#        image: yakshaveinc/snapcraft:core18
-#    snapcraft_script:
-#        - 'apt-get -y update'
-#        - 'cd contrib/snapcraft && snapcraft'
-#
-#
-#upload_snap_task:
-#    only_if: >-
-#        $CIRRUS_BRANCH != $DEST_BRANCH &&
-#        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-#        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
-#
-#    # Only when PR or branch is merged into master
-#
-#    depends_on:
-#        - "test_building_snap"
-#
-#    container:
-#        image: yakshaveinc/snapcraft:core18
-#
-#    env:
-#        SNAPCRAFT_LOGIN: ENCRYPTED[d8e82eb31c6372fec07f405f413d57806026b1a9f8400033531ebcd54d6750a5e4a8b1f68e3ec65c98c65e0d9b2a6a75]
-#    snapcraft_login_file:
-#        path: /root/.snapcraft/login.cfg
-#        variable_name: SNAPCRAFT_LOGIN
-#    snapcraft_script:
-#        - 'apt-get -y update'
-#        - 'snapcraft login --with "/root/.snapcraft/login.cfg"'
-#        - 'cd contrib/snapcraft && snapcraft && snapcraft push *.snap --release edge'
 
 
 docs_task:


### PR DESCRIPTION
Prior to this commit, these tests were disabled to avoid their debugging impacting the general update to F31 for other areas.  This PR re-enables all the disabled tests.

Signed-off-by: Chris Evich <cevich@redhat.com>