### PR TITLE
set --conmon-pidfile

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -501,6 +501,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	s.CapDrop = c.CapDrop
 	s.Privileged = c.Privileged
 	s.ReadOnlyFilesystem = c.ReadOnly
+	s.ConmonPidFile = c.ConmonPIDFile
 
 	// TODO
 	// ouitside of specgen and oci though

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -158,4 +158,20 @@ echo $rand        |   0 | $rand
     run_podman 1 image exists $NONLOCAL_IMAGE
 }
 
+# 'run --conmon-pidfile --cid-file' makes sure we don't regress on these flags.
+# Both are critical for systemd units.
+@test "podman run --conmon-pidfile --cidfile" {
+    pid=$(mktemp)
+    cid=$(mktemp)
+
+    # CID file exists -> expected to fail.
+    run_podman 125 run --rm --conmon-pidfile=$pid --cidfile=$cid $IMAGE ls
+
+    rm $pid $cid
+    run_podman run --name keepme --conmon-pidfile=$pid --cidfile=$cid --detach $IMAGE sleep infinity
+    stat $pid $cid
+    run_podman rm -f keepme
+    rm $pid $cid
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
The --conmon-pidfile was not set in the spec leading to failing systemd
units.  Also add a system test to prevent future regressions.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>