### PR TITLE
System tests: help messages: check required-arg

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -19,7 +19,7 @@ type loginOptionsWrapper struct {
 var (
 	loginOptions = loginOptionsWrapper{}
 	loginCommand = &cobra.Command{
-		Use:   "login [flags] REGISTRY",
+		Use:   "login [flags] [REGISTRY]",
 		Short: "Login to a container registry",
 		Long:  "Login to a container registry on a specified server.",
 		RunE:  login,

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -14,7 +14,7 @@ import (
 var (
 	logoutOptions = auth.LogoutOptions{}
 	logoutCommand = &cobra.Command{
-		Use:   "logout [flags] REGISTRY",
+		Use:   "logout [flags] [REGISTRY]",
 		Short: "Logout of a container registry",
 		Long:  "Remove the cached username and password for the registry.",
 		RunE:  logout,


### PR DESCRIPTION
If a usage message is of the form '... [flags] ARGNAME',
where ARGNAME is all-caps and not in brackets, it must
be a required argument. Try running podman subcommand
without ARGNAME, and make sure that podman bails out
with an informative message. (Since this message is
freeform in each subcommand, not Cobra-generated,
we have a lot of possible variations to check for).

Fix podman login/logout Use messages to indicate that
REGISTRY is now optional (as of #5233).

This test has actually been in place for over a year but
due to a typo on my part -- a missing space -- it was
not being run. "For want of a space, much testing was lost".

Signed-off-by: Ed Santiago <santiago@redhat.com>