### PR TITLE
podman info needs to be run within the user namespace

### DIFF
--- a/cmd/podman/main_local.go
+++ b/cmd/podman/main_local.go
@@ -253,7 +253,6 @@ func executeCommandInUserNS(cmd *cobra.Command) bool {
 	case _migrateCommand,
 		_mountCommand,
 		_renumberCommand,
-		_infoCommand,
 		_searchCommand,
 		_versionCommand:
 		return false


### PR DESCRIPTION
Accidently removed podman info from user namespace

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

Fixes: https://github.com/containers/libpod/issues/5746