### PR TITLE
Rename long cirrus job names

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -396,8 +396,12 @@ testing_task:
     env:
         ADD_SECOND_PARTITION: 'true'
         matrix:
-            TEST_REMOTE_CLIENT: 'true'
-            TEST_REMOTE_CLIENT: 'false'
+            - name: remote
+              env:
+                  TEST_REMOTE_CLIENT: 'true'
+            - name: local
+              env:
+                  TEST_REMOTE_CLIENT: 'false'
 
     networking_script: '${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/networking.sh'
     setup_environment_script: '$SCRIPT_BASE/setup_environment.sh |& ${TIMESTAMP}'
@@ -448,8 +452,12 @@ special_testing_rootless_task:
         ADD_SECOND_PARTITION: 'true'
         SPECIALMODE: 'rootless'  # See docs
         matrix:
-            TEST_REMOTE_CLIENT: 'true'
-            TEST_REMOTE_CLIENT: 'false'
+            - name: remote
+              env:
+                  TEST_REMOTE_CLIENT: 'true'
+            - name: local
+              env:
+                  TEST_REMOTE_CLIENT: 'false'
 
     timeout_in: 60m
 
@@ -649,8 +657,12 @@ verify_test_built_images_task:
     env:
         ADD_SECOND_PARTITION: 'true'
         matrix:
-            TEST_REMOTE_CLIENT: 'true'
-            TEST_REMOTE_CLIENT: 'false'
+            - name: remote
+              env:
+                  TEST_REMOTE_CLIENT: 'true'
+            - name: local
+              env:
+                  TEST_REMOTE_CLIENT: 'false'
         matrix:
             # Required env. var. by check_image_script
             PACKER_BUILDER_NAME: "fedora-30"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,11 +34,16 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ###
+    FEDORA_NAME: "fedora-31"
+    PRIOR_FEDORA_NAME: "fedora-30"
+    UBUNTU_NAME: "ubuntu-19"
+    PRIOR_UBUNTU_NAME: "ubuntu-18"
+
     _BUILT_IMAGE_SUFFIX: "libpod-5940307564953600"
-    FEDORA_CACHE_IMAGE_NAME: "fedora-31-${_BUILT_IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-30-${_BUILT_IMAGE_SUFFIX}"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-19-${_BUILT_IMAGE_SUFFIX}"
-    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "ubuntu-18-${_BUILT_IMAGE_SUFFIX}"
+    FEDORA_CACHE_IMAGE_NAME: "${FEDORA_NAME}-${_BUILT_IMAGE_SUFFIX}"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "${PRIOR_FEDORA_NAME}-${_BUILT_IMAGE_SUFFIX}"
+    UBUNTU_CACHE_IMAGE_NAME: "${UBUNTU_NAME}-${_BUILT_IMAGE_SUFFIX}"
+    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "${PRIOR_UBUNTU_NAME}-${_BUILT_IMAGE_SUFFIX}"
 
     ####
     #### Variables for composing new cache-images (used in PR testing) from
@@ -370,7 +375,7 @@ image_prune_task:
 
 # This task does the unit and integration testing for every platform
 testing_task:
-
+    alias: "testing"
     depends_on:
         - "gating"
         - "vendor"
@@ -383,13 +388,18 @@ testing_task:
         $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
         $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
 
-    gce_instance:
-        matrix:
-            image_name: "${FEDORA_CACHE_IMAGE_NAME}"
-            image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
-            # Multiple test failures on Ubuntu 19 - Fixes TBD in future PR
-            # TODO: image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
-            image_name: "${PRIOR_UBUNTU_CACHE_IMAGE_NAME}"
+    matrix:
+        - name: "test ${FEDORA_NAME}"
+          gce_instance:
+              image_name: "${FEDORA_CACHE_IMAGE_NAME}"
+        - name: "test ${PRIOR_FEDORA_NAME}"
+          gce_instance:
+              image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
+        # Multiple test failures on Ubuntu 19 - Fixes TBD in future PR
+        # TODO: image_name: "${UBUNTU_CACHE_IMAGE_NAME}"
+        - name: "test ${PRIOR_UBUNTU_NAME}"
+          gce_instance:
+              image_name: "${PRIOR_UBUNTU_CACHE_IMAGE_NAME}"
 
     timeout_in: 120m
 
@@ -475,7 +485,7 @@ special_testing_rootless_task:
 
 
 special_testing_in_podman_task:
-
+    alias: "special_testing_in_podman"
     depends_on:
         - "gating"
         - "varlink_api"
@@ -487,12 +497,13 @@ special_testing_in_podman_task:
         $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
         $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
 
-    gce_instance:
-        matrix:
-            # FIXME: Integration testing currently broken for F31 hosts
-            # Error: container_linux.go:345: starting container process caused "process_linux.go:281: applying cgroup configuration for process caused \"mountpoint for cgroup not found\"": OCI runtime error
-            # image_name: "${FEDORA_CACHE_IMAGE_NAME}"
-            image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
+    matrix:
+        # FIXME: Integration testing currently broken for F31 hosts
+        # Error: container_linux.go:345: starting container process caused "process_linux.go:281: applying cgroup configuration for process caused \"mountpoint for cgroup not found\"": OCI runtime error
+        # image_name: "${FEDORA_CACHE_IMAGE_NAME}"
+        - name: "in-podman ${PRIOR_FEDORA_NAME}"
+          gce_instance:
+              image_name: "${PRIOR_FEDORA_CACHE_IMAGE_NAME}"
 
     env:
         ADD_SECOND_PARTITION: 'true'
@@ -517,7 +528,7 @@ special_testing_in_podman_task:
 
 
 special_testing_cross_task:
-
+    alias: "special_testing_cross"
     depends_on:
         - "gating"
         - "varlink_api"
@@ -527,10 +538,13 @@ special_testing_cross_task:
         $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
         $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
 
-    env:
-        matrix:
-            CROSS_PLATFORM: 'windows'
-            CROSS_PLATFORM: 'darwin'
+    matrix:
+        - name: 'cross-platform: windows'
+          env:
+              CROSS_PLATFORM: 'windows'
+        - name: 'cross-platform: darwin'
+          env:
+              CROSS_PLATFORM: 'darwin'
 
     timeout_in: 20m
 
@@ -665,11 +679,11 @@ verify_test_built_images_task:
                   TEST_REMOTE_CLIENT: 'false'
         matrix:
             # Required env. var. by check_image_script
-            PACKER_BUILDER_NAME: "fedora-30"
-            PACKER_BUILDER_NAME: "fedora-31"
-            PACKER_BUILDER_NAME: "ubuntu-18"
+            PACKER_BUILDER_NAME: "${FEDORA_NAME}"
+            PACKER_BUILDER_NAME: "${PRIOR_FEDORA_NAME}"
+            PACKER_BUILDER_NAME: "${PRIOR_UBUNTU_NAME}"
             # Multiple test failures on ${UBUNTU_CACHE_IMAGE_NAME}
-            # PACKER_BUILDER_NAME: "ubuntu-19"
+            # PACKER_BUILDER_NAME: "${UBUNTU_NAME}"
 
     networking_script: '${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/networking.sh'
     installed_packages_script: '$SCRIPT_BASE/logcollector.sh packages'


### PR DESCRIPTION
Basically, add a 'name' tag (remote, local) to each incantation
of TEST_REMOTE_CLIENT: true/false

I have no idea if this will work or what results it'll produce.

Signed-off-by: Ed Santiago <santiago@redhat.com>