### PR TITLE
avoid adding to nil map

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -62,7 +62,8 @@ func Join(base map[string]string, override map[string]string) map[string]string 
 
 // ParseFile parses the specified path for environment variables and returns them
 // as a map.
-func ParseFile(path string) (env map[string]string, err error) {
+func ParseFile(path string) (_ map[string]string, err error) {
+	env := make(map[string]string)
 	defer func() {
 		if err != nil {
 			err = errors.Wrapf(err, "error parsing env file %q", path)


### PR DESCRIPTION
we need to make the environment map to avoid throwing an error when trying to add an environment value from file.

Signed-off-by: Brent Baude <bbaude@redhat.com>