### PR TITLE
Cirrus: Fix fedora-minimal mirroring

### DIFF
--- a/contrib/fedora-minimal/Dockerfile
+++ b/contrib/fedora-minimal/Dockerfile
@@ -1,1 +1,1 @@
-FROM fedora-minimal:latest
+FROM registry.fedoraproject.org/fedora-minimal:latest


### PR DESCRIPTION
Builds of this dockerfile fail on quay.io due to not being able to pull
the base image.  Use a fully-qualified FROM name to work around this.

Signed-off-by: Chris Evich <cevich@redhat.com>