### PR TITLE
Do not join pod namespaces without an infra ctr

### DIFF
--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -26,7 +26,7 @@ func GetDefaultNamespaceMode(nsType string, cfg *config.Config, pod *libpod.Pod)
 	nsType = strings.ToLower(nsType)
 
 	// If the pod is not nil - check shared namespaces
-	if pod != nil {
+	if pod != nil && pod.HasInfraContainer() {
 		podMode := false
 		switch {
 		case nsType == "pid" && pod.SharesPID():


### PR DESCRIPTION
We do not want to join pod namespaces if no infra container is present. A pod may claim it shares namespaces without an infra container (I'll take an action item to fix that - it really should not be allowed), which was tripping up our default namespace code and forcing us to try and join the namespaces of the nonexistant infra container.