### PR TITLE
    fix commands without input

### DIFF
--- a/cmd/podman/containers/attach.go
+++ b/cmd/podman/containers/attach.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/containers/libpod/cmd/podman/registry"
+	"github.com/containers/libpod/cmd/podman/validate"
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -17,12 +18,7 @@ var (
 		Short: "Attach to a running container",
 		Long:  attachDescription,
 		RunE:  attach,
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 1 || (len(args) == 0 && !cmd.Flag("latest").Changed) {
-				return errors.Errorf("attach requires the name or id of one running container or the latest flag")
-			}
-			return nil
-		},
+		Args:  validate.IdOrLatestArgs,
 		Example: `podman attach ctrID
   podman attach 1234
   podman attach --no-stdin foobar`,
@@ -33,6 +29,7 @@ var (
 		Short: attachCommand.Short,
 		Long:  attachCommand.Long,
 		RunE:  attachCommand.RunE,
+		Args:  validate.IdOrLatestArgs,
 		Example: `podman container attach ctrID
 	podman container attach 1234
 	podman container attach --no-stdin foobar`,

--- a/cmd/podman/containers/commit.go
+++ b/cmd/podman/containers/commit.go
@@ -30,6 +30,7 @@ var (
 	}
 
 	containerCommitCommand = &cobra.Command{
+		Args:  cobra.MinimumNArgs(1),
 		Use:   commitCommand.Use,
 		Short: commitCommand.Short,
 		Long:  commitCommand.Long,

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -33,6 +33,7 @@ var (
 	}
 
 	containerCreateCommand = &cobra.Command{
+		Args:  cobra.MinimumNArgs(1),
 		Use:   createCommand.Use,
 		Short: createCommand.Short,
 		Long:  createCommand.Long,

--- a/cmd/podman/containers/exec.go
+++ b/cmd/podman/containers/exec.go
@@ -16,20 +16,22 @@ var (
 	execDescription = `Execute the specified command inside a running container.
 `
 	execCommand = &cobra.Command{
-		Use:   "exec [flags] CONTAINER [COMMAND [ARG...]]",
-		Short: "Run a process in a running container",
-		Long:  execDescription,
-		RunE:  exec,
+		Use:                   "exec [flags] CONTAINER [COMMAND [ARG...]]",
+		Short:                 "Run a process in a running container",
+		Long:                  execDescription,
+		RunE:                  exec,
+		DisableFlagsInUseLine: true,
 		Example: `podman exec -it ctrID ls
   podman exec -it -w /tmp myCtr pwd
   podman exec --user root ctrID ls`,
 	}
 
 	containerExecCommand = &cobra.Command{
-		Use:   execCommand.Use,
-		Short: execCommand.Short,
-		Long:  execCommand.Long,
-		RunE:  execCommand.RunE,
+		Use:                   execCommand.Use,
+		Short:                 execCommand.Short,
+		Long:                  execCommand.Long,
+		RunE:                  execCommand.RunE,
+		DisableFlagsInUseLine: true,
 		Example: `podman container exec -it ctrID ls
   podman container exec -it -w /tmp myCtr pwd
   podman container exec --user root ctrID ls`,
@@ -79,6 +81,10 @@ func init() {
 
 func exec(cmd *cobra.Command, args []string) error {
 	var nameOrId string
+
+	if len(args) == 0 && !execOpts.Latest {
+		return errors.New("exec requires the name or ID of a container or the --latest flag")
+	}
 	execOpts.Cmd = args
 	if !execOpts.Latest {
 		execOpts.Cmd = args[1:]

--- a/cmd/podman/containers/export.go
+++ b/cmd/podman/containers/export.go
@@ -28,6 +28,7 @@ var (
 	}
 
 	containerExportCommand = &cobra.Command{
+		Args:  cobra.MinimumNArgs(1),
 		Use:   exportCommand.Use,
 		Short: exportCommand.Short,
 		Long:  exportCommand.Long,

--- a/cmd/podman/containers/kill.go
+++ b/cmd/podman/containers/kill.go
@@ -30,6 +30,9 @@ var (
 	}
 
 	containerKillCommand = &cobra.Command{
+		Args: func(cmd *cobra.Command, args []string) error {
+			return parse.CheckAllLatestAndCIDFile(cmd, args, false, false)
+		},
 		Use:   killCommand.Use,
 		Short: killCommand.Short,
 		Long:  killCommand.Long,

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -38,6 +38,9 @@ var (
 		Short: rmCommand.Use,
 		Long:  rmCommand.Long,
 		RunE:  rmCommand.RunE,
+		Args: func(cmd *cobra.Command, args []string) error {
+			return parse.CheckAllLatestAndCIDFile(cmd, args, false, true)
+		},
 		Example: `podman container rm imageID
   podman container rm mywebserver myflaskserver 860a4b23
   podman container rm --force --all

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -20,6 +20,7 @@ import (
 var (
 	runDescription = "Runs a command in a new container from the given image"
 	runCommand     = &cobra.Command{
+		Args:  cobra.MinimumNArgs(1),
 		Use:   "run [flags] IMAGE [COMMAND [ARG...]]",
 		Short: "Run a command in a new container",
 		Long:  runDescription,
@@ -30,6 +31,7 @@ var (
 	}
 
 	containerRunCommand = &cobra.Command{
+		Args:  cobra.MinimumNArgs(1),
 		Use:   runCommand.Use,
 		Short: runCommand.Short,
 		Long:  runCommand.Long,

--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -34,6 +34,9 @@ var (
 		Short: stopCommand.Short,
 		Long:  stopCommand.Long,
 		RunE:  stopCommand.RunE,
+		Args: func(cmd *cobra.Command, args []string) error {
+			return parse.CheckAllLatestAndCIDFile(cmd, args, false, true)
+		},
 		Example: `podman container stop ctrID
   podman container stop --latest
   podman container stop --time 2 mywebserver 6e534f14da9d`,

--- a/cmd/podman/containers/unmount.go
+++ b/cmd/podman/containers/unmount.go
@@ -40,6 +40,9 @@ var (
 		Short: umountCommand.Short,
 		Long:  umountCommand.Long,
 		RunE:  umountCommand.RunE,
+		Args: func(cmd *cobra.Command, args []string) error {
+			return parse.CheckAllLatestAndCIDFile(cmd, args, false, false)
+		},
 		Example: `podman container umount ctrID
   podman container umount ctrID1 ctrID2 ctrID3
   podman container umount --all`,

--- a/cmd/podman/containers/wait.go
+++ b/cmd/podman/containers/wait.go
@@ -34,6 +34,7 @@ var (
 		Short: waitCommand.Short,
 		Long:  waitCommand.Long,
 		RunE:  waitCommand.RunE,
+		Args:  validate.IdOrLatestArgs,
 		Example: `podman container wait --latest
   podman container wait --interval 5000 ctrID
   podman container wait ctrID1 ctrID2`,

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -45,6 +45,7 @@ var (
 		Short: pullCmd.Short,
 		Long:  pullCmd.Long,
 		RunE:  pullCmd.RunE,
+		Args:  cobra.ExactArgs(1),
 		Example: `podman image pull imageName
   podman image pull fedora:latest`,
 	}

--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -19,7 +19,7 @@ type loginOptionsWrapper struct {
 var (
 	loginOptions = loginOptionsWrapper{}
 	loginCommand = &cobra.Command{
-		Use:   "login [flags] REGISTRY",
+		Use:   "login [flags] [REGISTRY]",
 		Short: "Login to a container registry",
 		Long:  "Login to a container registry on a specified server.",
 		RunE:  login,

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -14,7 +14,7 @@ import (
 var (
 	logoutOptions = auth.LogoutOptions{}
 	logoutCommand = &cobra.Command{
-		Use:   "logout [flags] REGISTRY",
+		Use:   "logout [flags] [REGISTRY]",
 		Short: "Logout of a container registry",
 		Long:  "Remove the cached username and password for the registry.",
 		RunE:  logout,

--- a/test/system/015-help.bats
+++ b/test/system/015-help.bats
@@ -71,7 +71,7 @@ function check_help() {
             # try to read username/password from stdin.
             dprint "podman $@ $cmd (without required args)"
             run_podman 125 "$@" $cmd </dev/null
-            is "$output" "Error:.* \(require\|specif\|must\|provide\|need\|choose\)" \
+            is "$output" "Error:.* \(require\|specif\|must\|provide\|need\|choose\|accepts\)" \
                "'podman $@ $cmd' without required arg"
         fi
 


### PR DESCRIPTION
in cases where commands require input and we dont provide it, we often would segv.  This can be attributed in many cases to the subcommand not picked up the cobra Args attribute or neither had them.

this includes eds pr #6054 