### PR TITLE
Attempt manual removal of CNI IP allocations on refresh

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -1436,13 +1436,6 @@ func (c *Container) copyOwnerAndPerms(source, dest string) error {
 	return nil
 }
 
-// Teardown CNI config on refresh
-func (c *Container) refreshCNI() error {
-	// Let's try and delete any lingering network config...
-	podNetwork := c.runtime.getPodNetwork(c.ID(), c.config.Name, "", c.config.Networks, c.config.PortMappings, c.config.StaticIP, c.config.StaticMAC)
-	return c.runtime.netPlugin.TearDownPod(podNetwork)
-}
-
 // Get cgroup path in a format suitable for the OCI spec
 func (c *Container) getOCICgroupPath() (string, error) {
 	unified, err := cgroups.IsCgroup2UnifiedMode()

--- a/libpod/container_internal_unsupported.go
+++ b/libpod/container_internal_unsupported.go
@@ -41,10 +41,6 @@ func (c *Container) copyOwnerAndPerms(source, dest string) error {
 	return nil
 }
 
-func (c *Container) refreshCNI() error {
-	return define.ErrNotImplemented
-}
-
 func (c *Container) getOCICgroupPath() (string, error) {
 	return "", define.ErrNotImplemented
 }

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -657,6 +657,13 @@ func resultToBasicNetworkConfig(result *cnitypes.Result) (InspectBasicNetworkCon
 	return config, nil
 }
 
+// This is a horrible hack, necessary because CNI does not properly clean up
+// after itself on an unclean reboot. Return what we're pretty sure is the path
+// to CNI's internal files (it's not really exposed to us).
+func getCNINetworksDir() (string, error) {
+	return "/var/lib/cni/networks", nil
+}
+
 type logrusDebugWriter struct {
 	prefix string
 }

--- a/libpod/networking_unsupported.go
+++ b/libpod/networking_unsupported.go
@@ -23,3 +23,7 @@ func (r *Runtime) createNetNS(ctr *Container) (err error) {
 func (c *Container) getContainerNetworkInfo() (*InspectNetworkSettings, error) {
 	return nil, define.ErrNotImplemented
 }
+
+func getCNINetworksDir() (string, error) {
+	return "", define.ErrNotImplemented
+}


### PR DESCRIPTION
We previously attempted to work within CNI to do this, without success. So let's do it manually, instead. We know where the files should live, so we can remove them ourselves instead. This solves issues around sudden reboots where containers do not have time to fully tear themselves down, and leave IP address allocations which, for various reasons, are not stored in tmpfs and persist through reboot.

Fixes #5433
