### PR TITLE
enable rootless mount tests

### DIFF
--- a/cmd/podman/containers/unmount.go
+++ b/cmd/podman/containers/unmount.go
@@ -27,9 +27,6 @@ var (
 		Args: func(cmd *cobra.Command, args []string) error {
 			return parse.CheckAllLatestAndCIDFile(cmd, args, false, false)
 		},
-		Annotations: map[string]string{
-			registry.ParentNSRequired: "",
-		},
 		Example: `podman umount ctrID
   podman umount ctrID1 ctrID2 ctrID3
   podman umount --all`,

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -18,7 +18,6 @@ var _ = Describe("Podman mount", func() {
 	)
 
 	BeforeEach(func() {
-		SkipIfRootlessV2()
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
Remove the annotation from the umount command to make mount tests pass
and let podman-umount run as a non-root user.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>