### PR TITLE
Set up ulimits for rootless containers.

### DIFF
--- a/pkg/spec/config_linux.go
+++ b/pkg/spec/config_linux.go
@@ -16,6 +16,7 @@ import (
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -365,4 +366,28 @@ func GetStatFromPath(path string) (unix.Stat_t, error) {
 	s := unix.Stat_t{}
 	err := unix.Stat(path, &s)
 	return s, err
+}
+
+func getNOFILESettings() (uint64, uint64) {
+	if rootless.IsRootless() {
+		var rlimit unix.Rlimit
+		if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit); err == nil {
+			return rlimit.Cur, rlimit.Max
+		} else {
+			logrus.Warnf("failed to return RLIMIT_NOFILE ulimit %q", err)
+		}
+	}
+	return kernelMax, kernelMax
+}
+
+func getNPROCSettings() (uint64, uint64) {
+	if rootless.IsRootless() {
+		var rlimit unix.Rlimit
+		if err := unix.Getrlimit(unix.RLIMIT_NPROC, &rlimit); err == nil {
+			return rlimit.Cur, rlimit.Max
+		} else {
+			logrus.Warnf("failed to return RLIMIT_NPROC ulimit %q", err)
+		}
+	}
+	return kernelMax, kernelMax
 }

--- a/pkg/spec/config_unsupported.go
+++ b/pkg/spec/config_unsupported.go
@@ -34,3 +34,11 @@ func DevicesFromPath(g *generate.Generator, devicePath string) error {
 func deviceCgroupRules(g *generate.Generator, deviceCgroupRules []string) error {
 	return errors.New("function not implemented")
 }
+
+func getNOFILESettings() (uint64, uint64) {
+	return kernelMax, kernelMax
+}
+
+func getNPROCSettings() (uint64, uint64) {
+	return kernelMax, kernelMax
+}


### PR DESCRIPTION
Currently we are setting the maximum limits for rootful podman containers,
no reason not to set them by default for rootless users as well

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>