### PR TITLE
Support label filters for podman pod ps

### DIFF
--- a/cmd/podman/shared/pod.go
+++ b/cmd/podman/shared/pod.go
@@ -162,7 +162,7 @@ func FilterAllPodsWithFilterFunc(r *libpod.Runtime, filters ...libpod.PodFilter)
 func GenerateFilterFunction(r *libpod.Runtime, filters []string) ([]libpod.PodFilter, error) {
 	var filterFuncs []libpod.PodFilter
 	for _, f := range filters {
-		filterSplit := strings.Split(f, "=")
+		filterSplit := strings.SplitN(f, "=", 2)
 		if len(filterSplit) < 2 {
 			return nil, errors.Errorf("filter input must be in the form of filter=value: %s is invalid", f)
 		}
@@ -253,6 +253,22 @@ func generatePodFilterFuncs(filter, filterValue string) (
 			}
 			if strings.ToLower(status) == filterValue {
 				return true
+			}
+			return false
+		}, nil
+	case "label":
+		var filterArray = strings.SplitN(filterValue, "=", 2)
+		var filterKey = filterArray[0]
+		if len(filterArray) > 1 {
+			filterValue = filterArray[1]
+		} else {
+			filterValue = ""
+		}
+		return func(p *libpod.Pod) bool {
+			for labelKey, labelValue := range p.Labels() {
+				if labelKey == filterKey && ("" == filterValue || labelValue == filterValue) {
+					return true
+				}
 			}
 			return false
 		}, nil

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -519,6 +519,21 @@ func (p *PodmanTestIntegration) CreatePod(name string) (*PodmanSessionIntegratio
 	return session, session.ExitCode(), session.OutputToString()
 }
 
+// CreatePod creates a pod with no infra container and some labels.
+// it optionally takes a pod name
+func (p *PodmanTestIntegration) CreatePodWithLabels(name string, labels map[string]string) (*PodmanSessionIntegration, int, string) {
+	var podmanArgs = []string{"pod", "create", "--infra=false", "--share", ""}
+	if name != "" {
+		podmanArgs = append(podmanArgs, "--name", name)
+	}
+	for labelKey, labelValue := range labels {
+		podmanArgs = append(podmanArgs, "--label", fmt.Sprintf("%s=%s", labelKey, labelValue))
+	}
+	session := p.Podman(podmanArgs)
+	session.WaitWithDefaultTimeout()
+	return session, session.ExitCode(), session.OutputToString()
+}
+
 func (p *PodmanTestIntegration) RunTopContainerInPod(name, pod string) *PodmanSessionIntegration {
 	var podmanArgs = []string{"run", "--pod", pod}
 	if name != "" {


### PR DESCRIPTION
Update the podman pod ps command to support filtering by labels.
This brings the command in line with the documentation as well as
the functionality by the containers equivalent podman ps.

Signed-off-by: Stefano Pogliani <stefano@spogliani.net>

Information from the issue template:

/kind bug

**Steps to reproduce the issue:**

1. Execute `podman pod ps --filter 'label=some.label'`

**Describe the results you received:**
The command fails:

```
$ podman pod ps --filter 'label=some.label'
Error: invalid filter: label is an invalid filter
```

**Describe the results you expected:**
A, possibly empty, list of pods with the label set (for the `label=KEY` version) or with the label matching `VALUE` (for the `label=KEY=VALUE` version).

**Output of `podman version`:**

```
Version:            1.8.1
RemoteAPI Version:  1
Go Version:         go1.13.6
OS/Arch:            linux/amd64
```

**Package info (e.g. output of `rpm -q podman` or `apt list podman`):**

```
podman-1.8.1-2.fc31.x86_64
```

**Additional notes:**
I've tried my best to follow the [CONTRIBUTING](https://github.com/containers/libpod/blob/master/CONTRIBUTING.md) guidelines but tests seem to fail on master itself.
Even for the subset of tests I worked near, some tests seem to fail on master even without my changes.

Please also note that I'm very inexperienced with golang.