### PR TITLE
rootless: make cgroup ownership detection not fatal

### DIFF
--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -174,13 +174,13 @@ func setupRootless(cmd *cobra.Command, args []string) error {
 	if os.Geteuid() == 0 {
 		ownsCgroup, err := cgroups.UserOwnsCurrentSystemdCgroup()
 		if err != nil {
-			return err
-		}
-		conf, err := runtime.GetConfig()
-		if err != nil {
-			return err
+			logrus.Warnf("Failed to detect the owner for the current cgroup: %v", err)
 		}
 		if !ownsCgroup {
+			conf, err := runtime.GetConfig()
+			if err != nil {
+				return err
+			}
 			unitName := fmt.Sprintf("podman-%d.scope", os.Getpid())
 			if err := utils.RunUnderSystemdScope(os.Getpid(), "user.slice", unitName); err != nil {
 				if conf.Engine.CgroupManager == config.SystemdCgroupsManager {


### PR DESCRIPTION
do not fail if we cannot detect the cgroup ownership.  The detection
fails when running in a container, since the cgroup showed in
/proc/self/cgroup is not accessible, due to the runtime mounting it
directly as the cgroup root.

Closes: https://github.com/containers/libpod/issues/5488

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>