### PR TITLE
check --get-login when login

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -63,6 +63,6 @@ func login(cmd *cobra.Command, args []string) error {
 		DockerCertPath:              loginOptions.CertDir,
 		DockerInsecureSkipTLSVerify: skipTLS,
 	}
-
+	loginOptions.GetLoginSet = cmd.Flag("get-login").Changed
 	return auth.Login(context.Background(), &sysCtx, &loginOptions.LoginOptions, args[0])
 }


### PR DESCRIPTION
Check --get-login is set in podman since it is not shared option from c/common and does not valid by the package.

Signed-off-by: Qi Wang <qiwan@redhat.com>