### PR TITLE
run/create were processing options after the image name

### DIFF
--- a/cmd/podmanV2/containers/create.go
+++ b/cmd/podmanV2/containers/create.go
@@ -40,6 +40,7 @@ func init() {
 	})
 	//common.GetCreateFlags(createCommand)
 	flags := createCommand.Flags()
+	flags.SetInterspersed(false)
 	flags.AddFlagSet(common.GetCreateFlags(&cliVals))
 	flags.AddFlagSet(common.GetNetFlags())
 	flags.SetNormalizeFunc(common.AliasFlags)

--- a/cmd/podmanV2/containers/run.go
+++ b/cmd/podmanV2/containers/run.go
@@ -46,6 +46,7 @@ func init() {
 		Command: runCommand,
 	})
 	flags := runCommand.Flags()
+	flags.SetInterspersed(false)
 	flags.AddFlagSet(common.GetCreateFlags(&cliVals))
 	flags.AddFlagSet(common.GetNetFlags())
 	flags.SetNormalizeFunc(common.AliasFlags)


### PR DESCRIPTION
	flags.SetInterspersed(false)

Needs to be added to allow options to be used within the containers.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>