### PR TITLE
when removing networks for tests, force should be used

### DIFF
--- a/test/e2e/network_create_test.go
+++ b/test/e2e/network_create_test.go
@@ -58,7 +58,7 @@ func genericPluginsToPortMap(plugins interface{}, pluginType string) (network.Po
 }
 
 func (p *PodmanTestIntegration) removeCNINetwork(name string) {
-	session := p.Podman([]string{"network", "rm", name})
+	session := p.Podman([]string{"network", "rm", "-f", name})
 	session.WaitWithDefaultTimeout()
 	Expect(session.ExitCode()).To(BeZero())
 }


### PR DESCRIPTION
when removing networks in integration tests, we should should force; otherwise if the network has containers associated with it, it will fail to remove.

Signed-off-by: Brent Baude <bbaude@redhat.com>