### PR TITLE
use `pause:3.2` image for infra containers

### DIFF
--- a/libpod.conf
+++ b/libpod.conf
@@ -74,7 +74,7 @@ cni_default_network = "podman"
 #namespace = ""
 
 # Default infra (pause) image name for pod infra containers
-infra_image = "k8s.gcr.io/pause:3.1"
+infra_image = "k8s.gcr.io/pause:3.2"
 
 # Default command to run the infra container
 infra_command = "/pause"

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -4,7 +4,7 @@ var (
 	// DefaultInitPath is the default path to the container-init binary
 	DefaultInitPath = "/usr/libexec/podman/catatonit"
 	// DefaultInfraImage to use for infra container
-	DefaultInfraImage = "k8s.gcr.io/pause:3.1"
+	DefaultInfraImage = "k8s.gcr.io/pause:3.2"
 	// DefaultInfraCommand to be run in an infra container
 	DefaultInfraCommand = "/pause"
 	// DefaultSHMLockPath is the default path for SHM locks

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -10,7 +10,7 @@ var (
 	ALPINEAMD64ID     = "961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e66dd4"
 	ALPINEARM64DIGEST = "docker.io/library/alpine@sha256:db7f3dcef3d586f7dd123f107c93d7911515a5991c4b9e51fa2a43e46335a43e"
 	ALPINEARM64ID     = "915beeae46751fc564998c79e73a1026542e945ca4f73dc841d09ccc6c2c0672"
-	infra             = "k8s.gcr.io/pause:3.1"
+	infra             = "k8s.gcr.io/pause:3.2"
 	BB                = "docker.io/library/busybox:latest"
 	healthcheck       = "docker.io/libpod/alpine_healthcheck:latest"
 	ImageCacheDir     = "/tmp/podman/imagecachedir"

--- a/test/endpoint/endpoint.go
+++ b/test/endpoint/endpoint.go
@@ -26,7 +26,7 @@ var (
 	ImageCacheDir    = "/tmp/podman/imagecachedir"
 	VarlinkBinary    = "/usr/bin/varlink"
 	ALPINE           = "docker.io/library/alpine:latest"
-	infra            = "k8s.gcr.io/pause:3.1"
+	infra            = "k8s.gcr.io/pause:3.2"
 	BB               = "docker.io/library/busybox:latest"
 	redis            = "docker.io/library/redis:alpine"
 	fedoraMinimal    = "quay.io/libpod/fedora-minimal:latest"


### PR DESCRIPTION
The `pause:3.1` has wrong configs for non-amd64 images as they all claim
to be for amd64.  The issue has now been fixed in the latest
`pause:3.2`.

[1] https://github.com/kubernetes/kubernetes/issues/87325

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>