### PR TITLE
Fix `podman pod create --infra=false`

### DIFF
--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/libpod/pkg/specgen"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -81,6 +82,7 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	if !createOptions.Infra {
+		logrus.Debugf("Not creating an infra container")
 		if cmd.Flag("infra-command").Changed {
 			return errors.New("cannot set infra-command without an infra container")
 		}
@@ -114,6 +116,7 @@ func create(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	createOptions.Net.Network = specgen.Namespace{}
 	if cmd.Flag("network").Changed {
 		netInput, err := cmd.Flags().GetString("network")
 		if err != nil {
@@ -132,6 +135,7 @@ func create(cmd *cobra.Command, args []string) error {
 			n.NSMode = specgen.Bridge
 			createOptions.Net.CNINetworks = strings.Split(netInput, ",")
 		}
+		createOptions.Net.Network = n
 	}
 	if len(createOptions.Net.PublishPorts) > 0 {
 		if !createOptions.Infra {

--- a/pkg/specgen/pod_validate.go
+++ b/pkg/specgen/pod_validate.go
@@ -1,7 +1,6 @@
 package specgen
 
 import (
-	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
 )
@@ -37,8 +36,8 @@ func (p *PodSpecGenerator) Validate() error {
 		return err
 	}
 	if p.NoInfra {
-		if p.NetNS.NSMode == NoNetwork {
-			return errors.New("NoInfra and a none network cannot be used toegther")
+		if p.NetNS.NSMode != Default && p.NetNS.NSMode != "" {
+			return errors.New("NoInfra and network modes cannot be used toegther")
 		}
 		if p.StaticIP != nil {
 			return exclusivePodOptions("NoInfra", "StaticIP")
@@ -86,13 +85,6 @@ func (p *PodSpecGenerator) Validate() error {
 	}
 
 	// Set Defaults
-	if p.NetNS.Value == "" {
-		if rootless.IsRootless() {
-			p.NetNS.NSMode = Slirp
-		} else {
-			p.NetNS.NSMode = Bridge
-		}
-	}
 	if len(p.InfraImage) < 1 {
 		p.InfraImage = containerConfig.Engine.InfraImage
 	}


### PR DESCRIPTION
We were accidentally setting incorrect defaults for the network namespace for rootless `pod create` when infra containers were not being created. This should resolve that issue.
