### PR TITLE
Modify namespace generation code for specgen

### DIFF
--- a/cmd/podman/common/netflags.go
+++ b/cmd/podman/common/netflags.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/parse"
 	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/containers/libpod/pkg/specgen"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -159,9 +160,13 @@ func NetFlagsToNetOptions(cmd *cobra.Command) (*entities.NetOptions, error) {
 			return nil, err
 		}
 
-		return nil, errors.Errorf("network %s is not yet supported", network)
-		// TODO How do I convert a string network to a Specgen.Namespace?
-		//		opts.Network = specgen.Namespace{NSMode: network}
+		ns, cniNets, err := specgen.ParseNetworkNamespace(network)
+		if err != nil {
+			return nil, err
+		}
+
+		opts.Network = ns
+		opts.CNINetworks = cniNets
 	}
 
 	return &opts, err

--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -86,9 +86,6 @@ func (s *SpecGenerator) Validate() error {
 	//
 	// ContainerNetworkConfig
 	//
-	if !s.NetNS.IsPrivate() && s.ConfigureNetNS {
-		return errors.New("can only configure network namespace when creating a network a network namespace")
-	}
 	// useimageresolveconf conflicts with dnsserver, dnssearch, dnsoption
 	if s.UseImageResolvConf {
 		if len(s.DNSServers) > 0 {

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -15,6 +15,7 @@ import (
 func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerator) error {
 	var appendEntryPoint bool
 
+	// TODO add support for raw rootfs
 	newImage, err := r.ImageRuntime().NewFromLocal(s.Image)
 	if err != nil {
 		return err

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -217,28 +217,7 @@ func SpecGenToOCI(s *specgen.SpecGenerator, rt *libpod.Runtime, newImage *image.
 	}
 
 	// NAMESPACES
-
-	if err := pidConfigureGenerator(s, &g); err != nil {
-		return nil, err
-	}
-
-	if err := userConfigureGenerator(s, &g); err != nil {
-		return nil, err
-	}
-
-	if err := networkConfigureGenerator(s, &g); err != nil {
-		return nil, err
-	}
-
-	if err := utsConfigureGenerator(s, &g, rt); err != nil {
-		return nil, err
-	}
-
-	if err := ipcConfigureGenerator(s, &g); err != nil {
-		return nil, err
-	}
-
-	if err := cgroupConfigureGenerator(s, &g); err != nil {
+	if err := specConfigureNamespaces(s, &g, rt); err != nil {
 		return nil, err
 	}
 	configSpec := g.Config


### PR DESCRIPTION
Namespaces have now been changed to properly handle all cases. Spec handling code for namespaces was consolidated in a single function.

Still missing:
- Image ports
- Pod namespaces likely still broken in Podmanv2 (we need to leave namespaces defaulted in the specgen unless we have a good reason not to)
