### PR TITLE
`--format` and `--filter` options for `network ls` and `network inspect` command

### DIFF
--- a/cmd/podman/networks/list.go
+++ b/cmd/podman/networks/list.go
@@ -40,8 +40,9 @@ var (
 func networkListFlags(flags *pflag.FlagSet) {
 	// TODO enable filters based on something
 	//flags.StringSliceVarP(&networklistCommand.Filter, "filter", "f",  []string{}, "Pause all running containers")
-	flags.StringVarP(&networkListOptions.Format, "format", "f", "", "Pretty-print containers to JSON or using a Go template")
+	flags.StringVarP(&networkListOptions.Format, "format", "f", "", "Pretty-print networks to JSON or using a Go template")
 	flags.BoolVarP(&networkListOptions.Quiet, "quiet", "q", false, "display only names")
+	flags.StringVarP(&networkListOptions.Filter, "filter", "", "", "Provide filter values (e.g. 'name=podman')")
 }
 
 func init() {
@@ -59,6 +60,14 @@ func networkList(cmd *cobra.Command, args []string) error {
 		nlprs []NetworkListPrintReports
 	)
 
+	// validate the filter pattern.
+	if len(networkListOptions.Filter) > 0 {
+		tokens := strings.Split(networkListOptions.Filter, "=")
+		if len(tokens) != 2 {
+			return fmt.Errorf("invalid filter syntax : %s", networkListOptions.Filter)
+		}
+	}
+
 	responses, err := registry.ContainerEngine().NetworkList(registry.Context(), networkListOptions)
 	if err != nil {
 		return err
@@ -69,7 +78,7 @@ func networkList(cmd *cobra.Command, args []string) error {
 		return quietOut(responses)
 	}
 
-	if networkListOptions.Format == "json" {
+	if strings.ToLower(networkListOptions.Format) == "json" {
 		return jsonOut(responses)
 	}
 

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1024,6 +1024,8 @@ _podman_network_inspect() {
     local boolean_options="
 	--help
 	-h
+	--format
+	-f
     "
     _complete_ "$options_with_args" "$boolean_options"
 
@@ -1042,6 +1044,9 @@ _podman_network_ls() {
     -h
 	--quiet
 	-q
+	--format
+	-f
+	-- filter
     "
     _complete_ "$options_with_args" "$boolean_options"
 

--- a/docs/source/markdown/podman-network-inspect.1.md
+++ b/docs/source/markdown/podman-network-inspect.1.md
@@ -9,6 +9,15 @@ podman\-network\-inspect - Displays the raw CNI network configuration for one or
 ## DESCRIPTION
 Display the raw (JSON format) network configuration. This command is not available for rootless users.
 
+## OPTIONS
+**--quiet**, **-q**
+
+The `quiet` option will restrict the output to only the network names.
+
+**--format**, **-f**
+
+Pretty-print networks to JSON or using a Go template.
+
 ## EXAMPLE
 
 Inspect the default podman network
@@ -41,6 +50,11 @@ Inspect the default podman network
     ]
 }
 ]
+```
+
+```
+# podman network inspect podman --format '{{(index  .plugins  0).ipam.ranges}}'
+[[map[gateway:10.88.0.1 subnet:10.88.0.0/16]]]
 ```
 
 ## SEE ALSO

--- a/docs/source/markdown/podman-network-ls.1.md
+++ b/docs/source/markdown/podman-network-ls.1.md
@@ -12,7 +12,15 @@ Displays a list of existing podman networks. This command is not available for r
 ## OPTIONS
 **--quiet**, **-q**
 
-The `quiet` option will restrict the output to only the network names
+The `quiet` option will restrict the output to only the network names.
+
+**--format**, **-f**
+
+Pretty-print networks to JSON or using a Go template.
+
+**--filter**
+
+Provide filter values (e.g. 'name=podman').
 
 ## EXAMPLE
 
@@ -33,6 +41,14 @@ Display only network names
 podman
 podman2
 outside
+podman9
+```
+
+Display name of network which support bridge plugin
+```
+# podman network ls --filter plugin=portmap --format {{.Name}}
+podman
+podman2
 podman9
 ```
 

--- a/pkg/domain/entities/network.go
+++ b/pkg/domain/entities/network.go
@@ -10,6 +10,7 @@ import (
 type NetworkListOptions struct {
 	Format string
 	Quiet  bool
+	Filter string
 }
 
 // NetworkListReport describes the results from listing networks
@@ -19,6 +20,7 @@ type NetworkListReport struct {
 
 // NetworkInspectOptions describes options for inspect networks
 type NetworkInspectOptions struct {
+	Format string
 }
 
 // NetworkInspectReport describes the results from inspect networks

--- a/pkg/domain/infra/abi/network.go
+++ b/pkg/domain/infra/abi/network.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
+	"github.com/containernetworking/cni/libcni"
 	cniversion "github.com/containernetworking/cni/pkg/version"
 	"github.com/containers/libpod/libpod"
 	"github.com/containers/libpod/pkg/domain/entities"
@@ -39,8 +41,19 @@ func (ic *ContainerEngine) NetworkList(ctx context.Context, options entities.Net
 		return nil, err
 	}
 
+	var tokens []string
+	// tokenize the networkListOptions.Filter in key=value.
+	if len(options.Filter) > 0 {
+		tokens = strings.Split(options.Filter, "=")
+		if len(tokens) != 2 {
+			return nil, fmt.Errorf("invalid filter syntax : %s", options.Filter)
+		}
+	}
+
 	for _, n := range networks {
-		reports = append(reports, &entities.NetworkListReport{NetworkConfigList: n})
+		if ifPassesFilterTest(n, tokens) {
+			reports = append(reports, &entities.NetworkListReport{NetworkConfigList: n})
+		}
 	}
 	return reports, nil
 }
@@ -255,4 +268,26 @@ func createMacVLAN(r *libpod.Runtime, name string, options entities.NetworkCreat
 	cniPathName := filepath.Join(cniConfigPath, fmt.Sprintf("%s.conflist", name))
 	err = ioutil.WriteFile(cniPathName, b, 0644)
 	return cniPathName, err
+}
+
+func ifPassesFilterTest(netconf *libcni.NetworkConfigList, filter []string) bool {
+	result := false
+	if len(filter) == 0 {
+		// No filter, so pass
+		return true
+	}
+	switch strings.ToLower(filter[0]) {
+	case "name":
+		if filter[1] == netconf.Name {
+			result = true
+		}
+	case "plugin":
+		plugins := network.GetCNIPlugins(netconf)
+		if strings.Contains(plugins, filter[1]) {
+			result = true
+		}
+	default:
+		result = false
+	}
+	return result
 }


### PR DESCRIPTION
This PR is for fixing bug #5205 
This adds following options to network commands 
  - `podman network ls --filter` option 
  -  `podman network inspect --format` option

NOTE: _Since the CNI conf file does not have defined structure and is read as read & stored as `map of interfaces`, its difficult to get similar output as of `docker` as specified in https://github.com/containers/libpod/issues/5205#issue-565036875. until we create an internal structure. Which may not be good idea, as it may require to sync up with libcni code. Ideally, this structure should be defined in libcni code._

PTAL: @medyagh @afbjorklund, If this helps your use case.