### PR TITLE
Use the containers.conf cni_config_dir option for inspect and delete

### DIFF
--- a/pkg/network/devices.go
+++ b/pkg/network/devices.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/containers/common/pkg/config"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/containers/libpod/utils"
 	"github.com/sirupsen/logrus"
@@ -11,12 +12,12 @@ import (
 
 // GetFreeDeviceName returns a device name that is unused; used when no network
 // name is provided by user
-func GetFreeDeviceName() (string, error) {
+func GetFreeDeviceName(config *config.Config) (string, error) {
 	var (
 		deviceNum  uint
 		deviceName string
 	)
-	networkNames, err := GetNetworkNamesFromFileSystem()
+	networkNames, err := GetNetworkNamesFromFileSystem(config)
 	if err != nil {
 		return "", err
 	}
@@ -24,7 +25,7 @@ func GetFreeDeviceName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	bridgeNames, err := GetBridgeNamesFromFileSystem()
+	bridgeNames, err := GetBridgeNamesFromFileSystem(config)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/network/files.go
+++ b/pkg/network/files.go
@@ -9,8 +9,16 @@ import (
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator"
+	"github.com/containers/common/pkg/config"
 	"github.com/pkg/errors"
 )
+
+func GetCNIConfDir(config *config.Config) string {
+	if len(config.Network.NetworkConfigDir) < 1 {
+		return CNIConfigDir
+	}
+	return config.Network.NetworkConfigDir
+}
 
 // LoadCNIConfsFromDir loads all the CNI configurations from a dir
 func LoadCNIConfsFromDir(dir string) ([]*libcni.NetworkConfigList, error) {
@@ -33,8 +41,8 @@ func LoadCNIConfsFromDir(dir string) ([]*libcni.NetworkConfigList, error) {
 
 // GetCNIConfigPathByName finds a CNI network by name and
 // returns its configuration file path
-func GetCNIConfigPathByName(name string) (string, error) {
-	files, err := libcni.ConfFiles(CNIConfigDir, []string{".conflist"})
+func GetCNIConfigPathByName(config *config.Config, name string) (string, error) {
+	files, err := libcni.ConfFiles(GetCNIConfDir(config), []string{".conflist"})
 	if err != nil {
 		return "", err
 	}
@@ -52,8 +60,8 @@ func GetCNIConfigPathByName(name string) (string, error) {
 
 // ReadRawCNIConfByName reads the raw CNI configuration for a CNI
 // network by name
-func ReadRawCNIConfByName(name string) ([]byte, error) {
-	confFile, err := GetCNIConfigPathByName(name)
+func ReadRawCNIConfByName(config *config.Config, name string) ([]byte, error) {
+	confFile, err := GetCNIConfigPathByName(config, name)
 	if err != nil {
 		return nil, err
 	}
@@ -73,9 +81,10 @@ func GetCNIPlugins(list *libcni.NetworkConfigList) string {
 
 // GetNetworksFromFilesystem gets all the networks from the cni configuration
 // files
-func GetNetworksFromFilesystem() ([]*allocator.Net, error) {
+func GetNetworksFromFilesystem(config *config.Config) ([]*allocator.Net, error) {
 	var cniNetworks []*allocator.Net
-	networks, err := LoadCNIConfsFromDir(CNIConfigDir)
+
+	networks, err := LoadCNIConfsFromDir(GetCNIConfDir(config))
 	if err != nil {
 		return nil, err
 	}
@@ -96,9 +105,10 @@ func GetNetworksFromFilesystem() ([]*allocator.Net, error) {
 
 // GetNetworkNamesFromFileSystem gets all the names from the cni network
 // configuration files
-func GetNetworkNamesFromFileSystem() ([]string, error) {
+func GetNetworkNamesFromFileSystem(config *config.Config) ([]string, error) {
 	var networkNames []string
-	networks, err := LoadCNIConfsFromDir(CNIConfigDir)
+
+	networks, err := LoadCNIConfsFromDir(GetCNIConfDir(config))
 	if err != nil {
 		return nil, err
 	}
@@ -133,9 +143,10 @@ func GetInterfaceNameFromConfig(path string) (string, error) {
 
 // GetBridgeNamesFromFileSystem is a convenience function to get all the bridge
 // names from the configured networks
-func GetBridgeNamesFromFileSystem() ([]string, error) {
+func GetBridgeNamesFromFileSystem(config *config.Config) ([]string, error) {
 	var bridgeNames []string
-	networks, err := LoadCNIConfsFromDir(CNIConfigDir)
+
+	networks, err := LoadCNIConfsFromDir(GetCNIConfDir(config))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator"
+	"github.com/containers/common/pkg/config"
 	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -56,8 +57,8 @@ func GetLiveNetworkNames() ([]string, error) {
 
 // GetFreeNetwork looks for a free network according to existing cni configuration
 // files and network interfaces.
-func GetFreeNetwork() (*net.IPNet, error) {
-	networks, err := GetNetworksFromFilesystem()
+func GetFreeNetwork(config *config.Config) (*net.IPNet, error) {
+	networks, err := GetNetworksFromFilesystem(config)
 	if err != nil {
 		return nil, err
 	}
@@ -131,8 +132,8 @@ func networkIntersect(n1, n2 *net.IPNet) bool {
 
 // ValidateUserNetworkIsAvailable returns via an error if a network is available
 // to be used
-func ValidateUserNetworkIsAvailable(userNet *net.IPNet) error {
-	networks, err := GetNetworksFromFilesystem()
+func ValidateUserNetworkIsAvailable(config *config.Config, userNet *net.IPNet) error {
+	networks, err := GetNetworksFromFilesystem(config)
 	if err != nil {
 		return err
 	}
@@ -153,8 +154,8 @@ func ValidateUserNetworkIsAvailable(userNet *net.IPNet) error {
 
 // RemoveNetwork removes a given network by name.  If the network has container associated with it, that
 // must be handled outside the context of this.
-func RemoveNetwork(name string) error {
-	cniPath, err := GetCNIConfigPathByName(name)
+func RemoveNetwork(config *config.Config, name string) error {
+	cniPath, err := GetCNIConfigPathByName(config, name)
 	if err != nil {
 		return err
 	}
@@ -181,8 +182,8 @@ func RemoveNetwork(name string) error {
 }
 
 // InspectNetwork reads a CNI config and returns its configuration
-func InspectNetwork(name string) (map[string]interface{}, error) {
-	b, err := ReadRawCNIConfByName(name)
+func InspectNetwork(config *config.Config, name string) (map[string]interface{}, error) {
+	b, err := ReadRawCNIConfByName(config, name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The pkg/network/files.go methods currently use the constant '/etc/cni/net.d'
for network handling. This results in the unability of podman-network-inspect
and podman-network-rm to locate the cni network configuration files.
This commit propagates the libpod.Runtime through the networking methods and
finally makes use of its configuration (config.Network.NetworkConfigDir).
Closes #6212

Signed-off-by: Maximilian Müller <maxm123@techie.com>