### PR TITLE
User specified environment happen after other environments are set

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -326,10 +326,6 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 		}
 		defaultEnv = env.Join(env.DefaultEnvVariables, defaultEnv)
 	}
-	config.Env = env.Join(defaultEnv, config.Env)
-	for name, val := range config.Env {
-		g.AddProcessEnv(name, val)
-	}
 
 	if err := addRlimits(config, &g); err != nil {
 		return nil, err
@@ -359,6 +355,11 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 
 	if err := config.Cgroup.ConfigureGenerator(&g); err != nil {
 		return nil, err
+	}
+
+	config.Env = env.Join(defaultEnv, config.Env)
+	for name, val := range config.Env {
+		g.AddProcessEnv(name, val)
 	}
 	configSpec := g.Config
 

--- a/test/e2e/run_env_test.go
+++ b/test/e2e/run_env_test.go
@@ -1,0 +1,138 @@
+// +build !remoteclient
+
+package integration
+
+import (
+	"os"
+
+	. "github.com/containers/libpod/test/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Podman run", func() {
+	var (
+		tempdir    string
+		err        error
+		podmanTest *PodmanTestIntegration
+	)
+
+	BeforeEach(func() {
+		tempdir, err = CreateTempDirInTempDir()
+		if err != nil {
+			os.Exit(1)
+		}
+		podmanTest = PodmanTestCreate(tempdir)
+		podmanTest.Setup()
+		podmanTest.SeedImages()
+	})
+
+	AfterEach(func() {
+		podmanTest.Cleanup()
+		f := CurrentGinkgoTestDescription()
+		processTestResult(f)
+
+	})
+
+	It("podman run environment test", func() {
+		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv", "HOME"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ := session.GrepString("/root")
+		Expect(match).Should(BeTrue())
+
+		session = podmanTest.Podman([]string{"run", "--rm", "--user", "2", ALPINE, "printenv", "HOME"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ = session.GrepString("/sbin")
+		Expect(match).Should(BeTrue())
+
+		session = podmanTest.Podman([]string{"run", "--rm", "--env", "HOME=/foo", ALPINE, "printenv", "HOME"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ = session.GrepString("/foo")
+		Expect(match).Should(BeTrue())
+
+		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO=BAR,BAZ", ALPINE, "printenv", "FOO"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ = session.GrepString("BAR,BAZ")
+		Expect(match).Should(BeTrue())
+
+		session = podmanTest.Podman([]string{"run", "--rm", "--env", "PATH=/bin", ALPINE, "printenv", "PATH"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ = session.GrepString("/bin")
+		Expect(match).Should(BeTrue())
+
+		os.Setenv("FOO", "BAR")
+		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO", ALPINE, "printenv", "FOO"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ = session.GrepString("BAR")
+		Expect(match).Should(BeTrue())
+		os.Unsetenv("FOO")
+
+		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO", ALPINE, "printenv", "FOO"})
+		session.WaitWithDefaultTimeout()
+		Expect(len(session.OutputToString())).To(Equal(0))
+		Expect(session.ExitCode()).To(Equal(1))
+
+		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		// This currently does not work
+		// Re-enable when hostname is an env variable
+		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "sh", "-c", "printenv"})
+		session.Wait(10)
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ = session.GrepString("HOSTNAME")
+		Expect(match).Should(BeTrue())
+	})
+
+	It("podman run --host-env environment test", func() {
+		env := append(os.Environ(), "FOO=BAR")
+		session := podmanTest.PodmanAsUser([]string{"run", "--rm", "--env-host", ALPINE, "/bin/printenv", "FOO"}, 0, 0, "", env)
+
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ := session.GrepString("BAR")
+		Expect(match).Should(BeTrue())
+
+		session = podmanTest.PodmanAsUser([]string{"run", "--rm", "--env", "FOO=BAR1", "--env-host", ALPINE, "/bin/printenv", "FOO"}, 0, 0, "", env)
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ = session.GrepString("BAR1")
+		Expect(match).Should(BeTrue())
+		os.Unsetenv("FOO")
+	})
+
+	It("podman run --http-proxy test", func() {
+		os.Setenv("http_proxy", "1.2.3.4")
+		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv", "http_proxy"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ := session.GrepString("1.2.3.4")
+		Expect(match).Should(BeTrue())
+
+		session = podmanTest.Podman([]string{"run", "--http-proxy=false", ALPINE, "printenv", "http_proxy"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(1))
+		Expect(session.OutputToString()).To(Equal(""))
+
+		session = podmanTest.Podman([]string{"run", "--env", "http_proxy=5.6.7.8", ALPINE, "printenv", "http_proxy"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ = session.GrepString("5.6.7.8")
+		Expect(match).Should(BeTrue())
+		os.Unsetenv("http_proxy")
+
+		session = podmanTest.Podman([]string{"run", "--http-proxy=false", "--env", "http_proxy=5.6.7.8", ALPINE, "printenv", "http_proxy"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ = session.GrepString("5.6.7.8")
+		Expect(match).Should(BeTrue())
+		os.Unsetenv("http_proxy")
+	})
+})

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -193,80 +193,6 @@ var _ = Describe("Podman run", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 	})
 
-	It("podman run environment test", func() {
-		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv", "HOME"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		match, _ := session.GrepString("/root")
-		Expect(match).Should(BeTrue())
-
-		session = podmanTest.Podman([]string{"run", "--rm", "--user", "2", ALPINE, "printenv", "HOME"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		match, _ = session.GrepString("/sbin")
-		Expect(match).Should(BeTrue())
-
-		session = podmanTest.Podman([]string{"run", "--rm", "--env", "HOME=/foo", ALPINE, "printenv", "HOME"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		match, _ = session.GrepString("/foo")
-		Expect(match).Should(BeTrue())
-
-		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO=BAR,BAZ", ALPINE, "printenv", "FOO"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		match, _ = session.GrepString("BAR,BAZ")
-		Expect(match).Should(BeTrue())
-
-		session = podmanTest.Podman([]string{"run", "--rm", "--env", "PATH=/bin", ALPINE, "printenv", "PATH"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		match, _ = session.GrepString("/bin")
-		Expect(match).Should(BeTrue())
-
-		os.Setenv("FOO", "BAR")
-		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO", ALPINE, "printenv", "FOO"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		match, _ = session.GrepString("BAR")
-		Expect(match).Should(BeTrue())
-		os.Unsetenv("FOO")
-
-		session = podmanTest.Podman([]string{"run", "--rm", "--env", "FOO", ALPINE, "printenv", "FOO"})
-		session.WaitWithDefaultTimeout()
-		Expect(len(session.OutputToString())).To(Equal(0))
-		Expect(session.ExitCode()).To(Equal(1))
-
-		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-
-		// This currently does not work
-		// Re-enable when hostname is an env variable
-		session = podmanTest.Podman([]string{"run", "--rm", ALPINE, "sh", "-c", "printenv"})
-		session.Wait(10)
-		Expect(session.ExitCode()).To(Equal(0))
-		match, _ = session.GrepString("HOSTNAME")
-		Expect(match).Should(BeTrue())
-	})
-
-	It("podman run --host-env environment test", func() {
-		env := append(os.Environ(), "FOO=BAR")
-		session := podmanTest.PodmanAsUser([]string{"run", "--rm", "--env-host", ALPINE, "/bin/printenv", "FOO"}, 0, 0, "", env)
-
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		match, _ := session.GrepString("BAR")
-		Expect(match).Should(BeTrue())
-
-		session = podmanTest.PodmanAsUser([]string{"run", "--rm", "--env", "FOO=BAR1", "--env-host", ALPINE, "/bin/printenv", "FOO"}, 0, 0, "", env)
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		match, _ = session.GrepString("BAR1")
-		Expect(match).Should(BeTrue())
-		os.Unsetenv("FOO")
-	})
-
 	It("podman run limits test", func() {
 		SkipIfRootless()
 		session := podmanTest.Podman([]string{"run", "--rm", "--ulimit", "rtprio=99", "--cap-add=sys_nice", fedoraMinimal, "cat", "/proc/self/sched"})
@@ -873,21 +799,6 @@ USER mail`
 		session := podmanTest.Podman([]string{"run", "-dt", "--add-host", "test1:127.0.0.1", "--no-hosts", ALPINE, "top"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError())
-	})
-
-	It("podman run --http-proxy test", func() {
-		os.Setenv("http_proxy", "1.2.3.4")
-		session := podmanTest.Podman([]string{"run", "--rm", ALPINE, "printenv", "http_proxy"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		match, _ := session.GrepString("1.2.3.4")
-		Expect(match).Should(BeTrue())
-
-		session = podmanTest.Podman([]string{"run", "--http-proxy=false", ALPINE, "printenv", "http_proxy"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(1))
-		Expect(session.OutputToString()).To(Equal(""))
-		os.Unsetenv("http_proxy")
 	})
 
 	It("podman run with restart-policy always restarts containers", func() {


### PR DESCRIPTION
When using varlink we want to make sure that user specified environment variables
take precedence over http-proxy environment.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>