### PR TITLE
image removal: refactor part 2

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -170,9 +170,9 @@ func run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	if runRmi {
-		_, err := registry.ImageEngine().Remove(registry.GetContext(), []string{args[0]}, entities.ImageRemoveOptions{})
-		if err != nil {
-			logrus.Errorf("%s", errors.Wrapf(err, "failed removing image"))
+		_, rmErrors := registry.ImageEngine().Remove(registry.GetContext(), []string{args[0]}, entities.ImageRemoveOptions{})
+		if len(rmErrors) > 0 {
+			logrus.Errorf("%s", errors.Wrapf(errorhandling.JoinErrors(rmErrors), "failed removing image"))
 		}
 	}
 	return nil

--- a/cmd/podman/images/rm.go
+++ b/cmd/podman/images/rm.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/registry"
 	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/containers/libpod/pkg/errorhandling"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -48,7 +49,9 @@ func rm(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("when using the --all switch, you may not pass any images names or IDs")
 	}
 
-	report, err := registry.ImageEngine().Remove(registry.GetContext(), args, imageOpts)
+	// Note: certain image-removal errors are non-fatal.  Hence, the report
+	// might be set even if err != nil.
+	report, rmErrors := registry.ImageEngine().Remove(registry.GetContext(), args, imageOpts)
 	if report != nil {
 		for _, u := range report.Untagged {
 			fmt.Println("Untagged: " + u)
@@ -62,5 +65,5 @@ func rm(cmd *cobra.Command, args []string) error {
 		registry.SetExitCode(report.ExitCode)
 	}
 
-	return err
+	return errorhandling.JoinErrors(rmErrors)
 }

--- a/libpod/runtime_img.go
+++ b/libpod/runtime_img.go
@@ -56,7 +56,7 @@ func (r *Runtime) RemoveImage(ctx context.Context, img *image.Image, force bool)
 				}
 			}
 		} else {
-			return nil, fmt.Errorf("could not remove image %s as it is being used by %d containers", img.ID(), len(imageCtrs))
+			return nil, errors.Wrapf(define.ErrImageInUse, "could not remove image %s as it is being used by %d containers", img.ID(), len(imageCtrs))
 		}
 	}
 

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containers/libpod/pkg/api/handlers/utils"
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/containers/libpod/pkg/domain/infra/abi"
+	"github.com/containers/libpod/pkg/errorhandling"
 	"github.com/containers/libpod/pkg/util"
 	utils2 "github.com/containers/libpod/utils"
 	"github.com/gorilla/schema"
@@ -700,8 +701,8 @@ func SearchImages(w http.ResponseWriter, r *http.Request) {
 	utils.WriteResponse(w, http.StatusOK, reports)
 }
 
-// ImagesRemove is the endpoint for image removal.
-func ImagesRemove(w http.ResponseWriter, r *http.Request) {
+// ImagesBatchRemove is the endpoint for batch image removal.
+func ImagesBatchRemove(w http.ResponseWriter, r *http.Request) {
 	runtime := r.Context().Value("runtime").(*libpod.Runtime)
 	decoder := r.Context().Value("decoder").(*schema.Decoder)
 	query := struct {
@@ -722,7 +723,49 @@ func ImagesRemove(w http.ResponseWriter, r *http.Request) {
 	opts := entities.ImageRemoveOptions{All: query.All, Force: query.Force}
 
 	imageEngine := abi.ImageEngine{Libpod: runtime}
-	rmReport, rmError := imageEngine.Remove(r.Context(), query.Images, opts)
-	report := handlers.LibpodImagesRemoveReport{ImageRemoveReport: *rmReport, Error: rmError.Error()}
+	rmReport, rmErrors := imageEngine.Remove(r.Context(), query.Images, opts)
+
+	strErrs := errorhandling.ErrorsToStrings(rmErrors)
+	report := handlers.LibpodImagesRemoveReport{ImageRemoveReport: *rmReport, Errors: strErrs}
 	utils.WriteResponse(w, http.StatusOK, report)
+}
+
+// ImagesRemove is the endpoint for removing one image.
+func ImagesRemove(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value("runtime").(*libpod.Runtime)
+	decoder := r.Context().Value("decoder").(*schema.Decoder)
+	query := struct {
+		Force bool `schema:"force"`
+	}{
+		Force: false,
+	}
+
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
+			errors.Wrapf(err, "failed to parse parameters for %s", r.URL.String()))
+		return
+	}
+
+	opts := entities.ImageRemoveOptions{Force: query.Force}
+	imageEngine := abi.ImageEngine{Libpod: runtime}
+	rmReport, rmErrors := imageEngine.Remove(r.Context(), []string{utils.GetName(r)}, opts)
+
+	// In contrast to batch-removal, where we're only setting the exit
+	// code, we need to have another closer look at the errors here and set
+	// the appropriate http status code.
+
+	switch rmReport.ExitCode {
+	case 0:
+		report := handlers.LibpodImagesRemoveReport{ImageRemoveReport: *rmReport, Errors: []string{}}
+		utils.WriteResponse(w, http.StatusOK, report)
+	case 1:
+		// 404 - no such image
+		utils.Error(w, "error removing image", http.StatusNotFound, errorhandling.JoinErrors(rmErrors))
+	case 2:
+		// 409 - conflict error (in use by containers)
+		utils.Error(w, "error removing image", http.StatusConflict, errorhandling.JoinErrors(rmErrors))
+	default:
+		// 500 - internal error
+		utils.Error(w, "failed to remove image", http.StatusInternalServerError, errorhandling.JoinErrors(rmErrors))
+	}
 }

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -41,7 +41,7 @@ type LibpodImagesPullReport struct {
 type LibpodImagesRemoveReport struct {
 	entities.ImageRemoveReport
 	// Image removal requires is to return data and an error.
-	Error string
+	Errors []string
 }
 
 type ContainersPruneReport struct {

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -822,7 +822,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/import"), s.APIHandler(libpod.ImagesImport)).Methods(http.MethodPost)
-	// swagger:operation GET /libpod/images/remove libpod libpodImagesRemove
+	// swagger:operation DELETE /libpod/images/remove libpod libpodImagesRemove
 	// ---
 	// tags:
 	//  - images
@@ -853,7 +853,37 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/BadParamError"
 	//   500:
 	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/remove"), s.APIHandler(libpod.ImagesRemove)).Methods(http.MethodGet)
+	r.Handle(VersionedPath("/libpod/images/remove"), s.APIHandler(libpod.ImagesBatchRemove)).Methods(http.MethodDelete)
+	// swagger:operation DELETE /libpod/images/{name:.*}/remove libpod libpodRemoveImage
+	// ---
+	// tags:
+	//  - images
+	// summary: Remove an image from the local storage.
+	// description: Remove an image from the local storage.
+	// parameters:
+	//  - in: path
+	//    name: name:.*
+	//    type: string
+	//    required: true
+	//    description: name or ID of image to remove
+	//  - in: query
+	//    name: force
+	//    type: boolean
+	//    description: remove the image even if used by containers or has other tags
+	// produces:
+	// - application/json
+	// responses:
+	//   200:
+	//     $ref: "#/responses/DocsImageDeleteResponse"
+	//   400:
+	//     $ref: "#/responses/BadParamError"
+	//   404:
+	//     $ref: '#/responses/NoSuchImage'
+	//   409:
+	//     $ref: '#/responses/ConflictError'
+	//   500:
+	//     $ref: '#/responses/InternalError'
+	r.Handle(VersionedPath("/libpod/images/{name:.*}/remove"), s.APIHandler(libpod.ImagesRemove)).Methods(http.MethodDelete)
 	// swagger:operation POST /libpod/images/pull libpod libpodImagesPull
 	// ---
 	// tags:
@@ -952,36 +982,6 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	//   500:
 	//      $ref: '#/responses/InternalError'
 	r.Handle(VersionedPath("/libpod/images/search"), s.APIHandler(libpod.SearchImages)).Methods(http.MethodGet)
-	// swagger:operation DELETE /libpod/images/{name:.*} libpod libpodRemoveImage
-	// ---
-	// tags:
-	//  - images
-	// summary: Remove Image
-	// description: Delete an image from local store
-	// parameters:
-	//  - in: path
-	//    name: name:.*
-	//    type: string
-	//    required: true
-	//    description: name or ID of image to delete
-	//  - in: query
-	//    name: force
-	//    type: boolean
-	//    description: remove the image even if used by containers or has other tags
-	// produces:
-	// - application/json
-	// responses:
-	//   200:
-	//     $ref: "#/responses/DocsImageDeleteResponse"
-	//   400:
-	//     $ref: "#/responses/BadParamError"
-	//   404:
-	//     $ref: '#/responses/NoSuchImage'
-	//   409:
-	//     $ref: '#/responses/ConflictError'
-	//   500:
-	//     $ref: '#/responses/InternalError'
-	r.Handle(VersionedPath("/libpod/images/{name:.*}"), s.APIHandler(compat.RemoveImage)).Methods(http.MethodDelete)
 	// swagger:operation GET /libpod/images/{name:.*}/get libpod libpodExportImage
 	// ---
 	// tags:

--- a/pkg/bindings/images/images.go
+++ b/pkg/bindings/images/images.go
@@ -109,36 +109,6 @@ func Load(ctx context.Context, r io.Reader, name *string) (*entities.ImageLoadRe
 	return &report, response.Process(&report)
 }
 
-// Remove deletes an image from local storage.  The optional force parameter
-// will forcibly remove the image by removing all all containers, including
-// those that are Running, first.
-func Remove(ctx context.Context, images []string, opts entities.ImageRemoveOptions) (*entities.ImageRemoveReport, error) {
-	var report handlers.LibpodImagesRemoveReport
-	conn, err := bindings.GetClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-	params := url.Values{}
-	params.Set("all", strconv.FormatBool(opts.All))
-	params.Set("force", strconv.FormatBool(opts.Force))
-	for _, i := range images {
-		params.Add("images", i)
-	}
-
-	response, err := conn.DoRequest(nil, http.MethodGet, "/images/remove", params)
-	if err != nil {
-		return nil, err
-	}
-	if err := response.Process(&report); err != nil {
-		return nil, err
-	}
-	var rmError error
-	if report.Error != "" {
-		rmError = errors.New(report.Error)
-	}
-	return &report.ImageRemoveReport, rmError
-}
-
 // Export saves an image from local storage as a tarball or image archive.  The optional format
 // parameter is used to change the format of the output.
 func Export(ctx context.Context, nameOrID string, w io.Writer, format *string, compress *bool) error {

--- a/pkg/bindings/images/rm.go
+++ b/pkg/bindings/images/rm.go
@@ -1,0 +1,65 @@
+package images
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/containers/libpod/pkg/api/handlers"
+	"github.com/containers/libpod/pkg/bindings"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/containers/libpod/pkg/errorhandling"
+)
+
+// BachtRemove removes a batch of images from the local storage.
+func BatchRemove(ctx context.Context, images []string, opts entities.ImageRemoveOptions) (*entities.ImageRemoveReport, []error) {
+	// FIXME - bindings tests are missing for this endpoint. Once the CI is
+	// re-enabled for bindings, we need to add them.  At the time of writing,
+	// the tests don't compile.
+	var report handlers.LibpodImagesRemoveReport
+	conn, err := bindings.GetClient(ctx)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	params := url.Values{}
+	params.Set("all", strconv.FormatBool(opts.All))
+	params.Set("force", strconv.FormatBool(opts.Force))
+	for _, i := range images {
+		params.Add("images", i)
+	}
+
+	response, err := conn.DoRequest(nil, http.MethodDelete, "/images/remove", params)
+	if err != nil {
+		return nil, []error{err}
+	}
+	if err := response.Process(&report); err != nil {
+		return nil, []error{err}
+	}
+
+	return &report.ImageRemoveReport, errorhandling.StringsToErrors(report.Errors)
+}
+
+// Remove removes an image from the local storage.  Use force to remove an
+// image, even if it's used by containers.
+func Remove(ctx context.Context, nameOrID string, force bool) (*entities.ImageRemoveReport, error) {
+	var report handlers.LibpodImagesRemoveReport
+	conn, err := bindings.GetClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	params := url.Values{}
+	params.Set("force", strconv.FormatBool(force))
+	response, err := conn.DoRequest(nil, http.MethodDelete, "/images/%s/remove", params, nameOrID)
+	if err != nil {
+		return nil, err
+	}
+	if err := response.Process(&report); err != nil {
+		return nil, err
+	}
+
+	errs := errorhandling.StringsToErrors(report.Errors)
+	return &report.ImageRemoveReport, errorhandling.JoinErrors(errs)
+}

--- a/pkg/bindings/test/manifests_test.go
+++ b/pkg/bindings/test/manifests_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Podman containers ", func() {
 		code, _ := bindings.CheckResponseCode(err)
 		Expect(code).To(BeNumerically("==", http.StatusInternalServerError))
 
-		_, err = images.Remove(bt.conn, id, nil)
+		_, err = images.Remove(bt.conn, id, false)
 		Expect(err).To(BeNil())
 
 		// create manifest list with images

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -19,7 +19,7 @@ type ImageEngine interface {
 	Prune(ctx context.Context, opts ImagePruneOptions) (*ImagePruneReport, error)
 	Pull(ctx context.Context, rawImage string, opts ImagePullOptions) (*ImagePullReport, error)
 	Push(ctx context.Context, source string, destination string, opts ImagePushOptions) error
-	Remove(ctx context.Context, images []string, opts ImageRemoveOptions) (*ImageRemoveReport, error)
+	Remove(ctx context.Context, images []string, opts ImageRemoveOptions) (*ImageRemoveReport, []error)
 	Save(ctx context.Context, nameOrId string, tags []string, options ImageSaveOptions) error
 	Search(ctx context.Context, term string, opts ImageSearchOptions) ([]ImageSearchReport, error)
 	Shutdown(ctx context.Context)

--- a/pkg/domain/infra/tunnel/images.go
+++ b/pkg/domain/infra/tunnel/images.go
@@ -20,8 +20,8 @@ func (ir *ImageEngine) Exists(_ context.Context, nameOrId string) (*entities.Boo
 	return &entities.BoolReport{Value: found}, err
 }
 
-func (ir *ImageEngine) Remove(ctx context.Context, imagesArg []string, opts entities.ImageRemoveOptions) (*entities.ImageRemoveReport, error) {
-	return images.Remove(ir.ClientCxt, imagesArg, opts)
+func (ir *ImageEngine) Remove(ctx context.Context, imagesArg []string, opts entities.ImageRemoveOptions) (*entities.ImageRemoveReport, []error) {
+	return images.BatchRemove(ir.ClientCxt, imagesArg, opts)
 }
 
 func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions) ([]*entities.ImageSummary, error) {

--- a/pkg/errorhandling/errorhandling.go
+++ b/pkg/errorhandling/errorhandling.go
@@ -2,9 +2,45 @@ package errorhandling
 
 import (
 	"os"
+	"strings"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
+
+// JoinErrors converts the error slice into a single human-readable error.
+func JoinErrors(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+
+	// `multierror` appends new lines which we need to remove to prevent
+	// blank lines when printing the error.
+	var multiE *multierror.Error
+	multiE = multierror.Append(multiE, errs...)
+	return errors.New(strings.TrimSpace(multiE.ErrorOrNil().Error()))
+}
+
+// ErrorsToString converts the slice of errors into a slice of corresponding
+// error messages.
+func ErrorsToStrings(errs []error) []string {
+	strErrs := make([]string, len(errs))
+	for i := range errs {
+		strErrs[i] = errs[i].Error()
+	}
+	return strErrs
+}
+
+// StringsToErrors converts a slice of error messages into a slice of
+// corresponding errors.
+func StringsToErrors(strErrs []string) []error {
+	errs := make([]error, len(strErrs))
+	for i := range strErrs {
+		errs[i] = errors.New(strErrs[i])
+	}
+	return errs
+}
 
 // SyncQuiet syncs a file and logs any error. Should only be used within
 // a defer.


### PR DESCRIPTION
Continue the refactoring of image removal.  I didn't manage to break all
the following changes into smaller and easier to digest commits due to
time constraints:

 * Return an error slice instead of a single error. Use multierror only
   in the client/frontend.  Reflect that in the types.

 * Use the batch image removal in the client while preserving the more
   rest-idiomatic single-image removal endpoint.

 * Add a new handler for the single-image removal endpoint to make it
   share the same code as the batch endpoint.

 * Expose bindings for the single and batch endpoints, so we can
   properly test them.

 * Add several convenience functions for error handling to
   pkg/errorhandling.

 * Set the correct error type in libpod to set the exit code to 2 when
   one or more containers are using an image.

 * Massage the bindings tests a bit and tackle compilation errors.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>