### PR TITLE
Fixes podman save fails when specifying an image using a digest fixes-5234

### DIFF
--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -1487,14 +1487,14 @@ func (i *Image) Save(ctx context.Context, source, format, output string, moreTag
 		}
 		manifestType = manifest.DockerV2Schema2MediaType
 	case "docker-archive", "":
-		dst := output
 		destImageName := imageNameForSaveDestination(i, source)
-		if destImageName != "" {
-			dst = fmt.Sprintf("%s:%s", dst, destImageName)
-		}
-		destRef, err = dockerarchive.ParseReference(dst) // FIXME? Add dockerarchive.NewReference
+		ref, err := dockerArchiveDstReference(destImageName)
 		if err != nil {
-			return errors.Wrapf(err, "error getting Docker archive ImageReference for %q", dst)
+			return err
+		}
+		destRef, err = dockerarchive.NewReference(output, ref)
+		if err != nil {
+			return errors.Wrapf(err, "error getting Docker archive ImageReference for %s:%v", output, ref)
 		}
 	default:
 		return errors.Errorf("unknown format option %q", format)
@@ -1512,6 +1512,23 @@ func (i *Image) Save(ctx context.Context, source, format, output string, moreTag
 	}
 	i.newImageEvent(events.Save)
 	return nil
+}
+
+// dockerArchiveDestReference returns a NamedTagged reference for a tagged image and nil for untagged image.
+func dockerArchiveDstReference(normalizedInput string) (reference.NamedTagged, error) {
+	if normalizedInput == "" {
+		return nil, nil
+	}
+	ref, err := reference.ParseNormalizedNamed(normalizedInput)
+	if err != nil {
+		return nil, errors.Wrapf(err, "docker-archive parsing reference %s", normalizedInput)
+	}
+	ref = reference.TagNameOnly(ref)
+	namedTagged, isTagged := ref.(reference.NamedTagged)
+	if !isTagged {
+		namedTagged = nil
+	}
+	return namedTagged, nil
 }
 
 // GetConfigBlob returns a schema2image.  If the image is not a schema2, then

--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -116,4 +116,16 @@ var _ = Describe("Podman save", func() {
 		Expect(save).To(ExitWithError())
 	})
 
+	It("podman save image with digest reference", func() {
+		// pull a digest reference
+		session := podmanTest.PodmanNoCache([]string{"pull", ALPINELISTDIGEST})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		// save a digest reference should exit without error.
+		outfile := filepath.Join(podmanTest.TempDir, "temp.tar")
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, ALPINELISTDIGEST})
+		save.WaitWithDefaultTimeout()
+		Expect(save.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
Adds check to parse normalized name and create docker archive dst reference
for tagged untagged image.

Signed-off-by: Sujil02 <sushah@redhat.com>