### PR TITLE
podman: avoid conmon zombie on exec

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -774,6 +774,10 @@ func (r *ConmonOCIRuntime) ExecContainer(c *Container, sessionID string, options
 	}()
 	attachToExecCalled = true
 
+	if err := execCmd.Wait(); err != nil {
+		return -1, nil, errors.Wrapf(err, "cannot run conmon")
+	}
+
 	pid, err := readConmonPipeData(parentSyncPipe, ociLog)
 
 	return pid, attachChan, err


### PR DESCRIPTION
conmon forks itself, so make sure we reap the first process and not
leave a zombie process.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>