### PR TITLE
exec: fix hang if control path is deleted

### DIFF
--- a/libpod/oci_attach_linux.go
+++ b/libpod/oci_attach_linux.go
@@ -200,8 +200,10 @@ func setupStdioChannels(streams *AttachStreams, conn *net.UnixConn, detachKeys [
 		var err error
 		if streams.AttachInput {
 			_, err = utils.CopyDetachable(conn, streams.InputStream, detachKeys)
-			if connErr := conn.CloseWrite(); connErr != nil {
-				logrus.Errorf("unable to close conn: %q", connErr)
+			if err == nil {
+				if connErr := conn.CloseWrite(); connErr != nil {
+					logrus.Errorf("unable to close conn: %q", connErr)
+				}
 			}
 		}
 		stdinDone <- err

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -122,6 +122,18 @@ var _ = Describe("Podman exec", func() {
 		Expect(session.ExitCode()).To(Equal(100))
 	})
 
+	It("podman exec terminal doesn't hang", func() {
+		setup := podmanTest.Podman([]string{"run", "-dti", fedoraMinimal, "sleep", "+Inf"})
+		setup.WaitWithDefaultTimeout()
+		Expect(setup.ExitCode()).To(Equal(0))
+
+		for i := 0; i < 5; i++ {
+			session := podmanTest.Podman([]string{"exec", "-lti", "true"})
+			session.WaitWithDefaultTimeout()
+			Expect(session.ExitCode()).To(Equal(0))
+		}
+	})
+
 	It("podman exec pseudo-terminal sanity check", func() {
 		setup := podmanTest.Podman([]string{"run", "--detach", "--name", "test1", fedoraMinimal, "sleep", "+Inf"})
 		setup.WaitWithDefaultTimeout()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -65,7 +65,6 @@ func CopyDetachable(dst io.Writer, src io.Reader, keys []byte) (written int64, e
 					break
 				}
 				if i == len(keys)-1 {
-					// src.Close()
 					return 0, ErrDetach
 				}
 				nr, er = src.Read(buf)


### PR DESCRIPTION
if the control path file is deleted, libpod hangs waiting for a reader
to open it.  Attempt to open it as non blocking until it returns an
error different than EINTR or EAGAIN.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>