### PR TITLE
Fix parsing of --network for `podman pod create`

### DIFF
--- a/pkg/specgen/pod_validate.go
+++ b/pkg/specgen/pod_validate.go
@@ -33,7 +33,7 @@ func (p *PodSpecGenerator) Validate() error {
 	}
 
 	// PodNetworkConfig
-	if err := p.NetNS.validate(); err != nil {
+	if err := validateNetNS(&p.NetNS); err != nil {
 		return err
 	}
 	if p.NoInfra {
@@ -83,10 +83,6 @@ func (p *PodSpecGenerator) Validate() error {
 	}
 	if p.NoManageHosts && len(p.HostAdd) > 0 {
 		return exclusivePodOptions("NoManageHosts", "HostAdd")
-	}
-
-	if err := p.NetNS.validate(); err != nil {
-		return err
 	}
 
 	// Set Defaults

--- a/pkg/specgen/podspecgen.go
+++ b/pkg/specgen/podspecgen.go
@@ -54,7 +54,7 @@ type PodNetworkConfig struct {
 	// namespace. This network will, by default, be shared with all
 	// containers in the pod.
 	// Cannot be set to FromContainer and FromPod.
-	// Setting this to anything except "" conflicts with NoInfra=true.
+	// Setting this to anything except default conflicts with NoInfra=true.
 	// Defaults to Bridge as root and Slirp as rootless.
 	// Mandatory.
 	NetNS Namespace `json:"netns,omitempty"`


### PR DESCRIPTION
Interpreting CNI networks was a bit broken, and it was causing rootless `podman pod create` to fail. Also, we were missing the `--net` alias for `--network`, so add that.

Fixes #6119