### PR TITLE
[WIP]fix pod stats flake

### DIFF
--- a/cmd/podman/containers/stats.go
+++ b/cmd/podman/containers/stats.go
@@ -234,7 +234,6 @@ func outputJSON(stats []*containerStats) error {
 			Pids:       j.PIDS(),
 		})
 	}
-
 	b, err := json.MarshalIndent(jstats, "", " ")
 	if err != nil {
 		return err

--- a/test/e2e/stats_test.go
+++ b/test/e2e/stats_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/containers/libpod/pkg/cgroups"
 	. "github.com/containers/libpod/test/utils"
@@ -87,13 +88,27 @@ var _ = Describe("Podman stats", func() {
 	})
 
 	It("podman stats with json output", func() {
+		var found bool
 		session := podmanTest.RunTopContainer("")
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		session = podmanTest.Podman([]string{"stats", "--all", "--no-stream", "--format", "json"})
-		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.IsJSONOutputValid()).To(BeTrue())
+		for i := 0; i < 5; i++ {
+			ps := podmanTest.Podman([]string{"ps", "-q"})
+			ps.WaitWithDefaultTimeout()
+			if len(ps.OutputToStringArray()) == 1 {
+				found = true
+				break
+			}
+			time.Sleep(time.Second)
+		}
+		Expect(found).To(BeTrue())
+		stats := podmanTest.Podman([]string{"stats", "--all", "--no-stream", "--format", "json"})
+		stats.WaitWithDefaultTimeout()
+		Expect(stats.ExitCode()).To(Equal(0))
+		fmt.Println("/////")
+		fmt.Println(stats.OutputToString())
+		fmt.Println("/////")
+		Expect(stats.IsJSONOutputValid()).To(BeTrue())
 	})
 
 	It("podman stats on a container with no net ns", func() {


### PR DESCRIPTION
it appears that the pod stats flake can be attributed to the fact that the container being run is not fully running when the stats call is made.  because the stats call is in format of json, it fails when nil

Signed-off-by: Brent Baude <bbaude@redhat.com>