### PR TITLE
V2 attach bindings and test

### DIFF
--- a/libpod/container_api.go
+++ b/libpod/container_api.go
@@ -285,6 +285,7 @@ func (c *Container) HTTPAttach(httpCon net.Conn, httpBuf *bufio.ReadWriter, stre
 
 	logrus.Infof("Performing HTTP Hijack attach to container %s", c.ID())
 
+	logSize := 0
 	if streamLogs {
 		// Get all logs for the container
 		logChan := make(chan *logs.LogLine)
@@ -302,7 +303,7 @@ func (c *Container) HTTPAttach(httpCon net.Conn, httpBuf *bufio.ReadWriter, stre
 					device := logLine.Device
 					var header []byte
 					headerLen := uint32(len(logLine.Msg))
-
+					logSize += len(logLine.Msg)
 					switch strings.ToLower(device) {
 					case "stdin":
 						header = makeHTTPAttachHeader(0, headerLen)
@@ -341,7 +342,7 @@ func (c *Container) HTTPAttach(httpCon net.Conn, httpBuf *bufio.ReadWriter, stre
 		if err := c.ReadLog(logOpts, logChan); err != nil {
 			return err
 		}
-		logrus.Debugf("Done reading logs for container %s", c.ID())
+		logrus.Debugf("Done reading logs for container %s, %d bytes", c.ID(), logSize)
 		if err := <-errChan; err != nil {
 			return err
 		}

--- a/libpod/oci_conmon_linux.go
+++ b/libpod/oci_conmon_linux.go
@@ -1704,6 +1704,8 @@ func httpAttachTerminalCopy(container *net.UnixConn, http *bufio.ReadWriter, cid
 	buf := make([]byte, bufferSize)
 	for {
 		numR, err := container.Read(buf)
+		logrus.Debugf("Read fd(%d) %d/%d bytes for container %s", int(buf[0]), numR, len(buf), cid)
+
 		if numR > 0 {
 			switch buf[0] {
 			case AttachPipeStdout:

--- a/libpod/util.go
+++ b/libpod/util.go
@@ -249,9 +249,8 @@ func hijackWriteErrorAndClose(toWrite error, cid string, terminal bool, httpCon 
 // length and stream. Accepts an integer indicating which stream we are sending
 // to (STDIN = 0, STDOUT = 1, STDERR = 2).
 func makeHTTPAttachHeader(stream byte, length uint32) []byte {
-	headerBuf := []byte{stream, 0, 0, 0}
-	lenBuf := []byte{0, 0, 0, 0}
-	binary.BigEndian.PutUint32(lenBuf, length)
-	headerBuf = append(headerBuf, lenBuf...)
-	return headerBuf
+	header := make([]byte, 8)
+	header[0] = stream
+	binary.BigEndian.PutUint32(header[4:], length)
+	return header
 }

--- a/pkg/api/handlers/compat/containers_attach.go
+++ b/pkg/api/handlers/compat/containers_attach.go
@@ -108,7 +108,7 @@ func AttachContainer(w http.ResponseWriter, r *http.Request) {
 
 	// This header string sourced from Docker:
 	// https://raw.githubusercontent.com/moby/moby/b95fad8e51bd064be4f4e58a996924f343846c85/api/server/router/container/container_routes.go
-	// Using literally to ensure compatability with existing clients.
+	// Using literally to ensure compatibility with existing clients.
 	fmt.Fprintf(connection, "HTTP/1.1 101 UPGRADED\r\nContent-Type: application/vnd.docker.raw-stream\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n")
 
 	logrus.Debugf("Hijack for attach of container %s successful", ctr.ID())

--- a/pkg/bindings/test/attach_test.go
+++ b/pkg/bindings/test/attach_test.go
@@ -1,0 +1,63 @@
+package test_bindings
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/containers/libpod/pkg/bindings"
+	"github.com/containers/libpod/pkg/bindings/containers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Podman containers attach", func() {
+	var (
+		bt *bindingTest
+		s  *gexec.Session
+	)
+
+	BeforeEach(func() {
+		bt = newBindingTest()
+		bt.RestoreImagesFromCache()
+		s = bt.startAPIService()
+		time.Sleep(1 * time.Second)
+		err := bt.NewConnection()
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		s.Kill()
+		bt.cleanup()
+	})
+
+	It("attach", func() {
+		name := "TopAttachTest"
+		id, err := bt.RunTopContainer(&name, nil, nil)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		tickTock := time.NewTimer(2 * time.Second)
+		go func() {
+			<-tickTock.C
+			timeout := uint(5)
+			err := containers.Stop(bt.conn, id, &timeout)
+			if err != nil {
+				GinkgoWriter.Write([]byte(err.Error()))
+			}
+		}()
+
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		go func() {
+			defer GinkgoRecover()
+
+			err := containers.Attach(bt.conn, id, nil, &bindings.PTrue, &bindings.PTrue, &bindings.PTrue, stdout, stderr)
+			Expect(err).ShouldNot(HaveOccurred())
+		}()
+
+		time.Sleep(5 * time.Second)
+
+		// First character/First line of top output
+		Expect(stdout.String()).Should(ContainSubstring("Mem: "))
+	})
+})

--- a/pkg/bindings/test/common_test.go
+++ b/pkg/bindings/test/common_test.go
@@ -191,7 +191,7 @@ func (b *bindingTest) restoreImageFromCache(i testImage) {
 func (b *bindingTest) RunTopContainer(containerName *string, insidePod *bool, podName *string) (string, error) {
 	s := specgen.NewSpecGenerator(alpine.name, false)
 	s.Terminal = false
-	s.Command = []string{"top"}
+	s.Command = []string{"/usr/bin/top"}
 	if containerName != nil {
 		s.Name = *containerName
 	}

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -302,6 +302,8 @@ var _ = Describe("Podman containers ", func() {
 
 		errChan = make(chan error)
 		go func() {
+			defer GinkgoRecover()
+
 			_, waitErr := containers.Wait(bt.conn, name, &running)
 			errChan <- waitErr
 			close(errChan)

--- a/pkg/bindings/test/test_suite_test.go
+++ b/pkg/bindings/test/test_suite_test.go
@@ -5,9 +5,14 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
 
 func TestTest(t *testing.T) {
+	if testing.Verbose() {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Test Suite")
 }


### PR DESCRIPTION
* Add ErrLostSync to report lost of sync when de-mux'ing stream
* Add logus.SetLevel(logrus.DebugLevel) when `go test -v` given
* Add context to debugging messages
* Add context to signal error returns

Signed-off-by: Jhon Honce <jhonce@redhat.com>