### PR TITLE
Enable prune integration test. Fixes container prune 

### DIFF
--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -869,7 +869,8 @@ func (r *Runtime) PruneContainers(filterFuncs []ContainerFilter) (map[string]int
 			logrus.Error(err)
 			return false
 		}
-		if state == define.ContainerStateStopped || state == define.ContainerStateExited {
+		if state == define.ContainerStateStopped || state == define.ContainerStateExited ||
+			state == define.ContainerStateCreated || state == define.ContainerStateConfigured {
 			return true
 		}
 		return false

--- a/test/e2e/prune_test.go
+++ b/test/e2e/prune_test.go
@@ -22,7 +22,6 @@ var _ = Describe("Podman prune", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)
@@ -149,6 +148,7 @@ var _ = Describe("Podman prune", func() {
 
 	It("podman system image prune unused images", func() {
 		SkipIfRemote()
+		Skip(v2fail)
 		podmanTest.RestoreAllArtifacts()
 		podmanTest.BuildImage(pruneImage, "alpine_bash:latest", "true")
 		prune := podmanTest.PodmanNoCache([]string{"system", "prune", "-a", "--force"})
@@ -162,6 +162,7 @@ var _ = Describe("Podman prune", func() {
 	})
 
 	It("podman system prune pods", func() {
+		Skip(v2fail)
 		session := podmanTest.Podman([]string{"pod", "create"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))


### PR DESCRIPTION
Fixes container prune to prune created and configured containers.
Disables a couple of system prune tests as not yet in with v2.

Signed-off-by: Sujil02 <sushah@redhat.com>