### PR TITLE
podmanv2 add pre-run to each commmand

### DIFF
--- a/cmd/podmanV2/containers/kill.go
+++ b/cmd/podmanV2/containers/kill.go
@@ -15,10 +15,11 @@ import (
 var (
 	killDescription = "The main process inside each container specified will be sent SIGKILL, or any signal specified with option --signal."
 	killCommand     = &cobra.Command{
-		Use:   "kill [flags] CONTAINER [CONTAINER...]",
-		Short: "Kill one or more running containers with a specific signal",
-		Long:  killDescription,
-		RunE:  kill,
+		Use:               "kill [flags] CONTAINER [CONTAINER...]",
+		Short:             "Kill one or more running containers with a specific signal",
+		Long:              killDescription,
+		RunE:              kill,
+		PersistentPreRunE: preRunE,
 		Args: func(cmd *cobra.Command, args []string) error {
 			return parse.CheckAllLatestAndCIDFile(cmd, args, false, false)
 		},

--- a/cmd/podmanV2/containers/pause.go
+++ b/cmd/podmanV2/containers/pause.go
@@ -15,10 +15,11 @@ import (
 var (
 	pauseDescription = `Pauses one or more running containers.  The container name or ID can be used.`
 	pauseCommand     = &cobra.Command{
-		Use:   "pause [flags] CONTAINER [CONTAINER...]",
-		Short: "Pause all the processes in one or more containers",
-		Long:  pauseDescription,
-		RunE:  pause,
+		Use:               "pause [flags] CONTAINER [CONTAINER...]",
+		Short:             "Pause all the processes in one or more containers",
+		Long:              pauseDescription,
+		RunE:              pause,
+		PersistentPreRunE: preRunE,
 		Example: `podman pause mywebserver
   podman pause 860a4b23
   podman pause -a`,

--- a/cmd/podmanV2/containers/restart.go
+++ b/cmd/podmanV2/containers/restart.go
@@ -18,10 +18,11 @@ var (
 
   A timeout before forcibly stopping can be set, but defaults to 10 seconds.`
 	restartCommand = &cobra.Command{
-		Use:   "restart [flags] CONTAINER [CONTAINER...]",
-		Short: "Restart one or more containers",
-		Long:  restartDescription,
-		RunE:  restart,
+		Use:               "restart [flags] CONTAINER [CONTAINER...]",
+		Short:             "Restart one or more containers",
+		Long:              restartDescription,
+		RunE:              restart,
+		PersistentPreRunE: preRunE,
 		Args: func(cmd *cobra.Command, args []string) error {
 			return parse.CheckAllLatestAndCIDFile(cmd, args, false, false)
 		},

--- a/cmd/podmanV2/containers/rm.go
+++ b/cmd/podmanV2/containers/rm.go
@@ -19,10 +19,11 @@ var (
 
   Command does not remove images. Running or unusable containers will not be removed without the -f option.`
 	rmCommand = &cobra.Command{
-		Use:   "rm [flags] CONTAINER [CONTAINER...]",
-		Short: "Remove one or more containers",
-		Long:  rmDescription,
-		RunE:  rm,
+		Use:               "rm [flags] CONTAINER [CONTAINER...]",
+		Short:             "Remove one or more containers",
+		Long:              rmDescription,
+		RunE:              rm,
+		PersistentPreRunE: preRunE,
 		Args: func(cmd *cobra.Command, args []string) error {
 			return parse.CheckAllLatestAndCIDFile(cmd, args, false, true)
 		},

--- a/cmd/podmanV2/containers/stop.go
+++ b/cmd/podmanV2/containers/stop.go
@@ -18,10 +18,11 @@ var (
 
   A timeout to forcibly stop the container can also be set but defaults to 10 seconds otherwise.`
 	stopCommand = &cobra.Command{
-		Use:   "stop [flags] CONTAINER [CONTAINER...]",
-		Short: "Stop one or more containers",
-		Long:  stopDescription,
-		RunE:  stop,
+		Use:               "stop [flags] CONTAINER [CONTAINER...]",
+		Short:             "Stop one or more containers",
+		Long:              stopDescription,
+		RunE:              stop,
+		PersistentPreRunE: preRunE,
 		Args: func(cmd *cobra.Command, args []string) error {
 			return parse.CheckAllLatestAndCIDFile(cmd, args, false, true)
 		},

--- a/cmd/podmanV2/containers/unpause.go
+++ b/cmd/podmanV2/containers/unpause.go
@@ -15,10 +15,11 @@ import (
 var (
 	unpauseDescription = `Unpauses one or more previously paused containers.  The container name or ID can be used.`
 	unpauseCommand     = &cobra.Command{
-		Use:   "unpause [flags] CONTAINER [CONTAINER...]",
-		Short: "Unpause the processes in one or more containers",
-		Long:  unpauseDescription,
-		RunE:  unpause,
+		Use:               "unpause [flags] CONTAINER [CONTAINER...]",
+		Short:             "Unpause the processes in one or more containers",
+		Long:              unpauseDescription,
+		RunE:              unpause,
+		PersistentPreRunE: preRunE,
 		Example: `podman unpause ctrID
   podman unpause --all`,
 	}

--- a/cmd/podmanV2/containers/wait.go
+++ b/cmd/podmanV2/containers/wait.go
@@ -18,10 +18,11 @@ var (
 	waitDescription = `Block until one or more containers stop and then print their exit codes.
 `
 	waitCommand = &cobra.Command{
-		Use:   "wait [flags] CONTAINER [CONTAINER...]",
-		Short: "Block on one or more containers",
-		Long:  waitDescription,
-		RunE:  wait,
+		Use:               "wait [flags] CONTAINER [CONTAINER...]",
+		Short:             "Block on one or more containers",
+		Long:              waitDescription,
+		RunE:              wait,
+		PersistentPreRunE: preRunE,
 		Args: func(cmd *cobra.Command, args []string) error {
 			return parse.CheckAllLatestAndCIDFile(cmd, args, false, false)
 		},


### PR DESCRIPTION
each container command needs a prerune because it is not part of the containers subcommand yet

Signed-off-by: Brent Baude <bbaude@redhat.com>