### PR TITLE
V2 podman system service

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,5 @@
 ---
 run:
-  build-tags:
-    - apparmor
-    - seccomp
-    - selinux
-    - ABISupport
   concurrency: 6
   deadline: 5m
   skip-dirs-use-default: true
@@ -12,6 +7,8 @@ run:
     - contrib
     - dependencies
     - test
+    - pkg/varlink
+    - pkg/varlinkapi
   skip-files:
     - iopodman.go
     - swagger.go
@@ -31,3 +28,7 @@ linters:
     - misspell
     - prealloc
     - unparam
+linters-settings:
+  errcheck:
+    check-blank: false
+    ignore: encoding/json:^Unmarshal,fmt:.*

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ endif
 
 .PHONY: golangci-lint
 golangci-lint: .gopathok varlink_generate .install.golangci-lint
-	$(GOBIN)/golangci-lint run
+	hack/golangci-lint.sh run
 
 .PHONY: gofmt
 gofmt: ## Verify the source code gofmt

--- a/cmd/podman/commands_remoteclient.go
+++ b/cmd/podman/commands_remoteclient.go
@@ -14,7 +14,7 @@ func getMainCommands() []*cobra.Command {
 }
 
 // commands that only the remoteclient implements
-func getAppCommands() []*cobra.Command {
+func getAppCommands() []*cobra.Command { // nolint:varcheck,deadcode,unused
 	return []*cobra.Command{}
 }
 
@@ -29,7 +29,7 @@ func getContainerSubCommands() []*cobra.Command {
 }
 
 // commands that only the remoteclient implements
-func getGenerateSubCommands() []*cobra.Command {
+func getGenerateSubCommands() []*cobra.Command { // nolint:varcheck,deadcode,unused
 	return []*cobra.Command{}
 }
 
@@ -126,7 +126,7 @@ func getDefaultPidsDescription() string {
 	return "Tune container pids limit (set 0 for unlimited, -1 for server defaults)"
 }
 
-func getDefaultShareNetwork() string {
+func getDefaultShareNetwork() string { // nolint:varcheck,deadcode,unused
 	return ""
 }
 

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -24,8 +24,8 @@ import (
 var (
 	exitCode = define.ExecErrorCodeGeneric
 	Ctx      context.Context
-	span     opentracing.Span
-	closer   io.Closer
+	span     opentracing.Span // nolint:varcheck,deadcode,unused
+	closer   io.Closer        // nolint:varcheck,deadcode,unused
 )
 
 // Commands that the remote and local client have

--- a/cmd/podman/service.go
+++ b/cmd/podman/service.go
@@ -91,7 +91,7 @@ func resolveApiURI(c *cliconfig.ServiceValues) (string, error) {
 
 	if len(c.InputArgs) > 0 {
 		apiURI = c.InputArgs[0]
-	} else if ok := systemd.SocketActivated(); ok {
+	} else if ok := systemd.SocketActivated(); ok { // nolint: gocritic
 		apiURI = ""
 	} else if rootless.IsRootless() {
 		xdg, err := util.GetRuntimeDir()
@@ -161,7 +161,7 @@ func runREST(r *libpod.Runtime, uri string, timeout time.Duration) error {
 }
 
 func runVarlink(r *libpod.Runtime, uri string, timeout time.Duration, c *cliconfig.ServiceValues) error {
-	var varlinkInterfaces = []*iopodman.VarlinkInterface{varlinkapi.New(&c.PodmanCommand, r)}
+	var varlinkInterfaces = []*iopodman.VarlinkInterface{varlinkapi.New(c.PodmanCommand.Command, r)}
 	service, err := varlink.NewService(
 		"Atomic",
 		"podman",
@@ -182,7 +182,7 @@ func runVarlink(r *libpod.Runtime, uri string, timeout time.Duration, c *cliconf
 	if err = service.Listen(uri, timeout); err != nil {
 		switch err.(type) {
 		case varlink.ServiceTimeoutError:
-			logrus.Infof("varlink service expired (use --timeout to increase session time beyond %d ms, 0 means never timeout)", timeout.String())
+			logrus.Infof("varlink service expired (use --timeout to increase session time beyond %s ms, 0 means never timeout)", timeout.String())
 			return nil
 		default:
 			return errors.Wrapf(err, "unable to start varlink service")

--- a/cmd/podman/service_dummy.go
+++ b/cmd/podman/service_dummy.go
@@ -5,6 +5,7 @@ package main
 import "github.com/spf13/cobra"
 
 var (
+	// nolint:varcheck,deadcode,unused
 	_serviceCommand = &cobra.Command{
 		Use: "",
 	}

--- a/cmd/podman/varlink.go
+++ b/cmd/podman/varlink.go
@@ -85,7 +85,7 @@ func varlinkCmd(c *cliconfig.VarlinkValues) error {
 	}
 	defer runtime.DeferredShutdown(false)
 
-	var varlinkInterfaces = []*iopodman.VarlinkInterface{varlinkapi.New(&c.PodmanCommand, runtime)}
+	var varlinkInterfaces = []*iopodman.VarlinkInterface{varlinkapi.New(c.PodmanCommand.Command, runtime)}
 	// Register varlink service. The metadata can be retrieved with:
 	// $ varlink info [varlink address URI]
 	service, err := varlink.NewService(

--- a/cmd/podman/varlink_dummy.go
+++ b/cmd/podman/varlink_dummy.go
@@ -5,6 +5,7 @@ package main
 import "github.com/spf13/cobra"
 
 var (
+	// nolint:varcheck,deadcode,unused
 	_varlinkCommand = &cobra.Command{
 		Use: "",
 	}

--- a/cmd/podmanV2/Makefile
+++ b/cmd/podmanV2/Makefile
@@ -1,2 +1,10 @@
-all:
-	CGO_ENABLED=1 GO111MODULE=off go build -tags 'ABISupport systemd seccomp'
+all: podman podman-remote
+
+podman:
+	CGO_ENABLED=1 GO111MODULE=off go build -tags 'ABISupport systemd varlink seccomp'
+
+podman-remote:
+	CGO_ENABLED=1 GO111MODULE=off go build -tags '!ABISupport systemd seccomp' -o podmanV2-remote
+
+clean:
+	rm podmanV2 podmanV2-remote

--- a/cmd/podmanV2/registry/registry.go
+++ b/cmd/podmanV2/registry/registry.go
@@ -9,7 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type CobraFuncs func(cmd *cobra.Command, args []string) error
+// DefaultAPIAddress is the default address of the REST socket
+const DefaultAPIAddress = "unix:/run/podman/podman.sock"
+
+// DefaultVarlinkAddress is the default address of the varlink socket
+const DefaultVarlinkAddress = "unix:/run/podman/io.podman"
 
 type CliCommand struct {
 	Mode    []entities.EngineMode

--- a/cmd/podmanV2/system/service.go
+++ b/cmd/podmanV2/system/service.go
@@ -1,0 +1,124 @@
+package system
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/containers/libpod/cmd/podmanV2/registry"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/libpod/pkg/systemd"
+	"github.com/containers/libpod/pkg/util"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	srvDescription = `Run an API service
+
+Enable a listening service for API access to Podman commands.
+`
+
+	srvCmd = &cobra.Command{
+		Use:   "service [flags] [URI]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Run API service",
+		Long:  srvDescription,
+		RunE:  service,
+		Example: `podman system service --time=0 unix:///tmp/podman.sock
+  podman system service --varlink --time=0 unix:///tmp/podman.sock`,
+	}
+
+	srvArgs = struct {
+		Timeout int64
+		Varlink bool
+	}{}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode},
+		Command: srvCmd,
+		Parent:  systemCmd,
+	})
+
+	flags := srvCmd.Flags()
+	flags.Int64VarP(&srvArgs.Timeout, "time", "t", 5, "Time until the service session expires in seconds.  Use 0 to disable the timeout")
+	flags.Int64Var(&srvArgs.Timeout, "timeout", 5, "Time until the service session expires in seconds.  Use 0 to disable the timeout")
+	flags.BoolVar(&srvArgs.Varlink, "varlink", false, "Use legacy varlink service instead of REST")
+
+	_ = flags.MarkDeprecated("varlink", "valink API is deprecated.")
+}
+
+func service(cmd *cobra.Command, args []string) error {
+	apiURI, err := resolveApiURI(args)
+	if err != nil {
+		return err
+	}
+	logrus.Infof("using API endpoint: \"%s\"", apiURI)
+
+	opts := entities.ServiceOptions{
+		URI:     apiURI,
+		Timeout: time.Duration(srvArgs.Timeout) * time.Second,
+		Command: cmd,
+	}
+
+	if srvArgs.Varlink {
+		return registry.ContainerEngine().VarlinkService(registry.GetContext(), opts)
+	}
+
+	logrus.Warn("This function is EXPERIMENTAL")
+	fmt.Fprintf(os.Stderr, "This function is EXPERIMENTAL.\n")
+	return registry.ContainerEngine().RestService(registry.GetContext(), opts)
+}
+
+func resolveApiURI(_url []string) (string, error) {
+
+	// When determining _*THE*_ listening endpoint --
+	// 1) User input wins always
+	// 2) systemd socket activation
+	// 3) rootless honors XDG_RUNTIME_DIR
+	// 4) if varlink -- adapter.DefaultVarlinkAddress
+	// 5) lastly adapter.DefaultAPIAddress
+
+	if _url == nil {
+		if v, found := os.LookupEnv("PODMAN_SOCKET"); found {
+			_url = []string{v}
+		}
+	}
+
+	switch {
+	case len(_url) > 0:
+		return _url[0], nil
+	case systemd.SocketActivated():
+		logrus.Info("using systemd socket activation to determine API endpoint")
+		return "", nil
+	case rootless.IsRootless():
+		xdg, err := util.GetRuntimeDir()
+		if err != nil {
+			return "", err
+		}
+
+		socketName := "podman.sock"
+		if srvArgs.Varlink {
+			socketName = "io.podman"
+		}
+		socketDir := filepath.Join(xdg, "podman", socketName)
+		if _, err := os.Stat(filepath.Dir(socketDir)); err != nil {
+			if os.IsNotExist(err) {
+				if err := os.Mkdir(filepath.Dir(socketDir), 0755); err != nil {
+					return "", err
+				}
+			} else {
+				return "", err
+			}
+		}
+		return "unix:" + socketDir, nil
+	case srvArgs.Varlink:
+		return registry.DefaultVarlinkAddress, nil
+	default:
+		return registry.DefaultAPIAddress, nil
+	}
+}

--- a/cmd/podmanV2/system/system.go
+++ b/cmd/podmanV2/system/system.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Command: podman _system_
-	cmd = &cobra.Command{
+	systemCmd = &cobra.Command{
 		Use:               "system",
 		Short:             "Manage podman",
 		Long:              "Manage podman",
@@ -21,10 +21,10 @@ var (
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
-		Command: cmd,
+		Command: systemCmd,
 	})
-	cmd.SetHelpTemplate(registry.HelpTemplate())
-	cmd.SetUsageTemplate(registry.UsageTemplate())
+	systemCmd.SetHelpTemplate(registry.HelpTemplate())
+	systemCmd.SetUsageTemplate(registry.UsageTemplate())
 }
 
 func preRunE(cmd *cobra.Command, args []string) error {

--- a/cmd/podmanV2/system/varlink.go
+++ b/cmd/podmanV2/system/varlink.go
@@ -1,0 +1,56 @@
+package system
+
+import (
+	"time"
+
+	"github.com/containers/libpod/cmd/podmanV2/registry"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/spf13/cobra"
+)
+
+var (
+	varlinkDescription = `Run varlink interface.  Podman varlink listens on the specified unix domain socket for incoming connects.
+
+  Tools speaking varlink protocol can remotely manage pods, containers and images.
+`
+	varlinkCmd = &cobra.Command{
+		Use:     "varlink [flags] [URI]",
+		Args:    cobra.MinimumNArgs(1),
+		Short:   "Run varlink interface",
+		Long:    varlinkDescription,
+		PreRunE: preRunE,
+		RunE:    varlinkE,
+		Example: `podman varlink unix:/run/podman/io.podman
+  podman varlink --timeout 5000 unix:/run/podman/io.podman`,
+	}
+	varlinkArgs = struct {
+		Timeout int64
+	}{}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: varlinkCmd,
+	})
+	varlinkCmd.SetHelpTemplate(registry.HelpTemplate())
+	varlinkCmd.SetUsageTemplate(registry.UsageTemplate())
+
+	flags := varlinkCmd.Flags()
+	flags.Int64VarP(&varlinkArgs.Timeout, "time", "t", 1000, "Time until the varlink session expires in milliseconds.  Use 0 to disable the timeout")
+	flags.Int64Var(&varlinkArgs.Timeout, "timeout", 1000, "Time until the varlink session expires in milliseconds.  Use 0 to disable the timeout")
+
+}
+
+func varlinkE(cmd *cobra.Command, args []string) error {
+	uri := registry.DefaultVarlinkAddress
+	if len(args) > 0 {
+		uri = args[0]
+	}
+	opts := entities.ServiceOptions{
+		URI:     uri,
+		Timeout: time.Duration(varlinkArgs.Timeout) * time.Second,
+		Command: cmd,
+	}
+	return registry.ContainerEngine().VarlinkService(registry.GetContext(), opts)
+}

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774 h1:SCbEWT58NSt7d2mcFdvxC9uyrdcTfvBbPLThhkDmXzg=
 github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774/go.mod h1:6/0dYRLLXyJjbkIPeeGyoJ/eKOSI0eU6eTlCBYibgd0=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -42,6 +43,7 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/checkpoint-restore/go-criu v0.0.0-20190109184317-bdb7599cd87b h1:T4nWG1TXIxeor8mAu5bFguPJgSIGhZqv/f0z55KCrJM=
 github.com/checkpoint-restore/go-criu v0.0.0-20190109184317-bdb7599cd87b/go.mod h1:TrMrLQfeENAPYPRsJuq3jsqdlRh3lvi6trTZJG8+tho=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
@@ -149,9 +151,11 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libnetwork v0.8.0-dev.2.0.20190625141545-5a177b73e316 h1:moehPjPiGUaWdwgOl92xRyFHJyaqXDHcCyW9M6nmCK4=
 github.com/docker/libnetwork v0.8.0-dev.2.0.20190625141545-5a177b73e316/go.mod h1:93m0aTqz6z+g32wla4l4WxTrdtvBRmVzYRkYvasA5Z8=
+github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU5CAUmr9zpesgbU6SWc8/B4mflAE4=
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e h1:p1yVGRW3nmb85p1Sh1ZJSDm4A4iKLS5QNbvUHMgGu/M=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -245,6 +249,7 @@ github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHh
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -291,7 +296,9 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -306,7 +313,9 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mistifyio/go-zfs v2.1.1+incompatible h1:gAMO1HM9xBRONLHHYnu5iFsOJUiJdNZo6oqSENd4eW8=
 github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/moby/sys/mountinfo v0.1.0/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
 github.com/moby/vpnkit v0.3.1-0.20200304131818-6bc1679a048d/go.mod h1:KyjUrL9cb6ZSNNAUwZfqRjhwwgJ3BJN+kXh0t43WTUQ=
@@ -381,6 +390,7 @@ github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsq
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913 h1:TnbXhKzrTOyuvWrjI8W6pcoI9XPbLHFXCdN2dtUw7Rw=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
+github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.0.0-20190227000051-27936f6d90f9/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -437,18 +447,22 @@ github.com/sirupsen/logrus v1.5.0 h1:1N5EYkVAPEywqZRJd7cwnRtCb6xJx7NH3T3WUTF980Q
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v0.0.7 h1:FfTH+vuMXOas8jmfb5/M7dzEYx7LpcLb7a0LPe34uOU=
 github.com/spf13/cobra v0.0.7/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/viper v1.4.0 h1:yXHLWeravcrgGyFSyCgdYpXQ9dR9c/WED3pg1RhxqEU=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+# Need to run linter twice to cover all the build tags code paths
+
+declare -A BUILD_TAGS
+BUILD_TAGS[default]="apparmor,seccomp,selinux"
+BUILD_TAGS[abi]="${BUILD_TAGS[default]},ABISupport,varlink,!remoteclient"
+BUILD_TAGS[tunnel]="${BUILD_TAGS[default]},!ABISupport,!varlink,remoteclient"
+
+[[ $1 == run ]] && shift
+
+for i in tunnel abi; do
+  echo Build Tags: ${BUILD_TAGS[$i]}
+  golangci-lint run --build-tags=${BUILD_TAGS[$i]} "$@"
+done

--- a/pkg/adapter/client.go
+++ b/pkg/adapter/client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/varlink/go/varlink"
 )
 
-var remoteEndpoint *Endpoint
+var remoteEndpoint *Endpoint // nolint: deadcode,unused
 
 func (r RemoteRuntime) RemoteEndpoint() (remoteEndpoint *Endpoint, err error) {
 	remoteConfigConnections, err := remoteclientconfig.ReadRemoteConfig(r.config)
@@ -26,8 +26,8 @@ func (r RemoteRuntime) RemoteEndpoint() (remoteEndpoint *Endpoint, err error) {
 		remoteEndpoint, err = newBridgeConnection(bridge, nil, r.cmd.LogLevel)
 		// if an environment variable for podman_varlink_address is defined,
 		// we used that as passed
-	} else if address := os.Getenv("PODMAN_VARLINK_ADDRESS"); address != "" {
-		logrus.Debug("creating a varlink address based on env variable: %s", address)
+	} else if address := os.Getenv("PODMAN_VARLINK_ADDRESS"); address != "" { // nolint:gocritic
+		logrus.Debugf("creating a varlink address based on env variable: %s", address)
 		remoteEndpoint, err = newSocketConnection(address)
 		//	if the user provides a remote host, we use it to configure a bridge connection
 	} else if len(r.cmd.RemoteHost) > 0 {
@@ -35,7 +35,7 @@ func (r RemoteRuntime) RemoteEndpoint() (remoteEndpoint *Endpoint, err error) {
 		if len(r.cmd.RemoteUserName) < 1 {
 			return nil, errors.New("you must provide a username when providing a remote host name")
 		}
-		rc := remoteclientconfig.RemoteConnection{r.cmd.RemoteHost, r.cmd.RemoteUserName, false, r.cmd.Port, r.cmd.IdentityFile, r.cmd.IgnoreHosts}
+		rc := remoteclientconfig.RemoteConnection{r.cmd.RemoteHost, r.cmd.RemoteUserName, false, r.cmd.Port, r.cmd.IdentityFile, r.cmd.IgnoreHosts} // nolint: govet
 		remoteEndpoint, err = newBridgeConnection("", &rc, r.cmd.LogLevel)
 		//  if the user has a config file with connections in it
 	} else if len(remoteConfigConnections.Connections) > 0 {
@@ -59,7 +59,7 @@ func (r RemoteRuntime) RemoteEndpoint() (remoteEndpoint *Endpoint, err error) {
 		logrus.Debug("creating a varlink address based default root address")
 		remoteEndpoint, err = newSocketConnection(DefaultVarlinkAddress)
 	}
-	return
+	return // nolint: nakedret
 }
 
 // Connect provides a varlink connection

--- a/pkg/adapter/pods_remote.go
+++ b/pkg/adapter/pods_remote.go
@@ -515,10 +515,10 @@ func (p *Pod) GetPodStats(previousContainerStats map[string]*libpod.ContainerSta
 		newStats := varlinkapi.ContainerStatsToLibpodContainerStats(stats)
 		// If the container wasn't running, don't include it
 		// but also suppress the error
-		if err != nil && errors.Cause(err) != define.ErrCtrStateInvalid {
+		if err != nil && errors.Cause(err) != define.ErrCtrStateInvalid { // nolint: govet
 			return nil, err
 		}
-		if err == nil {
+		if err == nil { // nolint: govet
 			newContainerStats[c.ID()] = &newStats
 		}
 	}

--- a/pkg/adapter/runtime_remote.go
+++ b/pkg/adapter/runtime_remote.go
@@ -180,7 +180,7 @@ type Pod struct {
 type remotepod struct {
 	config     *libpod.PodConfig
 	state      *libpod.PodInspectState
-	containers []libpod.PodContainerInfo
+	containers []libpod.PodContainerInfo // nolint: structcheck
 	Runtime    *LocalRuntime
 }
 
@@ -627,7 +627,7 @@ func (r *LocalRuntime) SendFileOverVarlink(source string) (string, error) {
 		return "", err
 	}
 	logrus.Debugf("sending %s over varlink connection", source)
-	reply, err := iopodman.SendFile().Send(r.Conn, varlink.Upgrade, "", int64(fileInfo.Size()))
+	reply, err := iopodman.SendFile().Send(r.Conn, varlink.Upgrade, "", fileInfo.Size())
 	if err != nil {
 		return "", err
 	}
@@ -754,9 +754,7 @@ func (r *LocalRuntime) InspectVolumes(ctx context.Context, c *cliconfig.VolumeIn
 			volumes = append(volumes, vol.Name())
 		}
 	} else {
-		for _, arg := range c.InputArgs {
-			volumes = append(volumes, arg)
-		}
+		volumes = append(volumes, c.InputArgs...)
 	}
 
 	for _, vol := range volumes {
@@ -855,7 +853,7 @@ func (r *LocalRuntime) SaveImage(ctx context.Context, c *cliconfig.SaveValues) e
 		}
 
 	}
-	if err != nil {
+	if err != nil { // nolint: govet
 		return err
 	}
 
@@ -927,7 +925,7 @@ func IsImageNotFound(err error) bool {
 	if errors.Cause(err) == image.ErrNoSuchImage {
 		return true
 	}
-	switch err.(type) {
+	switch err.(type) { // nolint: gocritic
 	case *iopodman.ImageNotFound:
 		return true
 	}
@@ -991,7 +989,7 @@ func (r *LocalRuntime) Events(c *cliconfig.EventValues) error {
 			Time:   eTime,
 			Type:   eType,
 		}
-		if c.Format == formats.JSONString {
+		if c.Format == formats.JSONString { // nolint: gocritic
 			jsonStr, err := event.ToJSONString()
 			if err != nil {
 				return errors.Wrapf(err, "unable to format json")
@@ -1008,6 +1006,7 @@ func (r *LocalRuntime) Events(c *cliconfig.EventValues) error {
 				return err
 			}
 		}
+
 		if _, err := w.Write([]byte("\n")); err != nil {
 			return err
 		}
@@ -1040,7 +1039,7 @@ func stringToChangeType(change string) archive.ChangeType {
 		return archive.ChangeAdd
 	case "D":
 		return archive.ChangeDelete
-	default:
+	default: // nolint: gocritic,stylecheck
 		logrus.Errorf("'%s' is unknown archive type", change)
 		fallthrough
 	case "C":

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -56,7 +56,7 @@ func newServer(runtime *libpod.Runtime, duration time.Duration, listener *net.Li
 	// If listener not provided try socket activation protocol
 	if listener == nil {
 		if _, found := os.LookupEnv("LISTEN_FDS"); !found {
-			return nil, errors.Errorf("Cannot create Server, no listener provided and socket activation protocol is not active.")
+			return nil, errors.Errorf("Cannot create API Server, no listener provided and socket activation protocol is not active.")
 		}
 
 		listeners, err := activation.Listeners()

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -23,13 +23,14 @@ type ContainerEngine interface {
 	ContainerRestart(ctx context.Context, namesOrIds []string, options RestartOptions) ([]*RestartReport, error)
 	ContainerRestore(ctx context.Context, namesOrIds []string, options RestoreOptions) ([]*RestoreReport, error)
 	ContainerRm(ctx context.Context, namesOrIds []string, options RmOptions) ([]*RmReport, error)
-	ContainerStart(ctx context.Context, namesOrIds []string, options ContainerStartOptions) ([]*ContainerStartReport, error)
 	ContainerRun(ctx context.Context, opts ContainerRunOptions) (*ContainerRunReport, error)
+	ContainerStart(ctx context.Context, namesOrIds []string, options ContainerStartOptions) ([]*ContainerStartReport, error)
 	ContainerStop(ctx context.Context, namesOrIds []string, options StopOptions) ([]*StopReport, error)
 	ContainerTop(ctx context.Context, options TopOptions) (*StringSliceReport, error)
 	ContainerUnpause(ctx context.Context, namesOrIds []string, options PauseUnPauseOptions) ([]*PauseUnpauseReport, error)
 	ContainerWait(ctx context.Context, namesOrIds []string, options WaitOptions) ([]WaitReport, error)
 	HealthCheckRun(ctx context.Context, nameOrId string, options HealthCheckOptions) (*define.HealthCheckResults, error)
+	Info(ctx context.Context) (*define.Info, error)
 	PodCreate(ctx context.Context, opts PodCreateOptions) (*PodCreateReport, error)
 	PodExists(ctx context.Context, nameOrId string) (*BoolReport, error)
 	PodInspect(ctx context.Context, options PodInspectOptions) (*PodInspectReport, error)
@@ -42,11 +43,11 @@ type ContainerEngine interface {
 	PodStop(ctx context.Context, namesOrIds []string, options PodStopOptions) ([]*PodStopReport, error)
 	PodTop(ctx context.Context, options PodTopOptions) (*StringSliceReport, error)
 	PodUnpause(ctx context.Context, namesOrIds []string, options PodunpauseOptions) ([]*PodUnpauseReport, error)
+	RestService(ctx context.Context, opts ServiceOptions) error
+	VarlinkService(ctx context.Context, opts ServiceOptions) error
 	VolumeCreate(ctx context.Context, opts VolumeCreateOptions) (*IdOrNameResponse, error)
 	VolumeInspect(ctx context.Context, namesOrIds []string, opts VolumeInspectOptions) ([]*VolumeInspectReport, error)
 	VolumeList(ctx context.Context, opts VolumeListOptions) ([]*VolumeListReport, error)
 	VolumePrune(ctx context.Context, opts VolumePruneOptions) ([]*VolumePruneReport, error)
 	VolumeRm(ctx context.Context, namesOrIds []string, opts VolumeRmOptions) ([]*VolumeRmReport, error)
-
-	Info(ctx context.Context) (*define.Info, error)
 }

--- a/pkg/domain/entities/system.go
+++ b/pkg/domain/entities/system.go
@@ -1,0 +1,14 @@
+package entities
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// ServiceOptions provides the input for starting an API Service
+type ServiceOptions struct {
+	URI     string         // Path to unix domain socket service should listen on
+	Timeout time.Duration  // duration of inactivity the service should wait before shutting down
+	Command *cobra.Command // CLI command provided. Used in V1 code
+}

--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -4,10 +4,88 @@ package abi
 
 import (
 	"context"
+	"net"
+	"strings"
 
 	"github.com/containers/libpod/libpod/define"
+	api "github.com/containers/libpod/pkg/api/server"
+	"github.com/containers/libpod/pkg/domain/entities"
+	iopodman "github.com/containers/libpod/pkg/varlink"
+	iopodmanAPI "github.com/containers/libpod/pkg/varlinkapi"
+	"github.com/containers/libpod/version"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/varlink/go/varlink"
 )
 
 func (ic *ContainerEngine) Info(ctx context.Context) (*define.Info, error) {
 	return ic.Libpod.Info()
+}
+
+func (ic *ContainerEngine) RestService(_ context.Context, opts entities.ServiceOptions) error {
+	var (
+		listener net.Listener
+		err      error
+	)
+
+	if opts.URI != "" {
+		fields := strings.Split(opts.URI, ":")
+		if len(fields) == 1 {
+			return errors.Errorf("%s is an invalid socket destination", opts.URI)
+		}
+		address := strings.Join(fields[1:], ":")
+		listener, err = net.Listen(fields[0], address)
+		if err != nil {
+			return errors.Wrapf(err, "unable to create socket %s", opts.URI)
+		}
+	}
+
+	server, err := api.NewServerWithSettings(ic.Libpod, opts.Timeout, &listener)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := server.Shutdown(); err != nil {
+			logrus.Warnf("Error when stopping API service: %s", err)
+		}
+	}()
+
+	err = server.Serve()
+	logrus.Debugf("%d/%d Active connections/Total connections\n", server.ActiveConnections, server.TotalConnections)
+	_ = listener.Close()
+	return err
+}
+
+func (ic *ContainerEngine) VarlinkService(_ context.Context, opts entities.ServiceOptions) error {
+	var varlinkInterfaces = []*iopodman.VarlinkInterface{
+		iopodmanAPI.New(opts.Command, ic.Libpod),
+	}
+
+	service, err := varlink.NewService(
+		"Atomic",
+		"podman",
+		version.Version,
+		"https://github.com/containers/libpod",
+	)
+	if err != nil {
+		return errors.Wrapf(err, "unable to create new varlink service")
+	}
+
+	for _, i := range varlinkInterfaces {
+		if err := service.RegisterInterface(i); err != nil {
+			return errors.Errorf("unable to register varlink interface %v", i)
+		}
+	}
+
+	// Run the varlink server at the given address
+	if err = service.Listen(opts.URI, opts.Timeout); err != nil {
+		switch err.(type) {
+		case varlink.ServiceTimeoutError:
+			logrus.Infof("varlink service expired (use --timeout to increase session time beyond %s ms, 0 means never timeout)", opts.Timeout.String())
+			return nil
+		default:
+			return errors.Wrapf(err, "unable to start varlink service")
+		}
+	}
+	return nil
 }

--- a/pkg/domain/infra/tunnel/system.go
+++ b/pkg/domain/infra/tunnel/system.go
@@ -2,11 +2,21 @@ package tunnel
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/bindings/system"
+	"github.com/containers/libpod/pkg/domain/entities"
 )
 
 func (ic *ContainerEngine) Info(ctx context.Context) (*define.Info, error) {
 	return system.Info(ic.ClientCxt)
+}
+
+func (ic *ContainerEngine) RestService(_ context.Context, _ entities.ServiceOptions) error {
+	panic(errors.New("rest service is not supported when tunneling"))
+}
+
+func (ic *ContainerEngine) VarlinkService(_ context.Context, _ entities.ServiceOptions) error {
+	panic(errors.New("varlink service is not supported when tunneling"))
 }

--- a/pkg/varlinkapi/attach.go
+++ b/pkg/varlinkapi/attach.go
@@ -44,7 +44,7 @@ func setupStreams(call iopodman.VarlinkCall) (*bufio.Reader, *bufio.Writer, *io.
 }
 
 // Attach connects to a containers console
-func (i *LibpodAPI) Attach(call iopodman.VarlinkCall, name string, detachKeys string, start bool) error {
+func (i *VarlinkAPI) Attach(call iopodman.VarlinkCall, name string, detachKeys string, start bool) error {
 	var finalErr error
 	resize := make(chan remotecommand.TerminalSize)
 	errChan := make(chan error)

--- a/pkg/varlinkapi/config.go
+++ b/pkg/varlinkapi/config.go
@@ -3,21 +3,20 @@
 package varlinkapi
 
 import (
-	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod"
 	iopodman "github.com/containers/libpod/pkg/varlink"
 	"github.com/spf13/cobra"
 )
 
-// LibpodAPI is the basic varlink struct for libpod
-type LibpodAPI struct {
+// VarlinkAPI is the basic varlink struct for libpod
+type VarlinkAPI struct {
 	Cli *cobra.Command
 	iopodman.VarlinkInterface
 	Runtime *libpod.Runtime
 }
 
 // New creates a new varlink client
-func New(cli *cliconfig.PodmanCommand, runtime *libpod.Runtime) *iopodman.VarlinkInterface {
-	lp := LibpodAPI{Cli: cli.Command, Runtime: runtime}
+func New(cli *cobra.Command, runtime *libpod.Runtime) *iopodman.VarlinkInterface {
+	lp := VarlinkAPI{Cli: cli, Runtime: runtime}
 	return iopodman.VarlinkNew(&lp)
 }

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -30,7 +30,7 @@ import (
 )
 
 // ListContainers ...
-func (i *LibpodAPI) ListContainers(call iopodman.VarlinkCall) error {
+func (i *VarlinkAPI) ListContainers(call iopodman.VarlinkCall) error {
 	var (
 		listContainers []iopodman.Container
 	)
@@ -54,7 +54,7 @@ func (i *LibpodAPI) ListContainers(call iopodman.VarlinkCall) error {
 	return call.ReplyListContainers(listContainers)
 }
 
-func (i *LibpodAPI) Ps(call iopodman.VarlinkCall, opts iopodman.PsOpts) error {
+func (i *VarlinkAPI) Ps(call iopodman.VarlinkCall, opts iopodman.PsOpts) error {
 	var (
 		containers []iopodman.PsContainer
 	)
@@ -106,7 +106,7 @@ func (i *LibpodAPI) Ps(call iopodman.VarlinkCall, opts iopodman.PsOpts) error {
 }
 
 // GetContainer ...
-func (i *LibpodAPI) GetContainer(call iopodman.VarlinkCall, id string) error {
+func (i *VarlinkAPI) GetContainer(call iopodman.VarlinkCall, id string) error {
 	ctr, err := i.Runtime.LookupContainer(id)
 	if err != nil {
 		return call.ReplyContainerNotFound(id, err.Error())
@@ -123,7 +123,7 @@ func (i *LibpodAPI) GetContainer(call iopodman.VarlinkCall, id string) error {
 }
 
 // GetContainersByContext returns a slice of container ids based on all, latest, or a list
-func (i *LibpodAPI) GetContainersByContext(call iopodman.VarlinkCall, all, latest bool, input []string) error {
+func (i *VarlinkAPI) GetContainersByContext(call iopodman.VarlinkCall, all, latest bool, input []string) error {
 	var ids []string
 
 	ctrs, err := shortcuts.GetContainersByContext(all, latest, input, i.Runtime)
@@ -141,7 +141,7 @@ func (i *LibpodAPI) GetContainersByContext(call iopodman.VarlinkCall, all, lates
 }
 
 // GetContainersByStatus returns a slice of containers filtered by a libpod status
-func (i *LibpodAPI) GetContainersByStatus(call iopodman.VarlinkCall, statuses []string) error {
+func (i *VarlinkAPI) GetContainersByStatus(call iopodman.VarlinkCall, statuses []string) error {
 	var (
 		filterFuncs []libpod.ContainerFilter
 		containers  []iopodman.Container
@@ -172,7 +172,7 @@ func (i *LibpodAPI) GetContainersByStatus(call iopodman.VarlinkCall, statuses []
 }
 
 // InspectContainer ...
-func (i *LibpodAPI) InspectContainer(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) InspectContainer(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -189,7 +189,7 @@ func (i *LibpodAPI) InspectContainer(call iopodman.VarlinkCall, name string) err
 }
 
 // ListContainerProcesses ...
-func (i *LibpodAPI) ListContainerProcesses(call iopodman.VarlinkCall, name string, opts []string) error {
+func (i *VarlinkAPI) ListContainerProcesses(call iopodman.VarlinkCall, name string, opts []string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -216,7 +216,7 @@ func (i *LibpodAPI) ListContainerProcesses(call iopodman.VarlinkCall, name strin
 }
 
 // GetContainerLogs ...
-func (i *LibpodAPI) GetContainerLogs(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) GetContainerLogs(call iopodman.VarlinkCall, name string) error {
 	var logs []string
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
@@ -277,7 +277,7 @@ func (i *LibpodAPI) GetContainerLogs(call iopodman.VarlinkCall, name string) err
 }
 
 // ListContainerChanges ...
-func (i *LibpodAPI) ListContainerChanges(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) ListContainerChanges(call iopodman.VarlinkCall, name string) error {
 	changes, err := i.Runtime.GetDiff("", name)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -297,7 +297,7 @@ func (i *LibpodAPI) ListContainerChanges(call iopodman.VarlinkCall, name string)
 }
 
 // ExportContainer ...
-func (i *LibpodAPI) ExportContainer(call iopodman.VarlinkCall, name, outPath string) error {
+func (i *VarlinkAPI) ExportContainer(call iopodman.VarlinkCall, name, outPath string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -319,7 +319,7 @@ func (i *LibpodAPI) ExportContainer(call iopodman.VarlinkCall, name, outPath str
 }
 
 // GetContainerStats ...
-func (i *LibpodAPI) GetContainerStats(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) GetContainerStats(call iopodman.VarlinkCall, name string) error {
 	if rootless.IsRootless() {
 		cgroupv2, err := cgroups.IsCgroup2UnifiedMode()
 		if err != nil {
@@ -359,7 +359,7 @@ func (i *LibpodAPI) GetContainerStats(call iopodman.VarlinkCall, name string) er
 }
 
 // StartContainer ...
-func (i *LibpodAPI) StartContainer(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) StartContainer(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -382,7 +382,7 @@ func (i *LibpodAPI) StartContainer(call iopodman.VarlinkCall, name string) error
 }
 
 // InitContainer initializes the container given by Varlink.
-func (i *LibpodAPI) InitContainer(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) InitContainer(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -397,7 +397,7 @@ func (i *LibpodAPI) InitContainer(call iopodman.VarlinkCall, name string) error 
 }
 
 // StopContainer ...
-func (i *LibpodAPI) StopContainer(call iopodman.VarlinkCall, name string, timeout int64) error {
+func (i *VarlinkAPI) StopContainer(call iopodman.VarlinkCall, name string, timeout int64) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -415,7 +415,7 @@ func (i *LibpodAPI) StopContainer(call iopodman.VarlinkCall, name string, timeou
 }
 
 // RestartContainer ...
-func (i *LibpodAPI) RestartContainer(call iopodman.VarlinkCall, name string, timeout int64) error {
+func (i *VarlinkAPI) RestartContainer(call iopodman.VarlinkCall, name string, timeout int64) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -427,7 +427,7 @@ func (i *LibpodAPI) RestartContainer(call iopodman.VarlinkCall, name string, tim
 }
 
 // ContainerExists looks in local storage for the existence of a container
-func (i *LibpodAPI) ContainerExists(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) ContainerExists(call iopodman.VarlinkCall, name string) error {
 	_, err := i.Runtime.LookupContainer(name)
 	if errors.Cause(err) == define.ErrNoSuchCtr {
 		return call.ReplyContainerExists(1)
@@ -440,7 +440,7 @@ func (i *LibpodAPI) ContainerExists(call iopodman.VarlinkCall, name string) erro
 
 // KillContainer kills a running container.  If you want to use the default SIGTERM signal, just send a -1
 // for the signal arg.
-func (i *LibpodAPI) KillContainer(call iopodman.VarlinkCall, name string, signal int64) error {
+func (i *VarlinkAPI) KillContainer(call iopodman.VarlinkCall, name string, signal int64) error {
 	killSignal := uint(syscall.SIGTERM)
 	if signal != -1 {
 		killSignal = uint(signal)
@@ -456,7 +456,7 @@ func (i *LibpodAPI) KillContainer(call iopodman.VarlinkCall, name string, signal
 }
 
 // PauseContainer ...
-func (i *LibpodAPI) PauseContainer(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) PauseContainer(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -468,7 +468,7 @@ func (i *LibpodAPI) PauseContainer(call iopodman.VarlinkCall, name string) error
 }
 
 // UnpauseContainer ...
-func (i *LibpodAPI) UnpauseContainer(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) UnpauseContainer(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -480,7 +480,7 @@ func (i *LibpodAPI) UnpauseContainer(call iopodman.VarlinkCall, name string) err
 }
 
 // WaitContainer ...
-func (i *LibpodAPI) WaitContainer(call iopodman.VarlinkCall, name string, interval int64) error {
+func (i *VarlinkAPI) WaitContainer(call iopodman.VarlinkCall, name string, interval int64) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -493,7 +493,7 @@ func (i *LibpodAPI) WaitContainer(call iopodman.VarlinkCall, name string, interv
 }
 
 // RemoveContainer ...
-func (i *LibpodAPI) RemoveContainer(call iopodman.VarlinkCall, name string, force bool, removeVolumes bool) error {
+func (i *VarlinkAPI) RemoveContainer(call iopodman.VarlinkCall, name string, force bool, removeVolumes bool) error {
 	ctx := getContext()
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
@@ -512,7 +512,7 @@ func (i *LibpodAPI) RemoveContainer(call iopodman.VarlinkCall, name string, forc
 }
 
 // EvictContainer ...
-func (i *LibpodAPI) EvictContainer(call iopodman.VarlinkCall, name string, removeVolumes bool) error {
+func (i *VarlinkAPI) EvictContainer(call iopodman.VarlinkCall, name string, removeVolumes bool) error {
 	ctx := getContext()
 	id, err := i.Runtime.EvictContainer(ctx, name, removeVolumes)
 	if err != nil {
@@ -522,7 +522,7 @@ func (i *LibpodAPI) EvictContainer(call iopodman.VarlinkCall, name string, remov
 }
 
 // DeleteStoppedContainers ...
-func (i *LibpodAPI) DeleteStoppedContainers(call iopodman.VarlinkCall) error {
+func (i *VarlinkAPI) DeleteStoppedContainers(call iopodman.VarlinkCall) error {
 	ctx := getContext()
 	var deletedContainers []string
 	containers, err := i.Runtime.GetAllContainers()
@@ -545,7 +545,7 @@ func (i *LibpodAPI) DeleteStoppedContainers(call iopodman.VarlinkCall) error {
 }
 
 // GetAttachSockets ...
-func (i *LibpodAPI) GetAttachSockets(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) GetAttachSockets(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -578,7 +578,7 @@ func (i *LibpodAPI) GetAttachSockets(call iopodman.VarlinkCall, name string) err
 }
 
 // ContainerCheckpoint ...
-func (i *LibpodAPI) ContainerCheckpoint(call iopodman.VarlinkCall, name string, keep, leaveRunning, tcpEstablished bool) error {
+func (i *VarlinkAPI) ContainerCheckpoint(call iopodman.VarlinkCall, name string, keep, leaveRunning, tcpEstablished bool) error {
 	ctx := getContext()
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
@@ -597,7 +597,7 @@ func (i *LibpodAPI) ContainerCheckpoint(call iopodman.VarlinkCall, name string, 
 }
 
 // ContainerRestore ...
-func (i *LibpodAPI) ContainerRestore(call iopodman.VarlinkCall, name string, keep, tcpEstablished bool) error {
+func (i *VarlinkAPI) ContainerRestore(call iopodman.VarlinkCall, name string, keep, tcpEstablished bool) error {
 	ctx := getContext()
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
@@ -615,7 +615,7 @@ func (i *LibpodAPI) ContainerRestore(call iopodman.VarlinkCall, name string, kee
 }
 
 // ContainerConfig returns just the container.config struct
-func (i *LibpodAPI) ContainerConfig(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) ContainerConfig(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -629,7 +629,7 @@ func (i *LibpodAPI) ContainerConfig(call iopodman.VarlinkCall, name string) erro
 }
 
 // ContainerArtifacts returns an untouched container's artifact in string format
-func (i *LibpodAPI) ContainerArtifacts(call iopodman.VarlinkCall, name, artifactName string) error {
+func (i *VarlinkAPI) ContainerArtifacts(call iopodman.VarlinkCall, name, artifactName string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -646,7 +646,7 @@ func (i *LibpodAPI) ContainerArtifacts(call iopodman.VarlinkCall, name, artifact
 }
 
 // ContainerInspectData returns the inspect data of a container in string format
-func (i *LibpodAPI) ContainerInspectData(call iopodman.VarlinkCall, name string, size bool) error {
+func (i *VarlinkAPI) ContainerInspectData(call iopodman.VarlinkCall, name string, size bool) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -664,7 +664,7 @@ func (i *LibpodAPI) ContainerInspectData(call iopodman.VarlinkCall, name string,
 }
 
 // ContainerStateData returns a container's state data in string format
-func (i *LibpodAPI) ContainerStateData(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) ContainerStateData(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
@@ -682,7 +682,7 @@ func (i *LibpodAPI) ContainerStateData(call iopodman.VarlinkCall, name string) e
 
 // GetContainerStatsWithHistory is a varlink endpoint that returns container stats based on current and
 // previous statistics
-func (i *LibpodAPI) GetContainerStatsWithHistory(call iopodman.VarlinkCall, prevStats iopodman.ContainerStats) error {
+func (i *VarlinkAPI) GetContainerStatsWithHistory(call iopodman.VarlinkCall, prevStats iopodman.ContainerStats) error {
 	con, err := i.Runtime.LookupContainer(prevStats.Id)
 	if err != nil {
 		return call.ReplyContainerNotFound(prevStats.Id, err.Error())
@@ -711,7 +711,7 @@ func (i *LibpodAPI) GetContainerStatsWithHistory(call iopodman.VarlinkCall, prev
 }
 
 // Spec ...
-func (i *LibpodAPI) Spec(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) Spec(call iopodman.VarlinkCall, name string) error {
 	ctr, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -727,7 +727,7 @@ func (i *LibpodAPI) Spec(call iopodman.VarlinkCall, name string) error {
 }
 
 // GetContainersLogs is the varlink endpoint to obtain one or more container logs
-func (i *LibpodAPI) GetContainersLogs(call iopodman.VarlinkCall, names []string, follow, latest bool, since string, tail int64, timestamps bool) error {
+func (i *VarlinkAPI) GetContainersLogs(call iopodman.VarlinkCall, names []string, follow, latest bool, since string, tail int64, timestamps bool) error {
 	var wg sync.WaitGroup
 	if call.WantsMore() {
 		call.Continues = true
@@ -784,7 +784,7 @@ func newPodmanLogLine(line *logs.LogLine) iopodman.LogLine {
 }
 
 // Top displays information about a container's running processes
-func (i *LibpodAPI) Top(call iopodman.VarlinkCall, nameOrID string, descriptors []string) error {
+func (i *VarlinkAPI) Top(call iopodman.VarlinkCall, nameOrID string, descriptors []string) error {
 	ctr, err := i.Runtime.LookupContainer(nameOrID)
 	if err != nil {
 		return call.ReplyContainerNotFound(ctr.ID(), err.Error())
@@ -797,7 +797,7 @@ func (i *LibpodAPI) Top(call iopodman.VarlinkCall, nameOrID string, descriptors 
 }
 
 // ExecContainer is the varlink endpoint to execute a command in a container
-func (i *LibpodAPI) ExecContainer(call iopodman.VarlinkCall, opts iopodman.ExecOpts) error {
+func (i *VarlinkAPI) ExecContainer(call iopodman.VarlinkCall, opts iopodman.ExecOpts) error {
 	if !call.WantsUpgrade() {
 		return call.ReplyErrorOccurred("client must use upgraded connection to exec")
 	}
@@ -901,7 +901,7 @@ func (i *LibpodAPI) ExecContainer(call iopodman.VarlinkCall, opts iopodman.ExecO
 }
 
 // HealthCheckRun executes defined container's healthcheck command and returns the container's health status.
-func (i *LibpodAPI) HealthCheckRun(call iopodman.VarlinkCall, nameOrID string) error {
+func (i *VarlinkAPI) HealthCheckRun(call iopodman.VarlinkCall, nameOrID string) error {
 	hcStatus, err := i.Runtime.HealthCheck(nameOrID)
 	if err != nil && hcStatus != libpod.HealthCheckFailure {
 		return call.ReplyErrorOccurred(err.Error())

--- a/pkg/varlinkapi/containers_create.go
+++ b/pkg/varlinkapi/containers_create.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CreateContainer ...
-func (i *LibpodAPI) CreateContainer(call iopodman.VarlinkCall, config iopodman.Create) error {
+func (i *VarlinkAPI) CreateContainer(call iopodman.VarlinkCall, config iopodman.Create) error {
 	generic := shared.VarlinkCreateToGeneric(config)
 	ctr, _, err := shared.CreateContainer(getContext(), &generic, i.Runtime)
 	if err != nil {

--- a/pkg/varlinkapi/events.go
+++ b/pkg/varlinkapi/events.go
@@ -3,7 +3,6 @@
 package varlinkapi
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/containers/libpod/libpod/events"
@@ -11,7 +10,7 @@ import (
 )
 
 // GetEvents is a remote endpoint to get events from the event log
-func (i *LibpodAPI) GetEvents(call iopodman.VarlinkCall, filter []string, since string, until string) error {
+func (i *VarlinkAPI) GetEvents(call iopodman.VarlinkCall, filter []string, since string, until string) error {
 	var (
 		fromStart   bool
 		eventsError error
@@ -43,9 +42,9 @@ func (i *LibpodAPI) GetEvents(call iopodman.VarlinkCall, filter []string, since 
 			Id:     event.ID,
 			Image:  event.Image,
 			Name:   event.Name,
-			Status: fmt.Sprintf("%s", event.Status),
+			Status: string(event.Status),
 			Time:   event.Time.Format(time.RFC3339Nano),
-			Type:   fmt.Sprintf("%s", event.Type),
+			Type:   string(event.Type),
 		})
 		if !call.Continues {
 			// For a one-shot on events, we break out here

--- a/pkg/varlinkapi/generate.go
+++ b/pkg/varlinkapi/generate.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GenerateKube ...
-func (i *LibpodAPI) GenerateKube(call iopodman.VarlinkCall, name string, service bool) error {
+func (i *VarlinkAPI) GenerateKube(call iopodman.VarlinkCall, name string, service bool) error {
 	pod, serv, err := shared.GenerateKube(name, service, i.Runtime)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())

--- a/pkg/varlinkapi/mount.go
+++ b/pkg/varlinkapi/mount.go
@@ -5,7 +5,7 @@ package varlinkapi
 import iopodman "github.com/containers/libpod/pkg/varlink"
 
 // ListContainerMounts ...
-func (i *LibpodAPI) ListContainerMounts(call iopodman.VarlinkCall) error {
+func (i *VarlinkAPI) ListContainerMounts(call iopodman.VarlinkCall) error {
 	mounts := make(map[string]string)
 	allContainers, err := i.Runtime.GetAllContainers()
 	if err != nil {
@@ -24,7 +24,7 @@ func (i *LibpodAPI) ListContainerMounts(call iopodman.VarlinkCall) error {
 }
 
 // MountContainer ...
-func (i *LibpodAPI) MountContainer(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) MountContainer(call iopodman.VarlinkCall, name string) error {
 	container, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -37,7 +37,7 @@ func (i *LibpodAPI) MountContainer(call iopodman.VarlinkCall, name string) error
 }
 
 // UnmountContainer ...
-func (i *LibpodAPI) UnmountContainer(call iopodman.VarlinkCall, name string, force bool) error {
+func (i *VarlinkAPI) UnmountContainer(call iopodman.VarlinkCall, name string, force bool) error {
 	container, err := i.Runtime.LookupContainer(name)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())

--- a/pkg/varlinkapi/pods.go
+++ b/pkg/varlinkapi/pods.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CreatePod ...
-func (i *LibpodAPI) CreatePod(call iopodman.VarlinkCall, create iopodman.PodCreate) error {
+func (i *VarlinkAPI) CreatePod(call iopodman.VarlinkCall, create iopodman.PodCreate) error {
 	var options []libpod.PodCreateOption
 	if create.Infra {
 		options = append(options, libpod.WithInfraContainer())
@@ -61,7 +61,7 @@ func (i *LibpodAPI) CreatePod(call iopodman.VarlinkCall, create iopodman.PodCrea
 }
 
 // ListPods ...
-func (i *LibpodAPI) ListPods(call iopodman.VarlinkCall) error {
+func (i *VarlinkAPI) ListPods(call iopodman.VarlinkCall) error {
 	var (
 		listPods []iopodman.ListPodData
 	)
@@ -82,7 +82,7 @@ func (i *LibpodAPI) ListPods(call iopodman.VarlinkCall) error {
 }
 
 // GetPod ...
-func (i *LibpodAPI) GetPod(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) GetPod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
 		return call.ReplyPodNotFound(name, err.Error())
@@ -98,7 +98,7 @@ func (i *LibpodAPI) GetPod(call iopodman.VarlinkCall, name string) error {
 }
 
 // GetPodsByStatus returns a slice of pods filtered by a libpod status
-func (i *LibpodAPI) GetPodsByStatus(call iopodman.VarlinkCall, statuses []string) error {
+func (i *VarlinkAPI) GetPodsByStatus(call iopodman.VarlinkCall, statuses []string) error {
 	filterFuncs := func(p *libpod.Pod) bool {
 		state, _ := shared.GetPodStatus(p)
 		for _, status := range statuses {
@@ -120,7 +120,7 @@ func (i *LibpodAPI) GetPodsByStatus(call iopodman.VarlinkCall, statuses []string
 }
 
 // InspectPod ...
-func (i *LibpodAPI) InspectPod(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) InspectPod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
 		return call.ReplyPodNotFound(name, err.Error())
@@ -137,7 +137,7 @@ func (i *LibpodAPI) InspectPod(call iopodman.VarlinkCall, name string) error {
 }
 
 // StartPod ...
-func (i *LibpodAPI) StartPod(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) StartPod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
 		return call.ReplyPodNotFound(name, err.Error())
@@ -158,7 +158,7 @@ func (i *LibpodAPI) StartPod(call iopodman.VarlinkCall, name string) error {
 }
 
 // StopPod ...
-func (i *LibpodAPI) StopPod(call iopodman.VarlinkCall, name string, timeout int64) error {
+func (i *VarlinkAPI) StopPod(call iopodman.VarlinkCall, name string, timeout int64) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
 		return call.ReplyPodNotFound(name, err.Error())
@@ -172,7 +172,7 @@ func (i *LibpodAPI) StopPod(call iopodman.VarlinkCall, name string, timeout int6
 }
 
 // RestartPod ...
-func (i *LibpodAPI) RestartPod(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) RestartPod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
 		return call.ReplyPodNotFound(name, err.Error())
@@ -194,7 +194,7 @@ func (i *LibpodAPI) RestartPod(call iopodman.VarlinkCall, name string) error {
 
 // KillPod kills the running containers in a pod.  If you want to use the default SIGTERM signal,
 // just send a -1 for the signal arg.
-func (i *LibpodAPI) KillPod(call iopodman.VarlinkCall, name string, signal int64) error {
+func (i *VarlinkAPI) KillPod(call iopodman.VarlinkCall, name string, signal int64) error {
 	killSignal := uint(syscall.SIGTERM)
 	if signal != -1 {
 		killSignal = uint(signal)
@@ -213,7 +213,7 @@ func (i *LibpodAPI) KillPod(call iopodman.VarlinkCall, name string, signal int64
 }
 
 // PausePod ...
-func (i *LibpodAPI) PausePod(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) PausePod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
 		return call.ReplyPodNotFound(name, err.Error())
@@ -227,7 +227,7 @@ func (i *LibpodAPI) PausePod(call iopodman.VarlinkCall, name string) error {
 }
 
 // UnpausePod ...
-func (i *LibpodAPI) UnpausePod(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) UnpausePod(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
 		return call.ReplyPodNotFound(name, err.Error())
@@ -241,7 +241,7 @@ func (i *LibpodAPI) UnpausePod(call iopodman.VarlinkCall, name string) error {
 }
 
 // RemovePod ...
-func (i *LibpodAPI) RemovePod(call iopodman.VarlinkCall, name string, force bool) error {
+func (i *VarlinkAPI) RemovePod(call iopodman.VarlinkCall, name string, force bool) error {
 	ctx := getContext()
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
@@ -255,7 +255,7 @@ func (i *LibpodAPI) RemovePod(call iopodman.VarlinkCall, name string, force bool
 }
 
 // GetPodStats ...
-func (i *LibpodAPI) GetPodStats(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) GetPodStats(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
 		return call.ReplyPodNotFound(name, err.Error())
@@ -291,7 +291,7 @@ func (i *LibpodAPI) GetPodStats(call iopodman.VarlinkCall, name string) error {
 }
 
 // GetPodsByContext returns a slice of pod ids based on all, latest, or a list
-func (i *LibpodAPI) GetPodsByContext(call iopodman.VarlinkCall, all, latest bool, input []string) error {
+func (i *VarlinkAPI) GetPodsByContext(call iopodman.VarlinkCall, all, latest bool, input []string) error {
 	var podids []string
 
 	pods, err := shortcuts.GetPodsByContext(all, latest, input, i.Runtime)
@@ -305,7 +305,7 @@ func (i *LibpodAPI) GetPodsByContext(call iopodman.VarlinkCall, all, latest bool
 }
 
 // PodStateData returns a container's state data in string format
-func (i *LibpodAPI) PodStateData(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) PodStateData(call iopodman.VarlinkCall, name string) error {
 	pod, err := i.Runtime.LookupPod(name)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -322,7 +322,7 @@ func (i *LibpodAPI) PodStateData(call iopodman.VarlinkCall, name string) error {
 }
 
 // TopPod provides the top stats for a given or latest pod
-func (i *LibpodAPI) TopPod(call iopodman.VarlinkCall, name string, latest bool, descriptors []string) error {
+func (i *VarlinkAPI) TopPod(call iopodman.VarlinkCall, name string, latest bool, descriptors []string) error {
 	var (
 		pod *libpod.Pod
 		err error

--- a/pkg/varlinkapi/system.go
+++ b/pkg/varlinkapi/system.go
@@ -16,7 +16,7 @@ import (
 )
 
 // GetVersion ...
-func (i *LibpodAPI) GetVersion(call iopodman.VarlinkCall) error {
+func (i *VarlinkAPI) GetVersion(call iopodman.VarlinkCall) error {
 	versionInfo, err := define.GetVersion()
 	if err != nil {
 		return err
@@ -33,7 +33,7 @@ func (i *LibpodAPI) GetVersion(call iopodman.VarlinkCall) error {
 }
 
 // GetInfo returns details about the podman host and its stores
-func (i *LibpodAPI) GetInfo(call iopodman.VarlinkCall) error {
+func (i *VarlinkAPI) GetInfo(call iopodman.VarlinkCall) error {
 	versionInfo, err := define.GetVersion()
 	if err != nil {
 		return err
@@ -106,7 +106,7 @@ func (i *LibpodAPI) GetInfo(call iopodman.VarlinkCall) error {
 }
 
 // GetVersion ...
-func (i *LibpodAPI) Reset(call iopodman.VarlinkCall) error {
+func (i *VarlinkAPI) Reset(call iopodman.VarlinkCall) error {
 	if err := i.Runtime.Reset(context.TODO()); err != nil {
 		logrus.Errorf("Reset Failed: %v", err)
 		if err := call.ReplyErrorOccurred(err.Error()); err != nil {

--- a/pkg/varlinkapi/transfers.go
+++ b/pkg/varlinkapi/transfers.go
@@ -4,7 +4,6 @@ package varlinkapi
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -14,7 +13,7 @@ import (
 )
 
 // SendFile allows a client to send a file to the varlink server
-func (i *LibpodAPI) SendFile(call iopodman.VarlinkCall, ftype string, length int64) error {
+func (i *VarlinkAPI) SendFile(call iopodman.VarlinkCall, ftype string, length int64) error {
 	if !call.WantsUpgrade() {
 		return call.ReplyErrorOccurred("client must use upgraded connection to send files")
 	}
@@ -40,14 +39,14 @@ func (i *LibpodAPI) SendFile(call iopodman.VarlinkCall, ftype string, length int
 
 	logrus.Debugf("successfully received %s", outputFile.Name())
 	// Send an ACK to the client
-	call.Call.Writer.WriteString(fmt.Sprintf("%s:", outputFile.Name()))
+	call.Call.Writer.WriteString(outputFile.Name())
 	call.Call.Writer.Flush()
 	return nil
 
 }
 
 // ReceiveFile allows the varlink server to send a file to a client
-func (i *LibpodAPI) ReceiveFile(call iopodman.VarlinkCall, filepath string, delete bool) error {
+func (i *VarlinkAPI) ReceiveFile(call iopodman.VarlinkCall, filepath string, delete bool) error {
 	if !call.WantsUpgrade() {
 		return call.ReplyErrorOccurred("client must use upgraded connection to send files")
 	}

--- a/pkg/varlinkapi/volumes.go
+++ b/pkg/varlinkapi/volumes.go
@@ -11,7 +11,7 @@ import (
 )
 
 // VolumeCreate creates a libpod volume based on input from a varlink connection
-func (i *LibpodAPI) VolumeCreate(call iopodman.VarlinkCall, options iopodman.VolumeCreateOpts) error {
+func (i *VarlinkAPI) VolumeCreate(call iopodman.VarlinkCall, options iopodman.VolumeCreateOpts) error {
 	var volumeOptions []libpod.VolumeCreateOption
 
 	if len(options.VolumeName) > 0 {
@@ -38,7 +38,7 @@ func (i *LibpodAPI) VolumeCreate(call iopodman.VarlinkCall, options iopodman.Vol
 }
 
 // VolumeRemove removes volumes by options.All or options.Volumes
-func (i *LibpodAPI) VolumeRemove(call iopodman.VarlinkCall, options iopodman.VolumeRemoveOpts) error {
+func (i *VarlinkAPI) VolumeRemove(call iopodman.VarlinkCall, options iopodman.VolumeRemoveOpts) error {
 	success, failed, err := shared.SharedRemoveVolumes(getContext(), i.Runtime, options.Volumes, options.All, options.Force)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -52,7 +52,7 @@ func (i *LibpodAPI) VolumeRemove(call iopodman.VarlinkCall, options iopodman.Vol
 }
 
 // GetVolumes returns all the volumes known to the remote system
-func (i *LibpodAPI) GetVolumes(call iopodman.VarlinkCall, args []string, all bool) error {
+func (i *VarlinkAPI) GetVolumes(call iopodman.VarlinkCall, args []string, all bool) error {
 	var (
 		err     error
 		reply   []*libpod.Volume
@@ -87,7 +87,7 @@ func (i *LibpodAPI) GetVolumes(call iopodman.VarlinkCall, args []string, all boo
 }
 
 // InspectVolume inspects a single volume, returning its JSON as a string.
-func (i *LibpodAPI) InspectVolume(call iopodman.VarlinkCall, name string) error {
+func (i *VarlinkAPI) InspectVolume(call iopodman.VarlinkCall, name string) error {
 	vol, err := i.Runtime.LookupVolume(name)
 	if err != nil {
 		return call.ReplyErrorOccurred(err.Error())
@@ -104,7 +104,7 @@ func (i *LibpodAPI) InspectVolume(call iopodman.VarlinkCall, name string) error 
 }
 
 // VolumesPrune removes unused images via a varlink call
-func (i *LibpodAPI) VolumesPrune(call iopodman.VarlinkCall) error {
+func (i *VarlinkAPI) VolumesPrune(call iopodman.VarlinkCall) error {
 	var (
 		prunedErrors []string
 		prunedNames  []string

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -221,8 +221,8 @@ func PodmanTestCreateUtil(tempDir string, remote bool) *PodmanTestIntegration {
 	ociRuntime := os.Getenv("OCI_RUNTIME")
 	if ociRuntime == "" {
 		var err error
-		ociRuntime, err = exec.LookPath("runc")
-		// If we cannot find the runc binary, setting to something static as we have no way
+		ociRuntime, err = exec.LookPath("crun")
+		// If we cannot find the crun binary, setting to something static as we have no way
 		// to return an error.  The tests will fail and point out that the runc binary could
 		// not be found nicely.
 		if err != nil {


### PR DESCRIPTION
* Added support for system service
* Enabled linting on the varlinkapi source, needed to support V2
  service command
* Add hack/golangci-lint.sh to support linting with multiple sets of build tags

Signed-off-by: Jhon Honce <jhonce@redhat.com>