### PR TITLE
remove imagefilter for varlink remote client

### DIFF
--- a/cmd/podman/images.go
+++ b/cmd/podman/images.go
@@ -155,7 +155,7 @@ func imagesCmd(c *cliconfig.ImagesValues) error {
 		return errors.New("can not specify an image and a filter")
 	}
 	filters := c.Filter
-	if len(filters) < 1 {
+	if len(filters) < 1 && len(image) > 0 {
 		filters = append(filters, fmt.Sprintf("reference=%s", image))
 	}
 

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -201,8 +201,11 @@ func (r *LocalRuntime) GetRWImages() ([]*ContainerImage, error) {
 }
 
 func (r *LocalRuntime) GetFilteredImages(filters []string, rwOnly bool) ([]*ContainerImage, error) {
+	if len(filters) > 0 {
+		return nil, errors.Wrap(define.ErrNotImplemented, "filtering images is not supported on the remote client")
+	}
 	var newImages []*ContainerImage
-	images, err := iopodman.ListImagesWithFilters().Call(r.Conn, filters)
+	images, err := iopodman.ListImages().Call(r.Conn)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
the api for getting images changed to use filters but back level podman versions cannot handle it.  so temporarily disabling the filtering for remote clients until the restful approach can be used.

Signed-off-by: Brent Baude <bbaude@redhat.com>