### PR TITLE
Set exit codes on errors.

### DIFF
--- a/cmd/podmanV2/containers/run.go
+++ b/cmd/podmanV2/containers/run.go
@@ -109,13 +109,14 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	runOpts.Spec = s
 	report, err := registry.ContainerEngine().ContainerRun(registry.GetContext(), runOpts)
+	// report.ExitCode is set by ContainerRun even it it returns an error
+	registry.SetExitCode(report.ExitCode)
 	if err != nil {
 		return err
 	}
 	if cliVals.Detach {
 		fmt.Println(report.Id)
 	}
-	registry.SetExitCode(report.ExitCode)
 	if runRmi {
 		_, err := registry.ImageEngine().Delete(registry.GetContext(), []string{report.Id}, entities.ImageDeleteOptions{})
 		if err != nil {


### PR DESCRIPTION
podmanV2 run fedora /etc
Should exit with 126
podmanV2 run fedora /etc/foobar
Should exit with 127
podmanv2 run --fobar fedora echo hello
Should exit with 125
podmanv2 run fedora bash -c "exit 100"
Should exit with 100

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>