### PR TITLE
Fix errors found when comparing podman v1 --help versus V2

### DIFF
--- a/cmd/podman/containers/logs.go
+++ b/cmd/podman/containers/logs.go
@@ -27,7 +27,7 @@ var (
 `
 	logsCommand = &cobra.Command{
 		Use:   "logs [flags] CONTAINER [CONTAINER...]",
-		Short: "Fetch the logs of one or more container",
+		Short: "Fetch the logs of one or more containers",
 		Long:  logsDescription,
 		RunE:  logs,
 		Example: `podman logs ctrID

--- a/cmd/podman/containers/prune.go
+++ b/cmd/podman/containers/prune.go
@@ -18,10 +18,10 @@ import (
 var (
 	pruneDescription = fmt.Sprintf(`podman container prune
 
-	Removes all stopped | exited containers`)
+	Removes all non running containers`)
 	pruneCommand = &cobra.Command{
 		Use:     "prune [flags]",
-		Short:   "Remove all stopped | exited containers",
+		Short:   "Remove all non running containers",
 		Long:    pruneDescription,
 		RunE:    prune,
 		Example: `podman container prune`,
@@ -50,7 +50,7 @@ func prune(cmd *cobra.Command, args []string) error {
 	}
 	if !force {
 		reader := bufio.NewReader(os.Stdin)
-		fmt.Println("WARNING! This will remove all stopped containers.")
+		fmt.Println("WARNING! This will remove all non running containers.")
 		fmt.Print("Are you sure you want to continue? [y/N] ")
 		answer, err := reader.ReadString('\n')
 		if err != nil {

--- a/cmd/podman/containers/rm.go
+++ b/cmd/podman/containers/rm.go
@@ -35,7 +35,7 @@ var (
 
 	containerRmCommand = &cobra.Command{
 		Use:   rmCommand.Use,
-		Short: rmCommand.Use,
+		Short: rmCommand.Short,
 		Long:  rmCommand.Long,
 		RunE:  rmCommand.RunE,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/cmd/podman/healthcheck/healthcheck.go
+++ b/cmd/podman/healthcheck/healthcheck.go
@@ -11,8 +11,8 @@ var (
 	// Command: healthcheck
 	healthCmd = &cobra.Command{
 		Use:              "healthcheck",
-		Short:            "Manage Healthcheck",
-		Long:             "Manage Healthcheck",
+		Short:            "Manage health checks on containers",
+		Long:             "Run health checks on containers",
 		TraverseChildren: true,
 		RunE:             validate.SubCommandExists,
 	}

--- a/cmd/podman/images/build.go
+++ b/cmd/podman/images/build.go
@@ -1,4 +1,4 @@
-package main
+package images
 
 import (
 	"os"
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // buildFlagsWrapper are local to cmd/ as the build code is using Buildah-internal
@@ -48,6 +49,17 @@ var (
   podman build --layers --force-rm --tag imageName .`,
 	}
 
+	imageBuildCmd = &cobra.Command{
+		Args:  buildCmd.Args,
+		Use:   buildCmd.Use,
+		Short: buildCmd.Short,
+		Long:  buildCmd.Long,
+		RunE:  buildCmd.RunE,
+		Example: `podman image build .
+  podman image build --creds=username:password -t imageName -f Containerfile.simple .
+  podman image build --layers --force-rm --tag imageName .`,
+	}
+
 	buildOpts = buildFlagsWrapper{}
 )
 
@@ -66,8 +78,17 @@ func init() {
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
 		Command: buildCmd,
 	})
-	flags := buildCmd.Flags()
+	buildFlags(buildCmd.Flags())
 
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: imageBuildCmd,
+		Parent:  imageCmd,
+	})
+	buildFlags(imageBuildCmd.Flags())
+}
+
+func buildFlags(flags *pflag.FlagSet) {
 	// Podman flags
 	flags.BoolVarP(&buildOpts.SquashAll, "squash-all", "", false, "Squash all layers into a single layer")
 

--- a/cmd/podman/images/diff.go
+++ b/cmd/podman/images/diff.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -28,9 +29,11 @@ func init() {
 		Command: diffCmd,
 		Parent:  imageCmd,
 	})
+	diffFlags(diffCmd.Flags())
+}
 
+func diffFlags(flags *pflag.FlagSet) {
 	diffOpts = &entities.DiffOptions{}
-	flags := diffCmd.Flags()
 	flags.BoolVar(&diffOpts.Archive, "archive", true, "Save the diff as a tar archive")
 	_ = flags.MarkDeprecated("archive", "Provided for backwards compatibility, has no impact on output.")
 	flags.StringVar(&diffOpts.Format, "format", "", "Change the output format")

--- a/cmd/podman/images/history.go
+++ b/cmd/podman/images/history.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -32,6 +33,15 @@ var (
 		RunE:    history,
 	}
 
+	imageHistoryCmd = &cobra.Command{
+		Args:    historyCmd.Args,
+		Use:     historyCmd.Use,
+		Short:   historyCmd.Short,
+		Long:    historyCmd.Long,
+		RunE:    historyCmd.RunE,
+		Example: `podman image history imageID`,
+	}
+
 	opts = struct {
 		human   bool
 		noTrunc bool
@@ -45,8 +55,17 @@ func init() {
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
 		Command: historyCmd,
 	})
+	historyFlags(historyCmd.Flags())
 
-	flags := historyCmd.Flags()
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: imageHistoryCmd,
+		Parent:  imageCmd,
+	})
+	historyFlags(imageHistoryCmd.Flags())
+}
+
+func historyFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.format, "format", "", "Change the output to JSON or a Go template")
 	flags.BoolVarP(&opts.human, "human", "H", true, "Display sizes and dates in human readable format")
 	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Do not truncate the output")

--- a/cmd/podman/images/import.go
+++ b/cmd/podman/images/import.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -26,6 +27,17 @@ var (
   cat ctr.tar | podman -q import --message "importing the ctr.tar tarball" - image-imported
   cat ctr.tar | podman import -`,
 	}
+
+	imageImportCommand = &cobra.Command{
+		Args:  cobra.MinimumNArgs(1),
+		Use:   importCommand.Use,
+		Short: importCommand.Short,
+		Long:  importCommand.Long,
+		RunE:  importCommand.RunE,
+		Example: `podman image import http://example.com/ctr.tar url-image
+  cat ctr.tar | podman -q image import --message "importing the ctr.tar tarball" - image-imported
+  cat ctr.tar | podman image import -`,
+	}
 )
 
 var (
@@ -37,8 +49,17 @@ func init() {
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
 		Command: importCommand,
 	})
+	importFlags(importCommand.Flags())
 
-	flags := importCommand.Flags()
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: imageImportCommand,
+		Parent:  imageCmd,
+	})
+	importFlags(imageImportCommand.Flags())
+}
+
+func importFlags(flags *pflag.FlagSet) {
 	flags.StringArrayVarP(&importOpts.Changes, "change", "c", []string{}, "Apply the following possible instructions to the created image (default []): CMD | ENTRYPOINT | ENV | EXPOSE | LABEL | STOPSIGNAL | USER | VOLUME | WORKDIR")
 	flags.StringVarP(&importOpts.Message, "message", "m", "", "Set commit message for imported image")
 	flags.BoolVarP(&importOpts.Quiet, "quiet", "q", false, "Suppress output")

--- a/cmd/podman/images/load.go
+++ b/cmd/podman/images/load.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -27,6 +28,14 @@ var (
 		RunE:  load,
 		Args:  cobra.MaximumNArgs(1),
 	}
+
+	imageLoadCommand = &cobra.Command{
+		Args:  cobra.MinimumNArgs(1),
+		Use:   loadCommand.Use,
+		Short: loadCommand.Short,
+		Long:  loadCommand.Long,
+		RunE:  loadCommand.RunE,
+	}
 )
 
 var (
@@ -38,8 +47,16 @@ func init() {
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
 		Command: loadCommand,
 	})
+	loadFlags(loadCommand.Flags())
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: imageLoadCommand,
+		Parent:  imageCmd,
+	})
+	loadFlags(imageLoadCommand.Flags())
+}
 
-	flags := loadCommand.Flags()
+func loadFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&loadOpts.Input, "input", "i", "", "Read from specified archive file (default: stdin)")
 	flags.BoolVarP(&loadOpts.Quiet, "quiet", "q", false, "Suppress the output")
 	flags.StringVar(&loadOpts.SignaturePolicy, "signature-policy", "", "Pathname of signature policy file")

--- a/cmd/podman/images/save.go
+++ b/cmd/podman/images/save.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -43,6 +44,16 @@ var (
   podman save --format docker-dir -o ubuntu-dir ubuntu
   podman save > alpine-all.tar alpine:latest`,
 	}
+	imageSaveCommand = &cobra.Command{
+		Args:  saveCommand.Args,
+		Use:   saveCommand.Use,
+		Short: saveCommand.Short,
+		Long:  saveCommand.Long,
+		RunE:  saveCommand.RunE,
+		Example: `podman image save --quiet -o myimage.tar imageID
+  podman image save --format docker-dir -o ubuntu-dir ubuntu
+  podman image save > alpine-all.tar alpine:latest`,
+	}
 )
 
 var (
@@ -54,7 +65,17 @@ func init() {
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
 		Command: saveCommand,
 	})
-	flags := saveCommand.Flags()
+	saveFlags(saveCommand.Flags())
+
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: imageSaveCommand,
+		Parent:  imageCmd,
+	})
+	saveFlags(imageSaveCommand.Flags())
+}
+
+func saveFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&saveOpts.Compress, "compress", false, "Compress tarball image layers when saving to a directory using the 'dir' transport. (default is same compression type as source)")
 	flags.StringVar(&saveOpts.Format, "format", define.V2s2Archive, "Save image to oci-archive, oci-dir (directory with oci manifest type), docker-archive, docker-dir (directory with v2s2 manifest type)")
 	flags.StringVarP(&saveOpts.Output, "output", "o", "", "Write to a specified file (default: stdout, which must be redirected)")

--- a/cmd/podman/images/tag.go
+++ b/cmd/podman/images/tag.go
@@ -18,12 +18,28 @@ var (
   podman tag imageID:latest myNewImage:newTag
   podman tag httpd myregistryhost:5000/fedora/httpd:v2`,
 	}
+
+	imageTagCommand = &cobra.Command{
+		Args:  tagCommand.Args,
+		Use:   tagCommand.Use,
+		Short: tagCommand.Short,
+		Long:  tagCommand.Long,
+		RunE:  tagCommand.RunE,
+		Example: `podman image tag 0e3bbc2 fedora:latest
+  podman image tag imageID:latest myNewImage:newTag
+  podman image tag httpd myregistryhost:5000/fedora/httpd:v2`,
+	}
 )
 
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
 		Command: tagCommand,
+	})
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: imageTagCommand,
+		Parent:  imageCmd,
 	})
 }
 

--- a/cmd/podman/images/untag.go
+++ b/cmd/podman/images/untag.go
@@ -17,12 +17,28 @@ var (
   podman untag imageID:latest otherImageName:latest
   podman untag httpd myregistryhost:5000/fedora/httpd:v2`,
 	}
+
+	imageUntagCommand = &cobra.Command{
+		Args:  untagCommand.Args,
+		Use:   untagCommand.Use,
+		Short: untagCommand.Short,
+		Long:  untagCommand.Long,
+		RunE:  untagCommand.RunE,
+		Example: `podman image untag 0e3bbc2
+  podman image untag imageID:latest otherImageName:latest
+  podman image untag httpd myregistryhost:5000/fedora/httpd:v2`,
+	}
 )
 
 func init() {
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
 		Command: untagCommand,
+	})
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: imageUntagCommand,
+		Parent:  imageCmd,
 	})
 }
 

--- a/cmd/podman/pods/pod.go
+++ b/cmd/podman/pods/pod.go
@@ -16,7 +16,7 @@ var (
 	podCmd = &cobra.Command{
 		Use:              "pod",
 		Short:            "Manage pods",
-		Long:             "Manage pods",
+		Long:             "Pods are a group of one or more containers sharing the same network, pid and ipc namespaces.",
 		TraverseChildren: true,
 		RunE:             validate.SubCommandExists,
 	}

--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -26,7 +26,7 @@ var (
 	psCmd = &cobra.Command{
 		Use:     "ps",
 		Aliases: []string{"ls", "list"},
-		Short:   "list pods",
+		Short:   "List pods",
 		Long:    psDescription,
 		RunE:    pods,
 		Args:    validate.NoArgs,

--- a/cmd/podman/pods/stats.go
+++ b/cmd/podman/pods/stats.go
@@ -35,7 +35,7 @@ var (
 	// Command: podman pod _pod_
 	statsCmd = &cobra.Command{
 		Use:   "stats [flags] [POD...]",
-		Short: "Display resource-usage statistics of pods",
+		Short: "Display a live stream of resource usage statistics for the containers in one or more pods",
 		Long:  statsDescription,
 		RunE:  stats,
 		Example: `podman pod stats

--- a/cmd/podman/pods/top.go
+++ b/cmd/podman/pods/top.go
@@ -25,7 +25,7 @@ var (
 
 	topCommand = &cobra.Command{
 		Use:   "top [flags] POD [FORMAT-DESCRIPTORS|ARGS]",
-		Short: "Display the running processes in a pod",
+		Short: "Display the running processes of containers in a pod",
 		Long:  topDescription,
 		RunE:  top,
 		Args:  cobra.ArbitraryArgs,

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -212,7 +212,7 @@ func rootFlags(opts *entities.PodmanConfig, flags *pflag.FlagSet) {
 	flags.StringSliceVar(&opts.Identities, "identity", []string{}, "path to SSH identity file")
 
 	cfg := opts.Config
-	flags.StringVar(&cfg.Engine.CgroupManager, "cgroup-manager", cfg.Engine.CgroupManager, opts.CGroupUsage)
+	flags.StringVar(&cfg.Engine.CgroupManager, "cgroup-manager", cfg.Engine.CgroupManager, "Cgroup manager to use (\"cgroupfs\"|\"systemd\")")
 	flags.StringVar(&opts.CpuProfile, "cpu-profile", "", "Path for the cpu profiling results")
 	flags.StringVar(&opts.ConmonPath, "conmon", "", "Path of the conmon binary")
 	flags.StringVar(&cfg.Engine.NetworkCmdPath, "network-cmd-path", cfg.Engine.NetworkCmdPath, "Path to the command for configuring the network")

--- a/cmd/podman/system/info.go
+++ b/cmd/podman/system/info.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -25,6 +26,15 @@ var (
 		RunE:    info,
 		Example: `podman info`,
 	}
+
+	systemInfoCommand = &cobra.Command{
+		Args:    infoCommand.Args,
+		Use:     infoCommand.Use,
+		Short:   infoCommand.Short,
+		Long:    infoCommand.Long,
+		RunE:    infoCommand.RunE,
+		Example: `podman system info`,
+	}
 )
 
 var (
@@ -37,7 +47,17 @@ func init() {
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
 		Command: infoCommand,
 	})
-	flags := infoCommand.Flags()
+	infoFlags(infoCommand.Flags())
+
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: systemInfoCommand,
+		Parent:  systemCmd,
+	})
+	infoFlags(systemInfoCommand.Flags())
+}
+
+func infoFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&debug, "debug", "D", false, "Display additional debug information")
 	flags.StringVarP(&inFormat, "format", "f", "", "Change the output format to JSON or a Go template")
 }


### PR DESCRIPTION
Mainly add missing commands to podman image, podman containers, podman system

Also fix some informations messages and descriptions.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>