### PR TITLE
Fix handling of overridden paths from database

### DIFF
--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -46,7 +46,6 @@ func init() {
 
 	// Podman flags.
 	flags.BoolVarP(&loginOptions.tlsVerify, "tls-verify", "", false, "Require HTTPS and verify certificates when contacting registries")
-	flags.BoolVarP(&loginOptions.GetLoginSet, "get-login", "", false, "Return the current login user for the registry")
 	loginOptions.Stdin = os.Stdin
 	loginOptions.Stdout = os.Stdout
 	loginOptions.AcceptUnspecifiedRegistry = true

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -37,7 +37,6 @@ func init() {
 
 	// Flags from the auth package.
 	flags.AddFlagSet(auth.GetLogoutFlags(&logoutOptions))
-	logoutOptions.Stdin = os.Stdin
 	logoutOptions.Stdout = os.Stdout
 	logoutOptions.AcceptUnspecifiedRegistry = true
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containernetworking/cni v0.7.2-0.20200304161608-4fae32b84921
 	github.com/containernetworking/plugins v0.8.5
 	github.com/containers/buildah v1.14.9-0.20200501175434-42a48f9373d9
-	github.com/containers/common v0.11.0
+	github.com/containers/common v0.11.1
 	github.com/containers/conmon v2.0.14+incompatible
 	github.com/containers/image/v5 v5.4.3
 	github.com/containers/psgo v1.5.0
@@ -35,7 +35,7 @@ require (
 	github.com/json-iterator/go v1.1.9
 	github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618
 	github.com/onsi/ginkgo v1.12.0
-	github.com/onsi/gomega v1.9.0
+	github.com/onsi/gomega v1.10.0
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 	github.com/opencontainers/runc v1.0.0-rc9

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/containers/buildah v1.14.9-0.20200501175434-42a48f9373d9 h1:EGegltin1
 github.com/containers/buildah v1.14.9-0.20200501175434-42a48f9373d9/go.mod h1:+2aNsVcd4pVzmVAbOfWN5X+0Lpz2rtICSGXbTSCzdBU=
 github.com/containers/common v0.10.0 h1:Km1foMJJBIxceA1/UCZcIuwf8sCF71sP5DwE6Oh1BEA=
 github.com/containers/common v0.10.0/go.mod h1:6A/moCuQITXLqBe5A0WKKTcCfCmEQRbknI05HcPzOL0=
-github.com/containers/common v0.11.0 h1:uFSBIl9iqoTIv8icBe9lPrYKkmSiGrAWr0a2PyJLrO4=
-github.com/containers/common v0.11.0/go.mod h1:ag8p8Xp2o1wPAPz/+bA7LVQlDavtg3M15RZLBWt/2KE=
+github.com/containers/common v0.11.1 h1:i++kltFD92bKfDeE3B+Bpe5jYVTnAibmIUUUnXYKoPo=
+github.com/containers/common v0.11.1/go.mod h1:2w3QE6VUmhltGYW4wV00h4okq1Crs7hNI1ZD2I0QRUY=
 github.com/containers/conmon v2.0.14+incompatible h1:knU1O1QxXy5YxtjMQVKEyCajROaehizK9FHaICl+P5Y=
 github.com/containers/conmon v2.0.14+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.4.3 h1:zn2HR7uu4hpvT5QQHgjqonOzKDuM1I1UHUEmzZT5sbs=
@@ -334,6 +334,8 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/onsi/gomega v1.10.0 h1:Gwkk+PTu/nfOwNMtUB/mRUv0X7ewW5dO4AERT1ThVKo=
+github.com/onsi/gomega v1.10.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/libpod/runtime.go
+++ b/libpod/runtime.go
@@ -752,7 +752,7 @@ type DBConfig struct {
 // mergeDBConfig merges the configuration from the database.
 func (r *Runtime) mergeDBConfig(dbConfig *DBConfig) error {
 
-	c := r.config.Engine
+	c := &r.config.Engine
 	if !r.storageSet.RunRootSet && dbConfig.StorageTmp != "" {
 		if r.storageConfig.RunRoot != dbConfig.StorageTmp &&
 			r.storageConfig.RunRoot != "" {

--- a/vendor/github.com/containers/common/pkg/auth/cli.go
+++ b/vendor/github.com/containers/common/pkg/auth/cli.go
@@ -7,16 +7,19 @@ import (
 )
 
 // LoginOptions represents common flags in login
-// caller should define bool or optionalBool fields for flags --get-login and --tls-verify
+// In addition, the caller should probably provide a --tls-verify flag (that affects the provided
+// *types.SystemContest)
 type LoginOptions struct {
 	// CLI flags managed by the FlagSet returned by GetLoginFlags
+	// Callers that use GetLoginFlags should not need to touch these values at all; callers that use
+	// other CLI frameworks should set them based on user input.
 	AuthFile      string
 	CertDir       string
 	Password      string
 	Username      string
 	StdinPassword bool
+	GetLoginSet   bool
 	// Options caller can set
-	GetLoginSet               bool      // set to true if --get-login is explicitly set
 	Stdin                     io.Reader // set to os.Stdin
 	Stdout                    io.Writer // set to os.Stdout
 	AcceptUnspecifiedRegistry bool      // set to true if allows login with unspecified registry
@@ -25,10 +28,11 @@ type LoginOptions struct {
 // LogoutOptions represents the results for flags in logout
 type LogoutOptions struct {
 	// CLI flags managed by the FlagSet returned by GetLogoutFlags
+	// Callers that use GetLogoutFlags should not need to touch these values at all; callers that use
+	// other CLI frameworks should set them based on user input.
 	AuthFile string
 	All      bool
 	// Options caller can set
-	Stdin                     io.Reader // set to os.Stdin
 	Stdout                    io.Writer // set to os.Stdout
 	AcceptUnspecifiedRegistry bool      // set to true if allows logout with unspecified registry
 }
@@ -41,6 +45,7 @@ func GetLoginFlags(flags *LoginOptions) *pflag.FlagSet {
 	fs.StringVarP(&flags.Password, "password", "p", "", "Password for registry")
 	fs.StringVarP(&flags.Username, "username", "u", "", "Username for registry")
 	fs.BoolVar(&flags.StdinPassword, "password-stdin", false, "Take the password from stdin")
+	fs.BoolVar(&flags.GetLoginSet, "get-login", false, "Return the current login user for the registry")
 	return &fs
 }
 

--- a/vendor/github.com/containers/common/pkg/config/config.go
+++ b/vendor/github.com/containers/common/pkg/config/config.go
@@ -442,16 +442,6 @@ func readConfigFromFile(path string, config *Config) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode configuration %v: %v", path, err)
 	}
-	if config.Engine.VolumePath != "" {
-		config.Engine.VolumePathSet = true
-	}
-	if config.Engine.StaticDir != "" {
-		config.Engine.StaticDirSet = true
-	}
-	if config.Engine.TmpDir != "" {
-		config.Engine.TmpDirSet = true
-	}
-
 	return config, err
 }
 

--- a/vendor/github.com/containers/common/pkg/config/default.go
+++ b/vendor/github.com/containers/common/pkg/config/default.go
@@ -479,6 +479,8 @@ func (c *Config) PidsLimit() int64 {
 		cgroup2, _ := cgroupv2.Enabled()
 		if cgroup2 {
 			return c.Containers.PidsLimit
+		} else {
+			return 0
 		}
 	}
 	return sysinfo.GetDefaultPidsLimit()

--- a/vendor/github.com/onsi/gomega/.travis.yml
+++ b/vendor/github.com/onsi/gomega/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.12.x
   - 1.13.x
+  - 1.14.x
   - gotip
 
 env:

--- a/vendor/github.com/onsi/gomega/CHANGELOG.md
+++ b/vendor/github.com/onsi/gomega/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.10.0
+
+### Features
+- Add HaveHTTPStatusMatcher (#378) [f335c94]
+- Changed matcher for content-type in VerifyJSONRepresenting (#377) [6024f5b]
+- Make ghttp usable with x-unit style tests (#376) [c0be499]
+- Implement PanicWith matcher (#381) [f8032b4]
+
 ## 1.9.0
 
 ### Features

--- a/vendor/github.com/onsi/gomega/gomega_dsl.go
+++ b/vendor/github.com/onsi/gomega/gomega_dsl.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
-const GOMEGA_VERSION = "1.9.0"
+const GOMEGA_VERSION = "1.10.0"
 
 const nilFailHandlerPanic = `You are trying to make an assertion, but Gomega's fail handler is nil.
 If you're using Ginkgo then you probably forgot to put your assertion in an It().
@@ -252,7 +252,7 @@ func Consistently(actual interface{}, intervals ...interface{}) AsyncAssertion {
 	return ConsistentlyWithOffset(0, actual, intervals...)
 }
 
-// ConsistentlyWithOffset operates like Consistnetly but takes an additional
+// ConsistentlyWithOffset operates like Consistently but takes an additional
 // initial argument to indicate an offset in the call stack. This is useful when building helper
 // functions that contain matchers. To learn more, read about `ExpectWithOffset`.
 func ConsistentlyWithOffset(offset int, actual interface{}, intervals ...interface{}) AsyncAssertion {
@@ -431,4 +431,33 @@ func toDuration(input interface{}) time.Duration {
 	}
 
 	panic(fmt.Sprintf("%v is not a valid interval.  Must be time.Duration, parsable duration string or a number.", input))
+}
+
+// Gomega describes the essential Gomega DSL. This interface allows libraries
+// to abstract between the standard package-level function implementations
+// and alternatives like *WithT.
+type Gomega interface {
+	Expect(actual interface{}, extra ...interface{}) Assertion
+	Eventually(actual interface{}, intervals ...interface{}) AsyncAssertion
+	Consistently(actual interface{}, intervals ...interface{}) AsyncAssertion
+}
+
+type globalFailHandlerGomega struct{}
+
+// DefaultGomega supplies the standard package-level implementation
+var Default Gomega = globalFailHandlerGomega{}
+
+// Expect is used to make assertions. See documentation for Expect.
+func (globalFailHandlerGomega) Expect(actual interface{}, extra ...interface{}) Assertion {
+	return Expect(actual, extra...)
+}
+
+// Eventually is used to make asynchronous assertions. See documentation for Eventually.
+func (globalFailHandlerGomega) Eventually(actual interface{}, extra ...interface{}) AsyncAssertion {
+	return Eventually(actual, extra...)
+}
+
+// Consistently is used to make asynchronous assertions. See documentation for Consistently.
+func (globalFailHandlerGomega) Consistently(actual interface{}, extra ...interface{}) AsyncAssertion {
+	return Consistently(actual, extra...)
 }

--- a/vendor/github.com/onsi/gomega/matchers.go
+++ b/vendor/github.com/onsi/gomega/matchers.go
@@ -390,6 +390,16 @@ func Panic() types.GomegaMatcher {
 	return &matchers.PanicMatcher{}
 }
 
+//PanicWith succeeds if actual is a function that, when invoked, panics with a specific value.
+//Actual must be a function that takes no arguments and returns no results.
+//
+//By default PanicWith uses Equal() to perform the match, however a
+//matcher can be passed in instead:
+//    Expect(fn).Should(PanicWith(MatchRegexp(`.+Foo$`)))
+func PanicWith(expected interface{}) types.GomegaMatcher {
+	return &matchers.PanicMatcher{Expected: expected}
+}
+
 //BeAnExistingFile succeeds if a file exists.
 //Actual must be a string representing the abs path to the file being checked.
 func BeAnExistingFile() types.GomegaMatcher {
@@ -406,6 +416,15 @@ func BeARegularFile() types.GomegaMatcher {
 //Actual must be a string representing the abs path to the file being checked.
 func BeADirectory() types.GomegaMatcher {
 	return &matchers.BeADirectoryMatcher{}
+}
+
+//HaveHTTPStatus succeeds if the Status or StatusCode field of an HTTP response matches.
+//Actual must be either a *http.Response or *httptest.ResponseRecorder.
+//Expected must be either an int or a string.
+//  Expect(resp).Should(HaveHTTPStatus(http.StatusOK))   // asserts that resp.StatusCode == 200
+//  Expect(resp).Should(HaveHTTPStatus("404 Not Found")) // asserts that resp.Status == "404 Not Found"
+func HaveHTTPStatus(expected interface{}) types.GomegaMatcher {
+	return &matchers.HaveHTTPStatusMatcher{Expected: expected}
 }
 
 //And succeeds only if all of the given matchers succeed.

--- a/vendor/github.com/onsi/gomega/matchers/have_http_status_matcher.go
+++ b/vendor/github.com/onsi/gomega/matchers/have_http_status_matcher.go
@@ -1,0 +1,42 @@
+package matchers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/onsi/gomega/format"
+)
+
+type HaveHTTPStatusMatcher struct {
+	Expected interface{}
+}
+
+func (matcher *HaveHTTPStatusMatcher) Match(actual interface{}) (success bool, err error) {
+	var resp *http.Response
+	switch a := actual.(type) {
+	case *http.Response:
+		resp = a
+	case *httptest.ResponseRecorder:
+		resp = a.Result()
+	default:
+		return false, fmt.Errorf("HaveHTTPStatus matcher expects *http.Response or *httptest.ResponseRecorder. Got:\n%s", format.Object(actual, 1))
+	}
+
+	switch e := matcher.Expected.(type) {
+	case int:
+		return resp.StatusCode == e, nil
+	case string:
+		return resp.Status == e, nil
+	}
+
+	return false, fmt.Errorf("HaveHTTPStatus matcher must be passed an int or a string. Got:\n%s", format.Object(matcher.Expected, 1))
+}
+
+func (matcher *HaveHTTPStatusMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to have HTTP status", matcher.Expected)
+}
+
+func (matcher *HaveHTTPStatusMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to have HTTP status", matcher.Expected)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/containers/buildah/pkg/secrets
 github.com/containers/buildah/pkg/supplemented
 github.com/containers/buildah/pkg/umask
 github.com/containers/buildah/util
-# github.com/containers/common v0.11.0
+# github.com/containers/common v0.11.1
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/auth
 github.com/containers/common/pkg/capabilities
@@ -375,7 +375,7 @@ github.com/onsi/ginkgo/reporters/stenographer
 github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
-# github.com/onsi/gomega v1.9.0
+# github.com/onsi/gomega v1.10.0
 github.com/onsi/gomega
 github.com/onsi/gomega/format
 github.com/onsi/gomega/gbytes


### PR DESCRIPTION
If the first time you run podman in a user account you do a
su - USER, and the second time, you run as the logged in USER
podman fails, because it is not handling the tmpdir definition
in the database. This PR fixes this problem.

vendor containers/common v0.11.1

This should fix a couple of issues we have seen in podman 1.9.1
with handling of libpod.conf.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>