### PR TITLE
system tests: small fixes for rawhide+cgroups v1

### DIFF
--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -8,8 +8,8 @@ load helpers
     # 2019-09 Fedora 31 and rawhide (32) are switching from runc to crun
     # because of cgroups v2; crun emits different error messages.
     # Default to runc:
-    err_no_such_cmd="Error: .*: starting container process caused .*exec:.*stat /no/such/command: no such file or directory"
-    err_no_exec_dir="Error: .*: starting container process caused .*exec:.* permission denied"
+    err_no_such_cmd="Error: .*: starting container process caused.*exec:.*stat /no/such/command: no such file or directory"
+    err_no_exec_dir="Error: .*: starting container process caused.*exec:.* permission denied"
 
     # ...but check the configured runtime engine, and switch to crun as needed
     run_podman info --format '{{ .Host.OCIRuntime.Path }}'

--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -33,6 +33,13 @@ function teardown() {
 # This test can fail in dev. environment because of SELinux.
 # quick fix: chcon -t container_runtime_exec_t ./bin/podman
 @test "podman generate - systemd - basic" {
+    # podman initializes this if unset, but systemctl doesn't
+    if is_rootless; then
+        if [ -z "$XDG_RUNTIME_DIR" ]; then
+            export XDG_RUNTIME_DIR=/run/user/$(id -u)
+        fi
+    fi
+
     cname=$(random_string)
     run_podman create --name $cname --detach $IMAGE top
 


### PR DESCRIPTION
Three small fixes for breaking tests on rawhide:

  1) run test: looks like runc changed the format of
     an error message, adding a colon in one place.
     runc is used on rawhide when booted in cgroups v1

  2) volumes test: difference in exit status and error
     message between runc and crun.

  3) systemd test: define XDG_RUNTIME_DIR if unset.
     podman helpfully sets this to a reasonable default,
     but the 'systemctl' commands used in this test do not.

Signed-off-by: Ed Santiago <santiago@redhat.com>