### PR TITLE
BATS help test: check usage string

### DIFF
--- a/cmd/podman/containers/unpause.go
+++ b/cmd/podman/containers/unpause.go
@@ -49,7 +49,7 @@ func init() {
 
 	registry.Commands = append(registry.Commands, registry.CliCommand{
 		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
-		Command: unpauseCommand,
+		Command: containerUnpauseCommand,
 		Parent:  containerCmd,
 	})
 


### PR DESCRIPTION
Now that we've agreed that usage messages should match
what the user typed, confirm it. IOW 'podman foo --help'
should not issue a usage message for 'podman container foo'.

Fix one broken instance, 'unpause'.

Signed-off-by: Ed Santiago <santiago@redhat.com>