### PR TITLE
Four small CI fixes:

### DIFF
--- a/contrib/cirrus/logcollector.sh
+++ b/contrib/cirrus/logcollector.sh
@@ -32,7 +32,7 @@ case $1 in
     df) showrun df -lhTx tmpfs ;;
     ginkgo) showrun cat $CIRRUS_WORKING_DIR/test/e2e/ginkgo-node-*.log ;;
     journal) showrun journalctl -b ;;
-    podman) showrun podman system info ;;
+    podman) showrun ./bin/podman system info ;;
     varlink)
        if [[ "$TEST_REMOTE_CLIENT" == "true" ]]
        then

--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -52,7 +52,7 @@ a.codelink:hover   { background: #000; color: #999; }
 a.timing           { text-decoration: none; }
 
 /* BATS styles */
-.bats-ok        { color: #3f3; }
+.bats-ok        { color: #393; }
 .bats-notok     { color: #F00; font-weight: bold; }
 .bats-skip      { color: #F90; }
 .bats-log       { color: #900; }
@@ -286,7 +286,8 @@ END_HTML
             $previous_timestamp = '';
             next LINE;
         }
-        elsif ($line =~ /^Running:/) {
+        # (bindings test sometimes emits 'Running' with leading bullet char)
+        elsif ($line =~ /^•?Running:/) {
             # Highlight the important (non-boilerplate) podman command.
             # Strip out the global podman options, but show them on hover
             $line =~ s{(\S+\/podman)((\s+--(root|runroot|runtime|tmpdir|storage-opt|conmon|cgroup-manager|cni-config-dir|storage-driver|events-backend) \S+)*)(.*)}{
@@ -309,6 +310,9 @@ END_HTML
         }
         elsif ($line =~ /^Error:/ || $line =~ / level=(warning|error) /) {
             $line = "<span class='log-warn'>" . $line . "</span>";
+        }
+        elsif ($line =~ /^panic:/) {
+            $line = "<span class='log-error'>" . $line . "</span>";
         }
         else {
             $current_output .= ' ' . $line;


### PR DESCRIPTION
  1) 'podman system info' (in logcollector): has been silently
     failing in special_testing_rootless, with:
       logcollector.sh: line 16: podman: command not found
     Use ./bin/podman instead of just podman; this is probably
     the right thing to do in the general case anyway

  2) logformatter: highlight 'panic:', seen in bindings test:
        https://storage.googleapis.com/cirrus-ci-5385732420009984-fcae48/artifacts/containers/libpod/6693715108429824/html/integration_test.log.html

  3) logformatter: handle Unicode bullet in front of 'Running',
     seen in bindings test.

  4) logformatter: turn down contrast on BATS 'ok' results,
     for legibility

Signed-off-by: Ed Santiago <santiago@redhat.com>