### PR TITLE
[CI:DOC]Use full repo name in podmanimage Dockerfiles

### DIFF
--- a/contrib/podmanimage/stable/Dockerfile
+++ b/contrib/podmanimage/stable/Dockerfile
@@ -6,7 +6,7 @@
 # This image can be used to create a secured container
 # that runs safely with privileges within the container.
 #
-FROM fedora:latest
+FROM registry.fedoraproject.org/fedora:latest
 
 # Don't include container-selinux and remove
 # directories used by yum that are just taking

--- a/contrib/podmanimage/stable/manual/Containerfile
+++ b/contrib/podmanimage/stable/manual/Containerfile
@@ -17,7 +17,7 @@
 #   `podman push quay.io/stable:v1.7.0 docker://quay.io/podman/stable:v1.7.0`
 #
 # Start Build Process using the latest Fedora
-FROM fedora:latest
+FROM registry.fedoraproject.org/fedora:latest
 
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking

--- a/contrib/podmanimage/testing/Dockerfile
+++ b/contrib/podmanimage/testing/Dockerfile
@@ -8,7 +8,7 @@
 # This image can be used to create a secured container
 # that runs safely with privileges within the container.
 #
-FROM fedora:latest
+FROM registry.fedoraproject.org/fedora:latest
 
 # Don't include container-selinux and remove
 # directories used by yum that are just taking

--- a/contrib/podmanimage/upstream/Dockerfile
+++ b/contrib/podmanimage/upstream/Dockerfile
@@ -8,7 +8,7 @@
 # The containers created by this image also come with a
 # Podman development environment in /root/podman.
 #
-FROM fedora:latest
+FROM registry.fedoraproject.org/fedora:latest
 ENV GOPATH=/root/podman
 
 # Install the software required to build Podman.


### PR DESCRIPTION
In the Buildah images, we had a problem where the testing image
was installed with an older version of Buildah than the stable
image.  This was apparently due to quay.io using Docker and Dockerhub
which has a version of Fedora that did not let testing
version of Buildah to be installed as it should have been.

This change fully specifies the name of the fedora image to
use.  This has not been a problem in Podman, but I'm carrying
this change here to avoid future problems.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>