### PR TITLE
fix reported compat issues

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -87,7 +87,7 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 		utils.InternalServerError(w, err)
 		return
 	}
-	if _, found := r.URL.Query()["limit"]; found {
+	if _, found := r.URL.Query()["limit"]; found && query.Limit != -1 {
 		last := query.Limit
 		if len(containers) > last {
 			containers = containers[len(containers)-last:]

--- a/pkg/api/handlers/utils/containers.go
+++ b/pkg/api/handlers/utils/containers.go
@@ -16,7 +16,7 @@ import (
 // ContainerCreateResponse is the response struct for creating a container
 type ContainerCreateResponse struct {
 	// ID of the container created
-	ID string `json:"id"`
+	ID string `json:"Id"`
 	// Warnings during container creation
 	Warnings []string `json:"Warnings"`
 }


### PR DESCRIPTION
honor -1 in in list containers for compatibility mode.  it is commonly used to indicate no limit.

change the json id parameter to Id in container create.

Fixes: #5553

Signed-off-by: Brent Baude <bbaude@redhat.com>