### PR TITLE
man page cross-reference fixes: part 2

### DIFF
--- a/cmd/podman/runlabel.go
+++ b/cmd/podman/runlabel.go
@@ -49,7 +49,7 @@ func init() {
 	flags.StringVar(&runlabelCommand.Creds, "creds", "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
 	flags.BoolVar(&runlabelCommand.Display, "display", false, "Preview the command that the label would run")
 	flags.BoolVar(&runlabelCommand.Replace, "replace", false, "Replace existing container with a new one from the image")
-	flags.StringVar(&runlabelCommand.Name, "name", "", "Assign a name to the container")
+	flags.StringVarP(&runlabelCommand.Name, "name", "n", "", "Assign a name to the container")
 
 	flags.StringVar(&runlabelCommand.Opt1, "opt1", "", "Optional parameter to pass for install")
 	flags.StringVar(&runlabelCommand.Opt2, "opt2", "", "Optional parameter to pass for install")

--- a/docs/source/markdown/podman-commit.1.md
+++ b/docs/source/markdown/podman-commit.1.md
@@ -38,10 +38,6 @@ Can be set multiple times
 Set the format of the image manifest and metadata.  The currently supported formats are _oci_ and _docker_.  If
 not specifically set, the default format used is _oci_.
 
-**--iidfile**=*ImageIDfile*
-
-Write the image ID to the file.
-
 **--include-volumes**
 
 Include in the committed image any volumes added to the container by the `--volume` or `--mount` options to the `podman create` and `podman run` commands.

--- a/docs/source/markdown/podman-container-runlabel.1.md
+++ b/docs/source/markdown/podman-container-runlabel.1.md
@@ -81,13 +81,6 @@ Suppress output information when pulling images
 If a container exists of the default or given name, as needed it will be stopped, deleted and a new container will be
 created from this image.
 
-**--rootfs**=*ROOTFS*
-
-Set rootfs
-
-**--storage**
-Use storage
-
 **--tls-verify**
 
 Require HTTPS and verify certificates when contacting registries (default: true). If explicitly set to true,

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -94,14 +94,6 @@ Write the container ID to the file
 
 Write the pid of the `conmon` process to a file. `conmon` runs in a separate process than Podman, so this is necessary when using systemd to restart Podman containers.
 
-**--cpu-count**=*limit*
-
-Limit the number of CPUs available for execution by the container.
-
-On Windows Server containers, this is approximated as a percentage of total CPU usage.
-
-On Windows Server containers, the processor resource controls are mutually exclusive, the order of precedence is CPUCount first, then CPUShares, and CPUPercent last.
-
 **--cpu-period**=*limit*
 
 Limit the CPU CFS (Completely Fair Scheduler) period


### PR DESCRIPTION
The other direction: fix or clean up elements documented in
man pages but which did/do not exist in actual podman:

  * runlabel: add missing "-n" alias for --name

And, remove man page entries for nonexistent options:

  * podman commit: --iidfile
  * podman container runlabel: --rootfs, --storage
  * podman create: --cpu-count

There are two problems I don't know how to deal with. Both
are related to main_local.go:rootCmd.PersistentFlags() :

  1) podman-build.1.md documents --cni-config-dir and
     --runtime options, but these are not actually options
     under podman build; they are global options. The
     documentation in this man page differs from that
     under podman-build.

  2) podman ps implements a binary --namespace option,
     but this option does not (cannot?) appear in --help
     because there's a global --namespace string option
     and Cobra somehow gets confused about this.

Do we really intend for global options to be parsed on
the right-hand side of subcommands? This strikes me as
unintuitive and potentially confusing, although the
fact that it has taken me this long to discover it
suggests that it's not _that_ confusing.

Suggestions welcome. I can file issues for 1/2 above,
or simply teach my script to special-case ignore them.

Signed-off-by: Ed Santiago <santiago@redhat.com>