### PR TITLE
V2 restore podman -v command

### DIFF
--- a/cmd/podman/registry/registry.go
+++ b/cmd/podman/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/containers/libpod/pkg/domain/infra"
@@ -86,7 +87,7 @@ func SubCommandExists(cmd *cobra.Command, args []string) error {
 // IdOrLatestArgs used to validate a nameOrId was provided or the "--latest" flag
 func IdOrLatestArgs(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 || (len(args) == 0 && !cmd.Flag("latest").Changed) {
-		return errors.New(`command requires a name, id  or the "--latest" flag`)
+		return fmt.Errorf("%s requires a name, id or the '--latest' flag", cmd.Name())
 	}
 	return nil
 }

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -78,6 +78,10 @@ func init() {
 	)
 
 	rootFlags(registry.PodmanConfig(), rootCmd.PersistentFlags())
+
+	// "version" is a local flag to avoid collisions with sub-commands that use "-v"
+	var dummyVersion bool
+	rootCmd.Flags().BoolVarP(&dummyVersion, "version", "v", false, "Version of Podman")
 }
 
 func Execute() {
@@ -205,11 +209,6 @@ func rootFlags(opts *entities.PodmanConfig, flags *pflag.FlagSet) {
 	// V2 flags
 	flags.StringVarP(&opts.Uri, "remote", "r", "", "URL to access Podman service")
 	flags.StringSliceVar(&opts.Identities, "identity", []string{}, "path to SSH identity file")
-
-	// Override default --help information of `--version` global flag
-	// TODO: restore -v option for version without breaking -v for volumes
-	var dummyVersion bool
-	flags.BoolVar(&dummyVersion, "version", false, "Version of Podman")
 
 	cfg := opts.Config
 	flags.StringVar(&cfg.Engine.CgroupManager, "cgroup-manager", cfg.Engine.CgroupManager, opts.CGroupUsage)

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/libpod/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman version", func() {
@@ -35,54 +36,49 @@ var _ = Describe("Podman version", func() {
 	It("podman version", func() {
 		session := podmanTest.Podman([]string{"version"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		Expect(len(session.OutputToStringArray())).To(BeNumerically(">", 2))
-		ok, _ := session.GrepString(version.Version)
-		Expect(ok).To(BeTrue())
+		Expect(session).Should(Exit(0))
+		Expect(session.Out.Contents()).Should(ContainSubstring(version.Version))
 	})
 
 	It("podman -v", func() {
-		Skip(v2fail)
 		session := podmanTest.Podman([]string{"-v"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		ok, _ := session.GrepString(version.Version)
-		Expect(ok).To(BeTrue())
+		Expect(session).Should(Exit(0))
+		Expect(session.Out.Contents()).Should(ContainSubstring(version.Version))
 	})
 
 	It("podman --version", func() {
 		session := podmanTest.Podman([]string{"--version"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		ok, _ := session.GrepString(version.Version)
-		Expect(ok).To(BeTrue())
+		Expect(session).Should(Exit(0))
+		Expect(session.Out.Contents()).Should(ContainSubstring(version.Version))
 	})
 
 	It("podman version --format json", func() {
 		session := podmanTest.Podman([]string{"version", "--format", "json"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 		Expect(session.IsJSONOutputValid()).To(BeTrue())
 	})
 
 	It("podman version --format json", func() {
 		session := podmanTest.Podman([]string{"version", "--format", "{{ json .}}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 		Expect(session.IsJSONOutputValid()).To(BeTrue())
 	})
 
 	It("podman version --format GO template", func() {
 		session := podmanTest.Podman([]string{"version", "--format", "{{ .Client.Version }}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"version", "--format", "{{ .Server.Version }}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 
 		session = podmanTest.Podman([]string{"version", "--format", "{{ .Version }}"})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session).Should(Exit(0))
 	})
 })


### PR DESCRIPTION
* Removed extra spaces and improved error message
* Updated tests to use gomega matchers

Signed-off-by: Jhon Honce <jhonce@redhat.com>