### PR TITLE
add {generate,play} kube

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -520,10 +520,13 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 			case "label":
 				// TODO selinux opts and label opts are the same thing
 				s.ContainerSecurityConfig.SelinuxOpts = append(s.ContainerSecurityConfig.SelinuxOpts, con[1])
+				s.Annotations[define.InspectAnnotationLabel] = con[1]
 			case "apparmor":
 				s.ContainerSecurityConfig.ApparmorProfile = con[1]
+				s.Annotations[define.InspectAnnotationApparmor] = con[1]
 			case "seccomp":
 				s.SeccompProfilePath = con[1]
+				s.Annotations[define.InspectAnnotationSeccomp] = con[1]
 			default:
 				return fmt.Errorf("invalid --security-opt 2: %q", opt)
 			}

--- a/cmd/podman/common/types.go
+++ b/cmd/podman/common/types.go
@@ -1,3 +1,0 @@
-package common
-
-var DefaultKernelNamespaces = "cgroup,ipc,net,uts"

--- a/cmd/podman/generate/kube.go
+++ b/cmd/podman/generate/kube.go
@@ -1,0 +1,65 @@
+package pods
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/containers/libpod/cmd/podman/registry"
+	"github.com/containers/libpod/cmd/podman/utils"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	kubeOptions     = entities.GenerateKubeOptions{}
+	kubeFile        = ""
+	kubeDescription = `Command generates Kubernetes pod and service YAML (v1 specification) from a podman container or pod.
+
+Whether the input is for a container or pod, Podman will always generate the specification as a pod.`
+
+	kubeCmd = &cobra.Command{
+		Use:   "kube [flags] CONTAINER | POD",
+		Short: "Generate Kubernetes YAML from a container or pod.",
+		Long:  kubeDescription,
+		RunE:  kube,
+		Args:  cobra.ExactArgs(1),
+		Example: `podman generate kube ctrID
+  podman generate kube podID
+  podman generate kube --service podID`,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode},
+		Command: kubeCmd,
+		Parent:  generateCmd,
+	})
+	flags := kubeCmd.Flags()
+	flags.BoolVarP(&kubeOptions.Service, "service", "s", false, "Generate YAML for a Kubernetes service object")
+	flags.StringVarP(&kubeFile, "filename", "f", "", "Write output to the specified path")
+	flags.SetNormalizeFunc(utils.AliasFlags)
+}
+
+func kube(cmd *cobra.Command, args []string) error {
+	report, err := registry.ContainerEngine().GenerateKube(registry.GetContext(), args[0], kubeOptions)
+	if err != nil {
+		return err
+	}
+
+	if cmd.Flags().Changed("filename") {
+		if _, err := os.Stat(kubeFile); err == nil {
+			return errors.Errorf("cannot write to %q - file exists", kubeFile)
+		}
+
+		if err := ioutil.WriteFile(kubeFile, []byte(report.Output), 0644); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	fmt.Println(report.Output)
+	return nil
+}

--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/containers/libpod/cmd/podman/images"
 	_ "github.com/containers/libpod/cmd/podman/manifest"
 	_ "github.com/containers/libpod/cmd/podman/networks"
+	_ "github.com/containers/libpod/cmd/podman/play"
 	_ "github.com/containers/libpod/cmd/podman/pods"
 	"github.com/containers/libpod/cmd/podman/registry"
 	_ "github.com/containers/libpod/cmd/podman/system"

--- a/cmd/podman/play/kube.go
+++ b/cmd/podman/play/kube.go
@@ -1,0 +1,83 @@
+package pods
+
+import (
+	"os"
+
+	"github.com/containers/common/pkg/auth"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/libpod/cmd/podman/registry"
+	"github.com/containers/libpod/cmd/podman/utils"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// playKubeOptionsWrapper allows for separating CLI-only fields from API-only
+// fields.
+type playKubeOptionsWrapper struct {
+	entities.PlayKubeOptions
+
+	TLSVerifyCLI bool
+}
+
+var (
+	// https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
+	defaultSeccompRoot = "/var/lib/kubelet/seccomp"
+	kubeOptions        = playKubeOptionsWrapper{}
+	kubeDescription    = `Command reads in a structured file of Kubernetes YAML.
+
+  It creates the pod and containers described in the YAML.  The containers within the pod are then started and the ID of the new Pod is output.`
+
+	kubeCmd = &cobra.Command{
+		Use:   "kube [flags] KUBEFILE",
+		Short: "Play a pod based on Kubernetes YAML.",
+		Long:  kubeDescription,
+		RunE:  kube,
+		Args:  cobra.ExactArgs(1),
+		Example: `podman play kube nginx.yml
+  podman play kube --creds user:password --seccomp-profile-root /custom/path apache.yml`,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode},
+		Command: kubeCmd,
+		Parent:  playCmd,
+	})
+
+	flags := kubeCmd.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
+	flags.StringVar(&kubeOptions.Credentials, "creds", "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
+	flags.StringVar(&kubeOptions.Network, "network", "", "Connect pod to CNI network(s)")
+	flags.BoolVarP(&kubeOptions.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
+	if !registry.IsRemote() {
+		flags.StringVar(&kubeOptions.Authfile, "authfile", auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
+		flags.StringVar(&kubeOptions.CertDir, "cert-dir", "", "`Pathname` of a directory containing TLS certificates and keys")
+		flags.BoolVar(&kubeOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
+		flags.StringVar(&kubeOptions.SignaturePolicy, "signature-policy", "", "`Pathname` of signature policy file (not usually used)")
+		flags.StringVar(&kubeOptions.SeccompProfileRoot, "seccomp-profile-root", defaultSeccompRoot, "Directory path for seccomp profiles")
+	}
+}
+
+func kube(cmd *cobra.Command, args []string) error {
+	// TLS verification in c/image is controlled via a `types.OptionalBool`
+	// which allows for distinguishing among set-true, set-false, unspecified
+	// which is important to implement a sane way of dealing with defaults of
+	// boolean CLI flags.
+	if cmd.Flags().Changed("tls-verify") {
+		kubeOptions.SkipTLSVerify = types.NewOptionalBool(!kubeOptions.TLSVerifyCLI)
+	}
+	if kubeOptions.Authfile != "" {
+		if _, err := os.Stat(kubeOptions.Authfile); err != nil {
+			return errors.Wrapf(err, "error getting authfile %s", kubeOptions.Authfile)
+		}
+	}
+
+	_, err := registry.ContainerEngine().PlayKube(registry.GetContext(), args[0], kubeOptions.PlayKubeOptions)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/podman/play/play.go
+++ b/cmd/podman/play/play.go
@@ -1,0 +1,26 @@
+package pods
+
+import (
+	"github.com/containers/libpod/cmd/podman/registry"
+	"github.com/containers/libpod/cmd/podman/validate"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Command: podman _play_
+	playCmd = &cobra.Command{
+		Use:              "play",
+		Short:            "Play a pod and its containers from a structured file.",
+		Long:             "Play structured data (e.g., Kubernetes pod or service yaml) based on containers and pods.",
+		TraverseChildren: true,
+		RunE:             validate.SubCommandExists,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode, entities.TunnelMode},
+		Command: playCmd,
+	})
+}

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/libpod/cmd/podman/validate"
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/containers/libpod/pkg/errorhandling"
+	createconfig "github.com/containers/libpod/pkg/spec"
 	"github.com/containers/libpod/pkg/specgen"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
@@ -57,7 +58,7 @@ func init() {
 	flags.StringVarP(&createOptions.Name, "name", "n", "", "Assign a name to the pod")
 	flags.StringVarP(&createOptions.Hostname, "hostname", "", "", "Set a hostname to the pod")
 	flags.StringVar(&podIDFile, "pod-id-file", "", "Write the pod ID to the file")
-	flags.StringVar(&share, "share", common.DefaultKernelNamespaces, "A comma delimited list of kernel namespaces the pod will share")
+	flags.StringVar(&share, "share", createconfig.DefaultKernelNamespaces, "A comma delimited list of kernel namespaces the pod will share")
 }
 
 func create(cmd *cobra.Command, args []string) error {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/containers/buildah v1.14.9-0.20200501175434-42a48f9373d9
 	github.com/containers/common v0.10.0
 	github.com/containers/conmon v2.0.14+incompatible
+	github.com/containers/image v3.0.2+incompatible
 	github.com/containers/image/v5 v5.4.3
 	github.com/containers/psgo v1.5.0
 	github.com/containers/storage v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,9 @@ github.com/containers/common v0.10.0 h1:Km1foMJJBIxceA1/UCZcIuwf8sCF71sP5DwE6Oh1
 github.com/containers/common v0.10.0/go.mod h1:6A/moCuQITXLqBe5A0WKKTcCfCmEQRbknI05HcPzOL0=
 github.com/containers/conmon v2.0.14+incompatible h1:knU1O1QxXy5YxtjMQVKEyCajROaehizK9FHaICl+P5Y=
 github.com/containers/conmon v2.0.14+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
+github.com/containers/image v1.5.1 h1:ssEuj1c24uJvdMkUa2IrawuEFZBP12p6WzrjNBTQxE0=
+github.com/containers/image v3.0.2+incompatible h1:B1lqAE8MUPCrsBLE86J0gnXleeRq8zJnQryhiiGQNyE=
+github.com/containers/image v3.0.2+incompatible/go.mod h1:8Vtij257IWSanUQKe1tAeNOm2sRVkSqQTVQ1IlwI3+M=
 github.com/containers/image/v5 v5.4.3 h1:zn2HR7uu4hpvT5QQHgjqonOzKDuM1I1UHUEmzZT5sbs=
 github.com/containers/image/v5 v5.4.3/go.mod h1:pN0tvp3YbDd7BWavK2aE0mvJUqVd2HmhPjekyWSFm0U=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b h1:Q8ePgVfHDplZ7U33NwHZkrVELsZP5fYj9pM5WBZB2GE=

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -1221,5 +1221,5 @@ func (c *Container) AutoRemove() bool {
 	if spec.Annotations == nil {
 		return false
 	}
-	return c.Spec().Annotations[InspectAnnotationAutoremove] == InspectResponseTrue
+	return c.Spec().Annotations[define.InspectAnnotationAutoremove] == define.InspectResponseTrue
 }

--- a/libpod/container_inspect.go
+++ b/libpod/container_inspect.go
@@ -16,73 +16,6 @@ import (
 	"github.com/syndtr/gocapability/capability"
 )
 
-const (
-	// InspectAnnotationCIDFile is used by Inspect to determine if a
-	// container ID file was created for the container.
-	// If an annotation with this key is found in the OCI spec, it will be
-	// used in the output of Inspect().
-	InspectAnnotationCIDFile = "io.podman.annotations.cid-file"
-	// InspectAnnotationAutoremove is used by Inspect to determine if a
-	// container will be automatically removed on exit.
-	// If an annotation with this key is found in the OCI spec and is one of
-	// the two supported boolean values (InspectResponseTrue and
-	// InspectResponseFalse) it will be used in the output of Inspect().
-	InspectAnnotationAutoremove = "io.podman.annotations.autoremove"
-	// InspectAnnotationVolumesFrom is used by Inspect to identify
-	// containers whose volumes are are being used by this container.
-	// It is expected to be a comma-separated list of container names and/or
-	// IDs.
-	// If an annotation with this key is found in the OCI spec, it will be
-	// used in the output of Inspect().
-	InspectAnnotationVolumesFrom = "io.podman.annotations.volumes-from"
-	// InspectAnnotationPrivileged is used by Inspect to identify containers
-	// which are privileged (IE, running with elevated privileges).
-	// It is expected to be a boolean, populated by one of
-	// InspectResponseTrue or InspectResponseFalse.
-	// If an annotation with this key is found in the OCI spec, it will be
-	// used in the output of Inspect().
-	InspectAnnotationPrivileged = "io.podman.annotations.privileged"
-	// InspectAnnotationPublishAll is used by Inspect to identify containers
-	// which have all the ports from their image published.
-	// It is expected to be a boolean, populated by one of
-	// InspectResponseTrue or InspectResponseFalse.
-	// If an annotation with this key is found in the OCI spec, it will be
-	// used in the output of Inspect().
-	InspectAnnotationPublishAll = "io.podman.annotations.publish-all"
-	// InspectAnnotationInit is used by Inspect to identify containers that
-	// mount an init binary in.
-	// It is expected to be a boolean, populated by one of
-	// InspectResponseTrue or InspectResponseFalse.
-	// If an annotation with this key is found in the OCI spec, it will be
-	// used in the output of Inspect().
-	InspectAnnotationInit = "io.podman.annotations.init"
-	// InspectAnnotationLabel is used by Inspect to identify containers with
-	// special SELinux-related settings. It is used to populate the output
-	// of the SecurityOpt setting.
-	// If an annotation with this key is found in the OCI spec, it will be
-	// used in the output of Inspect().
-	InspectAnnotationLabel = "io.podman.annotations.label"
-	// InspectAnnotationSeccomp is used by Inspect to identify containers
-	// with special Seccomp-related settings. It is used to populate the
-	// output of the SecurityOpt setting in Inspect.
-	// If an annotation with this key is found in the OCI spec, it will be
-	// used in the output of Inspect().
-	InspectAnnotationSeccomp = "io.podman.annotations.seccomp"
-	// InspectAnnotationApparmor is used by Inspect to identify containers
-	// with special Apparmor-related settings. It is used to populate the
-	// output of the SecurityOpt setting.
-	// If an annotation with this key is found in the OCI spec, it will be
-	// used in the output of Inspect().
-	InspectAnnotationApparmor = "io.podman.annotations.apparmor"
-
-	// InspectResponseTrue is a boolean True response for an inspect
-	// annotation.
-	InspectResponseTrue = "TRUE"
-	// InspectResponseFalse is a boolean False response for an inspect
-	// annotation.
-	InspectResponseFalse = "FALSE"
-)
-
 // inspectLocked inspects a container for low-level information.
 // The caller must held c.lock.
 func (c *Container) inspectLocked(size bool) (*define.InspectContainerData, error) {
@@ -452,26 +385,26 @@ func (c *Container) generateInspectContainerHostConfig(ctrSpec *spec.Spec, named
 
 	// Annotations
 	if ctrSpec.Annotations != nil {
-		hostConfig.ContainerIDFile = ctrSpec.Annotations[InspectAnnotationCIDFile]
-		if ctrSpec.Annotations[InspectAnnotationAutoremove] == InspectResponseTrue {
+		hostConfig.ContainerIDFile = ctrSpec.Annotations[define.InspectAnnotationCIDFile]
+		if ctrSpec.Annotations[define.InspectAnnotationAutoremove] == define.InspectResponseTrue {
 			hostConfig.AutoRemove = true
 		}
-		if ctrs, ok := ctrSpec.Annotations[InspectAnnotationVolumesFrom]; ok {
+		if ctrs, ok := ctrSpec.Annotations[define.InspectAnnotationVolumesFrom]; ok {
 			hostConfig.VolumesFrom = strings.Split(ctrs, ",")
 		}
-		if ctrSpec.Annotations[InspectAnnotationPrivileged] == InspectResponseTrue {
+		if ctrSpec.Annotations[define.InspectAnnotationPrivileged] == define.InspectResponseTrue {
 			hostConfig.Privileged = true
 		}
-		if ctrSpec.Annotations[InspectAnnotationInit] == InspectResponseTrue {
+		if ctrSpec.Annotations[define.InspectAnnotationInit] == define.InspectResponseTrue {
 			hostConfig.Init = true
 		}
-		if label, ok := ctrSpec.Annotations[InspectAnnotationLabel]; ok {
+		if label, ok := ctrSpec.Annotations[define.InspectAnnotationLabel]; ok {
 			hostConfig.SecurityOpt = append(hostConfig.SecurityOpt, fmt.Sprintf("label=%s", label))
 		}
-		if seccomp, ok := ctrSpec.Annotations[InspectAnnotationSeccomp]; ok {
+		if seccomp, ok := ctrSpec.Annotations[define.InspectAnnotationSeccomp]; ok {
 			hostConfig.SecurityOpt = append(hostConfig.SecurityOpt, fmt.Sprintf("seccomp=%s", seccomp))
 		}
-		if apparmor, ok := ctrSpec.Annotations[InspectAnnotationApparmor]; ok {
+		if apparmor, ok := ctrSpec.Annotations[define.InspectAnnotationApparmor]; ok {
 			hostConfig.SecurityOpt = append(hostConfig.SecurityOpt, fmt.Sprintf("apparmor=%s", apparmor))
 		}
 	}

--- a/libpod/define/annotations.go
+++ b/libpod/define/annotations.go
@@ -1,0 +1,68 @@
+package define
+
+const (
+	// InspectAnnotationCIDFile is used by Inspect to determine if a
+	// container ID file was created for the container.
+	// If an annotation with this key is found in the OCI spec, it will be
+	// used in the output of Inspect().
+	InspectAnnotationCIDFile = "io.podman.annotations.cid-file"
+	// InspectAnnotationAutoremove is used by Inspect to determine if a
+	// container will be automatically removed on exit.
+	// If an annotation with this key is found in the OCI spec and is one of
+	// the two supported boolean values (InspectResponseTrue and
+	// InspectResponseFalse) it will be used in the output of Inspect().
+	InspectAnnotationAutoremove = "io.podman.annotations.autoremove"
+	// InspectAnnotationVolumesFrom is used by Inspect to identify
+	// containers whose volumes are are being used by this container.
+	// It is expected to be a comma-separated list of container names and/or
+	// IDs.
+	// If an annotation with this key is found in the OCI spec, it will be
+	// used in the output of Inspect().
+	InspectAnnotationVolumesFrom = "io.podman.annotations.volumes-from"
+	// InspectAnnotationPrivileged is used by Inspect to identify containers
+	// which are privileged (IE, running with elevated privileges).
+	// It is expected to be a boolean, populated by one of
+	// InspectResponseTrue or InspectResponseFalse.
+	// If an annotation with this key is found in the OCI spec, it will be
+	// used in the output of Inspect().
+	InspectAnnotationPrivileged = "io.podman.annotations.privileged"
+	// InspectAnnotationPublishAll is used by Inspect to identify containers
+	// which have all the ports from their image published.
+	// It is expected to be a boolean, populated by one of
+	// InspectResponseTrue or InspectResponseFalse.
+	// If an annotation with this key is found in the OCI spec, it will be
+	// used in the output of Inspect().
+	InspectAnnotationPublishAll = "io.podman.annotations.publish-all"
+	// InspectAnnotationInit is used by Inspect to identify containers that
+	// mount an init binary in.
+	// It is expected to be a boolean, populated by one of
+	// InspectResponseTrue or InspectResponseFalse.
+	// If an annotation with this key is found in the OCI spec, it will be
+	// used in the output of Inspect().
+	InspectAnnotationInit = "io.podman.annotations.init"
+	// InspectAnnotationLabel is used by Inspect to identify containers with
+	// special SELinux-related settings. It is used to populate the output
+	// of the SecurityOpt setting.
+	// If an annotation with this key is found in the OCI spec, it will be
+	// used in the output of Inspect().
+	InspectAnnotationLabel = "io.podman.annotations.label"
+	// InspectAnnotationSeccomp is used by Inspect to identify containers
+	// with special Seccomp-related settings. It is used to populate the
+	// output of the SecurityOpt setting in Inspect.
+	// If an annotation with this key is found in the OCI spec, it will be
+	// used in the output of Inspect().
+	InspectAnnotationSeccomp = "io.podman.annotations.seccomp"
+	// InspectAnnotationApparmor is used by Inspect to identify containers
+	// with special Apparmor-related settings. It is used to populate the
+	// output of the SecurityOpt setting.
+	// If an annotation with this key is found in the OCI spec, it will be
+	// used in the output of Inspect().
+	InspectAnnotationApparmor = "io.podman.annotations.apparmor"
+
+	// InspectResponseTrue is a boolean True response for an inspect
+	// annotation.
+	InspectResponseTrue = "TRUE"
+	// InspectResponseFalse is a boolean False response for an inspect
+	// annotation.
+	InspectResponseFalse = "FALSE"
+)

--- a/libpod/kube.go
+++ b/libpod/kube.go
@@ -469,7 +469,7 @@ func generateKubeSecurityContext(c *Container) (*v1.SecurityContext, error) {
 	}
 
 	var selinuxOpts v1.SELinuxOptions
-	opts := strings.SplitN(c.config.Spec.Annotations[InspectAnnotationLabel], ":", 2)
+	opts := strings.SplitN(c.config.Spec.Annotations[define.InspectAnnotationLabel], ":", 2)
 	if len(opts) == 2 {
 		switch opts[0] {
 		case "type":

--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -19,7 +19,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// - application/json
 	// parameters:
 	//  - in: query
-	//    name: fromImage
+	//    name: fromImagepanic("implement me")
 	//    type: string
 	//    description: needs description
 	//  - in: query

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -43,6 +43,7 @@ type ContainerEngine interface {
 	ContainerWait(ctx context.Context, namesOrIds []string, options WaitOptions) ([]WaitReport, error)
 	Events(ctx context.Context, opts EventsOptions) error
 	GenerateSystemd(ctx context.Context, nameOrID string, opts GenerateSystemdOptions) (*GenerateSystemdReport, error)
+	GenerateKube(ctx context.Context, nameOrID string, opts GenerateKubeOptions) (*GenerateKubeReport, error)
 	SystemPrune(ctx context.Context, options SystemPruneOptions) (*SystemPruneReport, error)
 	HealthCheckRun(ctx context.Context, nameOrId string, options HealthCheckOptions) (*define.HealthCheckResults, error)
 	Info(ctx context.Context) (*define.Info, error)
@@ -50,6 +51,7 @@ type ContainerEngine interface {
 	NetworkInspect(ctx context.Context, namesOrIds []string, options NetworkInspectOptions) ([]NetworkInspectReport, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) ([]*NetworkListReport, error)
 	NetworkRm(ctx context.Context, namesOrIds []string, options NetworkRmOptions) ([]*NetworkRmReport, error)
+	PlayKube(ctx context.Context, path string, opts PlayKubeOptions) (*PlayKubeReport, error)
 	PodCreate(ctx context.Context, opts PodCreateOptions) (*PodCreateReport, error)
 	PodExists(ctx context.Context, nameOrId string) (*BoolReport, error)
 	PodInspect(ctx context.Context, options PodInspectOptions) (*PodInspectReport, error)

--- a/pkg/domain/entities/generate.go
+++ b/pkg/domain/entities/generate.go
@@ -20,3 +20,16 @@ type GenerateSystemdReport struct {
 	// entire content.
 	Output string
 }
+
+// GenerateKubeOptions control the generation of Kubernetes YAML files.
+type GenerateKubeOptions struct {
+	// Service - generate YAML for a Kubernetes _service_ object.
+	Service bool
+}
+
+// GenerateKubeReport
+type GenerateKubeReport struct {
+	// Output of the generate process. Either the generated files or their
+	// entire content.
+	Output string
+}

--- a/pkg/domain/entities/play.go
+++ b/pkg/domain/entities/play.go
@@ -1,0 +1,29 @@
+package entities
+
+import "github.com/containers/image/v5/types"
+
+// PlayKubeOptions controls playing kube YAML files.
+type PlayKubeOptions struct {
+	// Authfile - path to an authentication file.
+	Authfile string
+	// CertDir - to a directory containing TLS certifications and keys.
+	CertDir string
+	// Credentials - `username:password` for authentication against a
+	// container registry.
+	Credentials string
+	// Network - name of the CNI network to connect to.
+	Network string
+	// Quiet - suppress output when pulling images.
+	Quiet bool
+	// SignaturePolicy - path to a signature-policy file.
+	SignaturePolicy string
+	// SkipTLSVerify - skip https and certificate validation when
+	// contacting container registries.
+	SkipTLSVerify types.OptionalBool
+	// SeccompProfileRoot - path to a directory containing seccomp
+	// profiles.
+	SeccompProfileRoot string
+}
+
+// PlayKubeReport includes the results from executing play kube.
+type PlayKubeReport struct{}

--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -6,9 +6,12 @@ import (
 	"strings"
 
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/containers/libpod/pkg/systemd/generate"
+	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	k8sAPI "k8s.io/api/core/v1"
 )
 
 func (ic *ContainerEngine) GenerateSystemd(ctx context.Context, nameOrID string, options entities.GenerateSystemdOptions) (*entities.GenerateSystemdReport, error) {
@@ -171,4 +174,85 @@ func generateServiceName(ctr *libpod.Container, pod *libpod.Pod, options entitie
 		}
 	}
 	return ctrName, fmt.Sprintf("%s-%s", kind, name)
+}
+
+func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrID string, options entities.GenerateKubeOptions) (*entities.GenerateKubeReport, error) {
+	var (
+		pod          *libpod.Pod
+		podYAML      *k8sAPI.Pod
+		err          error
+		ctr          *libpod.Container
+		servicePorts []k8sAPI.ServicePort
+		serviceYAML  k8sAPI.Service
+	)
+	// Get the container in question.
+	ctr, err = ic.Libpod.LookupContainer(nameOrID)
+	if err != nil {
+		pod, err = ic.Libpod.LookupPod(nameOrID)
+		if err != nil {
+			return nil, err
+		}
+		podYAML, servicePorts, err = pod.GenerateForKube()
+	} else {
+		if len(ctr.Dependencies()) > 0 {
+			return nil, errors.Wrapf(define.ErrNotImplemented, "containers with dependencies")
+		}
+		podYAML, err = ctr.GenerateForKube()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if options.Service {
+		serviceYAML = libpod.GenerateKubeServiceFromV1Pod(podYAML, servicePorts)
+	}
+
+	output, err := generateKubeOutput(podYAML, &serviceYAML)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entities.GenerateKubeReport{Output: output}, nil
+}
+
+func generateKubeOutput(podYAML *k8sAPI.Pod, serviceYAML *k8sAPI.Service) (string, error) {
+	var (
+		output            []byte
+		marshalledPod     []byte
+		marshalledService []byte
+		err               error
+	)
+
+	marshalledPod, err = yaml.Marshal(podYAML)
+	if err != nil {
+		return "", err
+	}
+
+	if serviceYAML != nil {
+		marshalledService, err = yaml.Marshal(serviceYAML)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	header := `# Generation of Kubernetes YAML is still under development!
+#
+# Save the output of this file and use kubectl create -f to import
+# it into Kubernetes.
+#
+# Created with podman-%s
+`
+	podmanVersion, err := define.GetVersion()
+	if err != nil {
+		return "", err
+	}
+
+	output = append(output, []byte(fmt.Sprintf(header, podmanVersion.Version))...)
+	output = append(output, marshalledPod...)
+	if serviceYAML != nil {
+		output = append(output, []byte("---\n")...)
+		output = append(output, marshalledService...)
+	}
+
+	return string(output), nil
 }

--- a/pkg/domain/infra/abi/play.go
+++ b/pkg/domain/infra/abi/play.go
@@ -1,0 +1,550 @@
+package abi
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/buildah/pkg/parse"
+	"github.com/containers/image/v5/types"
+	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/image"
+	ann "github.com/containers/libpod/pkg/annotations"
+	"github.com/containers/libpod/pkg/domain/entities"
+	envLib "github.com/containers/libpod/pkg/env"
+	ns "github.com/containers/libpod/pkg/namespaces"
+	createconfig "github.com/containers/libpod/pkg/spec"
+	"github.com/containers/libpod/pkg/specgen/generate"
+	"github.com/containers/libpod/pkg/util"
+	"github.com/containers/storage"
+	"github.com/cri-o/ocicni/pkg/ocicni"
+	"github.com/docker/distribution/reference"
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+	kubeDirectoryPermission = 0755
+	// https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+	kubeFilePermission = 0644
+)
+
+func (ic *ContainerEngine) PlayKube(ctx context.Context, path string, options entities.PlayKubeOptions) (*entities.PlayKubeReport, error) {
+	var (
+		containers    []*libpod.Container
+		pod           *libpod.Pod
+		podOptions    []libpod.PodCreateOption
+		podYAML       v1.Pod
+		registryCreds *types.DockerAuthConfig
+		writer        io.Writer
+	)
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := yaml.Unmarshal(content, &podYAML); err != nil {
+		return nil, errors.Wrapf(err, "unable to read %q as YAML", path)
+	}
+
+	if podYAML.Kind != "Pod" {
+		return nil, errors.Errorf("invalid YAML kind: %q. Pod is the only supported Kubernetes YAML kind", podYAML.Kind)
+	}
+
+	// check for name collision between pod and container
+	podName := podYAML.ObjectMeta.Name
+	if podName == "" {
+		return nil, errors.Errorf("pod does not have a name")
+	}
+	for _, n := range podYAML.Spec.Containers {
+		if n.Name == podName {
+			fmt.Printf("a container exists with the same name (%q) as the pod in your YAML file; changing pod name to %s_pod\n", podName, podName)
+			podName = fmt.Sprintf("%s_pod", podName)
+		}
+	}
+
+	podOptions = append(podOptions, libpod.WithInfraContainer())
+	podOptions = append(podOptions, libpod.WithPodName(podName))
+	// TODO for now we just used the default kernel namespaces; we need to add/subtract this from yaml
+
+	hostname := podYAML.Spec.Hostname
+	if hostname == "" {
+		hostname = podName
+	}
+	podOptions = append(podOptions, libpod.WithPodHostname(hostname))
+
+	if podYAML.Spec.HostNetwork {
+		podOptions = append(podOptions, libpod.WithPodHostNetwork())
+	}
+
+	nsOptions, err := generate.GetNamespaceOptions(strings.Split(createconfig.DefaultKernelNamespaces, ","))
+	if err != nil {
+		return nil, err
+	}
+	podOptions = append(podOptions, nsOptions...)
+	podPorts := getPodPorts(podYAML.Spec.Containers)
+	podOptions = append(podOptions, libpod.WithInfraContainerPorts(podPorts))
+
+	if options.Network != "" {
+		switch strings.ToLower(options.Network) {
+		case "bridge", "host":
+			return nil, errors.Errorf("invalid value passed to --network: bridge or host networking must be configured in YAML")
+		case "":
+			return nil, errors.Errorf("invalid value passed to --network: must provide a comma-separated list of CNI networks")
+		default:
+			// We'll assume this is a comma-separated list of CNI
+			// networks.
+			networks := strings.Split(options.Network, ",")
+			logrus.Debugf("Pod joining CNI networks: %v", networks)
+			podOptions = append(podOptions, libpod.WithPodNetworks(networks))
+		}
+	}
+
+	// Create the Pod
+	pod, err = ic.Libpod.NewPod(ctx, podOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	podInfraID, err := pod.InfraContainerID()
+	if err != nil {
+		return nil, err
+	}
+	hasUserns := false
+	if podInfraID != "" {
+		podCtr, err := ic.Libpod.GetContainer(podInfraID)
+		if err != nil {
+			return nil, err
+		}
+		mappings, err := podCtr.IDMappings()
+		if err != nil {
+			return nil, err
+		}
+		hasUserns = len(mappings.UIDMap) > 0
+	}
+
+	namespaces := map[string]string{
+		// Disabled during code review per mheon
+		//"pid":  fmt.Sprintf("container:%s", podInfraID),
+		"net": fmt.Sprintf("container:%s", podInfraID),
+		"ipc": fmt.Sprintf("container:%s", podInfraID),
+		"uts": fmt.Sprintf("container:%s", podInfraID),
+	}
+	if hasUserns {
+		namespaces["user"] = fmt.Sprintf("container:%s", podInfraID)
+	}
+	if !options.Quiet {
+		writer = os.Stderr
+	}
+
+	dockerRegistryOptions := image.DockerRegistryOptions{
+		DockerRegistryCreds:         registryCreds,
+		DockerCertPath:              options.CertDir,
+		DockerInsecureSkipTLSVerify: options.SkipTLSVerify,
+	}
+
+	// map from name to mount point
+	volumes := make(map[string]string)
+	for _, volume := range podYAML.Spec.Volumes {
+		hostPath := volume.VolumeSource.HostPath
+		if hostPath == nil {
+			return nil, errors.Errorf("HostPath is currently the only supported VolumeSource")
+		}
+		if hostPath.Type != nil {
+			switch *hostPath.Type {
+			case v1.HostPathDirectoryOrCreate:
+				if _, err := os.Stat(hostPath.Path); os.IsNotExist(err) {
+					if err := os.Mkdir(hostPath.Path, kubeDirectoryPermission); err != nil {
+						return nil, errors.Errorf("Error creating HostPath %s at %s", volume.Name, hostPath.Path)
+					}
+				}
+				// Label a newly created volume
+				if err := libpod.LabelVolumePath(hostPath.Path); err != nil {
+					return nil, errors.Wrapf(err, "Error giving %s a label", hostPath.Path)
+				}
+			case v1.HostPathFileOrCreate:
+				if _, err := os.Stat(hostPath.Path); os.IsNotExist(err) {
+					f, err := os.OpenFile(hostPath.Path, os.O_RDONLY|os.O_CREATE, kubeFilePermission)
+					if err != nil {
+						return nil, errors.Errorf("Error creating HostPath %s at %s", volume.Name, hostPath.Path)
+					}
+					if err := f.Close(); err != nil {
+						logrus.Warnf("Error in closing newly created HostPath file: %v", err)
+					}
+				}
+				// unconditionally label a newly created volume
+				if err := libpod.LabelVolumePath(hostPath.Path); err != nil {
+					return nil, errors.Wrapf(err, "Error giving %s a label", hostPath.Path)
+				}
+			case v1.HostPathDirectory:
+			case v1.HostPathFile:
+			case v1.HostPathUnset:
+				// do nothing here because we will verify the path exists in validateVolumeHostDir
+				break
+			default:
+				return nil, errors.Errorf("Directories are the only supported HostPath type")
+			}
+		}
+
+		if err := parse.ValidateVolumeHostDir(hostPath.Path); err != nil {
+			return nil, errors.Wrapf(err, "Error in parsing HostPath in YAML")
+		}
+		volumes[volume.Name] = hostPath.Path
+	}
+
+	seccompPaths, err := initializeSeccompPaths(podYAML.ObjectMeta.Annotations, options.SeccompProfileRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, container := range podYAML.Spec.Containers {
+		pullPolicy := util.PullImageMissing
+		if len(container.ImagePullPolicy) > 0 {
+			pullPolicy, err = util.ValidatePullType(string(container.ImagePullPolicy))
+			if err != nil {
+				return nil, err
+			}
+		}
+		named, err := reference.ParseNormalizedNamed(container.Image)
+		if err != nil {
+			return nil, err
+		}
+		// In kube, if the image is tagged with latest, it should always pull
+		if tagged, isTagged := named.(reference.NamedTagged); isTagged {
+			if tagged.Tag() == image.LatestTag {
+				pullPolicy = util.PullImageAlways
+			}
+		}
+		newImage, err := ic.Libpod.ImageRuntime().New(ctx, container.Image, options.SignaturePolicy, options.Authfile, writer, &dockerRegistryOptions, image.SigningOptions{}, nil, pullPolicy)
+		if err != nil {
+			return nil, err
+		}
+		conf, err := kubeContainerToCreateConfig(ctx, container, ic.Libpod, newImage, namespaces, volumes, pod.ID(), podInfraID, seccompPaths)
+		if err != nil {
+			return nil, err
+		}
+		ctr, err := createconfig.CreateContainerFromCreateConfig(ic.Libpod, conf, ctx, pod)
+		if err != nil {
+			return nil, err
+		}
+		containers = append(containers, ctr)
+	}
+
+	// start the containers
+	for _, ctr := range containers {
+		if err := ctr.Start(ctx, true); err != nil {
+			// Making this a hard failure here to avoid a mess
+			// the other containers are in created status
+			return nil, err
+		}
+	}
+
+	// We've now successfully converted this YAML into a pod
+	// print our pod and containers, signifying we succeeded
+	fmt.Printf("Pod:\n%s\n", pod.ID())
+	if len(containers) == 1 {
+		fmt.Printf("Container:\n")
+	}
+	if len(containers) > 1 {
+		fmt.Printf("Containers:\n")
+	}
+	for _, ctr := range containers {
+		fmt.Println(ctr.ID())
+	}
+
+	return nil, nil
+}
+
+// getPodPorts converts a slice of kube container descriptions to an
+// array of ocicni portmapping descriptions usable in libpod
+func getPodPorts(containers []v1.Container) []ocicni.PortMapping {
+	var infraPorts []ocicni.PortMapping
+	for _, container := range containers {
+		for _, p := range container.Ports {
+			if p.HostPort != 0 && p.ContainerPort == 0 {
+				p.ContainerPort = p.HostPort
+			}
+			if p.Protocol == "" {
+				p.Protocol = "tcp"
+			}
+			portBinding := ocicni.PortMapping{
+				HostPort:      p.HostPort,
+				ContainerPort: p.ContainerPort,
+				Protocol:      strings.ToLower(string(p.Protocol)),
+			}
+			if p.HostIP != "" {
+				logrus.Debug("HostIP on port bindings is not supported")
+			}
+			// only hostPort is utilized in podman context, all container ports
+			// are accessible inside the shared network namespace
+			if p.HostPort != 0 {
+				infraPorts = append(infraPorts, portBinding)
+			}
+
+		}
+	}
+	return infraPorts
+}
+
+func setupSecurityContext(securityConfig *createconfig.SecurityConfig, userConfig *createconfig.UserConfig, containerYAML v1.Container) {
+	if containerYAML.SecurityContext == nil {
+		return
+	}
+	if containerYAML.SecurityContext.ReadOnlyRootFilesystem != nil {
+		securityConfig.ReadOnlyRootfs = *containerYAML.SecurityContext.ReadOnlyRootFilesystem
+	}
+	if containerYAML.SecurityContext.Privileged != nil {
+		securityConfig.Privileged = *containerYAML.SecurityContext.Privileged
+	}
+
+	if containerYAML.SecurityContext.AllowPrivilegeEscalation != nil {
+		securityConfig.NoNewPrivs = !*containerYAML.SecurityContext.AllowPrivilegeEscalation
+	}
+
+	if seopt := containerYAML.SecurityContext.SELinuxOptions; seopt != nil {
+		if seopt.User != "" {
+			securityConfig.SecurityOpts = append(securityConfig.SecurityOpts, fmt.Sprintf("label=user:%s", seopt.User))
+			securityConfig.LabelOpts = append(securityConfig.LabelOpts, fmt.Sprintf("user:%s", seopt.User))
+		}
+		if seopt.Role != "" {
+			securityConfig.SecurityOpts = append(securityConfig.SecurityOpts, fmt.Sprintf("label=role:%s", seopt.Role))
+			securityConfig.LabelOpts = append(securityConfig.LabelOpts, fmt.Sprintf("role:%s", seopt.Role))
+		}
+		if seopt.Type != "" {
+			securityConfig.SecurityOpts = append(securityConfig.SecurityOpts, fmt.Sprintf("label=type:%s", seopt.Type))
+			securityConfig.LabelOpts = append(securityConfig.LabelOpts, fmt.Sprintf("type:%s", seopt.Type))
+		}
+		if seopt.Level != "" {
+			securityConfig.SecurityOpts = append(securityConfig.SecurityOpts, fmt.Sprintf("label=level:%s", seopt.Level))
+			securityConfig.LabelOpts = append(securityConfig.LabelOpts, fmt.Sprintf("level:%s", seopt.Level))
+		}
+	}
+	if caps := containerYAML.SecurityContext.Capabilities; caps != nil {
+		for _, capability := range caps.Add {
+			securityConfig.CapAdd = append(securityConfig.CapAdd, string(capability))
+		}
+		for _, capability := range caps.Drop {
+			securityConfig.CapDrop = append(securityConfig.CapDrop, string(capability))
+		}
+	}
+	if containerYAML.SecurityContext.RunAsUser != nil {
+		userConfig.User = fmt.Sprintf("%d", *containerYAML.SecurityContext.RunAsUser)
+	}
+	if containerYAML.SecurityContext.RunAsGroup != nil {
+		if userConfig.User == "" {
+			userConfig.User = "0"
+		}
+		userConfig.User = fmt.Sprintf("%s:%d", userConfig.User, *containerYAML.SecurityContext.RunAsGroup)
+	}
+}
+
+// kubeContainerToCreateConfig takes a v1.Container and returns a createconfig describing a container
+func kubeContainerToCreateConfig(ctx context.Context, containerYAML v1.Container, runtime *libpod.Runtime, newImage *image.Image, namespaces map[string]string, volumes map[string]string, podID, infraID string, seccompPaths *kubeSeccompPaths) (*createconfig.CreateConfig, error) {
+	var (
+		containerConfig createconfig.CreateConfig
+		pidConfig       createconfig.PidConfig
+		networkConfig   createconfig.NetworkConfig
+		cgroupConfig    createconfig.CgroupConfig
+		utsConfig       createconfig.UtsConfig
+		ipcConfig       createconfig.IpcConfig
+		userConfig      createconfig.UserConfig
+		securityConfig  createconfig.SecurityConfig
+	)
+
+	// The default for MemorySwappiness is -1, not 0
+	containerConfig.Resources.MemorySwappiness = -1
+
+	containerConfig.Image = containerYAML.Image
+	containerConfig.ImageID = newImage.ID()
+	containerConfig.Name = containerYAML.Name
+	containerConfig.Tty = containerYAML.TTY
+
+	containerConfig.Pod = podID
+
+	imageData, _ := newImage.Inspect(ctx)
+
+	userConfig.User = "0"
+	if imageData != nil {
+		userConfig.User = imageData.Config.User
+	}
+
+	setupSecurityContext(&securityConfig, &userConfig, containerYAML)
+
+	securityConfig.SeccompProfilePath = seccompPaths.findForContainer(containerConfig.Name)
+
+	containerConfig.Command = []string{}
+	if imageData != nil && imageData.Config != nil {
+		containerConfig.Command = append(containerConfig.Command, imageData.Config.Entrypoint...)
+	}
+	if len(containerYAML.Command) != 0 {
+		containerConfig.Command = append(containerConfig.Command, containerYAML.Command...)
+	} else if imageData != nil && imageData.Config != nil {
+		containerConfig.Command = append(containerConfig.Command, imageData.Config.Cmd...)
+	}
+	if imageData != nil && len(containerConfig.Command) == 0 {
+		return nil, errors.Errorf("No command specified in container YAML or as CMD or ENTRYPOINT in this image for %s", containerConfig.Name)
+	}
+
+	containerConfig.UserCommand = containerConfig.Command
+
+	containerConfig.StopSignal = 15
+
+	containerConfig.WorkDir = "/"
+	if imageData != nil {
+		// FIXME,
+		// we are currently ignoring imageData.Config.ExposedPorts
+		containerConfig.BuiltinImgVolumes = imageData.Config.Volumes
+		if imageData.Config.WorkingDir != "" {
+			containerConfig.WorkDir = imageData.Config.WorkingDir
+		}
+		containerConfig.Labels = imageData.Config.Labels
+		if imageData.Config.StopSignal != "" {
+			stopSignal, err := util.ParseSignal(imageData.Config.StopSignal)
+			if err != nil {
+				return nil, err
+			}
+			containerConfig.StopSignal = stopSignal
+		}
+	}
+
+	if containerYAML.WorkingDir != "" {
+		containerConfig.WorkDir = containerYAML.WorkingDir
+	}
+	// If the user does not pass in ID mappings, just set to basics
+	if userConfig.IDMappings == nil {
+		userConfig.IDMappings = &storage.IDMappingOptions{}
+	}
+
+	networkConfig.NetMode = ns.NetworkMode(namespaces["net"])
+	ipcConfig.IpcMode = ns.IpcMode(namespaces["ipc"])
+	utsConfig.UtsMode = ns.UTSMode(namespaces["uts"])
+	// disabled in code review per mheon
+	//containerConfig.PidMode = ns.PidMode(namespaces["pid"])
+	userConfig.UsernsMode = ns.UsernsMode(namespaces["user"])
+	if len(containerConfig.WorkDir) == 0 {
+		containerConfig.WorkDir = "/"
+	}
+
+	containerConfig.Pid = pidConfig
+	containerConfig.Network = networkConfig
+	containerConfig.Uts = utsConfig
+	containerConfig.Ipc = ipcConfig
+	containerConfig.Cgroup = cgroupConfig
+	containerConfig.User = userConfig
+	containerConfig.Security = securityConfig
+
+	annotations := make(map[string]string)
+	if infraID != "" {
+		annotations[ann.SandboxID] = infraID
+		annotations[ann.ContainerType] = ann.ContainerTypeContainer
+	}
+	containerConfig.Annotations = annotations
+
+	// Environment Variables
+	envs := map[string]string{}
+	if imageData != nil {
+		imageEnv, err := envLib.ParseSlice(imageData.Config.Env)
+		if err != nil {
+			return nil, errors.Wrap(err, "error parsing image environment variables")
+		}
+		envs = imageEnv
+	}
+	for _, e := range containerYAML.Env {
+		envs[e.Name] = e.Value
+	}
+	containerConfig.Env = envs
+
+	for _, volume := range containerYAML.VolumeMounts {
+		hostPath, exists := volumes[volume.Name]
+		if !exists {
+			return nil, errors.Errorf("Volume mount %s specified for container but not configured in volumes", volume.Name)
+		}
+		if err := parse.ValidateVolumeCtrDir(volume.MountPath); err != nil {
+			return nil, errors.Wrapf(err, "error in parsing MountPath")
+		}
+		containerConfig.Volumes = append(containerConfig.Volumes, fmt.Sprintf("%s:%s", hostPath, volume.MountPath))
+	}
+	return &containerConfig, nil
+}
+
+// kubeSeccompPaths holds information about a pod YAML's seccomp configuration
+// it holds both container and pod seccomp paths
+type kubeSeccompPaths struct {
+	containerPaths map[string]string
+	podPath        string
+}
+
+// findForContainer checks whether a container has a seccomp path configured for it
+// if not, it returns the podPath, which should always have a value
+func (k *kubeSeccompPaths) findForContainer(ctrName string) string {
+	if path, ok := k.containerPaths[ctrName]; ok {
+		return path
+	}
+	return k.podPath
+}
+
+// initializeSeccompPaths takes annotations from the pod object metadata and finds annotations pertaining to seccomp
+// it parses both pod and container level
+// if the annotation is of the form "localhost/%s", the seccomp profile will be set to profileRoot/%s
+func initializeSeccompPaths(annotations map[string]string, profileRoot string) (*kubeSeccompPaths, error) {
+	seccompPaths := &kubeSeccompPaths{containerPaths: make(map[string]string)}
+	var err error
+	if annotations != nil {
+		for annKeyValue, seccomp := range annotations {
+			// check if it is prefaced with container.seccomp.security.alpha.kubernetes.io/
+			prefixAndCtr := strings.Split(annKeyValue, "/")
+			if prefixAndCtr[0]+"/" != v1.SeccompContainerAnnotationKeyPrefix {
+				continue
+			} else if len(prefixAndCtr) != 2 {
+				// this could be caused by a user inputting either of
+				// container.seccomp.security.alpha.kubernetes.io{,/}
+				// both of which are invalid
+				return nil, errors.Errorf("Invalid seccomp path: %s", prefixAndCtr[0])
+			}
+
+			path, err := verifySeccompPath(seccomp, profileRoot)
+			if err != nil {
+				return nil, err
+			}
+			seccompPaths.containerPaths[prefixAndCtr[1]] = path
+		}
+
+		podSeccomp, ok := annotations[v1.SeccompPodAnnotationKey]
+		if ok {
+			seccompPaths.podPath, err = verifySeccompPath(podSeccomp, profileRoot)
+		} else {
+			seccompPaths.podPath, err = libpod.DefaultSeccompPath()
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	return seccompPaths, nil
+}
+
+// verifySeccompPath takes a path and checks whether it is a default, unconfined, or a path
+// the available options are parsed as defined in https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+func verifySeccompPath(path string, profileRoot string) (string, error) {
+	switch path {
+	case v1.DeprecatedSeccompProfileDockerDefault:
+		fallthrough
+	case v1.SeccompProfileRuntimeDefault:
+		return libpod.DefaultSeccompPath()
+	case "unconfined":
+		return path, nil
+	default:
+		parts := strings.Split(path, "/")
+		if parts[0] == "localhost" {
+			return filepath.Join(profileRoot, parts[1]), nil
+		}
+		return "", errors.Errorf("invalid seccomp path: %s", path)
+	}
+}

--- a/pkg/domain/infra/tunnel/generate.go
+++ b/pkg/domain/infra/tunnel/generate.go
@@ -10,3 +10,7 @@ import (
 func (ic *ContainerEngine) GenerateSystemd(ctx context.Context, nameOrID string, options entities.GenerateSystemdOptions) (*entities.GenerateSystemdReport, error) {
 	return nil, errors.New("not implemented for tunnel")
 }
+
+func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrID string, options entities.GenerateKubeOptions) (*entities.GenerateKubeReport, error) {
+	return nil, errors.New("not implemented for tunnel")
+}

--- a/pkg/domain/infra/tunnel/play.go
+++ b/pkg/domain/infra/tunnel/play.go
@@ -1,0 +1,11 @@
+package tunnel
+
+import (
+	"context"
+
+	"github.com/containers/libpod/pkg/domain/entities"
+)
+
+func (ic *ContainerEngine) PlayKube(ctx context.Context, path string, options entities.PlayKubeOptions) (*entities.PlayKubeReport, error) {
+	return nil, errors.New("not implemented yet")
+}

--- a/pkg/domain/infra/tunnel/play.go
+++ b/pkg/domain/infra/tunnel/play.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/pkg/errors"
 )
 
 func (ic *ContainerEngine) PlayKube(ctx context.Context, path string, options entities.PlayKubeOptions) (*entities.PlayKubeReport, error) {

--- a/pkg/spec/namespaces.go
+++ b/pkg/spec/namespaces.go
@@ -17,6 +17,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// DefaultKernelNamespaces is a comma-separated list of default kernel
+// namespaces.
+const DefaultKernelNamespaces = "cgroup,ipc,net,uts"
+
 // ToCreateOptions converts the input to a slice of container create options.
 func (c *NetworkConfig) ToCreateOptions(runtime *libpod.Runtime, userns *UserConfig) ([]libpod.CtrCreateOption, error) {
 	var portBindings []ocicni.PortMapping
@@ -154,9 +158,9 @@ func (c *NetworkConfig) ConfigureGenerator(g *generate.Generator) error {
 	}
 
 	if c.PublishAll {
-		g.Config.Annotations[libpod.InspectAnnotationPublishAll] = libpod.InspectResponseTrue
+		g.Config.Annotations[define.InspectAnnotationPublishAll] = define.InspectResponseTrue
 	} else {
-		g.Config.Annotations[libpod.InspectAnnotationPublishAll] = libpod.InspectResponseFalse
+		g.Config.Annotations[define.InspectAnnotationPublishAll] = define.InspectResponseFalse
 	}
 
 	return nil

--- a/pkg/spec/security.go
+++ b/pkg/spec/security.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containers/common/pkg/capabilities"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -184,11 +185,11 @@ func (c *SecurityConfig) ConfigureGenerator(g *generate.Generator, user *UserCon
 		}
 		switch splitOpt[0] {
 		case "label":
-			configSpec.Annotations[libpod.InspectAnnotationLabel] = splitOpt[1]
+			configSpec.Annotations[define.InspectAnnotationLabel] = splitOpt[1]
 		case "seccomp":
-			configSpec.Annotations[libpod.InspectAnnotationSeccomp] = splitOpt[1]
+			configSpec.Annotations[define.InspectAnnotationSeccomp] = splitOpt[1]
 		case "apparmor":
-			configSpec.Annotations[libpod.InspectAnnotationApparmor] = splitOpt[1]
+			configSpec.Annotations[define.InspectAnnotationApparmor] = splitOpt[1]
 		}
 	}
 

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -7,6 +7,7 @@ import (
 	cconfig "github.com/containers/common/pkg/config"
 	"github.com/containers/common/pkg/sysinfo"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/cgroups"
 	"github.com/containers/libpod/pkg/env"
 	"github.com/containers/libpod/pkg/rootless"
@@ -436,29 +437,29 @@ func (config *CreateConfig) createConfigToOCISpec(runtime *libpod.Runtime, userM
 	}
 
 	if config.CidFile != "" {
-		configSpec.Annotations[libpod.InspectAnnotationCIDFile] = config.CidFile
+		configSpec.Annotations[define.InspectAnnotationCIDFile] = config.CidFile
 	}
 
 	if config.Rm {
-		configSpec.Annotations[libpod.InspectAnnotationAutoremove] = libpod.InspectResponseTrue
+		configSpec.Annotations[define.InspectAnnotationAutoremove] = define.InspectResponseTrue
 	} else {
-		configSpec.Annotations[libpod.InspectAnnotationAutoremove] = libpod.InspectResponseFalse
+		configSpec.Annotations[define.InspectAnnotationAutoremove] = define.InspectResponseFalse
 	}
 
 	if len(config.VolumesFrom) > 0 {
-		configSpec.Annotations[libpod.InspectAnnotationVolumesFrom] = strings.Join(config.VolumesFrom, ",")
+		configSpec.Annotations[define.InspectAnnotationVolumesFrom] = strings.Join(config.VolumesFrom, ",")
 	}
 
 	if config.Security.Privileged {
-		configSpec.Annotations[libpod.InspectAnnotationPrivileged] = libpod.InspectResponseTrue
+		configSpec.Annotations[define.InspectAnnotationPrivileged] = define.InspectResponseTrue
 	} else {
-		configSpec.Annotations[libpod.InspectAnnotationPrivileged] = libpod.InspectResponseFalse
+		configSpec.Annotations[define.InspectAnnotationPrivileged] = define.InspectResponseFalse
 	}
 
 	if config.Init {
-		configSpec.Annotations[libpod.InspectAnnotationInit] = libpod.InspectResponseTrue
+		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseTrue
 	} else {
-		configSpec.Annotations[libpod.InspectAnnotationInit] = libpod.InspectResponseFalse
+		configSpec.Annotations[define.InspectAnnotationInit] = define.InspectResponseFalse
 	}
 
 	return configSpec, nil

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -438,9 +438,9 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 		g.Config.Annotations = make(map[string]string)
 	}
 	if s.PublishExposedPorts {
-		g.Config.Annotations[libpod.InspectAnnotationPublishAll] = libpod.InspectResponseTrue
+		g.Config.Annotations[define.InspectAnnotationPublishAll] = define.InspectResponseTrue
 	} else {
-		g.Config.Annotations[libpod.InspectAnnotationPublishAll] = libpod.InspectResponseFalse
+		g.Config.Annotations[define.InspectAnnotationPublishAll] = define.InspectResponseFalse
 	}
 
 	return nil

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/specgen"
@@ -327,19 +328,19 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	//}
 
 	if s.Remove {
-		configSpec.Annotations[libpod.InspectAnnotationAutoremove] = libpod.InspectResponseTrue
+		configSpec.Annotations[define.InspectAnnotationAutoremove] = define.InspectResponseTrue
 	} else {
-		configSpec.Annotations[libpod.InspectAnnotationAutoremove] = libpod.InspectResponseFalse
+		configSpec.Annotations[define.InspectAnnotationAutoremove] = define.InspectResponseFalse
 	}
 
 	if len(s.VolumesFrom) > 0 {
-		configSpec.Annotations[libpod.InspectAnnotationVolumesFrom] = strings.Join(s.VolumesFrom, ",")
+		configSpec.Annotations[define.InspectAnnotationVolumesFrom] = strings.Join(s.VolumesFrom, ",")
 	}
 
 	if s.Privileged {
-		configSpec.Annotations[libpod.InspectAnnotationPrivileged] = libpod.InspectResponseTrue
+		configSpec.Annotations[define.InspectAnnotationPrivileged] = define.InspectResponseTrue
 	} else {
-		configSpec.Annotations[libpod.InspectAnnotationPrivileged] = libpod.InspectResponseFalse
+		configSpec.Annotations[define.InspectAnnotationPrivileged] = define.InspectResponseFalse
 	}
 
 	// TODO Init might not make it into the specgen and therefore is not available here.  We should deal

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -21,7 +21,6 @@ var _ = Describe("Podman generate kube", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -217,7 +217,6 @@ var _ = Describe("Podman generate kube", func() {
 	)
 
 	BeforeEach(func() {
-		Skip(v2fail)
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
Add the `podman generate kube` and `podman play kube` command.  The code
has largely been copied from Podman v1 but restructured to not leak the
K8s core API into the (remote) client.

Both commands are added in the same commit to allow for enabling the
tests at the same time.

Move some exports from `cmd/podman/common` to the appropriate places in
the backend to avoid circular dependencies.

Move definitions of label annotations to `libpod/define` and set the
security-opt labels in the frontend to make kube tests pass.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>