### PR TITLE
Switch to using --time as opposed to --timeout to better match Docker.

### DIFF
--- a/cmd/podman/cliconfig/config.go
+++ b/cmd/podman/cliconfig/config.go
@@ -174,7 +174,7 @@ type GenerateSystemdValues struct {
 	New           bool
 	Files         bool
 	RestartPolicy string
-	StopTimeout   int
+	StopTimeout   uint
 }
 
 type HistoryValues struct {

--- a/cmd/podman/generate_systemd.go
+++ b/cmd/podman/generate_systemd.go
@@ -43,9 +43,10 @@ func init() {
 	if !remoteclient {
 		flags.BoolVarP(&containerSystemdCommand.Files, "files", "f", false, "generate files instead of printing to stdout")
 	}
-	flags.IntVarP(&containerSystemdCommand.StopTimeout, "timeout", "t", -1, "stop timeout override")
+	flags.UintVarP(&containerSystemdCommand.StopTimeout, "time", "t", defaultContainerConfig.Engine.StopTimeout, "stop timeout override")
 	flags.StringVar(&containerSystemdCommand.RestartPolicy, "restart-policy", "on-failure", "applicable systemd restart-policy")
 	flags.BoolVarP(&containerSystemdCommand.New, "new", "", false, "create a new container instead of starting an existing one")
+	flags.SetNormalizeFunc(aliasFlags)
 }
 
 func generateSystemdCmd(c *cliconfig.GenerateSystemdValues) error {
@@ -54,11 +55,6 @@ func generateSystemdCmd(c *cliconfig.GenerateSystemdValues) error {
 		return errors.Wrapf(err, "could not get runtime")
 	}
 	defer runtime.DeferredShutdown(false)
-
-	// User input stop timeout must be 0 or greater
-	if c.Flag("timeout").Changed && c.StopTimeout < 0 {
-		return errors.New("timeout value must be 0 or greater")
-	}
 
 	unit, err := runtime.GenerateSystemd(c)
 	if err != nil {

--- a/cmd/podman/pod_stop.go
+++ b/cmd/podman/pod_stop.go
@@ -31,7 +31,7 @@ var (
 		},
 		Example: `podman pod stop mywebserverpod
   podman pod stop --latest
-  podman pod stop --timeout 0 490eb 3557fb`,
+  podman pod stop --time 0 490eb 3557fb`,
 	}
 )
 
@@ -43,7 +43,8 @@ func init() {
 	flags.BoolVarP(&podStopCommand.All, "all", "a", false, "Stop all running pods")
 	flags.BoolVarP(&podStopCommand.Ignore, "ignore", "i", false, "Ignore errors when a specified pod is missing")
 	flags.BoolVarP(&podStopCommand.Latest, "latest", "l", false, "Stop the latest pod podman is aware of")
-	flags.UintVarP(&podStopCommand.Timeout, "timeout", "t", 0, "Seconds to wait for pod stop before killing the container")
+	flags.UintVarP(&podStopCommand.Timeout, "time", "t", defaultContainerConfig.Engine.StopTimeout, "Seconds to wait for pod stop before killing the container")
+	flags.SetNormalizeFunc(aliasFlags)
 	markFlagHiddenForRemoteClient("ignore", flags)
 	markFlagHiddenForRemoteClient("latest", flags)
 }

--- a/cmd/podman/restart.go
+++ b/cmd/podman/restart.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/containers/libpod/cmd/podman/cliconfig"
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/adapter"
@@ -10,9 +12,9 @@ import (
 
 var (
 	restartCommand     cliconfig.RestartValues
-	restartDescription = `Restarts one or more running containers. The container ID or name can be used.
+	restartDescription = fmt.Sprintf(`Restarts one or more running containers. The container ID or name can be used.
 
-  A timeout before forcibly stopping can be set, but defaults to 10 seconds.`
+  A timeout before forcibly stopping can be set, but defaults to %d seconds.`, defaultContainerConfig.Engine.StopTimeout)
 	_restartCommand = &cobra.Command{
 		Use:   "restart [flags] CONTAINER [CONTAINER...]",
 		Short: "Restart one or more containers",
@@ -40,10 +42,9 @@ func init() {
 	flags.BoolVarP(&restartCommand.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
 	flags.BoolVar(&restartCommand.Running, "running", false, "Restart only running containers when --all is used")
 	flags.UintVarP(&restartCommand.Timeout, "time", "t", defaultContainerConfig.Engine.StopTimeout, "Seconds to wait for stop before killing the container")
-	flags.UintVar(&restartCommand.Timeout, "timeout", defaultContainerConfig.Engine.StopTimeout, "Seconds to wait for stop before killing the container")
 
-	markFlagHidden(flags, "timeout")
 	markFlagHiddenForRemoteClient("latest", flags)
+	flags.SetNormalizeFunc(aliasFlags)
 }
 
 func restartCmd(c *cliconfig.RestartValues) error {

--- a/cmd/podman/utils.go
+++ b/cmd/podman/utils.go
@@ -63,6 +63,8 @@ func aliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 		name = "health-timeout"
 	case "net":
 		name = "network"
+	case "timeout":
+		name = "time"
 	}
 	return pflag.NormalizedName(name)
 }

--- a/cmd/podmanV2/containers/stop.go
+++ b/cmd/podmanV2/containers/stop.go
@@ -8,14 +8,13 @@ import (
 	"github.com/containers/libpod/cmd/podmanV2/registry"
 	"github.com/containers/libpod/cmd/podmanV2/utils"
 	"github.com/containers/libpod/pkg/domain/entities"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 var (
-	stopDescription = `Stops one or more running containers.  The container name or ID can be used.
+	stopDescription = fmt.Sprintf(`Stops one or more running containers.  The container name or ID can be used.
 
-  A timeout to forcibly stop the container can also be set but defaults to 10 seconds otherwise.`
+  A timeout to forcibly stop the container can also be set but defaults to %d seconds otherwise.`, defaultContainerConfig.Engine.StopTimeout)
 	stopCommand = &cobra.Command{
 		Use:               "stop [flags] CONTAINER [CONTAINER...]",
 		Short:             "Stop one or more containers",
@@ -27,7 +26,7 @@ var (
 		},
 		Example: `podman stop ctrID
   podman stop --latest
-  podman stop --timeout 2 mywebserver 6e534f14da9d`,
+  podman stop --time 2 mywebserver 6e534f14da9d`,
 	}
 )
 
@@ -46,24 +45,21 @@ func init() {
 	flags.BoolVarP(&stopOptions.Ignore, "ignore", "i", false, "Ignore errors when a specified container is missing")
 	flags.StringArrayVarP(&stopOptions.CIDFiles, "cidfile", "", nil, "Read the container ID from the file")
 	flags.BoolVarP(&stopOptions.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
-	flags.UintVar(&stopTimeout, "time", defaultContainerConfig.Engine.StopTimeout, "Seconds to wait for stop before killing the container")
-	flags.UintVarP(&stopTimeout, "timeout", "t", defaultContainerConfig.Engine.StopTimeout, "Seconds to wait for stop before killing the container")
+	flags.UintVarP(&stopTimeout, "time", "t", defaultContainerConfig.Engine.StopTimeout, "Seconds to wait for stop before killing the container")
 	if registry.EngineOptions.EngineMode == entities.ABIMode {
 		_ = flags.MarkHidden("latest")
 		_ = flags.MarkHidden("cidfile")
 		_ = flags.MarkHidden("ignore")
 	}
+	flags.SetNormalizeFunc(utils.AliasFlags)
 }
 
 func stop(cmd *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
-	if cmd.Flag("timeout").Changed && cmd.Flag("time").Changed {
-		return errors.New("the --timeout and --time flags are mutually exclusive")
-	}
 	stopOptions.Timeout = defaultContainerConfig.Engine.StopTimeout
-	if cmd.Flag("timeout").Changed || cmd.Flag("time").Changed {
+	if cmd.Flag("time").Changed {
 		stopOptions.Timeout = stopTimeout
 	}
 

--- a/cmd/podmanV2/pods/stop.go
+++ b/cmd/podmanV2/pods/stop.go
@@ -26,7 +26,7 @@ var (
 		},
 		Example: `podman pod stop mywebserverpod
   podman pod stop --latest
-  podman pod stop --timeout 0 490eb 3557fb`,
+  podman pod stop --time 0 490eb 3557fb`,
 	}
 )
 
@@ -47,19 +47,20 @@ func init() {
 	flags.BoolVarP(&stopOptions.All, "all", "a", false, "Stop all running pods")
 	flags.BoolVarP(&stopOptions.Ignore, "ignore", "i", false, "Ignore errors when a specified pod is missing")
 	flags.BoolVarP(&stopOptions.Latest, "latest", "l", false, "Stop the latest pod podman is aware of")
-	flags.UintVarP(&timeout, "timeout", "t", 0, "Seconds to wait for pod stop before killing the container")
+	flags.UintVarP(&timeout, "time", "t", 0, "Seconds to wait for pod stop before killing the container")
 	if registry.IsRemote() {
 		_ = flags.MarkHidden("latest")
 		_ = flags.MarkHidden("ignore")
 
 	}
+	flags.SetNormalizeFunc(utils.AliasFlags)
 }
 
 func stop(cmd *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
-	if cmd.Flag("timeout").Changed {
+	if cmd.Flag("time").Changed {
 		stopOptions.Timeout = int(timeout)
 	}
 	responses, err := registry.ContainerEngine().PodStop(context.Background(), args, stopOptions)

--- a/cmd/podmanV2/utils/alias.go
+++ b/cmd/podmanV2/utils/alias.go
@@ -1,0 +1,24 @@
+package utils
+
+import "github.com/spf13/pflag"
+
+// AliasFlags is a function to handle backwards compatability with old flags
+func AliasFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	switch name {
+	case "healthcheck-command":
+		name = "health-cmd"
+	case "healthcheck-interval":
+		name = "health-interval"
+	case "healthcheck-retries":
+		name = "health-retries"
+	case "healthcheck-start-period":
+		name = "health-start-period"
+	case "healthcheck-timeout":
+		name = "health-timeout"
+	case "net":
+		name = "network"
+	case "timeout":
+		name = "time"
+	}
+	return pflag.NormalizedName(name)
+}

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2161,7 +2161,7 @@ _podman_run() {
 
 _podman_restart() {
      local options_with_args="
-     --timeout -t
+     --time -t
      "
      local boolean_options="
 	  --all
@@ -2171,8 +2171,6 @@ _podman_restart() {
 	  --latest
 	  -l
 	  --running
-	  --timeout
-	  -t
      "
      case "$cur" in
 	-*)
@@ -2462,7 +2460,7 @@ _podman_start() {
 }
 _podman_stop() {
      local options_with_args="
-     --timeout -t
+     --time -t
      "
      local boolean_options="
 	  --all
@@ -2656,7 +2654,7 @@ _podman_generate_systemd() {
     local options_with_args="
     --restart-policy
     -t
-    --timeout"
+    --time"
 
     local boolean_options="
     -h
@@ -3088,7 +3086,7 @@ _podman_pod_start() {
 _podman_pod_stop() {
   local options_with_args="
       -t
-      --timeout
+      --time
   "
 
   local boolean_options="

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -27,7 +27,7 @@ Use the name of the container for the start, stop, and description in the unit f
 Create a new container via podman-run instead of starting an existing one.  This option relies on container configuration files, which may not map directly to podman CLI flags; please review the generated output carefully before placing in production.
 Since we use systemd `Type=forking` service, using this option will force the container run with the detached param `-d`
 
-**--timeout**, **-t**=*value*
+**--time**, **-t**=*value*
 
 Override the default stop timeout for the container with the given value.
 

--- a/docs/source/markdown/podman-pod-stop.1.md
+++ b/docs/source/markdown/podman-pod-stop.1.md
@@ -27,7 +27,7 @@ Instead of providing the pod name or ID, stop the last created pod.
 
 The latest option is not supported on the remote client.
 
-**--timeout**, **-t**=*time*
+**--time**, **-t**=*time*
 
 Timeout to wait before forcibly stopping the containers in the pod.
 

--- a/docs/source/markdown/podman-restart.1.md
+++ b/docs/source/markdown/podman-restart.1.md
@@ -46,7 +46,7 @@ ff6cf1e5e77e6dba1efc7f3fcdb20e8b89ad8947bc0518be1fcb2c78681f226f
 
 Restart two containers by name with a timeout of 4 seconds
 ```
-$ podman restart --timeout 4 test1 test2
+$ podman restart --time 4 test1 test2
 c3bb026838c30e5097f079fa365c9a4769d52e1017588278fa00d5c68ebc1502
 17e13a63081a995136f907024bcfe50ff532917988a152da229db9d894c5a9ec
 ```

--- a/docs/source/markdown/podman-stop.1.md
+++ b/docs/source/markdown/podman-stop.1.md
@@ -9,7 +9,7 @@ podman\-stop - Stop one or more running containers
 **podman container stop** [*options*] *container* ...
 
 ## DESCRIPTION
-Stops one or more containers.  You may use container IDs or names as input. The **--timeout** switch
+Stops one or more containers.  You may use container IDs or names as input. The **--time** switch
 allows you to specify the number of seconds to wait before forcibly stopping the container after the stop command
 is issued to the container. The default is 10 seconds. By default, containers are stopped with SIGTERM
 and then SIGKILL after the timeout. The SIGTERM default can be overridden by the image used to create the
@@ -54,7 +54,7 @@ $ podman stop --cidfile /home/user/cidfile-1
 
 $ podman stop --cidfile /home/user/cidfile-1 --cidfile ./cidfile-2
 
-$ podman stop --timeout 2 860a4b235279
+$ podman stop --time 2 860a4b235279
 
 $ podman stop -a
 

--- a/pkg/adapter/containers.go
+++ b/pkg/adapter/containers.go
@@ -1213,8 +1213,8 @@ func (r *LocalRuntime) generateSystemdgenContainerInfo(c *cliconfig.GenerateSyst
 		return nil, false, err
 	}
 
-	timeout := int(ctr.StopTimeout())
-	if c.StopTimeout >= 0 {
+	timeout := ctr.StopTimeout()
+	if c.Flags().Changed("timeout") || c.Flags().Changed("time") {
 		timeout = c.StopTimeout
 	}
 

--- a/pkg/systemd/generate/systemdgen.go
+++ b/pkg/systemd/generate/systemdgen.go
@@ -31,7 +31,7 @@ type ContainerInfo struct {
 	InfraContainer string
 	// StopTimeout sets the timeout Podman waits before killing the container
 	// during service stop.
-	StopTimeout int
+	StopTimeout uint
 	// RestartPolicy of the systemd unit (e.g., no, on-failure, always).
 	RestartPolicy string
 	// PIDFile of the service. Required for forking services. Must point to the

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -431,7 +431,7 @@ func (p *PodmanTestIntegration) PodmanPID(args []string) (*PodmanSessionIntegrat
 // Cleanup cleans up the temporary store
 func (p *PodmanTestIntegration) Cleanup() {
 	// Remove all containers
-	stopall := p.Podman([]string{"stop", "-a", "--timeout", "0"})
+	stopall := p.Podman([]string{"stop", "-a", "--time", "0"})
 	stopall.Wait(90)
 
 	podstop := p.Podman([]string{"pod", "stop", "-a", "-t", "0"})

--- a/test/e2e/generate_systemd_test.go
+++ b/test/e2e/generate_systemd_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Podman generate systemd", func() {
 	})
 
 	It("podman generate systemd bad timeout value", func() {
-		session := podmanTest.Podman([]string{"generate", "systemd", "--timeout", "-1", "foobar"})
+		session := podmanTest.Podman([]string{"generate", "systemd", "--time", "-1", "foobar"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
 	})
@@ -57,7 +57,7 @@ var _ = Describe("Podman generate systemd", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
-		session = podmanTest.Podman([]string{"generate", "systemd", "--timeout", "1234", "foobar"})
+		session = podmanTest.Podman([]string{"generate", "systemd", "--time", "1234", "foobar"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -97,7 +97,7 @@ var _ = Describe("Podman generate systemd", func() {
 		n.WaitWithDefaultTimeout()
 		Expect(n.ExitCode()).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"generate", "systemd", "--timeout", "5", "nginx"})
+		session := podmanTest.Podman([]string{"generate", "systemd", "--time", "5", "nginx"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -118,7 +118,7 @@ var _ = Describe("Podman generate systemd", func() {
 		n.WaitWithDefaultTimeout()
 		Expect(n.ExitCode()).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"generate", "systemd", "--timeout", "42", "--name", "foo"})
+		session := podmanTest.Podman([]string{"generate", "systemd", "--time", "42", "--name", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -183,7 +183,7 @@ var _ = Describe("Podman generate systemd", func() {
 		n.WaitWithDefaultTimeout()
 		Expect(n.ExitCode()).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"generate", "systemd", "--timeout", "42", "--name", "--new", "foo"})
+		session := podmanTest.Podman([]string{"generate", "systemd", "-t", "42", "--name", "--new", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -214,7 +214,7 @@ var _ = Describe("Podman generate systemd", func() {
 		n.WaitWithDefaultTimeout()
 		Expect(n.ExitCode()).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"generate", "systemd", "--timeout", "42", "--name", "--new", "foo"})
+		session := podmanTest.Podman([]string{"generate", "systemd", "--time", "42", "--name", "--new", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -228,7 +228,7 @@ var _ = Describe("Podman generate systemd", func() {
 		n.WaitWithDefaultTimeout()
 		Expect(n.ExitCode()).To(Equal(0))
 
-		session := podmanTest.Podman([]string{"generate", "systemd", "--timeout", "42", "--name", "--new", "foo"})
+		session := podmanTest.Podman([]string{"generate", "systemd", "--time", "42", "--name", "--new", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(125))
 	})

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -255,7 +255,7 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(strings.Contains(mountOut2, volName)).To(BeTrue())
 
 		// Stop the container to unmount
-		podmanStopSession := podmanTest.Podman([]string{"stop", "--timeout", "0", ctrName})
+		podmanStopSession := podmanTest.Podman([]string{"stop", "--time", "0", ctrName})
 		podmanStopSession.WaitWithDefaultTimeout()
 		Expect(podmanStopSession.ExitCode()).To(Equal(0))
 


### PR DESCRIPTION
We need to consistently use --time rather then --timeout throughout the code.
Fix locations where timeout defaults are not set correctly as well.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>