### PR TITLE
APIv2: compatible api fixes

### DIFF
--- a/pkg/api/handlers/generic/containers.go
+++ b/pkg/api/handlers/generic/containers.go
@@ -58,9 +58,6 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 		// override any golang type defaults
 	}
 
-	// Default Size to false
-	query.Size = false
-
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
 		return
@@ -107,9 +104,6 @@ func GetContainer(w http.ResponseWriter, r *http.Request) {
 	}{
 		// override any golang type defaults
 	}
-
-	// Default Size to false
-	query.Size = false
 
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))

--- a/pkg/api/handlers/generic/containers.go
+++ b/pkg/api/handlers/generic/containers.go
@@ -57,6 +57,10 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 	}{
 		// override any golang type defaults
 	}
+
+	// Default Size to false
+	query.Size = false
+
 	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusBadRequest, errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
 		return
@@ -85,7 +89,7 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 
 	var list = make([]*handlers.Container, len(containers))
 	for i, ctnr := range containers {
-		api, err := handlers.LibpodToContainer(ctnr, infoData)
+		api, err := handlers.LibpodToContainer(ctnr, infoData, query.Size)
 		if err != nil {
 			utils.InternalServerError(w, err)
 			return

--- a/pkg/api/handlers/generic/images.go
+++ b/pkg/api/handlers/generic/images.go
@@ -305,7 +305,8 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Failed get images"))
 		return
 	}
-	var summaries = make([]*handlers.ImageSummary, len(images)+1)
+	// +1 removed from len(images) as this leaves a null entry at the end of the image array
+	var summaries = make([]*handlers.ImageSummary, len(images))
 	for j, img := range images {
 		is, err := handlers.ImageToImageSummary(img)
 		if err != nil {

--- a/pkg/api/handlers/generic/images.go
+++ b/pkg/api/handlers/generic/images.go
@@ -305,7 +305,6 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, errors.Wrap(err, "Failed get images"))
 		return
 	}
-	// +1 removed from len(images) as this leaves a null entry at the end of the image array
 	var summaries = make([]*handlers.ImageSummary, len(images))
 	for j, img := range images {
 		is, err := handlers.ImageToImageSummary(img)

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -347,7 +347,7 @@ func ImageDataToImageInspect(ctx context.Context, l *libpodImage.Image) (*ImageI
 
 }
 
-func LibpodToContainer(l *libpod.Container, infoData []define.InfoData) (*Container, error) {
+func LibpodToContainer(l *libpod.Container, infoData []define.InfoData, sz bool) (*Container, error) {
 	imageId, imageName := l.Image()
 
 	var (
@@ -366,11 +366,16 @@ func LibpodToContainer(l *libpod.Container, infoData []define.InfoData) (*Contai
 		stateStr = "created"
 	}
 
-	if sizeRW, err = l.RWSize(); err != nil {
-		return nil, err
-	}
-	if sizeRootFs, err = l.RootFsSize(); err != nil {
-		return nil, err
+	if sz {
+		if sizeRW, err = l.RWSize(); err != nil {
+			return nil, err
+		}
+		if sizeRootFs, err = l.RootFsSize(); err != nil {
+			return nil, err
+		}
+	} else {
+		sizeRW = 0
+		sizeRootFs = 0
 	}
 
 	return &Container{docker.Container{

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -355,11 +355,17 @@ func LibpodToContainer(l *libpod.Container, infoData []define.InfoData) (*Contai
 		sizeRootFs int64
 		sizeRW     int64
 		state      define.ContainerStatus
+		stateStr   string
 	)
 
 	if state, err = l.State(); err != nil {
 		return nil, err
 	}
+	stateStr = state.String()
+	if stateStr == "configured" {
+		stateStr = "created"
+	}
+
 	if sizeRW, err = l.RWSize(); err != nil {
 		return nil, err
 	}
@@ -378,7 +384,7 @@ func LibpodToContainer(l *libpod.Container, infoData []define.InfoData) (*Contai
 		SizeRw:     sizeRW,
 		SizeRootFs: sizeRootFs,
 		Labels:     l.Labels(),
-		State:      string(state),
+		State:      stateStr,
 		Status:     "",
 		HostConfig: struct {
 			NetworkMode string `json:",omitempty"`

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -355,13 +355,12 @@ func LibpodToContainer(l *libpod.Container, infoData []define.InfoData, sz bool)
 		sizeRootFs int64
 		sizeRW     int64
 		state      define.ContainerStatus
-		stateStr   string
 	)
 
 	if state, err = l.State(); err != nil {
 		return nil, err
 	}
-	stateStr = state.String()
+	stateStr := state.String()
 	if stateStr == "configured" {
 		stateStr = "created"
 	}
@@ -373,9 +372,6 @@ func LibpodToContainer(l *libpod.Container, infoData []define.InfoData, sz bool)
 		if sizeRootFs, err = l.RootFsSize(); err != nil {
 			return nil, err
 		}
-	} else {
-		sizeRW = 0
-		sizeRootFs = 0
 	}
 
 	return &Container{docker.Container{

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -403,13 +403,8 @@ func LibpodToContainer(l *libpod.Container, infoData []define.InfoData, sz bool)
 }
 
 func LibpodToContainerJSON(l *libpod.Container, sz bool) (*docker.ContainerJSON, error) {
-	var (
-		sizeRootFs int64
-		sizeRW     int64
-	)
-
 	_, imageName := l.Image()
-	inspect, err := l.Inspect(true)
+	inspect, err := l.Inspect(sz)
 	if err != nil {
 		return nil, err
 	}
@@ -444,18 +439,6 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*docker.ContainerJSON,
 		return nil, err
 	}
 
-	if sz {
-		if sizeRW, err = l.RWSize(); err != nil {
-			return nil, err
-		}
-		if sizeRootFs, err = l.RootFsSize(); err != nil {
-			return nil, err
-		}
-	} else {
-		sizeRW = 0
-		sizeRootFs = 0
-	}
-
 	cb := docker.ContainerJSONBase{
 		ID:              l.ID(),
 		Created:         l.CreatedTime().String(),
@@ -478,8 +461,8 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*docker.ContainerJSON,
 		ExecIDs:         inspect.ExecIDs,
 		HostConfig:      &hc,
 		GraphDriver:     graphDriver,
-		SizeRw:          &sizeRW,
-		SizeRootFs:      &sizeRootFs,
+		SizeRw:          inspect.SizeRw,
+		SizeRootFs:      &inspect.SizeRootFs,
 	}
 
 	stopTimeout := int(l.StopTimeout())

--- a/pkg/api/server/register_auth.go
+++ b/pkg/api/server/register_auth.go
@@ -7,5 +7,7 @@ import (
 
 func (s *APIServer) registerAuthHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/auth"), s.APIHandler(handlers.UnsupportedHandler))
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/auth", s.APIHandler(handlers.UnsupportedHandler))
 	return nil
 }

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -34,6 +34,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//     500:
 	//       $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/create"), s.APIHandler(generic.CreateContainer)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/create", s.APIHandler(generic.CreateContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /containers/json compat listContainers
 	// ---
 	// tags:
@@ -84,6 +86,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/json"), s.APIHandler(generic.ListContainers)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/json", s.APIHandler(generic.ListContainers)).Methods(http.MethodGet)
 	// swagger:operation POST  /containers/prune compat pruneContainers
 	// ---
 	// tags:
@@ -106,6 +110,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/prune"), s.APIHandler(handlers.PruneContainers)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/prune", s.APIHandler(handlers.PruneContainers)).Methods(http.MethodPost)
 	// swagger:operation DELETE /containers/{name} compat removeContainer
 	// ---
 	// tags:
@@ -145,6 +151,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}"), s.APIHandler(generic.RemoveContainer)).Methods(http.MethodDelete)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}", s.APIHandler(generic.RemoveContainer)).Methods(http.MethodDelete)
 	// swagger:operation GET /containers/{name}/json compat getContainer
 	// ---
 	// tags:
@@ -172,6 +180,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/json"), s.APIHandler(generic.GetContainer)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/json", s.APIHandler(generic.GetContainer)).Methods(http.MethodGet)
 	// swagger:operation POST /containers/{name}/kill compat killContainer
 	// ---
 	// tags:
@@ -202,6 +212,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/kill"), s.APIHandler(generic.KillContainer)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/kill", s.APIHandler(generic.KillContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /containers/{name}/logs compat logsFromContainer
 	// ---
 	// tags:
@@ -254,6 +266,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//      $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/logs"), s.APIHandler(generic.LogsFromContainer)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/logs", s.APIHandler(generic.LogsFromContainer)).Methods(http.MethodGet)
 	// swagger:operation POST /containers/{name}/pause compat pauseContainer
 	// ---
 	// tags:
@@ -276,7 +290,11 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/pause"), s.APIHandler(handlers.PauseContainer)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/pause", s.APIHandler(handlers.PauseContainer)).Methods(http.MethodPost)
 	r.HandleFunc(VersionedPath("/containers/{name}/rename"), s.APIHandler(handlers.UnsupportedHandler)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/rename", s.APIHandler(handlers.UnsupportedHandler)).Methods(http.MethodPost)
 	// swagger:operation POST /containers/{name}/restart compat restartContainer
 	// ---
 	// tags:
@@ -302,6 +320,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/restart"), s.APIHandler(handlers.RestartContainer)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/restart", s.APIHandler(handlers.RestartContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /containers/{name}/start compat startContainer
 	// ---
 	// tags:
@@ -330,6 +350,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/start"), s.APIHandler(handlers.StartContainer)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/start", s.APIHandler(handlers.StartContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /containers/{name}/stats compat statsContainer
 	// ---
 	// tags:
@@ -357,6 +379,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/stats"), s.APIHandler(generic.StatsContainer)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/stats", s.APIHandler(generic.StatsContainer)).Methods(http.MethodGet)
 	// swagger:operation POST /containers/{name}/stop compat stopContainer
 	// ---
 	// tags:
@@ -385,6 +409,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/stop"), s.APIHandler(handlers.StopContainer)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/stop", s.APIHandler(handlers.StopContainer)).Methods(http.MethodPost)
 	// swagger:operation GET /containers/{name}/top compat topContainer
 	// ---
 	// tags:
@@ -410,6 +436,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/top"), s.APIHandler(handlers.TopContainer)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/top", s.APIHandler(handlers.TopContainer)).Methods(http.MethodGet)
 	// swagger:operation POST /containers/{name}/unpause compat unpauseContainer
 	// ---
 	// tags:
@@ -432,6 +460,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/unpause"), s.APIHandler(handlers.UnpauseContainer)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/unpause", s.APIHandler(handlers.UnpauseContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /containers/{name}/wait compat waitContainer
 	// ---
 	// tags:
@@ -465,6 +495,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/wait"), s.APIHandler(generic.WaitContainer)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/wait", s.APIHandler(generic.WaitContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /containers/{name}/attach compat attachContainer
 	// ---
 	// tags:
@@ -520,6 +552,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/attach"), s.APIHandler(handlers.AttachContainer)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/attach", s.APIHandler(handlers.AttachContainer)).Methods(http.MethodPost)
 	// swagger:operation POST /containers/{name}/resize compat resizeContainer
 	// ---
 	// tags:
@@ -552,6 +586,8 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/containers/{name}/resize"), s.APIHandler(handlers.ResizeContainer)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/containers/{name}/resize", s.APIHandler(handlers.ResizeContainer)).Methods(http.MethodPost)
 
 	/*
 		libpod endpoints

--- a/pkg/api/server/register_distribution.go
+++ b/pkg/api/server/register_distribution.go
@@ -7,5 +7,7 @@ import (
 
 func (s *APIServer) registerDistributionHandlers(r *mux.Router) error {
 	r.HandleFunc(VersionedPath("/distribution/{name}/json"), handlers.UnsupportedHandler)
+	// Added non version path to URI to support docker non versioned paths
+	r.HandleFunc("/distribution/{name}/json", handlers.UnsupportedHandler)
 	return nil
 }

--- a/pkg/api/server/register_events.go
+++ b/pkg/api/server/register_events.go
@@ -35,5 +35,7 @@ func (s *APIServer) registerEventsHandlers(r *mux.Router) error {
 	//   500:
 	//     "$ref": "#/responses/InternalError"
 	r.Handle(VersionedPath("/events"), s.APIHandler(handlers.GetEvents)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/events", s.APIHandler(handlers.GetEvents)).Methods(http.MethodGet)
 	return nil
 }

--- a/pkg/api/server/register_exec.go
+++ b/pkg/api/server/register_exec.go
@@ -75,6 +75,8 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/containers/{name}/create"), s.APIHandler(handlers.CreateExec)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/containers/{name}/create", s.APIHandler(handlers.CreateExec)).Methods(http.MethodPost)
 	// swagger:operation POST /exec/{id}/start compat startExec
 	// ---
 	// tags:
@@ -111,6 +113,8 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/exec/{id}/start"), s.APIHandler(handlers.StartExec)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/exec/{id}/start", s.APIHandler(handlers.StartExec)).Methods(http.MethodPost)
 	// swagger:operation POST /exec/{id}/resize compat resizeExec
 	// ---
 	// tags:
@@ -142,6 +146,8 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/exec/{id}/resize"), s.APIHandler(handlers.ResizeExec)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/exec/{id}/resize", s.APIHandler(handlers.ResizeExec)).Methods(http.MethodPost)
 	// swagger:operation GET /exec/{id}/json compat inspectExec
 	// ---
 	// tags:
@@ -164,6 +170,8 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/exec/{id}/json"), s.APIHandler(handlers.InspectExec)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/exec/{id}/json", s.APIHandler(handlers.InspectExec)).Methods(http.MethodGet)
 
 	/*
 		libpod api follows

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -48,7 +48,11 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/images/create"), s.APIHandler(generic.CreateImageFromImage)).Methods(http.MethodPost).Queries("fromImage", "{fromImage}")
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/create", s.APIHandler(generic.CreateImageFromImage)).Methods(http.MethodPost).Queries("fromImage", "{fromImage}")
 	r.Handle(VersionedPath("/images/create"), s.APIHandler(generic.CreateImageFromSrc)).Methods(http.MethodPost).Queries("fromSrc", "{fromSrc}")
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/create", s.APIHandler(generic.CreateImageFromSrc)).Methods(http.MethodPost).Queries("fromSrc", "{fromSrc}")
 	// swagger:operation GET /images/json compat listImages
 	// ---
 	// tags:
@@ -84,6 +88,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/images/json"), s.APIHandler(generic.GetImages)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/json", s.APIHandler(generic.GetImages)).Methods(http.MethodGet)
 	// swagger:operation POST /images/load compat importImage
 	// ---
 	// tags:
@@ -108,6 +114,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/images/load"), s.APIHandler(generic.LoadImages)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/load", s.APIHandler(generic.LoadImages)).Methods(http.MethodPost)
 	// swagger:operation POST /images/prune compat pruneImages
 	// ---
 	// tags:
@@ -133,6 +141,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/images/prune"), s.APIHandler(generic.PruneImages)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/prune", s.APIHandler(generic.PruneImages)).Methods(http.MethodPost)
 	// swagger:operation GET /images/search compat searchImages
 	// ---
 	// tags:
@@ -166,6 +176,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/images/search"), s.APIHandler(handlers.SearchImages)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/search", s.APIHandler(handlers.SearchImages)).Methods(http.MethodGet)
 	// swagger:operation DELETE /images/{name:.*} compat removeImage
 	// ---
 	// tags:
@@ -198,6 +210,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/images/{name:.*}"), s.APIHandler(handlers.RemoveImage)).Methods(http.MethodDelete)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/{name:.*}", s.APIHandler(handlers.RemoveImage)).Methods(http.MethodDelete)
 	// swagger:operation GET /images/{name:.*}/get compat exportImage
 	// ---
 	// tags:
@@ -221,6 +235,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/images/{name:.*}/get"), s.APIHandler(generic.ExportImage)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/{name:.*}/get", s.APIHandler(generic.ExportImage)).Methods(http.MethodGet)
 	// swagger:operation GET /images/{name:.*}/history compat imageHistory
 	// ---
 	// tags:
@@ -243,6 +259,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/images/{name:.*}/history"), s.APIHandler(handlers.HistoryImage)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/{name:.*}/history", s.APIHandler(handlers.HistoryImage)).Methods(http.MethodGet)
 	// swagger:operation GET /images/{name:.*}/json compat inspectImage
 	// ---
 	// tags:
@@ -265,6 +283,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/images/{name:.*}/json"), s.APIHandler(generic.GetImage)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/{name:.*}/json", s.APIHandler(generic.GetImage)).Methods(http.MethodGet)
 	// swagger:operation POST /images/{name:.*}/tag compat tagImage
 	// ---
 	// tags:
@@ -299,6 +319,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/images/{name:.*}/tag"), s.APIHandler(handlers.TagImage)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/images/{name:.*}/tag", s.APIHandler(handlers.TagImage)).Methods(http.MethodPost)
 	// swagger:operation POST /commit compat commitContainer
 	// ---
 	// tags:
@@ -344,6 +366,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/commit"), s.APIHandler(generic.CommitContainer)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/commit", s.APIHandler(generic.CommitContainer)).Methods(http.MethodPost)
 
 	// swagger:operation POST /build compat buildImage
 	// ---
@@ -554,6 +578,8 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/build"), s.APIHandler(handlers.BuildImage)).Methods(http.MethodPost)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/build", s.APIHandler(handlers.BuildImage)).Methods(http.MethodPost)
 	/*
 		libpod endpoints
 	*/

--- a/pkg/api/server/register_info.go
+++ b/pkg/api/server/register_info.go
@@ -22,5 +22,7 @@ func (s *APIServer) registerInfoHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/info"), s.APIHandler(generic.GetInfo)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/info", s.APIHandler(generic.GetInfo)).Methods(http.MethodGet)
 	return nil
 }

--- a/pkg/api/server/register_monitor.go
+++ b/pkg/api/server/register_monitor.go
@@ -7,5 +7,7 @@ import (
 
 func (s *APIServer) registerMonitorHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/monitor"), s.APIHandler(handlers.UnsupportedHandler))
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/monitor", s.APIHandler(handlers.UnsupportedHandler))
 	return nil
 }

--- a/pkg/api/server/register_plugins.go
+++ b/pkg/api/server/register_plugins.go
@@ -7,5 +7,7 @@ import (
 
 func (s *APIServer) registerPluginsHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/plugins"), s.APIHandler(handlers.UnsupportedHandler))
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/plugins", s.APIHandler(handlers.UnsupportedHandler))
 	return nil
 }

--- a/pkg/api/server/register_swarm.go
+++ b/pkg/api/server/register_swarm.go
@@ -16,6 +16,14 @@ func (s *APIServer) registerSwarmHandlers(r *mux.Router) error {
 	r.PathPrefix("/v{version:[0-9.]+}/services/").HandlerFunc(noSwarm)
 	r.PathPrefix("/v{version:[0-9.]+}/swarm/").HandlerFunc(noSwarm)
 	r.PathPrefix("/v{version:[0-9.]+}/tasks/").HandlerFunc(noSwarm)
+
+	// Added non version path to URI to support docker non versioned paths
+	r.PathPrefix("/configs/").HandlerFunc(noSwarm)
+	r.PathPrefix("/nodes/").HandlerFunc(noSwarm)
+	r.PathPrefix("/secrets/").HandlerFunc(noSwarm)
+	r.PathPrefix("/services/").HandlerFunc(noSwarm)
+	r.PathPrefix("/swarm/").HandlerFunc(noSwarm)
+	r.PathPrefix("/tasks/").HandlerFunc(noSwarm)
 	return nil
 }
 

--- a/pkg/api/server/register_system.go
+++ b/pkg/api/server/register_system.go
@@ -9,5 +9,7 @@ import (
 
 func (s *APIServer) registerSystemHandlers(r *mux.Router) error {
 	r.Handle(VersionedPath("/system/df"), s.APIHandler(generic.GetDiskUsage)).Methods(http.MethodGet)
+	// Added non version path to URI to support docker non versioned paths
+	r.Handle("/system/df", s.APIHandler(generic.GetDiskUsage)).Methods(http.MethodGet)
 	return nil
 }


### PR DESCRIPTION
Added addition API handler registration without the need for a API version number, this mimics the structure of the docker API..
Updated GetImages handler to remove null entry at the end of the images array.
Change GetContainers to map status of configured to created.
Implemented size parameter with default of false on ListContainers handler.
Implemented size parameter on GetContainer. 