### PR TITLE
Bump to github.com/containers/common to v0.9.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containernetworking/cni v0.7.2-0.20200304161608-4fae32b84921
 	github.com/containernetworking/plugins v0.8.5
 	github.com/containers/buildah v1.14.8
-	github.com/containers/common v0.9.1
+	github.com/containers/common v0.9.2
 	github.com/containers/conmon v2.0.14+incompatible
 	github.com/containers/image/v5 v5.4.3
 	github.com/containers/psgo v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/containernetworking/plugins v0.8.5/go.mod h1:UZ2539umj8djuRQmBxuazHeJ
 github.com/containers/buildah v1.14.8 h1:JbMI0QSOmyZ30Mr2633uCXAj+Fajgh/EFS9xX/Y14oQ=
 github.com/containers/buildah v1.14.8/go.mod h1:ytEjHJQnRXC1ygXMyc0FqYkjcoCydqBQkOdxbH563QU=
 github.com/containers/common v0.8.1/go.mod h1:VxDJbaA1k6N1TNv9Rt6bQEF4hyKVHNfOfGA5L91ADEs=
-github.com/containers/common v0.9.1 h1:S5lkpnycTI29YzpNJ4RLv49g8sksgYNRNsugPmzQCR8=
-github.com/containers/common v0.9.1/go.mod h1:9YGKPwu6NFYQG2NtSP9bRhNGA8mgd1mUCCkOU2tr+Pc=
+github.com/containers/common v0.9.2 h1:TjhjKln4ShCA0a0cflsmUlHm1Bh2+oOZ5JW8pTxe0QM=
+github.com/containers/common v0.9.2/go.mod h1:9YGKPwu6NFYQG2NtSP9bRhNGA8mgd1mUCCkOU2tr+Pc=
 github.com/containers/conmon v2.0.14+incompatible h1:knU1O1QxXy5YxtjMQVKEyCajROaehizK9FHaICl+P5Y=
 github.com/containers/conmon v2.0.14+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.4.3 h1:zn2HR7uu4hpvT5QQHgjqonOzKDuM1I1UHUEmzZT5sbs=

--- a/vendor/github.com/containers/common/pkg/config/libpodConfig.go
+++ b/vendor/github.com/containers/common/pkg/config/libpodConfig.go
@@ -224,6 +224,12 @@ func newLibpodConfig(c *Config) error {
 		}
 	}
 
+	// hard code EventsLogger to "file" to match older podman versions.
+	if config.EventsLogger != "file" {
+		logrus.Debugf("Ignoring lipod.conf EventsLogger setting %q. Use containers.conf if you want to change this setting and remove libpod.conf files.", config.EventsLogger)
+		config.EventsLogger = "file"
+	}
+
 	c.libpodToContainersConfig(config)
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/containers/buildah/pkg/secrets
 github.com/containers/buildah/pkg/supplemented
 github.com/containers/buildah/pkg/umask
 github.com/containers/buildah/util
-# github.com/containers/common v0.9.1
+# github.com/containers/common v0.9.2
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/capabilities
 github.com/containers/common/pkg/cgroupv2


### PR DESCRIPTION
This allows us to fix issues with people with old libpod.conf

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>