### PR TITLE
[CI:DOCS] Fix Markdown typo in podman-create.1.md

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -44,7 +44,7 @@ each of stdin, stdout, and stderr.
 
 **--authfile**=*path*
 
-Path of the authentication file. Default is ${XDG_\RUNTIME\_DIR}/containers/auth.json
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json
 
 Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
 environment variable. `export REGISTRY_AUTH_FILE=path` (Not available for remote commands)


### PR DESCRIPTION
Fix a Markdown syntax typo


Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>