### PR TITLE
Makefile: fix a dependency issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,7 +373,7 @@ MANPAGES_MD ?= $(wildcard docs/source/markdown/*.md pkg/*/docs/*.md)
 MANPAGES ?= $(MANPAGES_MD:%.md=%)
 MANPAGES_DEST ?= $(subst markdown,man, $(subst source,build,$(MANPAGES)))
 
-$(MANPAGES): %: %.md .gopathok
+$(MANPAGES): %: %.md .install.md2man docdir
 	@sed -e 's/\((podman.*\.md)\)//' -e 's/\[\(podman.*\)\]/\1/' $<  | $(GOMD2MAN) -in /dev/stdin -out $(subst source/markdown,build/man,$@)
 
 .PHONY: docs
@@ -381,7 +381,7 @@ docdir:
 	mkdir -p docs/build/man
 
 .PHONY: docs
-docs: .install.md2man docdir $(MANPAGES) ## Generate documentation
+docs: $(MANPAGES) ## Generate documentation
 
 .PHONE: xref_helpmsgs_manpages
 xref_helpmsgs_manpages:


### PR DESCRIPTION
Instead of being depended by docs, docdir target should be depended by
MANPAGES, or else the path 'docs/build/man' might not exist when
GOMD2MAN tries to generate files in it.

This fixes a following build error:
| open docs/build/man/podman-volume-ls.1: no such file or directory
| Makefile:377: recipe for target 'docs/source/markdown/podman-volume-ls.1' failed
| make: *** [docs/source/markdown/podman-volume-ls.1] Error 1
| make: *** Waiting for unfinished jobs....
| open docs/build/man/podman-init.1: no such file or directory
| Makefile:377: recipe for target 'docs/source/markdown/podman-init.1' failed

Signed-off-by: Ming Liu <ming.liu@toradex.com>