### PR TITLE
podman-save: log when more than one image is specified

### DIFF
--- a/cmd/podman/save.go
+++ b/cmd/podman/save.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containers/libpod/pkg/adapter"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -68,6 +69,10 @@ func saveCmd(c *cliconfig.SaveValues) error {
 	args := c.InputArgs
 	if len(args) == 0 {
 		return errors.Errorf("need at least 1 argument")
+	}
+
+	if len(args) > 1 {
+		logrus.Errorf("only the first image will be saved but %d are specified", len(args))
 	}
 
 	runtime, err := adapter.GetRuntime(getContext(), &c.PodmanCommand)


### PR DESCRIPTION
Podman save can only save one image.  While we are planning to support
multiple images to catch up with Docker, we still need time to get the
work done.

Instead of ignoring other arguments, log when there are more than one.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>