### PR TITLE
create: do not calculate image size

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -101,7 +101,7 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		if err != nil {
 			return nil, nil, err
 		}
-		imageData, err = newImage.Inspect(ctx)
+		imageData, err = newImage.InspectNoSize(ctx)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/libpod/runtime_pod_infra_linux.go
+++ b/libpod/runtime_pod_infra_linux.go
@@ -147,7 +147,7 @@ func (r *Runtime) createInfraContainer(ctx context.Context, p *Pod) (*Container,
 		return nil, err
 	}
 
-	data, err := newImage.Inspect(ctx)
+	data, err := newImage.InspectNoSize(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
calculating the image size can be an expensive operation.  Avoid doing
it when creating a new container since the size is not needed.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>