### PR TITLE
V2 Fix support for tcp://[::]<port> connections

### DIFF
--- a/cmd/podman/system/service.go
+++ b/cmd/podman/system/service.go
@@ -57,7 +57,7 @@ func service(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	logrus.Infof("using API endpoint: \"%s\"", apiURI)
+	logrus.Infof("using API endpoint: '%s'", apiURI)
 
 	opts := entities.ServiceOptions{
 		URI:     apiURI,
@@ -75,7 +75,6 @@ func service(cmd *cobra.Command, args []string) error {
 }
 
 func resolveApiURI(_url []string) (string, error) {
-
 	// When determining _*THE*_ listening endpoint --
 	// 1) User input wins always
 	// 2) systemd socket activation
@@ -83,14 +82,15 @@ func resolveApiURI(_url []string) (string, error) {
 	// 4) if varlink -- adapter.DefaultVarlinkAddress
 	// 5) lastly adapter.DefaultAPIAddress
 
-	if _url == nil {
+	if len(_url) == 0 {
 		if v, found := os.LookupEnv("PODMAN_SOCKET"); found {
+			logrus.Debugf("PODMAN_SOCKET='%s' used to determine API endpoint", v)
 			_url = []string{v}
 		}
 	}
 
 	switch {
-	case len(_url) > 0:
+	case len(_url) > 0 && _url[0] != "":
 		return _url[0], nil
 	case systemd.SocketActivated():
 		logrus.Info("using systemd socket activation to determine API endpoint")

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -51,7 +51,7 @@ func NewServerWithSettings(runtime *libpod.Runtime, duration time.Duration, list
 func newServer(runtime *libpod.Runtime, duration time.Duration, listener *net.Listener) (*APIServer, error) {
 	// If listener not provided try socket activation protocol
 	if listener == nil {
-		if _, found := os.LookupEnv("LISTEN_FDS"); !found {
+		if _, found := os.LookupEnv("LISTEN_PID"); !found {
 			return nil, errors.Errorf("Cannot create API Server, no listener provided and socket activation protocol is not active.")
 		}
 
@@ -125,7 +125,7 @@ func newServer(runtime *libpod.Runtime, duration time.Duration, listener *net.Li
 			if err != nil {
 				methods = []string{"<N/A>"}
 			}
-			logrus.Debugf("Methods: %s Path: %s", strings.Join(methods, ", "), path)
+			logrus.Debugf("Methods: %6s Path: %s", strings.Join(methods, ", "), path)
 			return nil
 		})
 	}
@@ -179,6 +179,7 @@ func (s *APIServer) Shutdown() error {
 	}
 
 	// Gracefully shutdown server, duration of wait same as idle window
+	// TODO: Should we really wait the idle window for shutdown?
 	ctx, cancel := context.WithTimeout(context.Background(), s.idleTracker.Duration)
 	defer cancel()
 	go func() {

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -126,7 +126,7 @@ func tcpClient(_url *url.URL) (*http.Client, error) {
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("tcp", _url.Path)
+				return net.Dial("tcp", _url.Host)
 			},
 			DisableCompression: true,
 		},


### PR DESCRIPTION
* Fix support for socket activation, on remote and service

$ systemd-socket-activate -l 8083 --fdname=podman bin/podman system service --log-level=debug --time=30
$ bin/podman-remote --remote=tcp://[::]:8083 image ls

Or, use the podman.{socket,service} unit files

$ bin/podman-remote --remote=unix:///run/podman/podman.sock image ls

Signed-off-by: Jhon Honce <jhonce@redhat.com>