### PR TITLE
Add small fixes for 'podman run' from diffing inspect

### DIFF
--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -85,7 +85,12 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 		if err != nil {
 			return nil, err
 		}
-		options = append(options, libpod.WithRootFSFromImage(newImage.ID(), s.Image, s.RawImageName))
+		imgName := s.Image
+		names := newImage.Names()
+		if len(names) > 0 {
+			imgName = names[0]
+		}
+		options = append(options, libpod.WithRootFSFromImage(newImage.ID(), imgName, s.Image))
 	}
 	if err := s.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid config provided")

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -140,10 +140,6 @@ type ContainerStorageConfig struct {
 	// Conflicts with Rootfs.
 	// At least one of Image or Rootfs must be specified.
 	Image string `json:"image"`
-	// RawImageName is the unprocessed and not-normalized user-specified image
-	// name.  One use case for having this data at hand are auto-updates where
-	// the _exact_ user input is needed in order to look-up the correct image.
-	RawImageName string `json:"raw_image_name,omitempty"`
 	// Rootfs is the path to a directory that will be used as the
 	// container's root filesystem. No modification will be made to the
 	// directory, it will be directly mounted into the container as root.


### PR DESCRIPTION
To try and identify differences between Podman v1.9 and master, I ran a series of `podman run` commands with various flags through each, then inspecting the resulting containers and diffed the inspect JSON between each. This identified a number of issues which are fixed in this PR.

In order of discovery:
- Podman v2 gave short names for images, where Podman v1 gave the fully-qualified name. Simple enough fix (get image tags and use the first one if they're available)
- The --restart flag was not being parsed correctly when a number of retries was specified. Parsing has been corrected.
- The -m flag was not setting the swap limit (simple fix to set swap in that case if it's not explicitly set by the user)
- The --cpus flag was completely nonfunctional (wired in its logic)

Tests have been added for all of these to catch future regressions.