### PR TITLE
eat signal 23 in signal proxy

### DIFF
--- a/pkg/adapter/sigproxy_linux.go
+++ b/pkg/adapter/sigproxy_linux.go
@@ -20,7 +20,10 @@ func ProxySignals(ctr *libpod.Container) {
 		for s := range sigBuffer {
 			// Ignore SIGCHLD and SIGPIPE - these are mostly likely
 			// intended for the podman command itself.
-			if s == syscall.SIGCHLD || s == syscall.SIGPIPE {
+			// SIGURG was added because of golang 1.14 and its preemptive changes
+			// causing more signals to "show up".
+			// https://github.com/containers/libpod/issues/5483
+			if s == syscall.SIGCHLD || s == syscall.SIGPIPE || s == syscall.SIGURG {
 				continue
 			}
 


### PR DESCRIPTION
due to a change in golang-1.14 and it's changes to make go funcs with tight loops preemptive, signals are now getting "through" that never were before.

From the golang-1.14 announce:

Goroutines are now asynchronously preemptible. As a result, loops without function calls no longer potentially deadlock the scheduler or significantly delay garbage collection. This is supported on all platforms except windows/arm, darwin/arm, js/wasm, and plan9/*.

A consequence of the implementation of preemption is that on Unix systems, including Linux and macOS systems, programs built with Go 1.14 will receive more signals than programs built with earlier releases. This means that programs that use packages like syscall or golang.org/x/sys/unix will see more slow system calls fail with EINTR errors. Those programs will have to handle those errors in some way, most likely looping to try the system call again. For more information about this see man 7 signal for Linux systems or similar documentation for other systems.

Signed-off-by: Brent Baude <bbaude@redhat.com>