### PR TITLE
Missing double quotes in troubleshooting guide.

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -390,7 +390,7 @@ Choose one of the following:
   * Complete the build operation as a privileged user.
   * Install and configure fuse-overlayfs.
     * Install the fuse-overlayfs package for your Linux Distribution.
-    * Add `mount_program = "/usr/bin/fuse-overlayfs` under `[storage.options]` in your `~/.config/containers/storage.conf` file.
+    * Add `mount_program = "/usr/bin/fuse-overlayfs"` under `[storage.options]` in your `~/.config/containers/storage.conf` file.
 
 ### 16) rhel7-init based images don't work with cgroups v2
 


### PR DESCRIPTION
Missing double quotes in the solution for Rootless 'podman build' fails when using OverlayFS in troubleshooting quide.

Signed-off-by: Tony Benoy <me@tonybenoy.com>