### PR TITLE
[CI:DOCS] Update manpages for image volumes and MAC address

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -358,12 +358,12 @@ Defaults to `true`
 
 **--image-volume**, **builtin-volume**=*bind|tmpfs|ignore*
 
-Tells Podman how to handle the builtin image volumes. The options are: 'bind', 'tmpfs', or 'ignore' (default 'bind').
-bind: A directory is created inside the container state directory and bind mounted into
-the container for the volumes.
-tmpfs: The volume is mounted onto the container as a tmpfs, which allows the users to create
+Tells Podman how to handle the builtin image volumes. Default is **bind**.
+
+- **bind**: An anonymous named volume will be created and mounted into the container.
+- **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
 content that disappears when the container is stopped.
-ignore: All volumes are just ignored and no action is taken.
+- **ignore**: All volumes are just ignored and no action is taken.
 
 **--init**
 
@@ -444,8 +444,6 @@ Container MAC address (e.g. 92:d0:c6:0a:29:33)
 Remember that the MAC address in an Ethernet network must be unique.
 The IPv6 link-local address will be based on the device's MAC address
 according to RFC4862.
-
-Not currently supported
 
 **--memory**, **-m**=*limit*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -371,8 +371,7 @@ Defaults to **true**.
 
 Tells Podman how to handle the builtin image volumes. Default is **bind**.
 
-- **bind**: A directory is created inside the container state directory and bind mounted into
-the container for the volumes.
+- **bind**: An anonymous named volume will be created and mounted into the container.
 - **tmpfs**: The volume is mounted onto the container as a tmpfs, which allows the users to create
 content that disappears when the container is stopped.
 - **ignore**: All volumes are just ignored and no action is taken.
@@ -453,8 +452,6 @@ Container MAC address (e.g. **92:d0:c6:0a:29:33**).
 Remember that the MAC address in an Ethernet network must be unique.
 The IPv6 link-local address will be based on the device's MAC address
 according to RFC4862.
-
-Not currently supported
 
 **--memory**, **-m**=_number_[_unit_]
 


### PR DESCRIPTION
When reviewing the manpages for `podman run` to find options to test, I found a few mistakes. The description of how we handle image volumes is extremely outdated, and we now provide full support for the `--mac-address` option. Update the docs for these flags so they're accurate.
