### PR TITLE
Fix/improve pkg/storage.InitFSMounts

### DIFF
--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1334,7 +1334,7 @@ func WithNamedVolumes(volumes []*ContainerNamedVolume) CtrCreateOption {
 			}
 			destinations[vol.Dest] = true
 
-			mountOpts, err := util.ProcessOptions(vol.Options, false, nil)
+			mountOpts, err := util.ProcessOptions(vol.Options, false, "")
 			if err != nil {
 				return errors.Wrapf(err, "error processing options for named volume %q mounted at %q", vol.Name, vol.Dest)
 			}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -371,11 +371,9 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 	// BIND MOUNTS
 	configSpec.Mounts = SupercedeUserMounts(userMounts, configSpec.Mounts)
 	// Process mounts to ensure correct options
-	finalMounts, err := InitFSMounts(configSpec.Mounts)
-	if err != nil {
+	if err := InitFSMounts(configSpec.Mounts); err != nil {
 		return nil, err
 	}
-	configSpec.Mounts = finalMounts
 
 	// BLOCK IO
 	blkio, err := config.CreateBlockIO()

--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -867,9 +867,9 @@ func InitFSMounts(inputMounts []spec.Mount) ([]spec.Mount, error) {
 	var mounts []spec.Mount
 	for _, m := range inputMounts {
 		if m.Type == TypeBind {
-			baseMnt, err := findMount(m.Destination, systemMounts)
+			baseMnt, err := findMount(m.Source, systemMounts)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error looking up mountpoint for mount %s", m.Destination)
+				return nil, errors.Wrapf(err, "error looking up mountpoint for mount %s", m.Source)
 			}
 			var noexec, nosuid, nodev bool
 			for _, baseOpt := range strings.Split(baseMnt.Opts, ",") {

--- a/pkg/spec/storage.go
+++ b/pkg/spec/storage.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/util"
-	pmount "github.com/containers/storage/pkg/mount"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -856,44 +855,16 @@ func SupercedeUserMounts(mounts []spec.Mount, configMount []spec.Mount) []spec.M
 
 // Ensure mount options on all mounts are correct
 func InitFSMounts(mounts []spec.Mount) error {
-	// We need to look up mounts so we can figure out the proper mount flags
-	// to apply.
-	systemMounts, err := pmount.GetMounts()
-	if err != nil {
-		return errors.Wrapf(err, "error retrieving system mounts to look up mount options")
-	}
-
 	for i, m := range mounts {
-		if m.Type == TypeBind {
-			baseMnt, err := findMount(m.Source, systemMounts)
-			if err != nil {
-				return errors.Wrapf(err, "error looking up mountpoint for mount %s", m.Source)
-			}
-			var noexec, nosuid, nodev bool
-			for _, baseOpt := range strings.Split(baseMnt.Opts, ",") {
-				switch baseOpt {
-				case "noexec":
-					noexec = true
-				case "nosuid":
-					nosuid = true
-				case "nodev":
-					nodev = true
-				}
-			}
-
-			defaultMountOpts := new(util.DefaultMountOptions)
-			defaultMountOpts.Noexec = noexec
-			defaultMountOpts.Nosuid = nosuid
-			defaultMountOpts.Nodev = nodev
-
-			opts, err := util.ProcessOptions(m.Options, false, defaultMountOpts)
+		switch {
+		case m.Type == TypeBind:
+			opts, err := util.ProcessOptions(m.Options, false, m.Source)
 			if err != nil {
 				return err
 			}
 			mounts[i].Options = opts
-		}
-		if m.Type == TypeTmpfs && filepath.Clean(m.Destination) != "/dev" {
-			opts, err := util.ProcessOptions(m.Options, true, nil)
+		case m.Type == TypeTmpfs && filepath.Clean(m.Destination) != "/dev":
+			opts, err := util.ProcessOptions(m.Options, true, "")
 			if err != nil {
 				return err
 			}
@@ -901,25 +872,4 @@ func InitFSMounts(mounts []spec.Mount) error {
 		}
 	}
 	return nil
-}
-
-// TODO: We could make this a bit faster by building a tree of the mountpoints
-// and traversing it to identify the correct mount.
-func findMount(target string, mounts []*pmount.Info) (*pmount.Info, error) {
-	var err error
-	target, err = filepath.Abs(target)
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot resolve %s", target)
-	}
-	var bestSoFar *pmount.Info
-	for _, i := range mounts {
-		if bestSoFar != nil && len(bestSoFar.Mountpoint) > len(i.Mountpoint) {
-			// Won't be better than what we have already found
-			continue
-		}
-		if strings.HasPrefix(target, i.Mountpoint) {
-			bestSoFar = i
-		}
-	}
-	return bestSoFar, nil
 }

--- a/pkg/specgen/oci.go
+++ b/pkg/specgen/oci.go
@@ -215,11 +215,9 @@ func (s *SpecGenerator) toOCISpec(rt *libpod.Runtime, newImage *image.Image) (*s
 	// BIND MOUNTS
 	configSpec.Mounts = createconfig.SupercedeUserMounts(s.Mounts, configSpec.Mounts)
 	// Process mounts to ensure correct options
-	finalMounts, err := createconfig.InitFSMounts(configSpec.Mounts)
-	if err != nil {
+	if err := createconfig.InitFSMounts(configSpec.Mounts); err != nil {
 		return nil, err
 	}
-	configSpec.Mounts = finalMounts
 
 	// Add annotations
 	if configSpec.Annotations == nil {

--- a/pkg/util/mountOpts_linux.go
+++ b/pkg/util/mountOpts_linux.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func getDefaultMountOptions(path string) (defaultMountOptions, error) {
+	opts := defaultMountOptions{true, true, true}
+	if path == "" {
+		return opts, nil
+	}
+	var statfs unix.Statfs_t
+	if e := unix.Statfs(path, &statfs); e != nil {
+		return opts, &os.PathError{Op: "statfs", Path: path, Err: e}
+	}
+	opts.nodev = (statfs.Flags&unix.MS_NODEV == unix.MS_NODEV)
+	opts.noexec = (statfs.Flags&unix.MS_NOEXEC == unix.MS_NOEXEC)
+	opts.nosuid = (statfs.Flags&unix.MS_NOSUID == unix.MS_NOSUID)
+
+	return opts, nil
+}

--- a/pkg/util/mountOpts_other.go
+++ b/pkg/util/mountOpts_other.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package util
+
+func getDefaultMountOptions(path string) (opts defaultMountOptions, err error) {
+	return
+}


### PR DESCRIPTION
### Fix

Found the bug by reading the source for `InitFSMounts()`, confirmed with:

```console
$ ./bin/podman run -v /tmp:/tmp alpine true; echo $?
0

$ ./bin/podman run -v /tmp:/tmp:ro alpine true; echo $?
0

$ ./bin/podman run -v /tmp:/w0w:ro alpine true; echo $?
> Error: container_linux.go:349: starting container process caused "process_linux.go:449: container init caused \"rootfs_linux.go:58: mounting \\\"/tmp\\\" to rootfs \\\"/home/kir/.local/share/containers/storage/overlay/7636ef3650fc91ee4996ccc026532bb3cff7182c0430db662fffb933e0bcadc9/merged\\\" at \\\"/home/kir/.local/share/containers/storage/overlay/7636ef3650fc91ee4996ccc026532bb3cff7182c0430db662fffb933e0bcadc9/merged/w0w\\\" caused \\\"operation not permitted\\\"\"": OCI runtime permission denied error
> 126
```

The last command is not working because in-container mount point
(i.e. mount destination, not the mount source) is used to search
for a parent mount in /proc/self/mountinfo.

And yet the following
```console
$ ./bin/podman run -v /tmp:/run/test:ro alpine true; echo $?
0
```
still works fine! Here's why:

```console
$ mount | grep -E '/run |/tmp '
tmpfs on /run type tmpfs (rw,nosuid,nodev,seclabel,mode=755)
tmpfs on /tmp type tmpfs (rw,nosuid,nodev,seclabel)
```

Fixes: https://github.com/containers/libpod/pull/2432 (commit 0f5ae3c)
Related-to: https://github.com/containers/libpod/issues/2312

### Improve

Instead of getting mount options from /proc/self/mountinfo, which is
very costly to read/parse (and can even be unreliable), let's use
statfs(2) to figure out the flags we need.

