### PR TITLE
Correctly document libpod commit endpoint

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -967,7 +967,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/{name:.*}/tag"), s.APIHandler(compat.TagImage)).Methods(http.MethodPost)
-	// swagger:operation POST /commit libpod libpodCommitContainer
+	// swagger:operation POST /libpod/commit libpod libpodCommitContainer
 	// ---
 	// tags:
 	//  - containers


### PR DESCRIPTION
In #5588 it was forgotten and documentation still points to `/commit`.