### PR TITLE
Prepare for crun checkpoint support

### DIFF
--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -939,7 +939,7 @@ func (r *ConmonOCIRuntime) CheckpointContainer(ctr *Container, options Container
 func (r *ConmonOCIRuntime) SupportsCheckpoint() bool {
 	// Check if the runtime implements checkpointing. Currently only
 	// runc's checkpoint/restore implementation is supported.
-	cmd := exec.Command(r.path, "checkpoint", "-h")
+	cmd := exec.Command(r.path, "checkpoint", "--help")
 	if err := cmd.Start(); err != nil {
 		return false
 	}

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -930,6 +930,13 @@ func (r *ConmonOCIRuntime) CheckpointContainer(ctr *Container, options Container
 	if options.TCPEstablished {
 		args = append(args, "--tcp-established")
 	}
+	runtimeDir, err := util.GetRuntimeDir()
+	if err != nil {
+		return err
+	}
+	if err = os.Setenv("XDG_RUNTIME_DIR", runtimeDir); err != nil {
+		return errors.Wrapf(err, "cannot set XDG_RUNTIME_DIR")
+	}
 	args = append(args, ctr.ID())
 	return utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, nil, r.path, args...)
 }

--- a/test/e2e/checkpoint_test.go
+++ b/test/e2e/checkpoint_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Podman checkpoint", func() {
 		podmanTest.SeedImages()
 		// Check if the runtime implements checkpointing. Currently only
 		// runc's checkpoint/restore implementation is supported.
-		cmd := exec.Command(podmanTest.OCIRuntime, "checkpoint", "-h")
+		cmd := exec.Command(podmanTest.OCIRuntime, "checkpoint", "--help")
 		if err := cmd.Start(); err != nil {
 			Skip("OCI runtime does not support checkpoint/restore")
 		}


### PR DESCRIPTION
This includes two small changes for using crun with checkpoint support:

 * correctly set up XDG_RUNTIME_DIR (thanks to @giuseppe for helping with this)
 * adapt checkpoint support test to work with crun and runc