### PR TITLE
logformat: handle apiv2 results, add anchor links

### DIFF
--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -220,8 +220,8 @@ END_HTML
             $cirrus_task = $1;
         }
 
-        # BATS handling
-        if ($line =~ /^1\.\.\d+$/) {
+        # BATS handling (used also for apiv2 tests, which emit TAP output)
+        if ($line =~ /^1\.\.\d+$/ || $line =~ m!/test-apiv2!) {
             $looks_like_bats = 1;
         }
         if ($looks_like_bats) {
@@ -234,6 +234,10 @@ END_HTML
             elsif ($line =~ /^#\s/)            { $css = 'log'     }
 
             if ($css) {
+                # Make it linkable, e.g. foo.html#t--00001
+                if ($line =~ /^(not\s+)?ok\s+(\d+)/) {
+                    $line = sprintf("<a name='t--%05d'>%s</a>", $2, $line);
+                }
                 $line = "<span class='bats-$css'>$line</span>";
             }
 

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -355,7 +355,7 @@ done
 
 if [ -n "$service_pid" ]; then
     kill $service_pid
-    wait -f $service_pid
+    wait $service_pid
 fi
 
 test_count=$(<$testcounter_file)


### PR DESCRIPTION
apiv2 tests emit TAP-compliant output; recognize it and
highlight it the same way we do BATS tests.

Add anchor links to TAP output, so other tools (e.g.
cirrus-flake-summarize) can link to particular lines

And, remove a "-f" from "wait" in test-apiv2; looks
like there's some version of bash used in some CI VM
that doesn't grok it.

Signed-off-by: Ed Santiago <santiago@redhat.com>