### PR TITLE
v2 podman unshare command

### DIFF
--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -30,9 +30,6 @@ var (
 		Args: func(cmd *cobra.Command, args []string) error {
 			return parse.CheckAllLatestAndCIDFile(cmd, args, true, false)
 		},
-		Annotations: map[string]string{
-			registry.ParentNSRequired: "",
-		},
 	}
 
 	containerMountCommmand = &cobra.Command{

--- a/cmd/podman/system/unshare.go
+++ b/cmd/podman/system/unshare.go
@@ -1,0 +1,50 @@
+package system
+
+import (
+	"os"
+
+	"github.com/containers/libpod/cmd/podman/registry"
+	"github.com/containers/libpod/pkg/domain/entities"
+	"github.com/containers/libpod/pkg/rootless"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	unshareDescription = "Runs a command in a modified user namespace."
+	unshareCommand     = &cobra.Command{
+		Use:   "unshare [flags] [COMMAND [ARG]]",
+		Short: "Run a command in a modified user namespace",
+		Long:  unshareDescription,
+		RunE:  unshare,
+		Example: `podman unshare id
+  podman unshare cat /proc/self/uid_map,
+  podman unshare podman-script.sh`,
+	}
+)
+
+func init() {
+	registry.Commands = append(registry.Commands, registry.CliCommand{
+		Mode:    []entities.EngineMode{entities.ABIMode},
+		Command: unshareCommand,
+	})
+	flags := unshareCommand.Flags()
+	flags.SetInterspersed(false)
+}
+
+func unshare(cmd *cobra.Command, args []string) error {
+	if isRootless := rootless.IsRootless(); !isRootless {
+		return errors.Errorf("please use unshare with rootless")
+	}
+	// exec the specified command, if there is one
+	if len(args) < 1 {
+		// try to exec the shell, if one's set
+		shell, shellSet := os.LookupEnv("SHELL")
+		if !shellSet {
+			return errors.Errorf("no command specified and no $SHELL specified")
+		}
+		args = []string{shell}
+	}
+
+	return registry.ContainerEngine().Unshare(registry.Context(), args)
+}

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -71,6 +71,7 @@ type ContainerEngine interface {
 	SetupRootless(ctx context.Context, cmd *cobra.Command) error
 	Shutdown(ctx context.Context)
 	SystemDf(ctx context.Context, options SystemDfOptions) (*SystemDfReport, error)
+	Unshare(ctx context.Context, args []string) error
 	VarlinkService(ctx context.Context, opts ServiceOptions) error
 	VolumeCreate(ctx context.Context, opts VolumeCreateOptions) (*IdOrNameResponse, error)
 	VolumeInspect(ctx context.Context, namesOrIds []string, opts VolumeInspectOptions) ([]*VolumeInspectReport, error)

--- a/pkg/domain/infra/tunnel/system.go
+++ b/pkg/domain/infra/tunnel/system.go
@@ -30,3 +30,7 @@ func (ic *ContainerEngine) SystemPrune(ctx context.Context, options entities.Sys
 func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.SystemDfOptions) (*entities.SystemDfReport, error) {
 	panic(errors.New("system df is not supported on remote clients"))
 }
+
+func (ic *ContainerEngine) Unshare(ctx context.Context, args []string) error {
+	return errors.New("unshare is not supported on remote clients")
+}


### PR DESCRIPTION
add unshare command

add cp and init to container sub-command

allow mount to run as rootless

Signed-off-by: Brent Baude <bbaude@redhat.com>