### PR TITLE
rootlessport: use two different channels

### DIFF
--- a/pkg/specgen/namespaces.go
+++ b/pkg/specgen/namespaces.go
@@ -216,6 +216,8 @@ func ParseNetworkNamespace(ns string) (Namespace, []string, error) {
 	toReturn := Namespace{}
 	var cniNetworks []string
 	switch {
+	case ns == "slirp4netns":
+		toReturn.NSMode = Slirp
 	case ns == "pod":
 		toReturn.NSMode = FromPod
 	case ns == "bridge":


### PR DESCRIPTION
The same channel is written to by two different goroutines.

Use a different channel for each of them so to avoid writing to a closed channel.
    
Closes: https://github.com/containers/libpod/issues/6018
