### PR TITLE
Update vendor to containers/common v0.8.2

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -376,6 +376,10 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		}
 	}
 
+	usernsType := c.String("userns")
+	if !c.IsSet("userns") && !idmappings.HostUIDMapping {
+		usernsType = "private"
+	}
 	// Kernel Namespaces
 	// TODO Fix handling of namespace from pod
 	// Instead of integrating here, should be done in libpod
@@ -386,7 +390,7 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		"pid":    c.String("pid"),
 		"net":    c.String("network"),
 		"ipc":    c.String("ipc"),
-		"user":   c.String("userns"),
+		"user":   usernsType,
 		"uts":    c.String("uts"),
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containernetworking/cni v0.7.2-0.20200304161608-4fae32b84921
 	github.com/containernetworking/plugins v0.8.5
 	github.com/containers/buildah v1.14.8
-	github.com/containers/common v0.8.1
+	github.com/containers/common v0.8.2
 	github.com/containers/conmon v2.0.14+incompatible
 	github.com/containers/image/v5 v5.4.3
 	github.com/containers/psgo v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/containers/buildah v1.14.8 h1:JbMI0QSOmyZ30Mr2633uCXAj+Fajgh/EFS9xX/Y
 github.com/containers/buildah v1.14.8/go.mod h1:ytEjHJQnRXC1ygXMyc0FqYkjcoCydqBQkOdxbH563QU=
 github.com/containers/common v0.8.1 h1:1IUwAtZ4mC7GYRr4AC23cHf2oXCuoLzTUoSzIkSgnYw=
 github.com/containers/common v0.8.1/go.mod h1:VxDJbaA1k6N1TNv9Rt6bQEF4hyKVHNfOfGA5L91ADEs=
+github.com/containers/common v0.8.2 h1:TzbHcY1C6xAcZyPk0UJLAKVpW77AUkw5DWoApWB8Ge8=
+github.com/containers/common v0.8.2/go.mod h1:VxDJbaA1k6N1TNv9Rt6bQEF4hyKVHNfOfGA5L91ADEs=
 github.com/containers/conmon v2.0.14+incompatible h1:knU1O1QxXy5YxtjMQVKEyCajROaehizK9FHaICl+P5Y=
 github.com/containers/conmon v2.0.14+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.4.3 h1:zn2HR7uu4hpvT5QQHgjqonOzKDuM1I1UHUEmzZT5sbs=

--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -376,6 +376,8 @@
 #            "/usr/local/sbin/kata-runtime",
 #            "/sbin/kata-runtime",
 #            "/bin/kata-runtime",
+#            "/usr/bin/kata-qemu",
+#            "/usr/bin/kata-fc",
 # ]
 
 # Number of seconds to wait for container to exit before sending kill signal.

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -141,13 +141,18 @@ func DefaultConfig() (*Config, error) {
 		netns = "slirp4netns"
 	}
 
+	cgroupNS := "host"
+	if cgroup2, _ := cgroupv2.Enabled(); cgroup2 {
+		cgroupNS = "private"
+	}
+
 	return &Config{
 		Containers: ContainersConfig{
 			Devices:             []string{},
 			Volumes:             []string{},
 			Annotations:         []string{},
 			ApparmorProfile:     DefaultApparmorProfile,
-			CgroupNS:            "private",
+			CgroupNS:            cgroupNS,
 			DefaultCapabilities: DefaultCapabilities,
 			DefaultSysctls:      []string{},
 			DefaultUlimits:      getDefaultProcessLimits(),
@@ -172,7 +177,7 @@ func DefaultConfig() (*Config, error) {
 			SeccompProfile: SeccompDefaultPath,
 			ShmSize:        DefaultShmSize,
 			UTSNS:          "private",
-			UserNS:         "private",
+			UserNS:         "host",
 			UserNSSize:     DefaultUserNSSize,
 		},
 		Network: NetworkConfig{
@@ -246,6 +251,8 @@ func defaultConfigFromMemory() (*EngineConfig, error) {
 			"/usr/local/sbin/kata-runtime",
 			"/sbin/kata-runtime",
 			"/bin/kata-runtime",
+			"/usr/bin/kata-qemu",
+			"/usr/bin/kata-fc",
 		},
 	}
 	c.ConmonEnvVars = []string{

--- a/vendor/github.com/containers/common/pkg/config/libpodConfig.go
+++ b/vendor/github.com/containers/common/pkg/config/libpodConfig.go
@@ -224,6 +224,12 @@ func newLibpodConfig(c *Config) error {
 		}
 	}
 
+	// hard code EventsLogger to "file" to match older podman versions.
+	if config.EventsLogger != "file" {
+		logrus.Debugf("Ignoring lipod.conf EventsLogger setting %q. Use containers.conf if you want to change this setting and remove libpod.conf files.", config.EventsLogger)
+		config.EventsLogger = "file"
+	}
+
 	c.libpodToContainersConfig(config)
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/containers/buildah/pkg/secrets
 github.com/containers/buildah/pkg/supplemented
 github.com/containers/buildah/pkg/umask
 github.com/containers/buildah/util
-# github.com/containers/common v0.8.1
+# github.com/containers/common v0.8.2
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/capabilities
 github.com/containers/common/pkg/cgroupv2


### PR DESCRIPTION
This will fix a couple of issues caused by the move to containers.conf

If a libpod.conf file still exists,  we will ignore its events_logger
definition and use "file"

If you are running rootless on cgroupsV1 we will default to host cgroupns.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>