### PR TITLE
generate systemd: remove leading slashes

### DIFF
--- a/pkg/systemd/generate/systemdgen.go
+++ b/pkg/systemd/generate/systemdgen.go
@@ -96,11 +96,11 @@ Before={{- range $index, $value := .RequiredServices -}}{{if $index}} {{end}}{{ 
 [Service]
 Restart={{.RestartPolicy}}
 {{- if .New}}
-ExecStartPre=/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
+ExecStartPre=/usr/bin/rm -f %t/%n-pid %t/%n-cid
 ExecStart={{.RunCommand}}
-ExecStop={{.Executable}} stop --ignore --cidfile /%t/%n-cid {{if (ge .StopTimeout 0)}}-t {{.StopTimeout}}{{end}}
-ExecStopPost={{.Executable}} rm --ignore -f --cidfile /%t/%n-cid
-PIDFile=/%t/%n-pid
+ExecStop={{.Executable}} stop --ignore --cidfile %t/%n-cid {{if (ge .StopTimeout 0)}}-t {{.StopTimeout}}{{end}}
+ExecStopPost={{.Executable}} rm --ignore -f --cidfile %t/%n-cid
+PIDFile=%t/%n-pid
 {{- else}}
 ExecStart={{.Executable}} start {{.ContainerName}}
 ExecStop={{.Executable}} stop {{if (ge .StopTimeout 0)}}-t {{.StopTimeout}}{{end}} {{.ContainerName}}
@@ -160,8 +160,8 @@ func CreateContainerSystemdUnit(info *ContainerInfo, opts Options) (string, erro
 		command := []string{
 			info.Executable,
 			"run",
-			"--conmon-pidfile", "/%t/%n-pid",
-			"--cidfile", "/%t/%n-cid",
+			"--conmon-pidfile", "%t/%n-pid",
+			"--cidfile", "%t/%n-cid",
 			"--cgroups=no-conmon",
 		}
 		command = append(command, info.CreateCommand[index:]...)

--- a/pkg/systemd/generate/systemdgen_test.go
+++ b/pkg/systemd/generate/systemdgen_test.go
@@ -131,11 +131,11 @@ After=network-online.target
 
 [Service]
 Restart=always
-ExecStartPre=/usr/bin/rm -f /%t/%n-pid /%t/%n-cid
-ExecStart=/usr/bin/podman run --conmon-pidfile /%t/%n-pid --cidfile /%t/%n-cid --cgroups=no-conmon --name jadda-jadda --hostname hello-world awesome-image:latest command arg1 ... argN
-ExecStop=/usr/bin/podman stop --ignore --cidfile /%t/%n-cid -t 42
-ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile /%t/%n-cid
-PIDFile=/%t/%n-pid
+ExecStartPre=/usr/bin/rm -f %t/%n-pid %t/%n-cid
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/%n-pid --cidfile %t/%n-cid --cgroups=no-conmon --name jadda-jadda --hostname hello-world awesome-image:latest command arg1 ... argN
+ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%n-cid -t 42
+ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
+PIDFile=%t/%n-pid
 KillMode=none
 Type=forking
 

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Podman generate systemd", func() {
 		found, _ := session.GrepString("# container-foo.service")
 		Expect(found).To(BeTrue())
 
-		found, _ = session.GrepString("stop --ignore --cidfile /%t/%n-cid -t 42")
+		found, _ = session.GrepString("stop --ignore --cidfile %t/%n-cid -t 42")
 		Expect(found).To(BeTrue())
 	})
 


### PR DESCRIPTION
Remove leading slashes from the run-dir paths. It was meant to make it
explicit that we're dealing with an absolute path but user feedback has
shown that most are aware.  It also cleans up the path in the systemctl
status output.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>