### PR TITLE
swagger: more consistency fixes

### DIFF
--- a/pkg/api/server/register_manifest.go
+++ b/pkg/api/server/register_manifest.go
@@ -38,7 +38,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/manifests/create"), s.APIHandler(libpod.ManifestCreate)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/manifests/{name}/json manifests Inspect
+	// swagger:operation GET /libpod/manifests/{name:.*}/json manifests Inspect
 	// ---
 	// summary: Inspect
 	// description: Display a manifest list
@@ -46,7 +46,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	// - application/json
 	// parameters:
 	//  - in: path
-	//    name: name
+	//    name: name:.*
 	//    type: string
 	//    required: true
 	//    description: the name or ID of the manifest
@@ -58,14 +58,14 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/manifests/{name:.*}/json"), s.APIHandler(libpod.ManifestInspect)).Methods(http.MethodGet)
-	// swagger:operation POST /libpod/manifests/{name}/add manifests AddManifest
+	// swagger:operation POST /libpod/manifests/{name:.*}/add manifests AddManifest
 	// ---
 	// description: Add an image to a manifest list
 	// produces:
 	// - application/json
 	// parameters:
 	//  - in: path
-	//    name: name
+	//    name: name:.*
 	//    type: string
 	//    required: true
 	//    description: the name or ID of the manifest
@@ -84,7 +84,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/manifests/{name:.*}/add"), s.APIHandler(libpod.ManifestAdd)).Methods(http.MethodPost)
-	// swagger:operation DELETE /libpod/manifests/{name} manifests RemoveManifest
+	// swagger:operation DELETE /libpod/manifests/{name:.*} manifests RemoveManifest
 	// ---
 	// summary: Remove
 	// description: Remove an image from a manifest list
@@ -92,7 +92,7 @@ func (s *APIServer) registerManifestHandlers(r *mux.Router) error {
 	// - application/json
 	// parameters:
 	//  - in: path
-	//    name: name
+	//    name: name:.*
 	//    type: string
 	//    required: true
 	//    description: the image associated with the manifest


### PR DESCRIPTION
Some new 'manifests' entries have the wrong {name} parameter

Signed-off-by: Ed Santiago <santiago@redhat.com>