### PR TITLE
Revert "Default CPUShares in Inspect are 1024"

### DIFF
--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -445,9 +445,6 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 	hostConfig.ShmSize = c.config.ShmSize
 	hostConfig.Runtime = "oci"
 
-	// Default CPUShares is 1024, but we may overwrite below.
-	hostConfig.CpuShares = 1024
-
 	// This is very expensive to initialize.
 	// So we don't want to initialize it unless we absolutely have to - IE,
 	// there are things that require a major:minor to path translation.


### PR DESCRIPTION
cpu-share is 0 in docker inspect, see for more details
https://github.com/moby/moby/issues/35452

This reverts commit eb229d526c04f17ca8b7e65abba745fd5b465a6c.

Signed-off-by: Sagi Shnaidman <sshnaidm@redhat.com>