### PR TITLE
Remove nonexistent --set arg from runlabel documentation

### DIFF
--- a/docs/source/markdown/podman-container-runlabel.1.md
+++ b/docs/source/markdown/podman-container-runlabel.1.md
@@ -85,10 +85,6 @@ created from this image.
 
 Set rootfs
 
-**--set**=*NAME*=*VALUE*
-
-Set name & value
-
 **--storage**
 Use storage
 


### PR DESCRIPTION
As far as I can tell from looking through the git history of `cmd/podman/runlabel.go`, there never was a `--set` option.  I'm not sure why it was in the documentation for the command.