### PR TITLE
container prune remove state created, configured

### DIFF
--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -1057,7 +1057,8 @@ func (r *LocalRuntime) Prune(ctx context.Context, maxWorkers int, filters []stri
 		if c.PodID() != "" {
 			return false
 		}
-		if state == define.ContainerStateStopped || state == define.ContainerStateExited {
+		if state == define.ContainerStateStopped || state == define.ContainerStateExited ||
+			state == define.ContainerStateCreated || state == define.ContainerStateConfigured {
 			return true
 		}
 		return false

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -59,6 +59,34 @@ var _ = Describe("Podman prune", func() {
 		Expect(podmanTest.NumberOfContainers()).To(Equal(1))
 	})
 
+	It("podman container prune after create containers", func() {
+		create := podmanTest.Podman([]string{"create", "--name", "test", BB})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(Equal(0))
+
+		prune := podmanTest.Podman([]string{"container", "prune", "-f"})
+		prune.WaitWithDefaultTimeout()
+		Expect(prune.ExitCode()).To(Equal(0))
+
+		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
+	})
+
+	It("podman container prune after create & init containers", func() {
+		create := podmanTest.Podman([]string{"create", "--name", "test", BB})
+		create.WaitWithDefaultTimeout()
+		Expect(create.ExitCode()).To(Equal(0))
+
+		init := podmanTest.Podman([]string{"init", "test"})
+		init.WaitWithDefaultTimeout()
+		Expect(init.ExitCode()).To(Equal(0))
+
+		prune := podmanTest.Podman([]string{"container", "prune", "-f"})
+		prune.WaitWithDefaultTimeout()
+		Expect(prune.ExitCode()).To(Equal(0))
+
+		Expect(podmanTest.NumberOfContainers()).To(Equal(0))
+	})
+
 	It("podman image prune none images", func() {
 		SkipIfRemote()
 		podmanTest.BuildImage(pruneImage, "alpine_bash:latest", "true")

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Podman volume prune", func() {
 		session = podmanTest.Podman([]string{"volume", "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(len(session.OutputToStringArray())).To(Equal(2))
+		Expect(len(session.OutputToStringArray())).To(Equal(0))
 
 		podmanTest.Cleanup()
 	})


### PR DESCRIPTION
podman container prune should remove containers with state Created, Configured to be compatible with docker

Signed-off-by: Qi Wang <qiwan@redhat.com>