### PR TITLE
podmanV2: fix nil deref

### DIFF
--- a/cmd/podmanV2/root.go
+++ b/cmd/podmanV2/root.go
@@ -71,7 +71,7 @@ func preRunE(cmd *cobra.Command, _ []string) error {
 	cmd.SetHelpTemplate(registry.HelpTemplate())
 	cmd.SetUsageTemplate(registry.UsageTemplate())
 
-	if cmd.Flag("cpu_profile").Changed {
+	if cmd.Flag("cpu-profile").Changed {
 		f, err := os.Create(registry.PodmanOptions.CpuProfile)
 		if err != nil {
 			return errors.Wrapf(err, "unable to create cpu profiling file %s",


### PR DESCRIPTION
Fix a typo when looking up a flag causing a nil deref and all commands
to fail.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>