### PR TITLE
abi: do not attempt to setup rootless if euid==0

### DIFF
--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -86,6 +86,7 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command) 
 				}
 			}
 		}
+		return nil
 	}
 
 	pausePidPath, err := util.GetRootlessPauseProcessPidPath()


### PR DESCRIPTION
if the process has already euid==0 do not attempt to setup rootless.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>