### PR TITLE
V2 Restore rmi tests

### DIFF
--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -141,4 +141,7 @@ var (
 	// ErrConmonOutdated indicates the version of conmon found (whether via the configuration or $PATH)
 	// is out of date for the current podman version
 	ErrConmonOutdated = errors.New("outdated conmon version")
+
+	// ErrImageInUse indicates the requested operation failed because the image was in use
+	ErrImageInUse = errors.New("image is being used")
 )

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -466,7 +466,7 @@ func (ir *ImageEngine) Remove(ctx context.Context, images []string, opts entitie
 	}()
 
 	// deleteImage is an anonymous function to conveniently delete an image
-	// withouth having to pass all local data around.
+	// without having to pass all local data around.
 	deleteImage := func(img *image.Image) error {
 		results, err := ir.Libpod.RemoveImage(ctx, img, opts.Force)
 		switch errors.Cause(err) {
@@ -476,6 +476,9 @@ func (ir *ImageEngine) Remove(ctx context.Context, images []string, opts entitie
 			inUseErrors = true // Important for exit codes in Podman.
 			return errors.New(
 				fmt.Sprintf("A container associated with containers/storage, i.e. via Buildah, CRI-O, etc., may be associated with this image: %-12.12s\n", img.ID()))
+		case define.ErrImageInUse:
+			inUseErrors = true
+			return err
 		default:
 			otherErrors = true // Important for exit codes in Podman.
 			return err

--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman rmi", func() {
@@ -17,7 +18,6 @@ var _ = Describe("Podman rmi", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)
@@ -37,21 +37,21 @@ var _ = Describe("Podman rmi", func() {
 	It("podman rmi bogus image", func() {
 		session := podmanTest.Podman([]string{"rmi", "debian:6.0.10"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(1))
+		Expect(session).Should(Exit(1))
 
 	})
 
 	It("podman rmi with fq name", func() {
 		session := podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 	})
 
 	It("podman rmi with short name", func() {
 		session := podmanTest.PodmanNoCache([]string{"rmi", "alpine"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 	})
 
@@ -62,7 +62,7 @@ var _ = Describe("Podman rmi", func() {
 		images := podmanTest.PodmanNoCache([]string{"images"})
 		images.WaitWithDefaultTimeout()
 		fmt.Println(images.OutputToStringArray())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 	})
 
@@ -70,22 +70,22 @@ var _ = Describe("Podman rmi", func() {
 		podmanTest.RestoreArtifact(nginx)
 		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 	})
 
 	It("podman rmi tagged image", func() {
 		setup := podmanTest.PodmanNoCache([]string{"images", "-q", ALPINE})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup.ExitCode()).To(Equal(0))
+		Expect(setup).Should(Exit(0))
 
 		session := podmanTest.PodmanNoCache([]string{"tag", "alpine", "foo:bar", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		result := podmanTest.PodmanNoCache([]string{"images", "-q", "foo"})
 		result.WaitWithDefaultTimeout()
-		Expect(result.ExitCode()).To(Equal(0))
+		Expect(result).Should(Exit(0))
 
 		Expect(result.LineInOutputContains(setup.OutputToString())).To(BeTrue())
 	})
@@ -93,12 +93,12 @@ var _ = Describe("Podman rmi", func() {
 	It("podman rmi image with tags by ID cannot be done without force", func() {
 		setup := podmanTest.PodmanNoCache([]string{"images", "-q", ALPINE})
 		setup.WaitWithDefaultTimeout()
-		Expect(setup.ExitCode()).To(Equal(0))
+		Expect(setup).Should(Exit(0))
 		alpineId := setup.OutputToString()
 
 		session := podmanTest.PodmanNoCache([]string{"tag", "alpine", "foo:bar", "foo"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		// Trying without --force should fail
 		result := podmanTest.PodmanNoCache([]string{"rmi", alpineId})
@@ -108,80 +108,80 @@ var _ = Describe("Podman rmi", func() {
 		// With --force it should work
 		resultForce := podmanTest.PodmanNoCache([]string{"rmi", "-f", alpineId})
 		resultForce.WaitWithDefaultTimeout()
-		Expect(resultForce.ExitCode()).To(Equal(0))
+		Expect(resultForce).Should(Exit(0))
 	})
 
 	It("podman rmi image that is a parent of another image", func() {
 		SkipIfRemote()
 		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"run", "--name", "c_test", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"commit", "-q", "c_test", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"rm", "c_test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"images", "-q"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(1))
 
 		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(2))
 		untaggedImg := session.OutputToStringArray()[1]
 
 		session = podmanTest.PodmanNoCache([]string{"rmi", "-f", untaggedImg})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(2))
+		Expect(session).Should(Exit(2))
 	})
 
 	It("podman rmi image that is created from another named imaged", func() {
 		SkipIfRemote()
 		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"create", "--name", "c_test1", ALPINE, "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"commit", "-q", "c_test1", "test1"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"create", "--name", "c_test2", "test1", "true"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"commit", "-q", "c_test2", "test2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"rm", "-a"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"rmi", "test2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"images", "-q"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(2))
 	})
 
@@ -189,7 +189,7 @@ var _ = Describe("Podman rmi", func() {
 		SkipIfRemote()
 		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		dockerfile := `FROM docker.io/library/alpine:latest
 		RUN mkdir hello
@@ -208,51 +208,51 @@ var _ = Describe("Podman rmi", func() {
 
 		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 		numOfImages := len(session.OutputToStringArray())
 
 		session = podmanTest.PodmanNoCache([]string{"rmi", "test2"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 		Expect(numOfImages - len(session.OutputToStringArray())).To(Equal(2))
 
 		session = podmanTest.PodmanNoCache([]string{"rmi", "test"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(1))
 
 		podmanTest.BuildImage(dockerfile, "test3", "true")
 
 		session = podmanTest.PodmanNoCache([]string{"rmi", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"rmi", "test3"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 		Expect(len(session.OutputToString())).To(Equal(0))
 	})
 
 	It("podman rmi -a with no images should be exit 0", func() {
 		session := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session2 := podmanTest.PodmanNoCache([]string{"rmi", "-fa"})
 		session2.WaitWithDefaultTimeout()
-		Expect(session2.ExitCode()).To(Equal(0))
+		Expect(session2).Should(Exit(0))
 	})
 
 	It("podman rmi -a with parent|child images", func() {
@@ -269,11 +269,11 @@ RUN find $LOCAL
 		session := podmanTest.PodmanNoCache([]string{"rmi", "-a"})
 		session.WaitWithDefaultTimeout()
 		fmt.Println(session.OutputToString())
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		images := podmanTest.PodmanNoCache([]string{"images", "-aq"})
 		images.WaitWithDefaultTimeout()
-		Expect(images.ExitCode()).To(Equal(0))
+		Expect(images).Should(Exit(0))
 		Expect(len(images.OutputToStringArray())).To(Equal(0))
 	})
 
@@ -282,7 +282,7 @@ RUN find $LOCAL
 	It("podman image rm is the same as rmi", func() {
 		session := podmanTest.PodmanNoCache([]string{"image", "rm"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(125))
+		Expect(session).Should(Exit(125))
 		match, _ := session.ErrorGrepString("image name or ID must be specified")
 		Expect(match).To(BeTrue())
 	})


### PR DESCRIPTION
* Introduced define.ErrImageInUse to assist in determining the exit code
  without resorting string searches.

Signed-off-by: Jhon Honce <jhonce@redhat.com>