### PR TITLE
spec: fix order for setting rlimits

### DIFF
--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -545,10 +545,14 @@ func addRlimits(config *CreateConfig, g *generate.Generator) error {
 			if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit); err != nil {
 				logrus.Warnf("failed to return RLIMIT_NOFILE ulimit %q", err)
 			}
-			current = rlimit.Cur
-			max = rlimit.Max
+			if rlimit.Cur < current {
+				current = rlimit.Cur
+			}
+			if rlimit.Max < max {
+				max = rlimit.Max
+			}
 		}
-		g.AddProcessRlimits("RLIMIT_NOFILE", current, max)
+		g.AddProcessRlimits("RLIMIT_NOFILE", max, current)
 	}
 	if !nprocSet {
 		max := kernelMax
@@ -558,10 +562,14 @@ func addRlimits(config *CreateConfig, g *generate.Generator) error {
 			if err := unix.Getrlimit(unix.RLIMIT_NPROC, &rlimit); err != nil {
 				logrus.Warnf("failed to return RLIMIT_NPROC ulimit %q", err)
 			}
-			current = rlimit.Cur
-			max = rlimit.Max
+			if rlimit.Cur < current {
+				current = rlimit.Cur
+			}
+			if rlimit.Max < max {
+				max = rlimit.Max
+			}
 		}
-		g.AddProcessRlimits("RLIMIT_NPROC", current, max)
+		g.AddProcessRlimits("RLIMIT_NPROC", max, current)
 	}
 
 	return nil

--- a/test/e2e/generate_kube_test.go
+++ b/test/e2e/generate_kube_test.go
@@ -21,7 +21,6 @@ var _ = Describe("Podman generate kube", func() {
 	)
 
 	BeforeEach(func() {
-		SkipIfRootlessV2()
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)

--- a/test/e2e/play_kube_test.go
+++ b/test/e2e/play_kube_test.go
@@ -217,7 +217,6 @@ var _ = Describe("Podman generate kube", func() {
 	)
 
 	BeforeEach(func() {
-		SkipIfRootlessV2()
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
also make sure that the limits we set for rootless are not higher than
what we'd set for root containers.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>