### PR TITLE
Fixes podman save fails when specifying an image using a digest #5234

### DIFF
--- a/test/e2e/save_test.go
+++ b/test/e2e/save_test.go
@@ -116,4 +116,16 @@ var _ = Describe("Podman save", func() {
 		Expect(save).To(ExitWithError())
 	})
 
+	It("podman save image with digest reference", func() {
+		// pull a digest reference
+		session := podmanTest.PodmanNoCache([]string{"pull", ALPINELISTDIGEST})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		// save a digest reference should exit without error.
+		outfile := filepath.Join(podmanTest.TempDir, "temp.tar")
+		save := podmanTest.PodmanNoCache([]string{"save", "-o", outfile, ALPINELISTDIGEST})
+		save.WaitWithDefaultTimeout()
+		Expect(save.ExitCode()).To(Equal(0))
+	})
 })


### PR DESCRIPTION
Adds check to parse normalized name and create docker archive dst reference
for tagged untagged image. Relevant test case added.

Signed-off-by: Sujil02 <sushah@redhat.com>