### PR TITLE
pkg: drop variable trueFlag

### DIFF
--- a/pkg/bindings/test/pods_test.go
+++ b/pkg/bindings/test/pods_test.go
@@ -79,10 +79,8 @@ var _ = Describe("Podman pods", func() {
 
 	// The test validates the list pod endpoint with passing filters as the params.
 	It("List pods with filters", func() {
-		var (
-			newpod2  string = "newpod2"
-			trueFlag        = true
-		)
+		newpod2 := "newpod2"
+
 		bt.Podcreate(&newpod2)
 		_, err = bt.RunTopContainer(nil, &bindings.PTrue, &newpod)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
it causes the CI to fail with:

./pods_test.go:84:4: trueFlag declared and not used

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>