### PR TITLE
Add command to build podman-remote-static

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,10 @@ endif
 .PHONY: podman
 podman: bin/podman
 
+.PHONY: bin/podman-remote-static
+podman-remote-static: bin/podman-remote-static
+	CGO_ENABLED=0 $(GO) build $(BUILDFLAGS) -gcflags '$(GCFLAGS)' -asmflags '$(ASMFLAGS)' -ldflags '$(LDFLAGS_PODMAN_STATIC)' -tags "!ABISupport varlink containers_image_openpgp remoteclient" -o bin/podman-remote-static $(PROJECT)/cmd/podman
+
 .PHONY: bin/podman-remote
 bin/podman-remote: .gopathok $(SOURCES) go.mod go.sum $(PODMAN_VARLINK_DEPENDENCIES) ## Build with podman on remote environment
 	$(GO_BUILD) $(BUILDFLAGS) -gcflags '$(GCFLAGS)' -asmflags '$(ASMFLAGS)' -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS) remoteclient" -o $@ $(PROJECT)/cmd/podman


### PR DESCRIPTION
CRC Team wants a static podman-remote that it can install on any linux
box.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>