### PR TITLE
turn off color-mode for bindings

### DIFF
--- a/contrib/cirrus/integration_test.sh
+++ b/contrib/cirrus/integration_test.sh
@@ -45,7 +45,7 @@ case "$SPECIALMODE" in
     bindings)
 	    make
         make install PREFIX=/usr ETCDIR=/etc
-	    cd pkg/bindings/test && ginkgo -r
+	    cd pkg/bindings/test && ginkgo -trace -noColor -debug  -r
 	;;
     none)
         make


### PR DESCRIPTION
the binding ginkgo tests were using color mode which throws in a bunch of ansi garbage that makes it hard to read the logs

Signed-off-by: Brent Baude <bbaude@redhat.com>