### PR TITLE
v2podman container cleanup

### DIFF
--- a/cmd/podmanV2/containers/cleanup.go
+++ b/cmd/podmanV2/containers/cleanup.go
@@ -1,0 +1,75 @@
+package containers
+
+import (
+	"fmt"
+
+	"github.com/containers/libpod/cmd/podmanV2/parse"
+	"github.com/containers/libpod/cmd/podmanV2/registry"
+	"github.com/containers/libpod/cmd/podmanV2/utils"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cleanupDescription = `
+   podman container cleanup
+
+   Cleans up mount points and network stacks on one or more containers from the host. The container name or ID can be used. This command is used internally when running containers, but can also be used if container cleanup has failed when a container exits.
+`
+	cleanupCommand = &cobra.Command{
+		Use:   "cleanup [flags] CONTAINER [CONTAINER...]",
+		Short: "Cleanup network and mountpoints of one or more containers",
+		Long:  cleanupDescription,
+		RunE:  cleanup,
+		Args: func(cmd *cobra.Command, args []string) error {
+			return parse.CheckAllLatestAndCIDFile(cmd, args, false, false)
+		},
+		Example: `podman container cleanup --latest
+  podman container cleanup ctrID1 ctrID2 ctrID3
+  podman container cleanup --all`,
+	}
+)
+
+var (
+	cleanupOptions entities.ContainerCleanupOptions
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode},
+		Parent:  containerCmd,
+		Command: cleanupCommand,
+	})
+	flags := cleanupCommand.Flags()
+	flags.BoolVarP(&cleanupOptions.All, "all", "a", false, "Cleans up all containers")
+	flags.BoolVarP(&cleanupOptions.Latest, "latest", "l", false, "Act on the latest container podman is aware of")
+	flags.BoolVar(&cleanupOptions.Remove, "rm", false, "After cleanup, remove the container entirely")
+	flags.BoolVar(&cleanupOptions.RemoveImage, "rmi", false, "After cleanup, remove the image entirely")
+
+}
+
+func cleanup(cmd *cobra.Command, args []string) error {
+	var (
+		errs utils.OutputErrors
+	)
+	responses, err := registry.ContainerEngine().ContainerCleanup(registry.GetContext(), args, cleanupOptions)
+	if err != nil {
+		return err
+	}
+	for _, r := range responses {
+		if r.CleanErr == nil && r.RmErr == nil && r.RmiErr == nil {
+			fmt.Println(r.Id)
+			continue
+		}
+		if r.RmErr != nil {
+			errs = append(errs, r.RmErr)
+		}
+		if r.RmiErr != nil {
+			errs = append(errs, r.RmiErr)
+		}
+		if r.CleanErr != nil {
+			errs = append(errs, r.CleanErr)
+		}
+	}
+	return errs.PrintErrors()
+}

--- a/cmd/podmanV2/containers/run.go
+++ b/cmd/podmanV2/containers/run.go
@@ -5,15 +5,14 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
-	"github.com/containers/libpod/pkg/domain/entities"
-
+	"github.com/containers/common/pkg/config"
 	"github.com/containers/libpod/cmd/podmanV2/common"
 	"github.com/containers/libpod/cmd/podmanV2/registry"
 	"github.com/containers/libpod/libpod/define"
+	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/containers/libpod/pkg/specgen"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -75,6 +74,30 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	ie, err := registry.NewImageEngine(cmd, args)
+	if err != nil {
+		return err
+	}
+	br, err := ie.Exists(registry.GetContext(), args[0])
+	if err != nil {
+		return err
+	}
+	pullPolicy, err := config.ValidatePullPolicy(cliVals.Pull)
+	if err != nil {
+		return err
+	}
+	if !br.Value || pullPolicy == config.PullImageAlways {
+		if pullPolicy == config.PullImageNever {
+			return errors.New("unable to find a name and tag match for busybox in repotags: no such image")
+		}
+		_, pullErr := ie.Pull(registry.GetContext(), args[0], entities.ImagePullOptions{
+			Authfile: cliVals.Authfile,
+			Quiet:    cliVals.Quiet,
+		})
+		if pullErr != nil {
+			return pullErr
+		}
+	}
 	// If -i is not set, clear stdin
 	if !cliVals.Interactive {
 		runOpts.InputStream = nil
@@ -110,7 +133,9 @@ func run(cmd *cobra.Command, args []string) error {
 	runOpts.Spec = s
 	report, err := registry.ContainerEngine().ContainerRun(registry.GetContext(), runOpts)
 	// report.ExitCode is set by ContainerRun even it it returns an error
-	registry.SetExitCode(report.ExitCode)
+	if report != nil {
+		registry.SetExitCode(report.ExitCode)
+	}
 	if err != nil {
 		return err
 	}
@@ -118,7 +143,7 @@ func run(cmd *cobra.Command, args []string) error {
 		fmt.Println(report.Id)
 	}
 	if runRmi {
-		_, err := registry.ImageEngine().Delete(registry.GetContext(), []string{report.Id}, entities.ImageDeleteOptions{})
+		_, err := registry.ImageEngine().Delete(registry.GetContext(), []string{args[0]}, entities.ImageDeleteOptions{})
 		if err != nil {
 			logrus.Errorf("%s", errors.Wrapf(err, "failed removing image"))
 		}

--- a/cmd/podmanV2/containers/wait.go
+++ b/cmd/podmanV2/containers/wait.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/containers/libpod/cmd/podmanV2/parse"
 	"github.com/containers/libpod/cmd/podmanV2/registry"
 	"github.com/containers/libpod/cmd/podmanV2/utils"
 	"github.com/containers/libpod/libpod/define"
@@ -23,9 +22,7 @@ var (
 		Long:              waitDescription,
 		RunE:              wait,
 		PersistentPreRunE: preRunE,
-		Args: func(cmd *cobra.Command, args []string) error {
-			return parse.CheckAllLatestAndCIDFile(cmd, args, false, false)
-		},
+		Args:              registry.IdOrLatestArgs,
 		Example: `podman wait --latest
   podman wait --interval 5000 ctrID
   podman wait ctrID1 ctrID2`,

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -508,7 +508,7 @@ var _ = Describe("Podman containers ", func() {
 		_, err = bt.RunTopContainer(&name2, &bindings.PFalse, nil)
 		Expect(err).To(BeNil())
 		containerLatestList, err := containers.List(bt.conn, nil, nil, &latestContainers, nil, nil, nil)
-		err = containers.Kill(bt.conn, containerLatestList[0].Names[0], "SIGTERM")
+		err = containers.Kill(bt.conn, containerLatestList[0].Names(), "SIGTERM")
 		Expect(err).To(BeNil())
 	})
 

--- a/pkg/domain/entities/container_ps.go
+++ b/pkg/domain/entities/container_ps.go
@@ -68,7 +68,7 @@ func (l ListContainer) State() string {
 		state = "Up " + t + " ago"
 	case "configured":
 		state = "Created"
-	case "exited":
+	case "exited", "stopped":
 		t := units.HumanDuration(time.Since(time.Unix(l.ExitedAt, 0)))
 		state = fmt.Sprintf("Exited (%d) %s ago", l.ExitCode, t)
 	default:

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -265,3 +265,21 @@ type ContainerRunReport struct {
 	ExitCode int
 	Id       string
 }
+
+// ContainerCleanupOptions are the CLI values for the
+// cleanup command
+type ContainerCleanupOptions struct {
+	All         bool
+	Latest      bool
+	Remove      bool
+	RemoveImage bool
+}
+
+// ContainerCleanupReport describes the response from a
+// container cleanup
+type ContainerCleanupReport struct {
+	CleanErr error
+	Id       string
+	RmErr    error
+	RmiErr   error
+}

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -10,6 +10,7 @@ import (
 type ContainerEngine interface {
 	ContainerAttach(ctx context.Context, nameOrId string, options AttachOptions) error
 	ContainerCheckpoint(ctx context.Context, namesOrIds []string, options CheckpointOptions) ([]*CheckpointReport, error)
+	ContainerCleanup(ctx context.Context, namesOrIds []string, options ContainerCleanupOptions) ([]*ContainerCleanupReport, error)
 	ContainerCommit(ctx context.Context, nameOrId string, options CommitOptions) (*CommitReport, error)
 	ContainerCreate(ctx context.Context, s *specgen.SpecGenerator) (*ContainerCreateReport, error)
 	ContainerDiff(ctx context.Context, nameOrId string, options DiffOptions) (*DiffReport, error)

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/image/v5/manifest"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/image"
 	libpodImage "github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/domain/entities"
@@ -27,10 +28,11 @@ import (
 )
 
 func (ir *ImageEngine) Exists(_ context.Context, nameOrId string) (*entities.BoolReport, error) {
-	if _, err := ir.Libpod.ImageRuntime().NewFromLocal(nameOrId); err != nil {
-		return &entities.BoolReport{}, nil
+	_, err := ir.Libpod.ImageRuntime().NewFromLocal(nameOrId)
+	if err != nil && errors.Cause(err) != define.ErrNoSuchImage {
+		return nil, err
 	}
-	return &entities.BoolReport{Value: true}, nil
+	return &entities.BoolReport{Value: err == nil}, nil
 }
 
 func (ir *ImageEngine) Delete(ctx context.Context, nameOrId []string, opts entities.ImageDeleteOptions) (*entities.ImageDeleteReport, error) {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -334,3 +334,7 @@ func (ic *ContainerEngine) ContainerDiff(ctx context.Context, nameOrId string, _
 	changes, err := containers.Diff(ic.ClientCxt, nameOrId)
 	return &entities.DiffReport{Changes: changes}, err
 }
+
+func (ic *ContainerEngine) ContainerCleanup(ctx context.Context, namesOrIds []string, options entities.ContainerCleanupOptions) ([]*entities.ContainerCleanupReport, error) {
+	return nil, errors.New("not implemented")
+}


### PR DESCRIPTION
add the ability to clean up after a container has attempted to run.  this is also important for podman run --rm --rmi.

also included are fixes and tweaks to various code bits to correct regressions on output.

Signed-off-by: Brent Baude <bbaude@redhat.com>