### PR TITLE
Fix handling of --cidfile on create/run

### DIFF
--- a/test/e2e/stop_test.go
+++ b/test/e2e/stop_test.go
@@ -18,7 +18,6 @@ var _ = Describe("Podman stop", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
Currently create and run are ignoring the cidfile flag.

Enable stop_test.go to make sure this works.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>