### PR TITLE
podmanV2: implement top

### DIFF
--- a/cmd/podmanV2/containers/top.go
+++ b/cmd/podmanV2/containers/top.go
@@ -1,0 +1,91 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/containers/libpod/cmd/podmanV2/registry"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/containers/psgo"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	topDescription = fmt.Sprintf(`Similar to system "top" command.
+
+  Specify format descriptors to alter the output.
+
+  Running "podman top -l pid pcpu seccomp" will print the process ID, the CPU percentage and the seccomp mode of each process of the latest container.
+  Format Descriptors:
+    %s`, strings.Join(psgo.ListDescriptors(), ","))
+
+	topOptions = entities.TopOptions{}
+
+	topCommand = &cobra.Command{
+		Use:               "top [flags] CONTAINER [FORMAT-DESCRIPTORS|ARGS]",
+		Short:             "Display the running processes of a container",
+		Long:              topDescription,
+		PersistentPreRunE: preRunE,
+		RunE:              top,
+		Args:              cobra.ArbitraryArgs,
+		Example: `podman top ctrID
+podman top --latest
+podman top ctrID pid seccomp args %C
+podman top ctrID -eo user,pid,comm`,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: topCommand,
+	})
+
+	topCommand.SetHelpTemplate(registry.HelpTemplate())
+	topCommand.SetUsageTemplate(registry.UsageTemplate())
+
+	flags := topCommand.Flags()
+	flags.SetInterspersed(false)
+	flags.BoolVar(&topOptions.ListDescriptors, "list-descriptors", false, "")
+	flags.BoolVarP(&topOptions.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
+
+	_ = flags.MarkHidden("list-descriptors") // meant only for bash completion
+	if registry.IsRemote() {
+		_ = flags.MarkHidden("latest")
+	}
+}
+
+func top(cmd *cobra.Command, args []string) error {
+	if topOptions.ListDescriptors {
+		fmt.Println(strings.Join(psgo.ListDescriptors(), "\n"))
+		return nil
+	}
+
+	if len(args) < 1 && !topOptions.Latest {
+		return errors.Errorf("you must provide the name or id of a running container")
+	}
+
+	if topOptions.Latest {
+		topOptions.Descriptors = args
+	} else {
+		topOptions.NameOrID = args[0]
+		topOptions.Descriptors = args[1:]
+	}
+
+	topResponse, err := registry.ContainerEngine().ContainerTop(context.Background(), topOptions)
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 5, 1, 3, ' ', 0)
+	for _, proc := range topResponse.Value {
+		if _, err := fmt.Fprintln(w, proc); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -22,6 +22,11 @@ type BoolReport struct {
 	Value bool
 }
 
+// StringSliceReport wraps a string slice.
+type StringSliceReport struct {
+	Value []string
+}
+
 type PauseUnPauseOptions struct {
 	All bool
 }
@@ -42,6 +47,16 @@ type StopOptions struct {
 type StopReport struct {
 	Err error
 	Id  string
+}
+
+type TopOptions struct {
+	// CLI flags.
+	ListDescriptors bool
+	Latest          bool
+
+	// Options for the API.
+	Descriptors []string
+	NameOrID    string
 }
 
 type KillOptions struct {

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -14,6 +14,8 @@ type ContainerEngine interface {
 	ContainerUnpause(ctx context.Context, namesOrIds []string, options PauseUnPauseOptions) ([]*PauseUnpauseReport, error)
 	ContainerStop(ctx context.Context, namesOrIds []string, options StopOptions) ([]*StopReport, error)
 	ContainerWait(ctx context.Context, namesOrIds []string, options WaitOptions) ([]WaitReport, error)
+	ContainerTop(ctx context.Context, options TopOptions) (*StringSliceReport, error)
+
 	PodExists(ctx context.Context, nameOrId string) (*BoolReport, error)
 	PodKill(ctx context.Context, namesOrIds []string, options PodKillOptions) ([]*PodKillReport, error)
 	PodPause(ctx context.Context, namesOrIds []string, options PodPauseOptions) ([]*PodPauseReport, error)
@@ -22,6 +24,7 @@ type ContainerEngine interface {
 	PodStop(ctx context.Context, namesOrIds []string, options PodStopOptions) ([]*PodStopReport, error)
 	PodRm(ctx context.Context, namesOrIds []string, options PodRmOptions) ([]*PodRmReport, error)
 	PodUnpause(ctx context.Context, namesOrIds []string, options PodunpauseOptions) ([]*PodUnpauseReport, error)
+
 	VolumeCreate(ctx context.Context, opts VolumeCreateOptions) (*IdOrNameResponse, error)
 	VolumeInspect(ctx context.Context, namesOrIds []string, opts VolumeInspectOptions) ([]*VolumeInspectReport, error)
 	VolumeRm(ctx context.Context, namesOrIds []string, opts VolumeRmOptions) ([]*VolumeRmReport, error)

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -255,3 +255,25 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 	}
 	return reports, nil
 }
+
+func (ic *ContainerEngine) ContainerTop(ctx context.Context, options entities.TopOptions) (*entities.StringSliceReport, error) {
+	var (
+		container *libpod.Container
+		err       error
+	)
+
+	// Look up the container.
+	if options.Latest {
+		container, err = ic.Libpod.GetLatestContainer()
+	} else {
+		container, err = ic.Libpod.LookupContainer(options.NameOrID)
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to lookup requested container")
+	}
+
+	// Run Top.
+	report := &entities.StringSliceReport{}
+	report.Value, err = container.Top(options.Descriptors)
+	return report, err
+}

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/containers/libpod/pkg/bindings/containers"
 	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/pkg/errors"
 )
 
 func (ic *ContainerEngine) ContainerExists(ctx context.Context, nameOrId string) (*entities.BoolReport, error) {
@@ -155,4 +156,19 @@ func (ic *ContainerEngine) ContainerInspect(ctx context.Context, namesOrIds []st
 		reports = append(reports, &entities.ContainerInspectReport{InspectContainerData: data})
 	}
 	return reports, nil
+}
+
+func (ic *ContainerEngine) ContainerTop(ctx context.Context, options entities.TopOptions) (*entities.StringSliceReport, error) {
+	switch {
+	case options.Latest:
+		return nil, errors.New("latest is not supported")
+	case options.NameOrID == "":
+		return nil, errors.New("NameOrID must be specified")
+	}
+
+	topOutput, err := containers.Top(ic.ClientCxt, options.NameOrID, options.Descriptors)
+	if err != nil {
+		return nil, err
+	}
+	return &entities.StringSliceReport{Value: topOutput}, nil
 }


### PR DESCRIPTION
Implement the `top` command for podmanV2. `registry.ContainerEngine()`
is currently returning `<nil>`, so we're creating a new engine in
top.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>