### PR TITLE
Do not error on pids.current stats if ctr.path is empty

### DIFF
--- a/pkg/cgroups/pids.go
+++ b/pkg/cgroups/pids.go
@@ -44,8 +44,12 @@ func (c *pidHandler) Destroy(ctr *CgroupControl) error {
 
 // Stat fills a metrics structure with usage stats for the controller
 func (c *pidHandler) Stat(ctr *CgroupControl, m *Metrics) error {
-	var PIDRoot string
+	if ctr.path != "" {
+		// nothing we can do to retrieve the pids.current path
+		return nil
+	}
 
+	var PIDRoot string
 	if ctr.cgroup2 {
 		PIDRoot = filepath.Join(cgroupRoot, ctr.path)
 	} else {


### PR DESCRIPTION
If the ctr.path is empty, then we do not try to access
`/sys/fs/cgroup/pids/pids.current` any more because this path will be
wrong in any case. We now return and do not set the PIDs stats.

Refers to https://github.com/cri-o/cri-o/issues/3522

/assign @giuseppe 