### PR TITLE
Provide a json variable pointing to a configured json API

### DIFF
--- a/cmd/podman/common/default.go
+++ b/cmd/podman/common/default.go
@@ -1,5 +1,9 @@
 package common
 
+import (
+	"github.com/containers/libpod/cmd/podman/registry"
+)
+
 var (
 	// DefaultHealthCheckInterval default value
 	DefaultHealthCheckInterval = "30s"
@@ -11,4 +15,6 @@ var (
 	DefaultHealthCheckTimeout = "30s"
 	// DefaultImageVolume default value
 	DefaultImageVolume = "bind"
+	// Pull in configured json library
+	json = registry.JsonLibrary()
 )

--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"

--- a/cmd/podman/containers/container.go
+++ b/cmd/podman/containers/container.go
@@ -8,6 +8,9 @@ import (
 )
 
 var (
+	// Pull in configured json library
+	json = registry.JsonLibrary()
+
 	// Command: podman _container_
 	containerCmd = &cobra.Command{
 		Use:              "container",

--- a/cmd/podman/containers/inspect.go
+++ b/cmd/podman/containers/inspect.go
@@ -11,7 +11,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/registry"
 
 	"github.com/containers/libpod/pkg/domain/entities"
-	json "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"text/tabwriter"

--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"sort"

--- a/cmd/podman/images/history.go
+++ b/cmd/podman/images/history.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/registry"
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/docker/go-units"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -77,7 +76,6 @@ func history(cmd *cobra.Command, args []string) error {
 				layers[i].ImageHistoryLayer = l
 				layers[i].Created = l.Created.Format(time.RFC3339)
 			}
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			enc := json.NewEncoder(os.Stdout)
 			err = enc.Encode(layers)
 		}

--- a/cmd/podman/images/image.go
+++ b/cmd/podman/images/image.go
@@ -7,6 +7,9 @@ import (
 )
 
 var (
+	// Pull in configured json library
+	json = registry.JsonLibrary()
+
 	// Command: podman _image_
 	imageCmd = &cobra.Command{
 		Use:              "image",

--- a/cmd/podman/images/inspect.go
+++ b/cmd/podman/images/inspect.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"

--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containers/libpod/cmd/podman/registry"
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/docker/go-units"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -127,7 +126,6 @@ func writeJSON(imageS []*entities.ImageSummary) error {
 		imgs = append(imgs, h)
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	enc := json.NewEncoder(os.Stdout)
 	return enc.Encode(imgs)
 }

--- a/cmd/podman/pods/inspect.go
+++ b/cmd/podman/pods/inspect.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/registry"
 	"github.com/containers/libpod/pkg/domain/entities"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -55,7 +54,7 @@ func inspect(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	b, err := jsoniter.MarshalIndent(responses, "", "  ")
+	b, err := json.MarshalIndent(responses, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/pods/pod.go
+++ b/cmd/podman/pods/pod.go
@@ -8,6 +8,9 @@ import (
 )
 
 var (
+	// Pull in configured json library
+	json = registry.JsonLibrary()
+
 	// Command: podman _pod_
 	podCmd = &cobra.Command{
 		Use:              "pod",

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -2,7 +2,6 @@ package pods
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -11,10 +10,9 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/docker/go-units"
-
 	"github.com/containers/libpod/cmd/podman/registry"
 	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )

--- a/cmd/podman/registry/json.go
+++ b/cmd/podman/registry/json.go
@@ -1,0 +1,20 @@
+package registry
+
+import (
+	"sync"
+
+	jsoniter "github.com/json-iterator/go"
+)
+
+var (
+	json     jsoniter.API
+	jsonSync sync.Once
+)
+
+// JsonLibrary provides a "encoding/json" compatible API
+func JsonLibrary() jsoniter.API {
+	jsonSync.Do(func() {
+		json = jsoniter.ConfigCompatibleWithStandardLibrary
+	})
+	return json
+}

--- a/cmd/podman/report/diff.go
+++ b/cmd/podman/report/diff.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/containers/storage/pkg/archive"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 )
 
@@ -31,7 +30,7 @@ func ChangesToJSON(diffs *entities.DiffReport) error {
 		}
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	// Pull in configured json library
 	enc := json.NewEncoder(os.Stdout)
 	return enc.Encode(body)
 }

--- a/cmd/podman/report/report.go
+++ b/cmd/podman/report/report.go
@@ -1,0 +1,6 @@
+package report
+
+import "github.com/containers/libpod/cmd/podman/registry"
+
+// Pull in configured json library
+var json = registry.JsonLibrary()

--- a/cmd/podman/system/info.go
+++ b/cmd/podman/system/info.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"text/template"

--- a/cmd/podman/system/system.go
+++ b/cmd/podman/system/system.go
@@ -7,6 +7,9 @@ import (
 )
 
 var (
+	// Pull in configured json library
+	json = registry.JsonLibrary()
+
 	// Command: podman _system_
 	systemCmd = &cobra.Command{
 		Use:              "system",

--- a/cmd/podman/volumes/inspect.go
+++ b/cmd/podman/volumes/inspect.go
@@ -1,7 +1,6 @@
 package volumes
 
 import (
-	"encoding/json"
 	"fmt"
 	"html/template"
 	"os"

--- a/cmd/podman/volumes/volume.go
+++ b/cmd/podman/volumes/volume.go
@@ -7,6 +7,9 @@ import (
 )
 
 var (
+	// Pull in configured json library
+	json = registry.JsonLibrary()
+
 	// Command: podman _volume_
 	volumeCmd = &cobra.Command{
 		Use:              "volume",


### PR DESCRIPTION
* All commands now using the same instance of json API
* `json` variable created in each package to prevent `encoding/json`
  from being re-introduced

Signed-off-by: Jhon Honce <jhonce@redhat.com>