### PR TITLE
Makefile: install targets should not depend on build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,24 +470,34 @@ changelog: ## Generate changelog
 .PHONY: install
 install: .gopathok install.bin install.remote install.man install.cni install.systemd  ## Install binaries to system locations
 
-.PHONY: install.remote
-install.remote: podman-remote
+.PHONY: install.remote-nobuild
+install.remote-nobuild:
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 bin/podman-remote $(DESTDIR)$(BINDIR)/podman-remote
 	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(DESTDIR)$(BINDIR)/podman-remote bin/podman-remote
 
-.PHONY: install.bin
-install.bin: podman
+.PHONY: install.remote
+install.remote: podman-remote install.remote-nobuild
+
+.PHONY: install.bin-nobuild
+install.bin-nobuild:
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(BINDIR)
 	install ${SELINUXOPT} -m 755 bin/podman $(DESTDIR)$(BINDIR)/podman
 	test -z "${SELINUXOPT}" || chcon --verbose --reference=$(DESTDIR)$(BINDIR)/podman bin/podman
 
-install.man: docs
+.PHONY: install.bin
+install.bin: podman install.bin-nobuild
+
+.PHONY: install.man-nobuild
+install.man-nobuild:
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(MANDIR)/man1
 	install ${SELINUXOPT} -d -m 755 $(DESTDIR)$(MANDIR)/man5
 	install ${SELINUXOPT} -m 644 $(filter %.1,$(MANPAGES_DEST)) -t $(DESTDIR)$(MANDIR)/man1
 	install ${SELINUXOPT} -m 644 $(filter %.5,$(MANPAGES_DEST)) -t $(DESTDIR)$(MANDIR)/man5
 	install ${SELINUXOPT} -m 644 docs/source/markdown/links/*1 -t $(DESTDIR)$(MANDIR)/man1
+
+.PHONY: install.man
+install.man: docs install.man-nobuild
 
 .PHONY: install.config
 install.config:

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -377,12 +377,6 @@ Man pages for the %{name} commands
 # untar conmon
 tar zxf %{SOURCE1}
 
-sed -i 's/install.remote: podman-remote/install.remote:/' Makefile
-sed -i 's/install.bin: podman/install.bin:/' Makefile
-%if %{with doc}
-sed -i 's/install.man: docs/install.man:/' Makefile
-%endif
-
 %build
 mkdir _build
 pushd _build
@@ -417,22 +411,15 @@ popd
 %install
 install -dp %{buildroot}%{_unitdir}
 install -dp %{buildroot}%{_usr}/lib/systemd/user
+PODMAN_VERSION=%{version} %{__make} PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir} \
+        install.bin-nobuild \
+        install.remote-nobuild \
 %if %{with doc}
-PODMAN_VERSION=%{version} %{__make} PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir} \
-        install.bin \
-        install.remote \
-        install.man \
-        install.cni \
-        install.systemd \
-        install.completions
-%else
-PODMAN_VERSION=%{version} %{__make} PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir} \
-        install.bin \
-        install.remote \
-        install.cni \
-        install.systemd \
-        install.completions
+        install.man-nobuild \
 %endif
+        install.cni \
+        install.systemd \
+        install.completions
 
 mv pkg/hooks/README.md pkg/hooks/README-hooks.md
 


### PR DESCRIPTION
Distro packaging often uses non-default build and linker flags.
The current Makefile cannot be used in the package build process as it
will end up rebuilding the binaries with the default flags.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

PTAL @jnovy @haircommander @baude @rhatdan 

This undoes some of https://github.com/containers/libpod/pull/3757 and https://github.com/containers/libpod/pull/2923 and would likely make some people angry :) 