### PR TITLE
Fix SELinux functions names to not be repetitive

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -435,12 +435,12 @@ func (c *Container) setupStorage(ctx context.Context) error {
 	processLabel := containerInfo.ProcessLabel
 	switch {
 	case c.ociRuntime.SupportsKVM():
-		processLabel, err = selinux.SELinuxKVMLabel(processLabel)
+		processLabel, err = selinux.KVMLabel(processLabel)
 		if err != nil {
 			return err
 		}
 	case c.config.Systemd:
-		processLabel, err = selinux.SELinuxInitLabel(processLabel)
+		processLabel, err = selinux.InitLabel(processLabel)
 		if err != nil {
 			return err
 		}

--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -4,8 +4,8 @@ import (
 	"github.com/opencontainers/selinux/go-selinux"
 )
 
-// SELinuxKVMLabel returns labels for running kvm isolated containers
-func SELinuxKVMLabel(cLabel string) (string, error) {
+// KVMLabel returns labels for running kvm isolated containers
+func KVMLabel(cLabel string) (string, error) {
 	if cLabel == "" {
 		// selinux is disabled
 		return "", nil
@@ -15,8 +15,8 @@ func SELinuxKVMLabel(cLabel string) (string, error) {
 	return swapSELinuxLabel(cLabel, processLabel)
 }
 
-// SELinuxInitLabel returns labels for running systemd based containers
-func SELinuxInitLabel(cLabel string) (string, error) {
+// InitLabel returns labels for running systemd based containers
+func InitLabel(cLabel string) (string, error) {
 	if cLabel == "" {
 		// selinux is disabled
 		return "", nil


### PR DESCRIPTION
Since functions are now in an selinux subpackage, they should not start with
SELinux

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>