### PR TITLE
API v2 tests: usability improvements

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -11,7 +11,7 @@ podman pull $IMAGE &>/dev/null
 # Ensure clean slate
 podman rm -a -f &>/dev/null
 
-t GET libpod/containers/json 200 length=0
+t GET "libpod/containers/json (at start: clean slate)" 200 length=0
 
 podman run $IMAGE true
 

--- a/test/apiv2/40-pods.at
+++ b/test/apiv2/40-pods.at
@@ -3,7 +3,8 @@
 # test pod-related endpoints
 #
 
-t GET  libpod/pods/json            200 null
+t GET  "libpod/pods/json (clean slate at start)"   200 null
+
 t POST libpod/pods/create name=foo 201 .id~[0-9a-f]\\{64\\}
 pod_id=$(jq -r .id <<<"$output")
 t GET  libpod/pods/foo/exists      204
@@ -19,7 +20,8 @@ t GET  libpod/pods/json            200 \
   .[0].Containers\|length=1
 
 # Cannot create a dup pod with the same name
-t POST libpod/pods/create name=foo 409 .cause="pod already exists"
+t POST "libpod/pods/create (dup pod)" name=foo 409 \
+  .cause="pod already exists"
 
 #t POST libpod/pods/create a=b 400 .cause='bad parameter'  # FIXME: unimplemented
 
@@ -27,16 +29,18 @@ if root || have_cgroupsv2; then
     t POST libpod/pods/foo/pause   '' 200
 else
     # Rootless cgroupsv1 : unsupported
-    t POST libpod/pods/foo/pause '' 500 \
+    t POST "libpod/pods/foo/pause (rootless cgroups v1)" '' 500 \
       .cause="this container does not have a cgroup" \
       .message~".*pause pods containing rootless containers with cgroup V1"
 fi
-t POST libpod/pods/foo/unpause '' 200
-t POST libpod/pods/foo/unpause '' 200   # (2nd time)
-t POST libpod/pods/foo/stop    '' 304
-t POST libpod/pods/foo/restart '' 200
+t POST  libpod/pods/foo/unpause '' 200
+t POST "libpod/pods/foo/unpause (2nd unpause in a row)" '' 200
+t POST "libpod/pods/foo/stop (pod is already stopped)"  '' 304
+t POST  libpod/pods/foo/restart '' 200 \
+  .Errs=null \
+  .Id=$pod_id
 
-t POST libpod/pods/bar/restart '' 404
+t POST  "libpod/pods/bar/restart (restart on nonexistent pod)" '' 404
 
 # FIXME: I'm not sure what 'prune' is supposed to do; as of 20200224 it
 # just returns 200 (ok) with empty result list.
@@ -44,7 +48,7 @@ t POST libpod/pods/bar/restart '' 404
 #t POST libpod/pods/prune 'a=b' 400     # FIXME: 2020-02-24 returns 200
 
 # Clean up; and try twice, making sure that the second time fails
-t DELETE libpod/pods/foo 200
-t DELETE libpod/pods/foo 404
+t DELETE  libpod/pods/foo 200
+t DELETE "libpod/pods/foo (pod has already been deleted)" 404
 
 # vim: filetype=sh

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -24,8 +24,10 @@ IMAGE=$PODMAN_TEST_IMAGE_FQN
 TMPDIR=${TMPDIR:-/tmp}
 WORKDIR=$(mktemp --tmpdir -d $ME.tmp.XXXXXX)
 
-# Log of all HTTP requests and responses
-LOG=${TMPDIR}/$ME.log.$(date +'%Y%m%dT%H%M%S')
+# Log of all HTTP requests and responses; always make '.log' point to latest
+LOGBASE=${TMPDIR}/$ME.log
+LOG=${LOGBASE}.$(date +'%Y%m%dT%H%M%S')
+ln -sf $LOG $LOGBASE
 
 HOST=localhost
 PORT=${PODMAN_SERVICE_PORT:-8081}
@@ -110,16 +112,20 @@ function _show_ok() {
     _bump $testcounter_file
     count=$(<$testcounter_file)
     if [ $ok -eq 1 ]; then
-        echo -e "${green}ok $count $testname${reset}"
+        echo -e "${green}ok $count ${TEST_CONTEXT} $testname${reset}"
+        echo    "ok $count ${TEST_CONTEXT} $testname" >>$LOG
         return
     fi
 
     # Failed
     local expect=$3
     local actual=$4
-    echo -e "${red}not ok $count $testname${reset}"
+    echo -e "${red}not ok $count ${TEST_CONTEXT} $testname${reset}"
     echo -e "${red}#  expected: $expect${reset}"
     echo -e "${red}#    actual: ${bold}$actual${reset}"
+
+    echo    "not ok $count ${TEST_CONTEXT} $testname" >>$LOG
+    echo    "  expected: $expect"
 
     _bump $failures_file
 }
@@ -168,6 +174,10 @@ function t() {
         testname="$testname [$1]"
         shift
     fi
+
+    # entrypoint path can include a descriptive comment; strip it off
+    path=${path%% *}
+
     # curl -X HEAD but without --head seems to wait for output anyway
     if [[ $method == "HEAD" ]]; then
         curl_args="--head"
@@ -196,13 +206,20 @@ function t() {
         exit 1
     fi
 
-    cat $WORKDIR/curl.headers.out $WORKDIR/curl.result.out >>$LOG 2>/dev/null || true
+    cat $WORKDIR/curl.headers.out >>$LOG 2>/dev/null || true
+    output=$(< $WORKDIR/curl.result.out)
+
+    # Log results. If JSON, filter through jq for readability
+    if egrep -qi '^Content-Type: application/json' $WORKDIR/curl.headers.out; then
+        jq . <<<"$output" >>$LOG
+    else
+        echo "$output" >>$LOG
+    fi
 
     # Test return code
     actual_code=$(head -n1 $WORKDIR/curl.headers.out | awk '/^HTTP/ { print $2}')
     is "$actual_code" "$expected_code" "$testname : status"
 
-    output=$(< $WORKDIR/curl.result.out)
 
     # Special case: 204/304, by definition, MUST NOT return content (rfc2616)
     if [[ $expected_code = 204 || $expected_code = 304 ]]; then
@@ -327,6 +344,7 @@ fi
 start_service
 
 for i in ${tests_to_run[@]}; do
+    TEST_CONTEXT="[$(basename $i .at)]"
     source $i
 done
 


### PR DESCRIPTION
* Allow for descriptive comment in 't' invocations, making it
  easier to distinguish similar requests
* Include test file basename (eg 40-pods) in 'ok/not ok' line
* Always symlink $TMPDIR/test-apiv2.log to latest YYMMDDetc file
* Include test result ('ok', 'not ok') in said log
* When curl results are JSON, filter them through jq into log

Signed-off-by: Ed Santiago <santiago@redhat.com>