### PR TITLE
Improve APIv2 support for Attach

### DIFF
--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -517,13 +517,13 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    name: logs
 	//    required: false
 	//    type: boolean
-	//    description: Not yet supported
+	//    description: Stream all logs from the container across the connection. Happens before streaming attach (if requested). At least one of logs or stream must be set
 	//  - in: query
 	//    name: stream
 	//    required: false
 	//    type: boolean
 	//    default: true
-	//    description: If passed, must be set to true; stream=false is not yet supported
+	//    description: Attach to the container. If unset, and logs is set, only the container's logs will be sent. At least one of stream or logs must be set
 	//  - in: query
 	//    name: stdout
 	//    required: false
@@ -1194,13 +1194,13 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//    name: logs
 	//    required: false
 	//    type: boolean
-	//    description: Not yet supported
+	//    description: Stream all logs from the container across the connection. Happens before streaming attach (if requested). At least one of logs or stream must be set
 	//  - in: query
 	//    name: stream
 	//    required: false
 	//    type: boolean
 	//    default: true
-	//    description: If passed, must be set to true; stream=false is not yet supported
+	//    description: Attach to the container. If unset, and logs is set, only the container's logs will be sent. At least one of stream or logs must be set
 	//  - in: query
 	//    name: stdout
 	//    required: false


### PR DESCRIPTION
A few major fixes here:
- Support for attaching to Configured containers, to match Docker behavior.
- Support for stream parameter has been improved (we now properly handle cases where it is not set).
- Initial support for logs parameter has been added.

Still to do:
- The attach query parameters (stdin, stdout, stderr) must be supported even when the container has a terminal
- Logs parameter currently causes segfaults trying to read the logs, which is bad. Also does not split logs into stdin/out/err when terminal is not specified.
- Errors do not seem to be written after the hijack has begun.
- Swagger must be updated to reflect these changes