### PR TITLE
rootless: don't set rlimits

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -537,7 +537,7 @@ func addRlimits(config *CreateConfig, g *generate.Generator) error {
 	// If not explicitly overridden by the user, default number of open
 	// files and number of processes to the maximum they can be set to
 	// (without overriding a sysctl)
-	if !nofileSet {
+	if !nofileSet && !isRootless {
 		max := kernelMax
 		current := kernelMax
 		if isRootless {

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -21,7 +21,6 @@ var _ = Describe("Podman generate kube", func() {
 	)
 
 	BeforeEach(func() {
-		SkipIfRootlessV2()
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -217,7 +217,6 @@ var _ = Describe("Podman generate kube", func() {
 	)
 
 	BeforeEach(func() {
-		SkipIfRootlessV2()
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
Also enable the kube tests for rootless again since they're passing now.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>