### PR TITLE
Add --os to manifest add

### DIFF
--- a/cmd/podman/manifest/add.go
+++ b/cmd/podman/manifest/add.go
@@ -34,6 +34,7 @@ func init() {
 	flags.StringSliceVar(&manifestAddOpts.Annotation, "annotation", nil, "set an `annotation` for the specified image")
 	flags.StringVar(&manifestAddOpts.Arch, "arch", "", "override the `architecture` of the specified image")
 	flags.StringSliceVar(&manifestAddOpts.Features, "features", nil, "override the `features` of the specified image")
+	flags.StringVar(&manifestAddOpts.OS, "os", "", "override the `OS` of the specified image")
 	flags.StringVar(&manifestAddOpts.OSVersion, "os-version", "", "override the OS `version` of the specified image")
 	flags.StringVar(&manifestAddOpts.Variant, "variant", "", "override the `Variant` of the specified image")
 }

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1760,6 +1760,7 @@ _podman_manifest_add() {
      --annotation
      --arch
      --features
+     --os
      --os-version
      --variant
      "

--- a/docs/source/markdown/podman-manifest-add.1.md
+++ b/docs/source/markdown/podman-manifest-add.1.md
@@ -38,6 +38,13 @@ retrieved from the image's configuration information.
 Specify the features list which the list or index records as requirements for
 the image.  This option is rarely used.
 
+**--os**
+
+Override the OS which the list or index records as a requirement for the image.
+If *imagename* refers to a manifest list or image index, the OS information
+will be retrieved from it.  Otherwise, it will be retrieved from the image's
+configuration information.
+
 **--os-version**
 
 Specify the OS version which the list or index records as a requirement for the

--- a/libpod/image/manifests.go
+++ b/libpod/image/manifests.go
@@ -19,6 +19,7 @@ type ManifestAddOpts struct {
 	Arch       string            `json:"arch"`
 	Features   []string          `json:"features"`
 	Images     []string          `json:"images"`
+	OS         string            `json:"os"`
 	OSVersion  string            `json:"os_version"`
 	Variant    string            `json:"variant"`
 }
@@ -85,6 +86,11 @@ func addManifestToList(ref types.ImageReference, list manifests.List, systemCont
 	d, err := list.Add(context.Background(), &systemContext, ref, opts.All)
 	if err != nil {
 		return nil, err
+	}
+	if opts.OS != "" {
+		if err := list.SetOS(d, opts.OS); err != nil {
+			return nil, err
+		}
 	}
 	if len(opts.OSVersion) > 0 {
 		if err := list.SetOSVersion(d, opts.OSVersion); err != nil {

--- a/pkg/domain/entities/manifest.go
+++ b/pkg/domain/entities/manifest.go
@@ -10,6 +10,7 @@ type ManifestAddOptions struct {
 	Arch       string   `json:"arch" schema:"arch"`
 	Features   []string `json:"features" schema:"features"`
 	Images     []string `json:"images" schema:"images"`
+	OS         string   `json:"os" schema:"os"`
 	OSVersion  string   `json:"os_version" schema:"os_version"`
 	Variant    string   `json:"variant" schema:"variant"`
 }

--- a/pkg/domain/infra/abi/manifest.go
+++ b/pkg/domain/infra/abi/manifest.go
@@ -79,6 +79,7 @@ func (ir *ImageEngine) ManifestAdd(ctx context.Context, opts entities.ManifestAd
 		Arch:      opts.Arch,
 		Features:  opts.Features,
 		Images:    opts.Images,
+		OS:        opts.OS,
 		OSVersion: opts.OSVersion,
 		Variant:   opts.Variant,
 	}

--- a/pkg/domain/infra/tunnel/manifest.go
+++ b/pkg/domain/infra/tunnel/manifest.go
@@ -41,6 +41,7 @@ func (ir *ImageEngine) ManifestAdd(ctx context.Context, opts entities.ManifestAd
 		Arch:      opts.Arch,
 		Features:  opts.Features,
 		Images:    opts.Images,
+		OS:        opts.OS,
 		OSVersion: opts.OSVersion,
 		Variant:   opts.Variant,
 	}

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -85,4 +85,17 @@ var _ = Describe("Podman manifest", func() {
 		Expect(session.OutputToString()).To(ContainSubstring(imageListPPC64LEInstanceDigest))
 		Expect(session.OutputToString()).To(ContainSubstring(imageListS390XInstanceDigest))
 	})
+
+	It("podman manifest add --os", func() {
+		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"manifest", "add", "--os", "bar", "foo", imageList})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		session = podmanTest.Podman([]string{"manifest", "inspect", "foo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(`"os": "bar"`))
+	})
 })


### PR DESCRIPTION
Add --os to manifest add for overriding the os field.

Signed-off-by: Qi Wang <qiwan@redhat.com>