### PR TITLE
Return labes in API (fixes #5882)

### DIFF
--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -311,7 +311,7 @@ func ImageDataToImageInspect(ctx context.Context, l *libpodImage.Image) (*ImageI
 		//	NetworkDisabled: false,
 		//	MacAddress:      "",
 		//	OnBuild:         nil,
-		//	Labels:          nil,
+		Labels: info.Labels,
 		//	StopSignal:      "",
 		//	StopTimeout:     nil,
 		//	Shell:           nil,


### PR DESCRIPTION
I couldn't test it yet. The main **why** about the code is the what is the difference between `info.Labels` and `info.Config.Labels`?