### PR TITLE
add os|arch attributes when building

### DIFF
--- a/cmd/podman/build.go
+++ b/cmd/podman/build.go
@@ -342,6 +342,7 @@ func buildCmd(c *cliconfig.BuildValues) error {
 	}
 
 	options := imagebuildah.BuildOptions{
+		Architecture:            c.Arch,
 		CommonBuildOpts:         &buildOpts,
 		AdditionalTags:          tags,
 		Annotations:             c.Annotation,
@@ -359,6 +360,7 @@ func buildCmd(c *cliconfig.BuildValues) error {
 		Layers:                  layers,
 		NamespaceOptions:        nsValues,
 		NoCache:                 c.NoCache,
+		OS:                      c.OS,
 		Out:                     stdout,
 		Output:                  output,
 		OutputFormat:            format,

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	. "github.com/containers/libpod/test/utils"
@@ -42,6 +43,15 @@ var _ = Describe("Podman build", func() {
 		session := podmanTest.PodmanNoCache([]string{"build", "build/basicalpine"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+
+		iid := session.OutputToStringArray()[len(session.OutputToStringArray())-1]
+
+		// Verify that OS and Arch are being set
+		inspect := podmanTest.PodmanNoCache([]string{"inspect", iid})
+		inspect.WaitWithDefaultTimeout()
+		data := inspect.InspectImageJSON()
+		Expect(data[0].Os).To(Equal(runtime.GOOS))
+		Expect(data[0].Architecture).To(Equal(runtime.GOARCH))
 
 		session = podmanTest.PodmanNoCache([]string{"rmi", "alpine"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
when building images, we can now add the os and arch of the image using overrides from the commandline.  the commandline options set sane defaults so we use those as well.

Fixes: #5503

Signed-off-by: Brent Baude <bbaude@redhat.com>