### PR TITLE
Make macOS unit tests runnable

### DIFF
--- a/cmd/podman/main_local_unsupported.go
+++ b/cmd/podman/main_local_unsupported.go
@@ -1,0 +1,44 @@
+// +build !remoteclient,!linux
+
+package main
+
+// The ONLY purpose of this file is to allow the subpackage to compile. Don’t expect anything
+// to work.
+
+import (
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+const remote = false
+
+func setSyslog() error {
+	return nil
+}
+
+func profileOn(cmd *cobra.Command) error {
+	return nil
+}
+
+func profileOff(cmd *cobra.Command) error {
+	return nil
+}
+
+func setupRootless(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func setRLimits() error {
+	return nil
+}
+
+func setUMask() {
+	// Be sure we can create directories with 0755 mode.
+	syscall.Umask(0022)
+}
+
+// checkInput can be used to verify any of the globalopt values
+func checkInput() error {
+	return nil
+}

--- a/cmd/podman/shared/funcs_linux_test.go
+++ b/cmd/podman/shared/funcs_linux_test.go
@@ -1,0 +1,119 @@
+package shared
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateCommand(t *testing.T) {
+	inputCommand := "docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo \"hello world\""
+	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo hello world"
+	newCommand, err := GenerateCommand(inputCommand, "foo", "bar", "")
+	assert.Nil(t, err)
+	assert.Equal(t, "hello world", newCommand[11])
+	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
+}
+
+func TestGenerateCommandCheckSubstitution(t *testing.T) {
+	type subsTest struct {
+		input      string
+		expected   string
+		shouldFail bool
+	}
+
+	absTmpFile, err := ioutil.TempFile("", "podmanRunlabelTestAbsolutePath")
+	assert.Nil(t, err, "error creating tempfile")
+	defer os.Remove(absTmpFile.Name())
+
+	relTmpFile, err := ioutil.TempFile("./", "podmanRunlabelTestRelativePath")
+	assert.Nil(t, err, "error creating tempfile")
+	defer os.Remove(relTmpFile.Name())
+	relTmpCmd, err := filepath.Abs(relTmpFile.Name())
+	assert.Nil(t, err, "error getting absolute path for relative tmpfile")
+
+	// this has a (low) potential of race conditions but no other way
+	removedTmpFile, err := ioutil.TempFile("", "podmanRunlabelTestRemove")
+	assert.Nil(t, err, "error creating tempfile")
+	os.Remove(removedTmpFile.Name())
+
+	absTmpCmd := fmt.Sprintf("%s --flag1 --flag2 --args=foo", absTmpFile.Name())
+	tests := []subsTest{
+		{
+			input:      "docker run -it alpine:latest",
+			expected:   "/proc/self/exe run -it alpine:latest",
+			shouldFail: false,
+		},
+		{
+			input:      "podman run -it alpine:latest",
+			expected:   "/proc/self/exe run -it alpine:latest",
+			shouldFail: false,
+		},
+		{
+			input:      absTmpCmd,
+			expected:   absTmpCmd,
+			shouldFail: false,
+		},
+		{
+			input:      "./" + relTmpFile.Name(),
+			expected:   relTmpCmd,
+			shouldFail: false,
+		},
+		{
+			input:      "ls -la",
+			expected:   "ls -la",
+			shouldFail: false,
+		},
+		{
+			input:      removedTmpFile.Name(),
+			expected:   "",
+			shouldFail: true,
+		},
+	}
+
+	for _, test := range tests {
+		newCommand, err := GenerateCommand(test.input, "foo", "bar", "")
+		if test.shouldFail {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+		}
+		assert.Equal(t, test.expected, strings.Join(newCommand, " "))
+	}
+}
+
+func TestGenerateCommandPath(t *testing.T) {
+	inputCommand := "docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
+	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
+	newCommand, _ := GenerateCommand(inputCommand, "foo", "bar", "")
+	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
+}
+
+func TestGenerateCommandNoSetName(t *testing.T) {
+	inputCommand := "docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
+	correctCommand := "/proc/self/exe run -it --name foo -e NAME=foo -e IMAGE=foo foo echo install"
+	newCommand, err := GenerateCommand(inputCommand, "foo", "", "")
+	assert.Nil(t, err)
+	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
+}
+
+func TestGenerateCommandNoName(t *testing.T) {
+	inputCommand := "docker run -it -e IMAGE=IMAGE IMAGE echo install"
+	correctCommand := "/proc/self/exe run -it -e IMAGE=foo foo echo install"
+	newCommand, err := GenerateCommand(inputCommand, "foo", "", "")
+	assert.Nil(t, err)
+	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
+}
+
+func TestGenerateCommandAlreadyPodman(t *testing.T) {
+	inputCommand := "podman run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
+	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
+	newCommand, err := GenerateCommand(inputCommand, "foo", "bar", "")
+	assert.Nil(t, err)
+	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
+}

--- a/cmd/podman/shared/funcs_test.go
+++ b/cmd/podman/shared/funcs_test.go
@@ -1,11 +1,6 @@
 package shared
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/containers/libpod/pkg/util"
@@ -16,113 +11,6 @@ var (
 	name      = "foo"
 	imageName = "bar"
 )
-
-func TestGenerateCommand(t *testing.T) {
-	inputCommand := "docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo \"hello world\""
-	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo hello world"
-	newCommand, err := GenerateCommand(inputCommand, "foo", "bar", "")
-	assert.Nil(t, err)
-	assert.Equal(t, "hello world", newCommand[11])
-	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
-}
-
-func TestGenerateCommandCheckSubstitution(t *testing.T) {
-	type subsTest struct {
-		input      string
-		expected   string
-		shouldFail bool
-	}
-
-	absTmpFile, err := ioutil.TempFile("", "podmanRunlabelTestAbsolutePath")
-	assert.Nil(t, err, "error creating tempfile")
-	defer os.Remove(absTmpFile.Name())
-
-	relTmpFile, err := ioutil.TempFile("./", "podmanRunlabelTestRelativePath")
-	assert.Nil(t, err, "error creating tempfile")
-	defer os.Remove(relTmpFile.Name())
-	relTmpCmd, err := filepath.Abs(relTmpFile.Name())
-	assert.Nil(t, err, "error getting absolute path for relative tmpfile")
-
-	// this has a (low) potential of race conditions but no other way
-	removedTmpFile, err := ioutil.TempFile("", "podmanRunlabelTestRemove")
-	assert.Nil(t, err, "error creating tempfile")
-	os.Remove(removedTmpFile.Name())
-
-	absTmpCmd := fmt.Sprintf("%s --flag1 --flag2 --args=foo", absTmpFile.Name())
-	tests := []subsTest{
-		{
-			input:      "docker run -it alpine:latest",
-			expected:   "/proc/self/exe run -it alpine:latest",
-			shouldFail: false,
-		},
-		{
-			input:      "podman run -it alpine:latest",
-			expected:   "/proc/self/exe run -it alpine:latest",
-			shouldFail: false,
-		},
-		{
-			input:      absTmpCmd,
-			expected:   absTmpCmd,
-			shouldFail: false,
-		},
-		{
-			input:      "./" + relTmpFile.Name(),
-			expected:   relTmpCmd,
-			shouldFail: false,
-		},
-		{
-			input:      "ls -la",
-			expected:   "ls -la",
-			shouldFail: false,
-		},
-		{
-			input:      removedTmpFile.Name(),
-			expected:   "",
-			shouldFail: true,
-		},
-	}
-
-	for _, test := range tests {
-		newCommand, err := GenerateCommand(test.input, "foo", "bar", "")
-		if test.shouldFail {
-			assert.NotNil(t, err)
-		} else {
-			assert.Nil(t, err)
-		}
-		assert.Equal(t, test.expected, strings.Join(newCommand, " "))
-	}
-}
-
-func TestGenerateCommandPath(t *testing.T) {
-	inputCommand := "docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
-	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
-	newCommand, _ := GenerateCommand(inputCommand, "foo", "bar", "")
-	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
-}
-
-func TestGenerateCommandNoSetName(t *testing.T) {
-	inputCommand := "docker run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
-	correctCommand := "/proc/self/exe run -it --name foo -e NAME=foo -e IMAGE=foo foo echo install"
-	newCommand, err := GenerateCommand(inputCommand, "foo", "", "")
-	assert.Nil(t, err)
-	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
-}
-
-func TestGenerateCommandNoName(t *testing.T) {
-	inputCommand := "docker run -it -e IMAGE=IMAGE IMAGE echo install"
-	correctCommand := "/proc/self/exe run -it -e IMAGE=foo foo echo install"
-	newCommand, err := GenerateCommand(inputCommand, "foo", "", "")
-	assert.Nil(t, err)
-	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
-}
-
-func TestGenerateCommandAlreadyPodman(t *testing.T) {
-	inputCommand := "podman run -it --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE echo install"
-	correctCommand := "/proc/self/exe run -it --name bar -e NAME=bar -e IMAGE=foo foo echo install"
-	newCommand, err := GenerateCommand(inputCommand, "foo", "bar", "")
-	assert.Nil(t, err)
-	assert.Equal(t, correctCommand, strings.Join(newCommand, " "))
-}
 
 func TestGenerateRunEnvironment(t *testing.T) {
 	opts := make(map[string]string)

--- a/libpod/container_top_unsupported.go
+++ b/libpod/container_top_unsupported.go
@@ -4,6 +4,12 @@ package libpod
 
 import "github.com/containers/libpod/libpod/define"
 
+// Top gathers statistics about the running processes in a container. It returns a
+// []string for output
+func (c *Container) Top(descriptors []string) ([]string, error) {
+	return nil, define.ErrNotImplemented
+}
+
 // GetContainerPidInformation returns process-related data of all processes in
 // the container.  The output data can be controlled via the `descriptors`
 // argument which expects format descriptors and supports all AIXformat

--- a/libpod/lock/shm/shm_lock_test.go
+++ b/libpod/lock/shm/shm_lock_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package shm
 
 import (

--- a/libpod/util_unsupported.go
+++ b/libpod/util_unsupported.go
@@ -25,7 +25,7 @@ func assembleSystemdCgroupName(baseSlice, newSlice string) (string, error) {
 
 // LabelVolumePath takes a mount path for a volume and gives it an
 // selinux label of either shared or not
-func LabelVolumePath(path string, shared bool) error {
+func LabelVolumePath(path string) error {
 	return define.ErrNotImplemented
 }
 

--- a/pkg/adapter/terminal_unsupported.go
+++ b/pkg/adapter/terminal_unsupported.go
@@ -1,0 +1,23 @@
+// +build !linux
+
+package adapter
+
+import (
+	"context"
+	"os"
+
+	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
+)
+
+// ExecAttachCtr execs and attaches to a container
+func ExecAttachCtr(ctx context.Context, ctr *libpod.Container, tty, privileged bool, env map[string]string, cmd []string, user, workDir string, streams *libpod.AttachStreams, preserveFDs uint, detachKeys string) (int, error) {
+	return -1, define.ErrNotImplemented
+}
+
+// StartAttachCtr starts and (if required) attaches to a container
+// if you change the signature of this function from os.File to io.Writer, it will trigger a downstream
+// error. we may need to just lint disable this one.
+func StartAttachCtr(ctx context.Context, ctr *libpod.Container, stdout, stderr, stdin *os.File, detachKeys string, sigProxy bool, startContainer bool, recursive bool) error { //nolint-interfacer
+	return define.ErrNotImplemented
+}

--- a/pkg/specgen/config_unsupported.go
+++ b/pkg/specgen/config_unsupported.go
@@ -3,10 +3,11 @@
 package specgen
 
 import (
+	"github.com/containers/libpod/libpod/image"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
 
-func (s *SpecGenerator) getSeccompConfig(configSpec *spec.Spec) (*spec.LinuxSeccomp, error) {
+func (s *SpecGenerator) getSeccompConfig(configSpec *spec.Spec, img *image.Image) (*spec.LinuxSeccomp, error) {
 	return nil, errors.New("function not supported on non-linux OS's")
 }

--- a/pkg/util/utils_linux_test.go
+++ b/pkg/util/utils_linux_test.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetImageConfigStopSignal(t *testing.T) {
+	// Linux-only beause parsing signal names is not supported on non-Linux systems by
+	// pkg/signal.
+	stopSignalValidInt, err := GetImageConfig([]string{"STOPSIGNAL 9"})
+	require.Nil(t, err)
+	assert.Equal(t, stopSignalValidInt.StopSignal, "9")
+
+	stopSignalValidString, err := GetImageConfig([]string{"STOPSIGNAL SIGKILL"})
+	require.Nil(t, err)
+	assert.Equal(t, stopSignalValidString.StopSignal, "9")
+
+	_, err = GetImageConfig([]string{"STOPSIGNAL 0"})
+	assert.NotNil(t, err)
+
+	_, err = GetImageConfig([]string{"STOPSIGNAL garbage"})
+	assert.NotNil(t, err)
+
+	_, err = GetImageConfig([]string{"STOPSIGNAL "})
+	assert.NotNil(t, err)
+}

--- a/pkg/util/utils_test.go
+++ b/pkg/util/utils_test.go
@@ -219,25 +219,6 @@ func TestGetImageConfigLabel(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestGetImageConfigStopSignal(t *testing.T) {
-	stopSignalValidInt, err := GetImageConfig([]string{"STOPSIGNAL 9"})
-	require.Nil(t, err)
-	assert.Equal(t, stopSignalValidInt.StopSignal, "9")
-
-	stopSignalValidString, err := GetImageConfig([]string{"STOPSIGNAL SIGKILL"})
-	require.Nil(t, err)
-	assert.Equal(t, stopSignalValidString.StopSignal, "9")
-
-	_, err = GetImageConfig([]string{"STOPSIGNAL 0"})
-	assert.NotNil(t, err)
-
-	_, err = GetImageConfig([]string{"STOPSIGNAL garbage"})
-	assert.NotNil(t, err)
-
-	_, err = GetImageConfig([]string{"STOPSIGNAL "})
-	assert.NotNil(t, err)
-}
-
 func TestGetImageConfigOnBuild(t *testing.T) {
 	onBuildOne, err := GetImageConfig([]string{"ONBUILD ADD /testdir1"})
 	require.Nil(t, err)


### PR DESCRIPTION
With this,
```console
% CGO_ENABLED=0 go test -tags='exclude_graphdriver_btrfs btrfs_noversion   exclude_graphdriver_devicemapper seccomp containers_image_openpgp' $(go list ./... | grep -v '^github.com/containers/libpod/\(test\|dependencies\|pkg/bindings/test\)')
```
succeeds.

(OTOH the `make` target, besides being much slower, eventually fails:
```console
% CGO_ENABLED=0 make localunit BUILDTAGS='exclude_graphdriver_btrfs btrfs_noversion   exclude_graphdriver_devicemapper seccomp containers_image_openpgp'
…
Failed to compile shm:

can't load package: package github.com/containers/libpod/libpod/lock/shm: build constraints exclude all Go files in /Users/mitr/Go/src/github.com/containers/libpod/libpod/lock/shm
```
)

This should probably be extended so that `make localunit` automatically does the right thing, but this is right now good enough for me to continue working.

See the individual commits for details.