### PR TITLE
V2 podman image tree

### DIFF
--- a/cmd/podman/images/tree.go
+++ b/cmd/podman/images/tree.go
@@ -1,0 +1,40 @@
+package images
+
+import (
+	"fmt"
+
+	"github.com/containers/libpod/cmd/podman/registry"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/spf13/cobra"
+)
+
+var (
+	treeDescription = "Prints layer hierarchy of an image in a tree format"
+	treeCmd         = &cobra.Command{
+		Use:     "tree [flags] IMAGE",
+		Args:    cobra.ExactArgs(1),
+		Short:   treeDescription,
+		Long:    treeDescription,
+		RunE:    tree,
+		Example: "podman image tree alpine:latest",
+	}
+	treeOpts entities.ImageTreeOptions
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: treeCmd,
+		Parent:  imageCmd,
+	})
+	treeCmd.Flags().BoolVar(&treeOpts.WhatRequires, "whatrequires", false, "Show all child images and layers of the specified image")
+}
+
+func tree(_ *cobra.Command, args []string) error {
+	results, err := registry.ImageEngine().Tree(registry.Context(), args[0], treeOpts)
+	if err != nil {
+		return err
+	}
+	fmt.Println(results.Tree)
+	return nil
+}

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -74,7 +74,7 @@ func GetImage(ctx context.Context, nameOrID string, size *bool) (*entities.Image
 	return &inspectedData, response.Process(&inspectedData)
 }
 
-func ImageTree(ctx context.Context, nameOrId string) error {
+func Tree(ctx context.Context, nameOrId string) error {
 	return bindings.ErrNotImplemented
 }
 

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -23,5 +23,6 @@ type ImageEngine interface {
 	Save(ctx context.Context, nameOrId string, tags []string, options ImageSaveOptions) error
 	Search(ctx context.Context, term string, opts ImageSearchOptions) ([]ImageSearchReport, error)
 	Tag(ctx context.Context, nameOrId string, tags []string, options ImageTagOptions) error
+	Tree(ctx context.Context, nameOrId string, options ImageTreeOptions) (*ImageTreeReport, error)
 	Untag(ctx context.Context, nameOrId string, tags []string, options ImageUntagOptions) error
 }

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -273,3 +273,13 @@ type ImageSaveOptions struct {
 	Output   string
 	Quiet    bool
 }
+
+// ImageTreeOptions provides options for ImageEngine.Tree()
+type ImageTreeOptions struct {
+	WhatRequires bool // Show all child images and layers of the specified image
+}
+
+// ImageTreeReport provides results from ImageEngine.Tree()
+type ImageTreeReport struct {
+	Tree string // TODO: Refactor move presentation work out of server
+}

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -476,3 +476,15 @@ func (ir *ImageEngine) Build(ctx context.Context, containerFiles []string, opts 
 	}
 	return &entities.BuildReport{ID: id}, nil
 }
+
+func (ir *ImageEngine) Tree(ctx context.Context, nameOrId string, opts entities.ImageTreeOptions) (*entities.ImageTreeReport, error) {
+	img, err := ir.Libpod.ImageRuntime().NewFromLocal(nameOrId)
+	if err != nil {
+		return nil, err
+	}
+	results, err := img.GenerateTree(opts.WhatRequires)
+	if err != nil {
+		return nil, err
+	}
+	return &entities.ImageTreeReport{Tree: results}, nil
+}

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -263,3 +263,7 @@ func (ir *ImageEngine) Config(_ context.Context) (*config.Config, error) {
 func (ir *ImageEngine) Build(ctx context.Context, containerFiles []string, opts entities.BuildOptions) (*entities.BuildReport, error) {
 	return nil, errors.New("not implemented yet")
 }
+
+func (ir *ImageEngine) Tree(ctx context.Context, nameOrId string, opts entities.ImageTreeOptions) (*entities.ImageTreeReport, error) {
+	return nil, errors.New("not implemented yet")
+}


### PR DESCRIPTION
* Basic port of V1 podman image tree ID

TODO: Refactor to return tree from service and format in presentation
layer
TODO: Support tunneling mode

Signed-off-by: Jhon Honce <jhonce@redhat.com>