### PR TITLE
podman rmi: refactor logic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
     - misspell
     - prealloc
     - unparam
+    - nakedret
 linters-settings:
   errcheck:
     check-blank: false

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -122,7 +122,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	if runRmi {
-		_, err := registry.ImageEngine().Delete(registry.GetContext(), []string{args[0]}, entities.ImageDeleteOptions{})
+		_, err := registry.ImageEngine().Remove(registry.GetContext(), []string{args[0]}, entities.ImageRemoveOptions{})
 		if err != nil {
 			logrus.Errorf("%s", errors.Wrapf(err, "failed removing image"))
 		}

--- a/cmd/podman/system/service.go
+++ b/cmd/podman/system/service.go
@@ -90,7 +90,8 @@ func service(cmd *cobra.Command, args []string) error {
 
 	logrus.Warn("This function is EXPERIMENTAL")
 	fmt.Fprintf(os.Stderr, "This function is EXPERIMENTAL.\n")
-	return registry.ContainerEngine().RestService(registry.GetContext(), opts)
+
+	return restService(opts, cmd.Flags(), registry.PodmanConfig())
 }
 
 func resolveApiURI(_url []string) (string, error) {

--- a/cmd/podman/system/service_abi.go
+++ b/cmd/podman/system/service_abi.go
@@ -1,0 +1,57 @@
+// +build ABISupport
+
+package system
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	api "github.com/containers/libpod/pkg/api/server"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/containers/libpod/pkg/domain/infra"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+)
+
+func restService(opts entities.ServiceOptions, flags *pflag.FlagSet, cfg *entities.PodmanConfig) error {
+	var (
+		listener *net.Listener
+		err      error
+	)
+
+	if opts.URI != "" {
+		fields := strings.Split(opts.URI, ":")
+		if len(fields) == 1 {
+			return errors.Errorf("%s is an invalid socket destination", opts.URI)
+		}
+		address := strings.Join(fields[1:], ":")
+		l, err := net.Listen(fields[0], address)
+		if err != nil {
+			return errors.Wrapf(err, "unable to create socket %s", opts.URI)
+		}
+		listener = &l
+	}
+
+	rt, err := infra.GetRuntime(context.Background(), flags, cfg)
+	if err != nil {
+		return err
+	}
+
+	server, err := api.NewServerWithSettings(rt, opts.Timeout, listener)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := server.Shutdown(); err != nil {
+			logrus.Warnf("Error when stopping API service: %s", err)
+		}
+	}()
+
+	err = server.Serve()
+	if listener != nil {
+		_ = (*listener).Close()
+	}
+	return err
+}

--- a/cmd/podman/system/service_unsupported.go
+++ b/cmd/podman/system/service_unsupported.go
@@ -1,0 +1,14 @@
+// +build !ABISupport
+
+package system
+
+import (
+	"errors"
+
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/spf13/pflag"
+)
+
+func restService(opts entities.ServiceOptions, flags *pflag.FlagSet, cfg *entities.PodmanConfig) error {
+	return errors.New("not supported")
+}

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -3,13 +3,22 @@
 # Need to run linter twice to cover all the build tags code paths
 
 declare -A BUILD_TAGS
+# TODO: add systemd tag
 BUILD_TAGS[default]="apparmor,seccomp,selinux"
 BUILD_TAGS[abi]="${BUILD_TAGS[default]},ABISupport,varlink,!remoteclient"
-BUILD_TAGS[tunnel]="${BUILD_TAGS[default]},!ABISupport,!varlink,remoteclient"
+BUILD_TAGS[tunnel]="${BUILD_TAGS[default]},!ABISupport,varlink,remoteclient"
+
+declare -A SKIP_DIRS
+SKIP_DIRS[abi]=""
+# TODO: add "ABISupport" build tag to pkg/api
+SKIP_DIRS[tunnel]="pkg/api"
 
 [[ $1 == run ]] && shift
 
 for i in tunnel abi; do
-  echo Build Tags: ${BUILD_TAGS[$i]}
-  golangci-lint run --build-tags=${BUILD_TAGS[$i]} "$@"
+  echo ""
+  echo Running golangci-lint for "$i"
+  echo Build Tags          "$i": ${BUILD_TAGS[$i]}
+  echo Skipped directories "$i": ${SKIP_DIRS[$i]}
+  golangci-lint run --build-tags=${BUILD_TAGS[$i]} --skip-dirs=${SKIP_DIRS[$i]} "$@"
 done

--- a/pkg/api/handlers/compat/events.go
+++ b/pkg/api/handlers/compat/events.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/libpod/events"
-	"github.com/containers/libpod/pkg/api/handlers"
 	"github.com/containers/libpod/pkg/api/handlers/utils"
+	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/gorilla/schema"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -70,7 +70,7 @@ func GetEvents(w http.ResponseWriter, r *http.Request) {
 	coder.SetEscapeHTML(true)
 
 	for event := range eventChannel {
-		e := handlers.EventToApiEvent(event)
+		e := entities.ConvertToEntitiesEvent(*event)
 		if err := coder.Encode(e); err != nil {
 			logrus.Errorf("unable to write json: %q", err)
 		}

--- a/pkg/api/handlers/swagger/swagger.go
+++ b/pkg/api/handlers/swagger/swagger.go
@@ -49,6 +49,13 @@ type swagLibpodImagesPullResponse struct {
 	Body handlers.LibpodImagesPullReport
 }
 
+// Remove response
+// swagger:response DocsLibpodImagesRemoveResponse
+type swagLibpodImagesRemoveResponse struct {
+	// in:body
+	Body handlers.LibpodImagesRemoveReport
+}
+
 // Delete response
 // swagger:response DocsImageDeleteResponse
 type swagImageDeleteResponse struct {

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -822,6 +822,38 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/import"), s.APIHandler(libpod.ImagesImport)).Methods(http.MethodPost)
+	// swagger:operation GET /libpod/images/remove libpod libpodImagesRemove
+	// ---
+	// tags:
+	//  - images
+	// summary: Remove one or more images from the storage.
+	// description: Remove one or more images from the storage.
+	// parameters:
+	//   - in: query
+	//     name: images
+	//     description: Images IDs or names to remove.
+	//     type: array
+	//     items:
+	//        type: string
+	//   - in: query
+	//     name: all
+	//     description: Remove all images.
+	//     type: boolean
+	//     default: true
+	//   - in: query
+	//     name: force
+	//     description: Force image removal (including containers using the images).
+	//     type: boolean
+	// produces:
+	// - application/json
+	// responses:
+	//   200:
+	//     $ref: "#/responses/DocsLibpodImagesRemoveResponse"
+	//   400:
+	//     $ref: "#/responses/BadParamError"
+	//   500:
+	//     $ref: '#/responses/InternalError'
+	r.Handle(VersionedPath("/libpod/images/remove"), s.APIHandler(libpod.ImagesRemove)).Methods(http.MethodGet)
 	// swagger:operation POST /libpod/images/pull libpod libpodImagesPull
 	// ---
 	// tags:

--- a/pkg/api/types/types.go
+++ b/pkg/api/types/types.go
@@ -1,0 +1,9 @@
+package types
+
+const (
+	// DefaultAPIVersion is the version of the API the server defaults to.
+	DefaultAPIVersion = "1.40" // See https://docs.docker.com/engine/api/v1.40/
+
+	// DefaultAPIVersion is the minimal required version of the API.
+	MinimalAPIVersion = "1.24"
+)

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containers/libpod/pkg/api/handlers"
+	"github.com/containers/libpod/pkg/api/types"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -27,7 +27,7 @@ var (
 	basePath = &url.URL{
 		Scheme: "http",
 		Host:   "d",
-		Path:   "/v" + handlers.MinimalApiVersion + "/libpod",
+		Path:   "/v" + types.MinimalAPIVersion + "/libpod",
 	}
 )
 

--- a/pkg/bindings/system/system.go
+++ b/pkg/bindings/system/system.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/containers/libpod/pkg/api/handlers"
 	"github.com/containers/libpod/pkg/bindings"
+	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -16,7 +16,7 @@ import (
 // Events allows you to monitor libdpod related events like container creation and
 // removal.  The events are then passed to the eventChan provided. The optional cancelChan
 // can be used to cancel the read of events and close down the HTTP connection.
-func Events(ctx context.Context, eventChan chan (handlers.Event), cancelChan chan bool, since, until *string, filters map[string][]string) error {
+func Events(ctx context.Context, eventChan chan (entities.Event), cancelChan chan bool, since, until *string, filters map[string][]string) error {
 	conn, err := bindings.GetClient(ctx)
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func Events(ctx context.Context, eventChan chan (handlers.Event), cancelChan cha
 	}
 	dec := json.NewDecoder(response.Body)
 	for {
-		e := handlers.Event{}
+		e := entities.Event{}
 		if err := dec.Decode(&e); err != nil {
 			if err == io.EOF {
 				break

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -54,7 +54,6 @@ type ContainerEngine interface {
 	PodStop(ctx context.Context, namesOrIds []string, options PodStopOptions) ([]*PodStopReport, error)
 	PodTop(ctx context.Context, options PodTopOptions) (*StringSliceReport, error)
 	PodUnpause(ctx context.Context, namesOrIds []string, options PodunpauseOptions) ([]*PodUnpauseReport, error)
-	RestService(ctx context.Context, opts ServiceOptions) error
 	SetupRootless(ctx context.Context, cmd *cobra.Command) error
 	VarlinkService(ctx context.Context, opts ServiceOptions) error
 	VolumeCreate(ctx context.Context, opts VolumeCreateOptions) (*IdOrNameResponse, error)

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -9,7 +9,6 @@ import (
 type ImageEngine interface {
 	Build(ctx context.Context, containerFiles []string, opts BuildOptions) (*BuildReport, error)
 	Config(ctx context.Context) (*config.Config, error)
-	Delete(ctx context.Context, nameOrId []string, opts ImageDeleteOptions) (*ImageDeleteReport, error)
 	Diff(ctx context.Context, nameOrId string, options DiffOptions) (*DiffReport, error)
 	Exists(ctx context.Context, nameOrId string) (*BoolReport, error)
 	History(ctx context.Context, nameOrId string, opts ImageHistoryOptions) (*ImageHistoryReport, error)
@@ -20,6 +19,7 @@ type ImageEngine interface {
 	Prune(ctx context.Context, opts ImagePruneOptions) (*ImagePruneReport, error)
 	Pull(ctx context.Context, rawImage string, opts ImagePullOptions) (*ImagePullReport, error)
 	Push(ctx context.Context, source string, destination string, opts ImagePushOptions) error
+	Remove(ctx context.Context, images []string, opts ImageRemoveOptions) (*ImageRemoveReport, error)
 	Save(ctx context.Context, nameOrId string, tags []string, options ImageSaveOptions) error
 	Search(ctx context.Context, term string, opts ImageSearchOptions) ([]ImageSearchReport, error)
 	Tag(ctx context.Context, nameOrId string, tags []string, options ImageTagOptions) error

--- a/pkg/domain/entities/events.go
+++ b/pkg/domain/entities/events.go
@@ -1,0 +1,61 @@
+package entities
+
+import (
+	"strconv"
+	"time"
+
+	libpodEvents "github.com/containers/libpod/libpod/events"
+	dockerEvents "github.com/docker/docker/api/types/events"
+)
+
+// Event combines various event-related data such as time, event type, status
+// and more.
+type Event struct {
+	// TODO: it would be nice to have full control over the types at some
+	// point and fork such Docker types.
+	dockerEvents.Message
+}
+
+// ConvertToLibpodEvent converts an entities event to a libpod one.
+func ConvertToLibpodEvent(e Event) *libpodEvents.Event {
+	exitCode, err := strconv.Atoi(e.Actor.Attributes["containerExitCode"])
+	if err != nil {
+		return nil
+	}
+	status, err := libpodEvents.StringToStatus(e.Action)
+	if err != nil {
+		return nil
+	}
+	t, err := libpodEvents.StringToType(e.Type)
+	if err != nil {
+		return nil
+	}
+	return &libpodEvents.Event{
+		ContainerExitCode: exitCode,
+		ID:                e.Actor.ID,
+		Image:             e.Actor.Attributes["image"],
+		Name:              e.Actor.Attributes["name"],
+		Status:            status,
+		Time:              time.Unix(e.Time, e.TimeNano),
+		Type:              t,
+	}
+}
+
+// ConvertToEntitiesEvent converts a libpod event to an entities one.
+func ConvertToEntitiesEvent(e libpodEvents.Event) *Event {
+	return &Event{dockerEvents.Message{
+		Type:   e.Type.String(),
+		Action: e.Status.String(),
+		Actor: dockerEvents.Actor{
+			ID: e.ID,
+			Attributes: map[string]string{
+				"image":             e.Image,
+				"name":              e.Name,
+				"containerExitCode": strconv.Itoa(e.ContainerExitCode),
+			},
+		},
+		Scope:    "local",
+		Time:     e.Time.Unix(),
+		TimeNano: e.Time.UnixNano(),
+	}}
+}

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -82,19 +82,24 @@ func (i *ImageSummary) IsDangling() bool {
 	return i.Dangling
 }
 
-type ImageDeleteOptions struct {
-	All   bool
+// ImageRemoveOptions can be used to alter image removal.
+type ImageRemoveOptions struct {
+	// All will remove all images.
+	All bool
+	// Foce will force image removal including containers using the images.
 	Force bool
 }
 
-// ImageDeleteResponse is the response for removing one or more image(s) from storage
-// and containers what was untagged vs actually removed
-type ImageDeleteReport struct {
-	Untagged      []string `json:",omitempty"`
-	Deleted       []string `json:",omitempty"`
-	Errors        []error
-	ImageNotFound error
-	ImageInUse    error
+// ImageRemoveResponse is the response for removing one or more image(s) from storage
+// and containers what was untagged vs actually removed.
+type ImageRemoveReport struct {
+	// Deleted images.
+	Deleted []string `json:",omitempty"`
+	// Untagged images. Can be longer than Deleted.
+	Untagged []string `json:",omitempty"`
+	// ExitCode describes the exit codes as described in the `podman rmi`
+	// man page.
+	ExitCode int
 }
 
 type ImageHistoryOptions struct{}

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1,5 +1,3 @@
-// +build ABISupport
-
 package abi
 
 import (

--- a/pkg/domain/infra/abi/events.go
+++ b/pkg/domain/infra/abi/events.go
@@ -1,5 +1,3 @@
-//+build ABISupport
-
 package abi
 
 import (

--- a/pkg/domain/infra/abi/healthcheck.go
+++ b/pkg/domain/infra/abi/healthcheck.go
@@ -1,5 +1,3 @@
-// +build ABISupport
-
 package abi
 
 import (

--- a/pkg/domain/infra/abi/images_list.go
+++ b/pkg/domain/infra/abi/images_list.go
@@ -1,5 +1,3 @@
-// +build ABISupport
-
 package abi
 
 import (

--- a/pkg/domain/infra/abi/pods.go
+++ b/pkg/domain/infra/abi/pods.go
@@ -1,5 +1,3 @@
-// +build ABISupport
-
 package abi
 
 import (

--- a/pkg/domain/infra/abi/runtime.go
+++ b/pkg/domain/infra/abi/runtime.go
@@ -1,5 +1,3 @@
-// +build ABISupport
-
 package abi
 
 import (

--- a/pkg/domain/infra/abi/terminal/sigproxy_linux.go
+++ b/pkg/domain/infra/abi/terminal/sigproxy_linux.go
@@ -1,5 +1,3 @@
-// +build ABISupport
-
 package terminal
 
 import (

--- a/pkg/domain/infra/abi/terminal/terminal.go
+++ b/pkg/domain/infra/abi/terminal/terminal.go
@@ -1,5 +1,3 @@
-// +build ABISupport
-
 package terminal
 
 import (

--- a/pkg/domain/infra/abi/terminal/terminal_linux.go
+++ b/pkg/domain/infra/abi/terminal/terminal_linux.go
@@ -1,5 +1,3 @@
-// +build ABISupport
-
 package terminal
 
 import (

--- a/pkg/domain/infra/tunnel/events.go
+++ b/pkg/domain/infra/tunnel/events.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/containers/libpod/pkg/api/handlers"
 	"github.com/containers/libpod/pkg/bindings/system"
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/pkg/errors"
@@ -21,10 +20,10 @@ func (ic *ContainerEngine) Events(ctx context.Context, opts entities.EventsOptio
 			filters[split[0]] = append(filters[split[0]], strings.Join(split[1:], "="))
 		}
 	}
-	binChan := make(chan handlers.Event)
+	binChan := make(chan entities.Event)
 	go func() {
 		for e := range binChan {
-			opts.EventChan <- e.ToLibpodEvent()
+			opts.EventChan <- entities.ConvertToLibpodEvent(e)
 		}
 	}()
 	return system.Events(ic.ClientCxt, binChan, nil, &opts.Since, &opts.Until, filters)

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -19,25 +19,8 @@ func (ir *ImageEngine) Exists(_ context.Context, nameOrId string) (*entities.Boo
 	return &entities.BoolReport{Value: found}, err
 }
 
-func (ir *ImageEngine) Delete(ctx context.Context, nameOrId []string, opts entities.ImageDeleteOptions) (*entities.ImageDeleteReport, error) {
-	report := entities.ImageDeleteReport{}
-
-	for _, id := range nameOrId {
-		results, err := images.Remove(ir.ClientCxt, id, &opts.Force)
-		if err != nil {
-			return nil, err
-		}
-		for _, e := range results {
-			if a, ok := e["Deleted"]; ok {
-				report.Deleted = append(report.Deleted, a)
-			}
-
-			if a, ok := e["Untagged"]; ok {
-				report.Untagged = append(report.Untagged, a)
-			}
-		}
-	}
-	return &report, nil
+func (ir *ImageEngine) Remove(ctx context.Context, imagesArg []string, opts entities.ImageRemoveOptions) (*entities.ImageRemoveReport, error) {
+	return images.Remove(ir.ClientCxt, imagesArg, opts)
 }
 
 func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions) ([]*entities.ImageSummary, error) {

--- a/pkg/domain/infra/tunnel/system.go
+++ b/pkg/domain/infra/tunnel/system.go
@@ -14,10 +14,6 @@ func (ic *ContainerEngine) Info(ctx context.Context) (*define.Info, error) {
 	return system.Info(ic.ClientCxt)
 }
 
-func (ic *ContainerEngine) RestService(_ context.Context, _ entities.ServiceOptions) error {
-	panic(errors.New("rest service is not supported when tunneling"))
-}
-
 func (ic *ContainerEngine) VarlinkService(_ context.Context, _ entities.ServiceOptions) error {
 	panic(errors.New("varlink service is not supported when tunneling"))
 }


### PR DESCRIPTION
While this commit was initially meant to fix #5847, it has turned into a
bigger refactoring which I did not manage to break into smaller pieces:

 * Fix #5847 by refactoring the image-removal logic.

 * Make the api handler for image-removal use the ABI code. This way,
   both (i.e., ABI and Tunnel) end up using the same code.  Achieving
   this code share required to move some code around to prevent circular
   dependencies.

 * Everything in pkg/api (excluding pkg/api/types) must now only be
   accessed from code using `ABISupport`.

 * Avoid imports from entities on handlers to prevent circular
   dependencies.

 * Move `podman system service` logic into `cmd` to prevent circular
   dependencies - it depends on pkg/api.

Fixes: #5847
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>