### PR TITLE
Stop wrapping pull messages

### DIFF
--- a/libpod/image/pull.go
+++ b/libpod/image/pull.go
@@ -334,11 +334,11 @@ func (ir *Runtime) doPullImage(ctx context.Context, sc *types.SystemContext, goa
 		// If the image passed in was fully-qualified, we will have 1 refpair.  Bc the image is fq'd, we don't need to yap about registries.
 		if !goal.usedSearchRegistries {
 			if pullErrors != nil && len(pullErrors.Errors) > 0 { // this should always be true
-				return nil, errors.Wrap(pullErrors.Errors[0], "unable to pull image")
+				return nil, pullErrors.Errors[0]
 			}
 			return nil, errors.Errorf("unable to pull image, or you do not have pull access")
 		}
-		return nil, pullErrors
+		return nil, errors.Cause(pullErrors)
 	}
 	if len(images) > 0 {
 		ir.newImageEvent(events.Pull, images[0])

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -443,7 +443,7 @@ func ImagesPull(w http.ResponseWriter, r *http.Request) {
 			nil,
 			util.PullImageAlways)
 		if err != nil {
-			utils.InternalServerError(w, errors.Wrapf(err, "error pulling image %q", query.Reference))
+			utils.InternalServerError(w, err)
 			return
 		}
 		res = append(res, handlers.LibpodImagesPullReport{ID: newImage.ID()})

--- a/pkg/domain/infra/abi/images.go
+++ b/pkg/domain/infra/abi/images.go
@@ -101,7 +101,7 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, options entiti
 	if imageRef.Transport().Name() == dockerarchive.Transport.Name() {
 		newImage, err := ir.Libpod.ImageRuntime().LoadFromArchiveReference(ctx, imageRef, options.SignaturePolicy, writer)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error pulling image %q", rawImage)
+			return nil, err
 		}
 		return &entities.ImagePullReport{Images: []string{newImage[0].ID()}}, nil
 	}
@@ -125,7 +125,7 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, options entiti
 	if !options.AllTags {
 		newImage, err := ir.Libpod.ImageRuntime().New(ctx, rawImage, options.SignaturePolicy, options.Authfile, writer, &dockerRegistryOptions, image.SigningOptions{}, nil, util.PullImageAlways)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error pulling image %q", rawImage)
+			return nil, err
 		}
 		return &entities.ImagePullReport{Images: []string{newImage.ID()}}, nil
 	}
@@ -166,7 +166,7 @@ func (ir *ImageEngine) Pull(ctx context.Context, rawImage string, options entiti
 	}
 
 	if len(tags) != len(foundIDs) {
-		return nil, errors.Errorf("error pulling image %q", rawImage)
+		return nil, err
 	}
 	return &entities.ImagePullReport{Images: foundIDs}, nil
 }


### PR DESCRIPTION
The length and size of our error messages on failure to pull
is huge.  This patch at least eliminates some of the wrapping.
But I think eventually we need to look at containers/image
and see if we can modify the error messages to something a little
more human friendly.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>