### PR TITLE
allow filters to work when listing containers

### DIFF
--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -32,10 +32,6 @@ func ContainerExists(w http.ResponseWriter, r *http.Request) {
 }
 
 func ListContainers(w http.ResponseWriter, r *http.Request) {
-	var (
-	//filterFuncs []libpod.ContainerFilter
-	//pss []entities.ListContainer
-	)
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
 		All       bool                `schema:"all"`
@@ -54,10 +50,10 @@ func ListContainers(w http.ResponseWriter, r *http.Request) {
 			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
 		return
 	}
-
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	opts := entities.ContainerListOptions{
 		All:       query.All,
+		Filters:   query.Filters,
 		Last:      query.Last,
 		Size:      query.Size,
 		Sort:      "",


### PR DESCRIPTION
enable filters when listing containers on the libpod endpoint.

Fixes: #5841

Signed-off-by: Brent Baude <bbaude@redhat.com>