### PR TITLE
auto-update: support authfiles

### DIFF
--- a/cmd/podman/auto-update.go
+++ b/cmd/podman/auto-update.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/containers/common/pkg/auth"
 	"github.com/containers/libpod/cmd/podman/registry"
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/containers/libpod/pkg/errorhandling"
@@ -11,16 +12,18 @@ import (
 )
 
 var (
+	autoUpdateOptions     = entities.AutoUpdateOptions{}
 	autoUpdateDescription = `Auto update containers according to their auto-update policy.
 
   Auto-update policies are specified with the "io.containers.autoupdate" label.
-  Note that this command is experimental.`
+  Note that this command is experimental. Please refer to the podman-auto-update(1) man page for details.`
 	autoUpdateCommand = &cobra.Command{
-		Use:     "auto-update [flags]",
-		Short:   "Auto update containers according to their auto-update policy",
-		Long:    autoUpdateDescription,
-		RunE:    autoUpdate,
-		Example: `podman auto-update`,
+		Use:   "auto-update [flags]",
+		Short: "Auto update containers according to their auto-update policy",
+		Long:  autoUpdateDescription,
+		RunE:  autoUpdate,
+		Example: `podman auto-update
+  podman auto-update --authfile ~/authfile.json`,
 	}
 )
 
@@ -29,6 +32,9 @@ func init() {
 		Mode:    []entities.EngineMode{entities.ABIMode},
 		Command: autoUpdateCommand,
 	})
+
+	flags := autoUpdateCommand.Flags()
+	flags.StringVar(&autoUpdateOptions.Authfile, "authfile", auth.GetDefaultAuthFile(), "Path to the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 }
 
 func autoUpdate(cmd *cobra.Command, args []string) error {
@@ -36,7 +42,7 @@ func autoUpdate(cmd *cobra.Command, args []string) error {
 		// Backwards compat. System tests expext this error string.
 		return errors.Errorf("`%s` takes no arguments", cmd.CommandPath())
 	}
-	report, failures := registry.ContainerEngine().AutoUpdate(registry.GetContext())
+	report, failures := registry.ContainerEngine().AutoUpdate(registry.GetContext(), autoUpdateOptions)
 	if report != nil {
 		for _, unit := range report.Units {
 			fmt.Println(unit)

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -702,6 +702,27 @@ __podman_images() {
 	__podman_q images $images_args | awk "$awk_script" | grep -v '<none>$'
 }
 
+_podman_auto_update() {
+  local options_with_args="
+      --authfile
+  "
+
+  local boolean_options="
+    --help
+    -h
+  "
+
+  _complete_ "$options_with_args" "$boolean_options"
+    case "$cur" in
+        -*)
+            COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+            ;;
+        *)
+            __podman_complete_volume_names
+            ;;
+    esac
+}
+
 # __podman_complete_volumes applies completion of volumes based on the current
 # value of `$cur` or the value of the optional first option `--cur`, if given.
 __podman_complete_volumes() {

--- a/docs/source/markdown/podman-auto-update.1.md
+++ b/docs/source/markdown/podman-auto-update.1.md
@@ -21,11 +21,21 @@ Note that `podman auto-update` relies on systemd and requires a fully-qualified 
 This enforcement is necessary to know which image to actually check and pull.
 If an image ID was used, Podman would not know which image to check/pull anymore.
 
+## OPTIONS
+
+**--authfile**=*path*
+
+Path of the authentication file. Default is ${XDG\_RUNTIME\_DIR}/containers/auth.json, which is set using `podman login`.
+If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using `docker login`. (Not available for remote commands)
+
+Note: You can also override the default path of the authentication file by setting the REGISTRY\_AUTH\_FILE
+environment variable. `export REGISTRY_AUTH_FILE=path`
+
 ## EXAMPLES
 
 ```
 # Start a container
-$ podman run -d busybox:latest top
+$ podman run --label "io.containers.autoupdate=image" -d busybox:latest top
 bc219740a210455fa27deacc96d50a9e20516492f1417507c13ce1533dbdcd9d
 
 # Generate a systemd unit for this container

--- a/pkg/domain/entities/auto-update.go
+++ b/pkg/domain/entities/auto-update.go
@@ -1,5 +1,11 @@
 package entities
 
+// AutoUpdateOptions are the options for running auto-update.
+type AutoUpdateOptions struct {
+	// Authfile to use when contacting registries.
+	Authfile string
+}
+
 // AutoUpdateReport contains the results from running auto-update.
 type AutoUpdateReport struct {
 	// Units - the restarted systemd units during auto-update.

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ContainerEngine interface {
-	AutoUpdate(ctx context.Context) (*AutoUpdateReport, []error)
+	AutoUpdate(ctx context.Context, options AutoUpdateOptions) (*AutoUpdateReport, []error)
 	Config(ctx context.Context) (*config.Config, error)
 	ContainerAttach(ctx context.Context, nameOrId string, options AttachOptions) error
 	ContainerCheckpoint(ctx context.Context, namesOrIds []string, options CheckpointOptions) ([]*CheckpointReport, error)

--- a/pkg/domain/infra/abi/auto-update.go
+++ b/pkg/domain/infra/abi/auto-update.go
@@ -7,7 +7,11 @@ import (
 	"github.com/containers/libpod/pkg/domain/entities"
 )
 
-func (ic *ContainerEngine) AutoUpdate(ctx context.Context) (*entities.AutoUpdateReport, []error) {
-	units, failures := autoupdate.AutoUpdate(ic.Libpod)
+func (ic *ContainerEngine) AutoUpdate(ctx context.Context, options entities.AutoUpdateOptions) (*entities.AutoUpdateReport, []error) {
+	// Convert the entities options to the autoupdate ones.  We can't use
+	// them in the entities package as low-level packages must not leak
+	// into the remote client.
+	autoOpts := autoupdate.Options{Authfile: options.Authfile}
+	units, failures := autoupdate.AutoUpdate(ic.Libpod, autoOpts)
 	return &entities.AutoUpdateReport{Units: units}, failures
 }

--- a/pkg/domain/infra/tunnel/auto-update.go
+++ b/pkg/domain/infra/tunnel/auto-update.go
@@ -7,6 +7,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (ic *ContainerEngine) AutoUpdate(ctx context.Context) (*entities.AutoUpdateReport, []error) {
+func (ic *ContainerEngine) AutoUpdate(ctx context.Context, options entities.AutoUpdateOptions) (*entities.AutoUpdateReport, []error) {
 	return nil, []error{errors.New("not implemented")}
 }


### PR DESCRIPTION
Support using custom authfiles for auto updates by adding a new
`--authfile` flag and passing it down into the backend.

Also do some minor fixes in the help text and the man page.

Fixes: #6159
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>