### PR TITLE
Ensure that exec sends resize events

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -793,7 +793,6 @@ func (r *ConmonOCIRuntime) ExecAttachResize(ctr *Container, sessionID string, ne
 	}
 	defer controlFile.Close()
 
-	logrus.Debugf("Received a resize event for container %s exec session %s: %+v", ctr.ID(), sessionID, newSize)
 	if _, err = fmt.Fprintf(controlFile, "%d %d %d\n", 1, newSize.Height, newSize.Width); err != nil {
 		return errors.Wrapf(err, "failed to write to ctl file to resize terminal")
 	}


### PR DESCRIPTION
We previously tried to send resize events only after the exec session successfully started, which makes sense (we might drop an event or two that came in before the exec session started
otherwise). However, the start function blocks, so waiting actually means we send no resize events at all, which it obviously worse than losing a few.. Sending resizes before attach starts seems to work fine in my testing, so let's do that until we get bug reports that it doesn't work.

Fixes #5584