### PR TITLE
enable integration tests for restart

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -217,12 +217,23 @@ func (ic *ContainerEngine) ContainerKill(ctx context.Context, namesOrIds []strin
 }
 func (ic *ContainerEngine) ContainerRestart(ctx context.Context, namesOrIds []string, options entities.RestartOptions) ([]*entities.RestartReport, error) {
 	var (
+		ctrs    []*libpod.Container
+		err     error
 		reports []*entities.RestartReport
 	)
-	ctrs, err := getContainersByContext(options.All, options.Latest, namesOrIds, ic.Libpod)
-	if err != nil {
-		return nil, err
+
+	if options.Running {
+		ctrs, err = ic.Libpod.GetRunningContainers()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		ctrs, err = getContainersByContext(options.All, options.Latest, namesOrIds, ic.Libpod)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	for _, con := range ctrs {
 		timeout := con.StopTimeout()
 		if options.Timeout != nil {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -115,11 +115,15 @@ func (ic *ContainerEngine) ContainerRestart(ctx context.Context, namesOrIds []st
 		t := int(*options.Timeout)
 		timeout = &t
 	}
+
 	ctrs, err := getContainersByContext(ic.ClientCxt, options.All, namesOrIds)
 	if err != nil {
 		return nil, err
 	}
 	for _, c := range ctrs {
+		if options.Running && c.State != define.ContainerStateRunning.String() {
+			continue
+		}
 		reports = append(reports, &entities.RestartReport{
 			Id:  c.ID,
 			Err: containers.Restart(ic.ClientCxt, c.ID, timeout),

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -17,7 +17,6 @@ var _ = Describe("Podman restart", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
enable integrations tests for container restart.  fixed bug where --running was not being honored.

Signed-off-by: Brent Baude <bbaude@redhat.com>