### PR TITLE
podmanv2-retry - new helper for testing v2

### DIFF
--- a/hack/podmanv2-retry
+++ b/hack/podmanv2-retry
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# podman-try - try running a command via PODMAN1; use PODMAN2 as fallback
+#
+# Intended for use with a podmanv2 client. If a command isn't yet
+# implemented, fall back to regular podman:
+#
+#    Set PODMAN_V2 to the path to a podman v2 client
+#    Set PODMAN_FALLBACK to the path to regular podman
+#
+# THIS IS IMPERFECT. In particular, it will not work if stdin is redirected
+# (e.g. 'podman ... < file' or 'something | podman'); nor for anything
+# that generates continuous output ('podman logs -f'); and probably more
+# situations.
+#
+
+die() {
+    echo "$(basename $0): $*" >&2
+    exit 1
+}
+
+test -n "$PODMAN_V2"       || die "Please set \$PODMAN_V2 (path to podman v2)"
+test -n "$PODMAN_FALLBACK" || die "Please set \$PODMAN_FALLBACK (path to podman)"
+
+
+result=$(${PODMAN_V2} "$@" 2>&1)
+rc=$?
+
+if [ $rc == 125 ]; then
+    if [[ "$result" =~ unrecognized\ command|unknown\ flag|unknown\ shorthand ]]; then
+        result=$(${PODMAN_FALLBACK} "$@")
+        rc=$?
+    fi
+fi
+
+echo -n "$result"
+exit $rc


### PR DESCRIPTION
./hack/podmanv2-retry will first invoke $PODMAN_V2 with given
arguments. If that fails with any of the following errors:

    unrecognized command
    unknown flag
    unknown shorthand

...it will run $PODMAN_FALLBACK with the same arguments.
Output and exit code will be those of the final podman command,
although be aware that stderr and stdout are combined.

This is a quick-hack script intended for use in v2 testing, to
test implemented commands without noise from unimplemented ones.

Signed-off-by: Ed Santiago <santiago@redhat.com>