### PR TITLE
Use creds form PullImage remote

### DIFF
--- a/API.md
+++ b/API.md
@@ -141,7 +141,7 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 
 [func Ps(opts: PsOpts) PsContainer](#Ps)
 
-[func PullImage(name: string) MoreResponse](#PullImage)
+[func PullImage(name: string, creds: AuthConfig) MoreResponse](#PullImage)
 
 [func PushImage(name: string, tag: string, compress: bool, format: string, removeSignatures: bool, signBy: string) MoreResponse](#PushImage)
 
@@ -196,6 +196,8 @@ in the [API.md](https://github.com/containers/libpod/blob/master/API.md) file in
 [func VolumesPrune() []string, []string](#VolumesPrune)
 
 [func WaitContainer(name: string, interval: int) int](#WaitContainer)
+
+[type AuthConfig](#AuthConfig)
 
 [type BuildInfo](#BuildInfo)
 
@@ -1027,7 +1029,7 @@ method Ps(opts: [PsOpts](#PsOpts)) [PsContainer](#PsContainer)</div>
 ### <a name="PullImage"></a>func PullImage
 <div style="background-color: #E8E8E8; padding: 15px; margin: 10px; border-radius: 10px;">
 
-method PullImage(name: [string](https://godoc.org/builtin#string)) [MoreResponse](#MoreResponse)</div>
+method PullImage(name: [string](https://godoc.org/builtin#string), creds: [AuthConfig](#AuthConfig)) [MoreResponse](#MoreResponse)</div>
 PullImage pulls an image from a repository to local storage.  After a successful pull, the image id and logs
 are returned as a [MoreResponse](#MoreResponse).  This connection also will handle a WantsMores request to send
 status as it occurs.
@@ -1283,6 +1285,13 @@ WaitContainer takes the name or ID of a container and waits the given interval i
 stops.  Upon stopping, the return code of the container is returned. If the container container cannot be found by ID
 or name, a [ContainerNotFound](#ContainerNotFound) error is returned.
 ## Types
+### <a name="AuthConfig"></a>type AuthConfig
+
+
+
+username [string](https://godoc.org/builtin#string)
+
+password [string](https://godoc.org/builtin#string)
 ### <a name="BuildInfo"></a>type BuildInfo
 
 BuildInfo is used to describe user input for building images

--- a/cmd/podman/varlink/io.podman.varlink
+++ b/cmd/podman/varlink/io.podman.varlink
@@ -105,6 +105,11 @@ type ImageSearchFilter (
     star_count: int
 )
 
+type AuthConfig (
+    username: string,
+    password: string
+)
+
 type KubePodService (
     pod: string,
     service: string
@@ -932,7 +937,7 @@ method ExportImage(name: string, destination: string, compress: bool, tags: []st
 # PullImage pulls an image from a repository to local storage.  After a successful pull, the image id and logs
 # are returned as a [MoreResponse](#MoreResponse).  This connection also will handle a WantsMores request to send
 # status as it occurs.
-method PullImage(name: string) -> (reply: MoreResponse)
+method PullImage(name: string, creds: AuthConfig) -> (reply: MoreResponse)
 
 # CreatePod creates a new empty pod.  It uses a [PodCreate](#PodCreate) type for input.
 # On success, the ID of the newly created pod will be returned.

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -288,7 +288,8 @@ func (r *LocalRuntime) NewImageFromLocal(name string) (*ContainerImage, error) {
 // LoadFromArchiveReference creates an image from a local archive
 func (r *LocalRuntime) LoadFromArchiveReference(ctx context.Context, srcRef types.ImageReference, signaturePolicyPath string, writer io.Writer) ([]*ContainerImage, error) {
 	var iid string
-	reply, err := iopodman.PullImage().Send(r.Conn, varlink.More, srcRef.DockerReference().String())
+	creds := iopodman.AuthConfig{}
+	reply, err := iopodman.PullImage().Send(r.Conn, varlink.More, srcRef.DockerReference().String(), creds)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +321,12 @@ func (r *LocalRuntime) New(ctx context.Context, name, signaturePolicyPath, authf
 	if label != nil {
 		return nil, errors.New("the remote client function does not support checking a remote image for a label")
 	}
-	reply, err := iopodman.PullImage().Send(r.Conn, varlink.More, name)
+	creds := iopodman.AuthConfig{}
+	if dockeroptions.DockerRegistryCreds != nil {
+		creds.Username = dockeroptions.DockerRegistryCreds.Username
+		creds.Password = dockeroptions.DockerRegistryCreds.Password
+	}
+	reply, err := iopodman.PullImage().Send(r.Conn, varlink.More, name, creds)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/varlinkapi/images.go
+++ b/pkg/varlinkapi/images.go
@@ -688,12 +688,18 @@ func (i *LibpodAPI) ExportImage(call iopodman.VarlinkCall, name, destination str
 }
 
 // PullImage pulls an image from a registry to the image store.
-func (i *LibpodAPI) PullImage(call iopodman.VarlinkCall, name string) error {
+func (i *LibpodAPI) PullImage(call iopodman.VarlinkCall, name string, creds iopodman.AuthConfig) error {
 	var (
 		imageID string
 		err     error
 	)
-	dockerRegistryOptions := image.DockerRegistryOptions{}
+	dockerRegistryOptions := image.DockerRegistryOptions{
+		DockerRegistryCreds: &types.DockerAuthConfig{
+			Username: creds.Username,
+			Password: creds.Password,
+		},
+	}
+
 	so := image.SigningOptions{}
 
 	if call.WantsMore() {


### PR DESCRIPTION
fix #5511
Adds creds argument to PullImage API and Enables podman-remote to pull image with --creds

Signed-off-by: Qi Wang <qiwan@redhat.com>