### PR TITLE
Move selinux labeling support from pkg/util to pkg/selinux

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -19,7 +19,7 @@ import (
 	"github.com/containers/libpod/pkg/hooks"
 	"github.com/containers/libpod/pkg/hooks/exec"
 	"github.com/containers/libpod/pkg/rootless"
-	"github.com/containers/libpod/pkg/util"
+	"github.com/containers/libpod/pkg/selinux"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/mount"
@@ -435,12 +435,12 @@ func (c *Container) setupStorage(ctx context.Context) error {
 	processLabel := containerInfo.ProcessLabel
 	switch {
 	case c.ociRuntime.SupportsKVM():
-		processLabel, err = util.SELinuxKVMLabel(processLabel)
+		processLabel, err = selinux.SELinuxKVMLabel(processLabel)
 		if err != nil {
 			return err
 		}
 	case c.config.Systemd:
-		processLabel, err = util.SELinuxInitLabel(processLabel)
+		processLabel, err = selinux.SELinuxInitLabel(processLabel)
 		if err != nil {
 			return err
 		}

--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -1,0 +1,40 @@
+package selinux
+
+import (
+	"github.com/opencontainers/selinux/go-selinux"
+)
+
+// SELinuxKVMLabel returns labels for running kvm isolated containers
+func SELinuxKVMLabel(cLabel string) (string, error) {
+	if cLabel == "" {
+		// selinux is disabled
+		return "", nil
+	}
+	processLabel, _ := selinux.KVMContainerLabels()
+	selinux.ReleaseLabel(processLabel)
+	return swapSELinuxLabel(cLabel, processLabel)
+}
+
+// SELinuxInitLabel returns labels for running systemd based containers
+func SELinuxInitLabel(cLabel string) (string, error) {
+	if cLabel == "" {
+		// selinux is disabled
+		return "", nil
+	}
+	processLabel, _ := selinux.InitContainerLabels()
+	selinux.ReleaseLabel(processLabel)
+	return swapSELinuxLabel(cLabel, processLabel)
+}
+
+func swapSELinuxLabel(cLabel, processLabel string) (string, error) {
+	dcon, err := selinux.NewContext(cLabel)
+	if err != nil {
+		return "", err
+	}
+	scon, err := selinux.NewContext(processLabel)
+	if err != nil {
+		return "", err
+	}
+	dcon["type"] = scon["type"]
+	return dcon.Get(), nil
+}

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/terminal"
@@ -645,41 +644,6 @@ func ValidateSysctls(strSlice []string) (map[string]string, error) {
 		}
 	}
 	return sysctl, nil
-}
-
-// SELinuxKVMLabel returns labels for running kvm isolated containers
-func SELinuxKVMLabel(cLabel string) (string, error) {
-	if cLabel == "" {
-		// selinux is disabled
-		return "", nil
-	}
-	processLabel, _ := selinux.KVMContainerLabels()
-	selinux.ReleaseLabel(processLabel)
-	return swapSELinuxLabel(cLabel, processLabel)
-}
-
-// SELinuxInitLabel returns labels for running systemd based containers
-func SELinuxInitLabel(cLabel string) (string, error) {
-	if cLabel == "" {
-		// selinux is disabled
-		return "", nil
-	}
-	processLabel, _ := selinux.InitContainerLabels()
-	selinux.ReleaseLabel(processLabel)
-	return swapSELinuxLabel(cLabel, processLabel)
-}
-
-func swapSELinuxLabel(cLabel, processLabel string) (string, error) {
-	dcon, err := selinux.NewContext(cLabel)
-	if err != nil {
-		return "", err
-	}
-	scon, err := selinux.NewContext(processLabel)
-	if err != nil {
-		return "", err
-	}
-	dcon["type"] = scon["type"]
-	return dcon.Get(), nil
 }
 
 func DefaultContainerConfig() *config.Config {


### PR DESCRIPTION
The goal here is to make the package less heavy and not overload
the pkg/util.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>