### PR TITLE
Turn on version.go except for -v check

### DIFF
--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -17,7 +17,6 @@ var _ = Describe("Podman version", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)
@@ -43,6 +42,7 @@ var _ = Describe("Podman version", func() {
 	})
 
 	It("podman -v", func() {
+		Skip(v2fail)
 		session := podmanTest.Podman([]string{"-v"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))


### PR DESCRIPTION
Currently podman -v does not work but the other version checks all pass.

enabling tests to that we can get more tests running in CI.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>