### PR TITLE
[v2] containers, init: skip invalid state errors with --all

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -837,7 +837,13 @@ func (ic *ContainerEngine) ContainerInit(ctx context.Context, namesOrIds []strin
 	}
 	for _, ctr := range ctrs {
 		report := entities.ContainerInitReport{Id: ctr.ID()}
-		report.Err = ctr.Init(ctx)
+		err := ctr.Init(ctx)
+
+		// If we're initializing all containers, ignore invalid state errors
+		if options.All && errors.Cause(err) == define.ErrCtrStateInvalid {
+			err = nil
+		}
+		report.Err = err
 		reports = append(reports, &report)
 	}
 	return reports, nil

--- a/test/e2e/init_test.go
+++ b/test/e2e/init_test.go
@@ -16,7 +16,6 @@ var _ = Describe("Podman init", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
reintroduce the same check that exists in v1.9.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>