### PR TITLE
[CI:DOCS]remove libpod.conf from spec

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -502,7 +502,6 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/vendor:%{gopath}
 %{_datadir}/zsh/site-functions/*
 %{_libexecdir}/%{name}/conmon
 %config(noreplace) %{_sysconfdir}/cni/net.d/87-%{name}-bridge.conflist
-%{_datadir}/containers/%{repo}.conf
 %{_unitdir}/io.podman.service
 %{_unitdir}/io.podman.socket
 %{_usr}/lib/systemd/user/io.podman.service


### PR DESCRIPTION
in the contrib rpm.spec.in, we no longer should try to package libpod.conf

Signed-off-by: Brent Baude <bbaude@redhat.com>