### PR TITLE
[ci:docs] Cleanup man pages for pull and push 

### DIFF
--- a/docs/source/markdown/podman-pull.1.md
+++ b/docs/source/markdown/podman-pull.1.md
@@ -4,9 +4,13 @@
 podman\-pull - Pull an image from a registry
 
 ## SYNOPSIS
-**podman pull** [*options*] *name*[:*tag*|@*digest*]
+**podman pull** [*options*] *source*
 
-**podman image pull** [*options*] *name*[:*tag*|@*digest*]
+**podman image pull** [*options*] *source*
+
+**podman pull** [*options*] [*transport*]*name*[:*tag*|@*digest*]
+
+**podman image pull** [*options*] [*transport*]*name*[:*tag*|@*digest*]
 
 ## DESCRIPTION
 Copies an image from a registry onto the local machine. **podman pull** pulls an
@@ -17,12 +21,12 @@ print the full image ID.  **podman pull** can also pull an image
 using its digest **podman pull** *image*@*digest*. **podman pull** can be used to pull
 images from archives and local storage using different transports.
 
-## imageID
-Image stored in local container/storage
+## Image storage
+Images are stored in local image storage.
 
 ## SOURCE
 
- The SOURCE is a location to get container images
+ The SOURCE is the location from which the container images are pulled.
  The Image "SOURCE" uses a "transport":"details" format.
 
  Multiple transports are supported:

--- a/docs/source/markdown/podman-push.1.md
+++ b/docs/source/markdown/podman-push.1.md
@@ -14,8 +14,8 @@ Push is mainly used to push images to registries, however **podman push**
 can be used to save images to tarballs and directories using the following
 transports: **dir:**, **docker-archive:**, **docker-daemon:** and **oci-archive:**.
 
-## imageID
-Image stored in local container/storage
+## Image storage
+Images are pushed from those stored in local image storage.
 
 ## DESTINATION
 


### PR DESCRIPTION
The podman pull man page has a section on source, but does not show
this in the top definitions.  This PR attempts to cleanup the man page
to make it more understandable.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

Fixes: https://github.com/containers/libpod/issues/5603