### PR TITLE
Fix invalid container path comparison for pid cgroup

### DIFF
--- a/pkg/cgroups/pids.go
+++ b/pkg/cgroups/pids.go
@@ -44,7 +44,7 @@ func (c *pidHandler) Destroy(ctr *CgroupControl) error {
 
 // Stat fills a metrics structure with usage stats for the controller
 func (c *pidHandler) Stat(ctr *CgroupControl, m *Metrics) error {
-	if ctr.path != "" {
+	if ctr.path == "" {
 		// nothing we can do to retrieve the pids.current path
 		return nil
 	}


### PR DESCRIPTION
This fixes the behavior to return nil for the PIDs cgroup if the
container path is empty.

cc @giuseppe 