### PR TITLE
exec: fix error code when conmon fails

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -340,6 +340,12 @@ func (c *Container) Exec(tty, privileged bool, env map[string]string, cmd []stri
 		if lastErr != nil {
 			logrus.Errorf(lastErr.Error())
 		}
+		// ErrorConmonRead is a bogus value set by podman to indicate reading a value from
+		// conmon failed. Since it is specifically not a valid exit code, we should set
+		// a generic error here
+		if exitCodeData.data == define.ErrorConmonRead {
+			exitCodeData.data = define.ExecErrorCodeGeneric
+		}
 		lastErr = errors.Wrapf(define.ErrOCIRuntime, "non zero exit code: %d", exitCodeData.data)
 	}
 


### PR DESCRIPTION
this is a cosmetic change that makes sure podman returns a sane error code when conmon dies underneath it

fixes the weirdness in this comment: https://github.com/containers/libpod/issues/5339#issuecomment-594836315

but unfortunately not the underlying problem.

Signed-off-by: Peter Hunt <pehunt@redhat.com>