### PR TITLE
Fix podman push and podman pull to check for authfile

### DIFF
--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -2,11 +2,13 @@ package images
 
 import (
 	"fmt"
+	"os"
 
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/libpod/cmd/podman/registry"
 	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -98,6 +100,11 @@ func imagePull(cmd *cobra.Command, args []string) error {
 	// boolean CLI flags.
 	if cmd.Flags().Changed("tls-verify") {
 		pullOptsAPI.TLSVerify = types.NewOptionalBool(pullOptions.TLSVerifyCLI)
+	}
+	if pullOptsAPI.Authfile != "" {
+		if _, err := os.Stat(pullOptsAPI.Authfile); err != nil {
+			return errors.Wrapf(err, "error getting authfile %s", pullOptsAPI.Authfile)
+		}
 	}
 
 	// Let's do all the remaining Yoga in the API to prevent us from

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -1,6 +1,8 @@
 package images
 
 import (
+	"os"
+
 	buildahcli "github.com/containers/buildah/pkg/cli"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/libpod/cmd/podman/registry"
@@ -112,6 +114,12 @@ func imagePush(cmd *cobra.Command, args []string) error {
 	// boolean CLI flags.
 	if cmd.Flags().Changed("tls-verify") {
 		pushOptsAPI.TLSVerify = types.NewOptionalBool(pushOptions.TLSVerifyCLI)
+	}
+
+	if pushOptsAPI.Authfile != "" {
+		if _, err := os.Stat(pushOptsAPI.Authfile); err != nil {
+			return errors.Wrapf(err, "error getting authfile %s", pushOptsAPI.Authfile)
+		}
 	}
 
 	// Let's do all the remaining Yoga in the API to prevent us from scattering

--- a/test/e2e/pull_test.go
+++ b/test/e2e/pull_test.go
@@ -22,7 +22,6 @@ var _ = Describe("Podman pull", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
This fixes pull_test.go push_test.go is still broken because of
lack of registry support.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>