### PR TITLE
enable volume integration tests

### DIFF
--- a/cmd/podman/volumes/list.go
+++ b/cmd/podman/volumes/list.go
@@ -2,6 +2,7 @@ package volumes
 
 import (
 	"context"
+	"fmt"
 	"html/template"
 	"io"
 	"os"
@@ -57,6 +58,9 @@ func list(cmd *cobra.Command, args []string) error {
 	if cliOpts.Quiet && cmd.Flag("format").Changed {
 		return errors.New("quiet and format flags cannot be used together")
 	}
+	if len(cliOpts.Filter) > 0 {
+		lsOpts.Filter = make(map[string][]string)
+	}
 	for _, f := range cliOpts.Filter {
 		filterSplit := strings.Split(f, "=")
 		if len(filterSplit) < 2 {
@@ -68,6 +72,10 @@ func list(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if cliOpts.Format == "json" {
+		return outputJSON(responses)
+	}
+
 	if len(responses) < 1 {
 		return nil
 	}
@@ -97,5 +105,14 @@ func list(cmd *cobra.Command, args []string) error {
 	if flusher, ok := w.(interface{ Flush() error }); ok {
 		return flusher.Flush()
 	}
+	return nil
+}
+
+func outputJSON(vols []*entities.VolumeListReport) error {
+	b, err := json.MarshalIndent(vols, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
 	return nil
 }

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1400,8 +1400,13 @@ func WithVolumeDriver(driver string) VolumeCreateOption {
 		if volume.valid {
 			return define.ErrVolumeFinalized
 		}
+		// only local driver is possible rn
+		if driver != define.VolumeDriverLocal {
+			return define.ErrNotImplemented
 
-		return define.ErrNotImplemented
+		}
+		volume.config.Driver = define.VolumeDriverLocal
+		return nil
 	}
 }
 

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -222,7 +222,6 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman run with tmpfs named volume mounts and unmounts", func() {
-		Skip(v2fail)
 		SkipIfRootless()
 		volName := "testvol"
 		mkVolume := podmanTest.Podman([]string{"volume", "create", "--opt", "type=tmpfs", "--opt", "device=tmpfs", "--opt", "o=nodev", "testvol"})
@@ -279,7 +278,6 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman named volume copyup", func() {
-		Skip(v2fail)
 		baselineSession := podmanTest.Podman([]string{"run", "--rm", "-t", "-i", ALPINE, "ls", "/etc/apk/"})
 		baselineSession.WaitWithDefaultTimeout()
 		Expect(baselineSession.ExitCode()).To(Equal(0))
@@ -311,7 +309,6 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman run with anonymous volume", func() {
-		Skip(v2fail)
 		list1 := podmanTest.Podman([]string{"volume", "list", "--quiet"})
 		list1.WaitWithDefaultTimeout()
 		Expect(list1.ExitCode()).To(Equal(0))
@@ -330,7 +327,6 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman rm -v removes anonymous volume", func() {
-		Skip(v2fail)
 		list1 := podmanTest.Podman([]string{"volume", "list", "--quiet"})
 		list1.WaitWithDefaultTimeout()
 		Expect(list1.ExitCode()).To(Equal(0))
@@ -359,7 +355,6 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman rm -v retains named volume", func() {
-		Skip(v2fail)
 		list1 := podmanTest.Podman([]string{"volume", "list", "--quiet"})
 		list1.WaitWithDefaultTimeout()
 		Expect(list1.ExitCode()).To(Equal(0))
@@ -398,7 +393,6 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("podman mount with invalid option fails", func() {
-		Skip(v2fail)
 		volName := "testVol"
 		volCreate := podmanTest.Podman([]string{"volume", "create", "--opt", "type=tmpfs", "--opt", "device=tmpfs", "--opt", "o=invalid", volName})
 		volCreate.WaitWithDefaultTimeout()
@@ -410,7 +404,6 @@ var _ = Describe("Podman run with volumes", func() {
 	})
 
 	It("Podman fix for CVE-2020-1726", func() {
-		Skip(v2fail)
 		volName := "testVol"
 		volCreate := podmanTest.Podman([]string{"volume", "create", volName})
 		volCreate.WaitWithDefaultTimeout()

--- a/test/e2e/volume_create_test.go
+++ b/test/e2e/volume_create_test.go
@@ -17,7 +17,6 @@ var _ = Describe("Podman volume create", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)

--- a/test/e2e/volume_inspect_test.go
+++ b/test/e2e/volume_inspect_test.go
@@ -17,7 +17,6 @@ var _ = Describe("Podman volume inspect", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)

--- a/test/e2e/volume_ls_test.go
+++ b/test/e2e/volume_ls_test.go
@@ -16,7 +16,6 @@ var _ = Describe("Podman volume ls", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)
@@ -56,6 +55,7 @@ var _ = Describe("Podman volume ls", func() {
 	})
 
 	It("podman ls volume with Go template", func() {
+		Skip(v2fail)
 		session := podmanTest.Podman([]string{"volume", "create", "myvol"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/volume_prune_test.go
+++ b/test/e2e/volume_prune_test.go
@@ -18,7 +18,6 @@ var _ = Describe("Podman volume prune", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)
@@ -66,6 +65,7 @@ var _ = Describe("Podman volume prune", func() {
 	})
 
 	It("podman system prune --volume", func() {
+		Skip(v2fail)
 		session := podmanTest.Podman([]string{"volume", "create"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))

--- a/test/e2e/volume_rm_test.go
+++ b/test/e2e/volume_rm_test.go
@@ -16,7 +16,6 @@ var _ = Describe("Podman volume rm", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
enabled integration tests for volumes.  there are two exceptions that still need work because of something not yet implemented.

also, add code to deal with the fact that containers conf appears to set a local volume driver where it used to be simply blank.

Signed-off-by: Brent Baude <bbaude@redhat.com>