### PR TITLE
Don't include SUBDIR in windows.zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ podman-remote-release-%.zip:
 	cp release.txt "$(TMPDIR)/"
 	cp ./bin/podman-remote-$*$(BINSFX) "$(TMPDIR)/$(SUBDIR)/podman$(BINSFX)"
 	cp -r ./docs/build/remote/$* "$(TMPDIR)/$(SUBDIR)/docs/"
-	cd "$(TMPDIR)" && \
+	cd "$(TMPDIR)/$(SUBDIR)" && \
 		zip --recurse-paths "$(CURDIR)/$@" "./release.txt" "./"
 	-rm -rf "$(TMPDIR)"
 


### PR DESCRIPTION
The zip file should returne podman.exe plus the documentation
directory.

Potential fix: https://github.com/containers/libpod/issues/5477

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>