### PR TITLE
Make `find` ignore dot files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ PKG_MANAGER ?= $(shell command -v dnf yum|head -n1)
 # ~/.local/bin is not in PATH on all systems
 PRE_COMMIT = $(shell command -v bin/venv/bin/pre-commit ~/.local/bin/pre-commit pre-commit | head -n1)
 
-SOURCES = $(shell find . -name "*.go")
+SOURCES = $(shell find . -path './.*' -prune -o -name "*.go")
 
 GO_BUILD=$(GO) build
 # Go module support: set `-mod=vendor` to use the vendored sources


### PR DESCRIPTION
There is no need to search for sources in hidden dirs. In my case
there are some development environment files that stand in the way.