### PR TITLE
Cirrus: Remove darwin/windows builds in gate-job

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -139,8 +139,6 @@ gating_task:
         - '/usr/local/bin/entrypoint.sh clean podman-remote |& ${TIMESTAMP}'
         - '/usr/local/bin/entrypoint.sh clean podman xref_helpmsgs_manpages BUILDTAGS="exclude_graphdriver_devicemapper selinux seccomp" |& ${TIMESTAMP}'
         - '/usr/local/bin/entrypoint.sh local-cross |& ${TIMESTAMP}'
-        - '/usr/local/bin/entrypoint.sh podman-remote-darwin |& ${TIMESTAMP}'
-        - '/usr/local/bin/entrypoint.sh podman-remote-windows |& ${TIMESTAMP}'
 
     # Verify some aspects of ci/related scripts
     ci_script:


### PR DESCRIPTION
It's advisable to have the initial gating job execute as quickly as
possible, weeding out simple mistakes early on, when possible.  However,
over time it has bloated to duplicate some more specific testing which
occurs in other tasks.  In this specific case the
`special_testing_cross` task.  Remove these duplicate items from the gate
job to speed things up for everyone.

Signed-off-by: Chris Evich <cevich@redhat.com>