### PR TITLE
swagger inconsistencies: fix /libpod/events

### DIFF
--- a/pkg/api/server/register_events.go
+++ b/pkg/api/server/register_events.go
@@ -63,6 +63,6 @@ func (s *APIServer) registerEventsHandlers(r *mux.Router) error {
 	//     description: returns a string of json data describing an event
 	//   500:
 	//     "$ref": "#/responses/InternalError"
-	r.Handle(VersionedPath("/events"), s.APIHandler(compat.GetEvents)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/events"), s.APIHandler(compat.GetEvents)).Methods(http.MethodGet)
 	return nil
 }


### PR DESCRIPTION
Fix a confusing inconsistency between swagger and actual
registration. I think this is the intention, but please
review carefully.

Signed-off-by: Ed Santiago <santiago@redhat.com>