### PR TITLE
Move selinux labeling support from pkg/util to pkg/selinux

### DIFF
--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"github.com/opencontainers/selinux/go-selinux"
+)
+
+// SELinuxKVMLabel returns labels for running kvm isolated containers
+func SELinuxKVMLabel(cLabel string) (string, error) {
+	if cLabel == "" {
+		// selinux is disabled
+		return "", nil
+	}
+	processLabel, _ := selinux.KVMContainerLabels()
+	selinux.ReleaseLabel(processLabel)
+	return swapSELinuxLabel(cLabel, processLabel)
+}
+
+// SELinuxInitLabel returns labels for running systemd based containers
+func SELinuxInitLabel(cLabel string) (string, error) {
+	if cLabel == "" {
+		// selinux is disabled
+		return "", nil
+	}
+	processLabel, _ := selinux.InitContainerLabels()
+	selinux.ReleaseLabel(processLabel)
+	return swapSELinuxLabel(cLabel, processLabel)
+}
+
+func swapSELinuxLabel(cLabel, processLabel string) (string, error) {
+	dcon, err := selinux.NewContext(cLabel)
+	if err != nil {
+		return "", err
+	}
+	scon, err := selinux.NewContext(processLabel)
+	if err != nil {
+		return "", err
+	}
+	dcon["type"] = scon["type"]
+	return dcon.Get(), nil
+}


### PR DESCRIPTION
The goal here is to make the package less heavy and not overload
the pkg/util.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>