### PR TITLE
cgroup: skip unified if we are using v1

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -517,6 +517,10 @@ func (c *CgroupControl) AddPid(pid int) error {
 	}
 
 	for _, n := range names {
+		// If we aren't using cgroup2, we won't write correctly to unified hierarchy
+		if !c.cgroup2 && n == "unified" {
+			continue
+		}
 		p := filepath.Join(c.getCgroupv1Path(n), "tasks")
 		if err := ioutil.WriteFile(p, pidString, 0644); err != nil {
 			return errors.Wrapf(err, "write %s", p)


### PR DESCRIPTION
There exists a chance for a node to be booted in v1, but have reminents of v2. An example is this CRI-O ci run: https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-federated-results/pr-logs/pull/cri-o_cri-o/3565/test_pull_request_crio_critest_fedora/11243/

We fail because we are incorrectly writing to the unified path, because we are v1. We should not write to the unified path if we are v1

Signed-off-by: Peter Hunt <pehunt@redhat.com>