### PR TITLE
fix bug --format {{json.}} of events

### DIFF
--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"html/template"
 	"os"
+	"strings"
 
 	"github.com/containers/buildah/pkg/formats"
 	"github.com/containers/libpod/cmd/podman/registry"
@@ -54,6 +55,9 @@ func eventsCmd(cmd *cobra.Command, args []string) error {
 		eventsError error
 		tmpl        *template.Template
 	)
+	if strings.Join(strings.Fields(eventFormat), "") == "{{json.}}" {
+		eventFormat = formats.JSONString
+	}
 	if eventFormat != formats.JSONString {
 		tmpl, err = template.New("events").Parse(eventFormat)
 		if err != nil {

--- a/docs/source/markdown/podman-events.1.md
+++ b/docs/source/markdown/podman-events.1.md
@@ -142,7 +142,7 @@ $ sudo podman events --since 5m
 
 Show Podman events in JSON Lines format
 ```
-events --format json
+$ podman events --format json
 {"ID":"683b0909d556a9c02fa8cd2b61c3531a965db42158627622d1a67b391964d519","Image":"localhost/myshdemo:latest","Name":"agitated_diffie","Status":"cleanup","Time":"2019-04-27T22:47:00.849932843-04:00","Type":"container"}
 {"ID":"a0f8ab051bfd43f9c5141a8a2502139707e4b38d98ac0872e57c5315381e88ad","Image":"docker.io/library/alpine:latest","Name":"friendly_tereshkova","Status":"unmount","Time":"2019-04-28T13:43:38.063017276-04:00","Type":"container"}
 ```

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -137,5 +137,19 @@ var _ = Describe("Podman events", func() {
 		_, exist := eventsMap["Status"]
 		Expect(exist).To(BeTrue())
 		Expect(test.ExitCode()).To(BeZero())
+
+		test = podmanTest.Podman([]string{"events", "--stream=false", "--format", "{{json.}}"})
+		test.WaitWithDefaultTimeout()
+		fmt.Println(test.OutputToStringArray())
+		jsonArr = test.OutputToStringArray()
+		Expect(len(jsonArr)).To(Not(BeZero()))
+		eventsMap = make(map[string]string)
+		err = json.Unmarshal([]byte(jsonArr[0]), &eventsMap)
+		if err != nil {
+			os.Exit(1)
+		}
+		_, exist = eventsMap["Status"]
+		Expect(exist).To(BeTrue())
+		Expect(test.ExitCode()).To(BeZero())
 	})
 })


### PR DESCRIPTION
Allow the `podman events --format` accept {{json.}} and complete small fix podman-events.1.md
fix #5981
Signed-off-by: Qi Wang <qiwan@redhat.com>