### PR TITLE
default to tunnel without ABISupport tag

### DIFF
--- a/cmd/podman/registry/config_abi.go
+++ b/cmd/podman/registry/config_abi.go
@@ -1,0 +1,7 @@
+// +build ABISupport
+
+package registry
+
+func init() {
+	abiSupport = true
+}

--- a/cmd/podman/registry/config_tunnel.go
+++ b/cmd/podman/registry/config_tunnel.go
@@ -1,0 +1,7 @@
+// +build !ABISupport
+
+package registry
+
+func init() {
+	abiSupport = false
+}

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -208,7 +208,7 @@ func syslogHook() {
 
 func rootFlags(opts *entities.PodmanConfig, flags *pflag.FlagSet) {
 	// V2 flags
-	flags.StringVarP(&opts.Uri, "remote", "r", "", "URL to access Podman service")
+	flags.StringVarP(&opts.Uri, "remote", "r", registry.DefaultAPIAddress, "URL to access Podman service")
 	flags.StringSliceVar(&opts.Identities, "identity", []string{}, "path to SSH identity file")
 
 	cfg := opts.Config


### PR DESCRIPTION
When compiling a Linux binary without ABISupport, default to use the
tunnel.  The behaviour is expected in `podman-remote`.

Also set a default for the remote flag so `podman-remote` works OOB.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>