### PR TITLE
system tests: enable skopeo REGISTRY_AUTH_FILE

### DIFF
--- a/test/system/150-login.bats
+++ b/test/system/150-login.bats
@@ -286,7 +286,6 @@ function _test_skopeo_credential_sharing() {
 }
 
 @test "podman login - shares credentials with skopeo - via envariable" {
-    skip "skopeo does not yet support REGISTRY_AUTH_FILE; #822"
     authfile=${PODMAN_LOGIN_WORKDIR}/auth-$(random_string 10).json
     rm -f $authfile
 


### PR DESCRIPTION
skopeo pr #829 adds REGISTRY_AUTH_FILE support; this lets us
enable the following test:

  podman login - shares credentials with skopeo - via envariable

(I seriously doubt that the CI VMs have been updated with the
new skopeo, but I can leave this PR in limbo until that happens.
Otherwise I'll forget to enable the test).

Signed-off-by: Ed Santiago <santiago@redhat.com>