### PR TITLE
golangci: enable goimports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
     - goconst
     - gocyclo
     - golint
-    - goimports
     - gosec
     - lll
     - maligned

--- a/cmd/podman/diff.go
+++ b/cmd/podman/diff.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/containers/buildah/pkg/formats"
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"

--- a/cmd/podman/network_list.go
+++ b/cmd/podman/network_list.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"errors"
+
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/containers/libpod/pkg/rootless"

--- a/cmd/podman/pod_pause.go
+++ b/cmd/podman/pod_pause.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/pkg/errors"

--- a/libpod/image/filters.go
+++ b/libpod/image/filters.go
@@ -3,13 +3,13 @@ package image
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/containers/libpod/pkg/inspect"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -21,7 +21,7 @@ import (
 	"github.com/containers/image/v5/directory"
 	dockerarchive "github.com/containers/image/v5/docker/archive"
 	ociarchive "github.com/containers/image/v5/oci/archive"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Runtime API

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/util"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/pkg/errors"

--- a/libpod/storage.go
+++ b/libpod/storage.go
@@ -8,7 +8,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/storage"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"

--- a/pkg/api/handlers/containers.go
+++ b/pkg/api/handlers/containers.go
@@ -2,12 +2,12 @@ package handlers
 
 import (
 	"fmt"
-	"github.com/docker/docker/api/types"
 	"net/http"
 
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/api/handlers/utils"
+	"github.com/docker/docker/api/types"
 	"github.com/gorilla/schema"
 	"github.com/pkg/errors"
 )

--- a/pkg/api/handlers/utils/handler.go
+++ b/pkg/api/handlers/utils/handler.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/apparmor/apparmor.go
+++ b/pkg/apparmor/apparmor.go
@@ -2,6 +2,7 @@ package apparmor
 
 import (
 	"errors"
+
 	libpodVersion "github.com/containers/libpod/version"
 )
 

--- a/pkg/bindings/containers/healthcheck.go
+++ b/pkg/bindings/containers/healthcheck.go
@@ -2,10 +2,10 @@ package containers
 
 import (
 	"context"
-	"github.com/containers/libpod/pkg/bindings"
 	"net/http"
 
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/pkg/bindings"
 )
 
 // RunHealthCheck executes the container's healthcheck and returns the health status of the

--- a/pkg/hooks/exec/exec.go
+++ b/pkg/hooks/exec/exec.go
@@ -5,13 +5,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io"
 	osexec "os/exec"
 	"time"
 
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // DefaultPostKillTimeout is the recommended default post-kill timeout.

--- a/pkg/lookup/lookup.go
+++ b/pkg/lookup/lookup.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/cyphar/filepath-securejoin"
+	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/user"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/specgen/create.go
+++ b/pkg/specgen/create.go
@@ -2,12 +2,13 @@ package specgen
 
 import (
 	"context"
+	"os"
+
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/config"
 	"github.com/containers/libpod/libpod/define"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"os"
 )
 
 // MakeContainer creates a container based on the SpecGenerator


### PR DESCRIPTION
Enable the goimports linter and fix reports.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>