### PR TITLE
Fix podman image sign help output

### DIFF
--- a/cmd/podman/sign.go
+++ b/cmd/podman/sign.go
@@ -35,8 +35,8 @@ var (
 			signCommand.Remote = remoteclient
 			return signCmd(&signCommand)
 		},
-		Example: `podman sign --sign-by mykey imageID
-  podman sign --sign-by mykey --directory ./mykeydir imageID`,
+		Example: `podman image sign --sign-by mykey imageID
+  podman image sign --sign-by mykey --directory ./mykeydir imageID`,
 	}
 )
 


### PR DESCRIPTION
Adjust the help output to mention `podman image sign` instead of just
`podman sign`.
