### PR TITLE
podman: split env variables in env and overrides

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -156,8 +156,7 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 	createFlags.String("entrypoint", "",
 		"Overwrite the default ENTRYPOINT of the image",
 	)
-	createFlags.StringArrayVarP(
-		&cf.env,
+	createFlags.StringArrayP(
 		"env", "e", containerConfig.Env(),
 		"Set environment variables in container",
 	)

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -32,7 +32,7 @@ type ContainerCLIOpts struct {
 	DeviceWriteBPs    []string
 	DeviceWriteIOPs   []string
 	Entrypoint        *string
-	env               []string
+	EnvOverrides      []string
 	EnvHost           bool
 	EnvFile           []string
 	Expose            []string

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -170,6 +170,13 @@ func createInit(c *cobra.Command) error {
 		val := c.Flag("entrypoint").Value.String()
 		cliVals.Entrypoint = &val
 	}
+	if c.Flags().Changed("env") {
+		env, err := c.Flags().GetStringArray("env")
+		if err != nil {
+			return errors.Wrapf(err, "retrieve env flag")
+		}
+		cliVals.EnvOverrides = env
+	}
 
 	// Docker-compatibility: the "-h" flag for run/create is reserved for
 	// the hostname (see https://github.com/containers/libpod/issues/1367).

--- a/pkg/specgen/generate/container.go
+++ b/pkg/specgen/generate/container.go
@@ -61,9 +61,7 @@ func CompleteSpec(ctx context.Context, r *libpod.Runtime, s *specgen.SpecGenerat
 			return err
 		}
 		for k, v := range envs {
-			if _, exists := s.Env[k]; !exists {
-				s.Env[v] = k
-			}
+			s.Env[k] = v
 		}
 	}
 

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -294,6 +294,9 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	for name, val := range s.Env {
 		g.AddProcessEnv(name, val)
 	}
+	for name, val := range s.EnvOverride {
+		g.AddProcessEnv(name, val)
+	}
 
 	if err := addRlimits(s, &g); err != nil {
 		return nil, err

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -43,9 +43,15 @@ type ContainerBasicConfig struct {
 	// Optional.
 	Command []string `json:"command,omitempty"`
 	// Env is a set of environment variables that will be set in the
-	// container.
+	// container.  They have lower precedence than the variables set in
+	// the image's configuration.
 	// Optional.
 	Env map[string]string `json:"env,omitempty"`
+	// EnvOverride is a set of environment variables that will be set in the
+	// container.  They have higher precedence than the variables set in
+	// the image's configuration.
+	// Optional.
+	EnvOverride map[string]string `json:"env_override,omitempty"`
 	// Terminal is whether the container will create a PTY.
 	Terminal bool `json:"terminal,omitempty"`
 	// Stdin is whether the container will keep its STDIN open.

--- a/test/e2e/build_test.go
+++ b/test/e2e/build_test.go
@@ -177,7 +177,6 @@ var _ = Describe("Podman build", func() {
 	})
 
 	It("podman Test PATH in built image", func() {
-		Skip(v2fail) // Run error - we don't set data from the image (i.e., PATH) yet
 		path := "/tmp:/bin:/usr/bin:/usr/sbin"
 		session := podmanTest.PodmanNoCache([]string{
 			"build", "-f", "build/basicalpine/Containerfile.path", "-t", "test-path",


### PR DESCRIPTION
There are three different priorities for applying env variables:

1) environment/config file environment variables
2) image's config
3) user overrides (--env)

The first and third kind are known to the client, while the image's
config is handled by the backend.

We need to carry the variables having different priorities in
different maps, so the backend can correctly build the final
environment configuration.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>