### PR TITLE
Add support for specifying CNI networks in podman play kube

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -318,6 +318,7 @@ type KubePlayValues struct {
 	Authfile           string
 	CertDir            string
 	Creds              string
+	Network            string
 	Quiet              bool
 	SignaturePolicy    string
 	TlsVerify          bool

--- a/cmd/podman/play_kube.go
+++ b/cmd/podman/play_kube.go
@@ -51,6 +51,7 @@ func init() {
 		flags.StringVar(&playKubeCommand.SeccompProfileRoot, "seccomp-profile-root", defaultSeccompRoot, "Directory path for seccomp profiles")
 		markFlagHidden(flags, "signature-policy")
 	}
+	flags.StringVar(&playKubeCommand.Network, "network", "", "Connect pod to CNI network(s)")
 }
 
 func playKubeCmd(c *cliconfig.KubePlayValues) error {

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2683,6 +2683,7 @@ _podman_play_kube() {
     --authfile
     --cert-dir
     --creds
+    --network
     "
 
     local boolean_options="

--- a/docs/source/markdown/podman-play-kube.1.md
+++ b/docs/source/markdown/podman-play-kube.1.md
@@ -36,6 +36,10 @@ The [username[:password]] to use to authenticate with the registry if required.
 If one or both values are not supplied, a command line prompt will appear and the
 value can be entered.  The password is entered without echo.
 
+**--network**=*cni networks*
+
+A comma-separated list of the names of CNI networks the pod should join.
+
 **--quiet**, **-q**
 
 Suppress output information when pulling images
@@ -62,8 +66,16 @@ $ podman play kube demo.yml
 52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
 ```
 
+CNI network(s) can be specified as comma-separated list using ``--network``
+```
+$ podman play kube demo.yml --network cni1,cni2
+52182811df2b1e73f36476003a66ec872101ea59034ac0d4d3a7b40903b955a6
+```
+
+Please take into account that CNI networks must be created first using podman-network-create(1).
+
 ## SEE ALSO
-podman(1), podman-container(1), podman-pod(1), podman-generate-kube(1), podman-play(1)
+podman(1), podman-container(1), podman-pod(1), podman-generate-kube(1), podman-play(1), podman-network-create(1)
 
 ## HISTORY
 December 2018, Originally compiled by Brent Baude (bbaude at redhat dot com)

--- a/pkg/adapter/pods.go
+++ b/pkg/adapter/pods.go
@@ -343,7 +343,7 @@ func (r *LocalRuntime) CreatePod(ctx context.Context, cli *cliconfig.PodCreateVa
 			logrus.Debugf("Pod will use host networking")
 			options = append(options, libpod.WithPodHostNetwork())
 		case "":
-			return "", errors.Errorf("invalid value passed to --net: must provide a comma-separated list of CNI networks or host")
+			return "", errors.Errorf("invalid value passed to --network: must provide a comma-separated list of CNI networks or host")
 		default:
 			// We'll assume this is a comma-separated list of CNI
 			// networks.


### PR DESCRIPTION
As far as I understood it is not possible to define container network on the yaml level (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pod-v1-core).

I am adding networking options to ``podman play cube`` though.