### PR TITLE
Fix podman rm to have correct exit codes

### DIFF
--- a/test/e2e/rm_test.go
+++ b/test/e2e/rm_test.go
@@ -17,7 +17,6 @@ var _ = Describe("Podman rm", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
If you attempt to remove a running container is it supposed to exit with
2
If you attempt to remove a non existing container is is supposed to exit with
1

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>