### PR TITLE
Allow users to set TMPDIR environment

### DIFF
--- a/cmd/podman/load.go
+++ b/cmd/podman/load.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/cmd/podman/shared/parse"
 	"github.com/containers/libpod/pkg/adapter"
+	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
@@ -75,7 +76,7 @@ func loadCmd(c *cliconfig.LoadValues) error {
 		if terminal.IsTerminal(int(os.Stdin.Fd())) {
 			return errors.Errorf("cannot read from terminal. Use command-line redirection or the --input flag.")
 		}
-		outFile, err := ioutil.TempFile("/var/tmp", "podman")
+		outFile, err := ioutil.TempFile(util.Tmpdir(), "podman")
 		if err != nil {
 			return errors.Errorf("error creating file %v", err)
 		}

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -1066,6 +1066,8 @@ b
 **/etc/subuid**
 **/etc/subgid**
 
+NOTE: Use the environment variable `TMPDIR` to change the temporary storage location of downloaded container images. Podman defaults to use `/var/tmp`.
+
 ## SEE ALSO
 subgid(5), subuid(5), libpod.conf(5), systemd.unit(5), setsebool(8), slirp4netns(1), fuse-overlayfs(1)
 

--- a/docs/source/markdown/podman-load.1.md
+++ b/docs/source/markdown/podman-load.1.md
@@ -30,6 +30,8 @@ Read from archive file, default is STDIN.
 
 The remote client requires the use of this option.
 
+NOTE: Use the environment variable `TMPDIR` to change the temporary storage location of container images. Podman defaults to use `/var/tmp`.
+
 **--quiet**, **-q**
 
 Suppress the progress output

--- a/docs/source/markdown/podman-pull.1.md
+++ b/docs/source/markdown/podman-pull.1.md
@@ -156,6 +156,8 @@ Storing signatures
 
 	registries.conf is the configuration file which specifies which container registries should be consulted when completing image names which do not include a registry or domain portion.
 
+NOTE: Use the environment variable `TMPDIR` to change the temporary storage location of downloaded container images. Podman defaults to use `/var/tmp`.
+
 ## SEE ALSO
 podman(1), podman-push(1), podman-login(1), containers-registries.conf(5)
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -1335,6 +1335,8 @@ b
 
 **/etc/subgid**
 
+NOTE: Use the environment variable `TMPDIR` to change the temporary storage location of downloaded container images. Podman defaults to use `/var/tmp`.
+
 ## SEE ALSO
 **subgid**(5), **subuid**(5), **libpod.conf**(5), **systemd.unit**(5), **setsebool**(8), **slirp4netns**(1), **fuse-overlayfs**(1).
 

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -209,11 +209,11 @@ func (r *Runtime) Import(ctx context.Context, source string, reference string, c
 }
 
 // donwloadFromURL downloads an image in the format "https:/example.com/myimage.tar"
-// and temporarily saves in it /var/tmp/importxyz, which is deleted after the image is imported
+// and temporarily saves in it $TMPDIR/importxyz, which is deleted after the image is imported
 func downloadFromURL(source string) (string, error) {
 	fmt.Printf("Downloading from %q\n", source)
 
-	outFile, err := ioutil.TempFile("/var/tmp", "import")
+	outFile, err := ioutil.TempFile(util.Tmpdir(), "import")
 	if err != nil {
 		return "", errors.Wrap(err, "error creating file")
 	}
@@ -234,9 +234,9 @@ func downloadFromURL(source string) (string, error) {
 }
 
 // DownloadFromFile reads all of the content from the reader and temporarily
-// saves in it /var/tmp/importxyz, which is deleted after the image is imported
+// saves in it $TMPDIR/importxyz, which is deleted after the image is imported
 func DownloadFromFile(reader *os.File) (string, error) {
-	outFile, err := ioutil.TempFile("/var/tmp", "import")
+	outFile, err := ioutil.TempFile(util.Tmpdir(), "import")
 	if err != nil {
 		return "", errors.Wrap(err, "error creating file")
 	}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -600,3 +600,12 @@ func HomeDir() (string, error) {
 	}
 	return home, nil
 }
+
+func Tmpdir() string {
+	tmpdir := os.Getenv("TMPDIR")
+	if tmpdir == "" {
+		tmpdir = "/var/tmp"
+	}
+
+	return tmpdir
+}


### PR DESCRIPTION
Some users have small /var/tmp directories and need to be able to specify a different location
for temporary files, which includes more space.

Fixes: https://github.com/containers/libpod/issues/5411

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>