### PR TITLE
Resolve apiv2 bindings test failures

### DIFF
--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -531,7 +531,7 @@ var _ = Describe("Podman containers ", func() {
 		Expect(err).ToNot(BeNil())
 	})
 
-	It("podman prune stoped containers", func() {
+	It("podman prune stopped containers", func() {
 		// Start and stop a container to enter in exited state.
 		var name = "top"
 		_, err := bt.RunTopContainer(&name, &bindings.PFalse, nil)
@@ -546,7 +546,7 @@ var _ = Describe("Podman containers ", func() {
 		Expect(len(pruneResponse.ID)).To(Equal(1))
 	})
 
-	It("podman prune stoped containers with filters", func() {
+	It("podman prune stopped containers with filters", func() {
 		// Start and stop a container to enter in exited state.
 		var name = "top"
 		_, err := bt.RunTopContainer(&name, &bindings.PFalse, nil)

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -41,11 +41,13 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 		if err != nil {
 			return err
 		}
-		sig, err := signal.ParseSignalNameOrNumber(stopSignal)
-		if err != nil {
-			return err
+		if stopSignal != "" {
+			sig, err := signal.ParseSignalNameOrNumber(stopSignal)
+			if err != nil {
+				return err
+			}
+			s.StopSignal = &sig
 		}
-		s.StopSignal = &sig
 	}
 
 	// Image envs from the image if they don't exist
@@ -60,9 +62,10 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 		if err != nil {
 			return err
 		}
+		s.Env = make(map[string]string)
 		for k, v := range envs {
 			if _, exists := s.Env[k]; !exists {
-				s.Env[v] = k
+				s.Env[k] = v
 			}
 		}
 	}
@@ -73,6 +76,7 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 	}
 
 	// labels from the image that dont exist already
+	s.Labels = make(map[string]string)
 	for k, v := range labels {
 		if _, exists := s.Labels[k]; !exists {
 			s.Labels[k] = v


### PR DESCRIPTION
V2 bindings tests were failing because of changes introduced in commit
a2ad5bb.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@rhatdan @baude @jwhonce @vrothberg PTAL.