### PR TITLE
separate healthcheck and container log paths

### DIFF
--- a/libpod/healthcheck.go
+++ b/libpod/healthcheck.go
@@ -238,7 +238,7 @@ func (c *Container) updateHealthCheckLog(hcl define.HealthCheckLog, inStartPerio
 
 // HealthCheckLogPath returns the path for where the health check log is
 func (c *Container) healthCheckLogPath() string {
-	return filepath.Join(filepath.Dir(c.LogPath()), "healthcheck.log")
+	return filepath.Join(filepath.Dir(c.state.RunDir), "healthcheck.log")
 }
 
 // GetHealthCheckLog returns HealthCheck results by reading the container's


### PR DESCRIPTION
instead of using the container log path to derive where to put the healthchecks, we now put them into the rundir to avoid collision of health check log files when the log path is set by user.

Fixes: #5915

Signed-off-by: Brent Baude <bbaude@redhat.com>