### PR TITLE
Cirrus: Use branch-specific image tags

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ###
-    _BUILT_IMAGE_SUFFIX: "libpod-5092203842240512"
+    _BUILT_IMAGE_SUFFIX: "libpod-6705215644631040"
     FEDORA_CACHE_IMAGE_NAME: "fedora-30-${_BUILT_IMAGE_SUFFIX}"
     # PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-29-${_BUILT_IMAGE_SUFFIX}"
     SPECIAL_FEDORA_CACHE_IMAGE_NAME: "xfedora-30-${_BUILT_IMAGE_SUFFIX}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -92,7 +92,7 @@ gating_task:
 
     # Runs within Cirrus's "community cluster"
     container:
-        image: "quay.io/libpod/gate:latest"
+        image: "quay.io/libpod/gate:$DEST_BRANCH"
         cpu: 4
         memory: 12
 
@@ -148,7 +148,7 @@ vendor_task:
 
     # Runs within Cirrus's "community cluster"
     container:
-        image: "quay.io/libpod/gate:latest"
+        image: "quay.io/libpod/gate:$DEST_BRANCH"
         cpu: 4
         memory: 12
 
@@ -180,7 +180,7 @@ varlink_api_task:
 
     # Runs within Cirrus's "community cluster"
     container:
-        image: "quay.io/libpod/gate:latest"
+        image: "quay.io/libpod/gate:$DEST_BRANCH"
         cpu: 4
         memory: 12
 
@@ -671,7 +671,7 @@ success_task:
         GOSRC: "/go/src/github.com/containers/libpod"
 
     container:
-        image: "quay.io/libpod/gate:latest"
+        image: "quay.io/libpod/gate:$DEST_BRANCH"
         cpu: 1
         memory: 1
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ###
-    _BUILT_IMAGE_SUFFIX: "libpod-5642998972416000"
+    _BUILT_IMAGE_SUFFIX: "libpod-5092203842240512"
     FEDORA_CACHE_IMAGE_NAME: "fedora-30-${_BUILT_IMAGE_SUFFIX}"
     # PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-29-${_BUILT_IMAGE_SUFFIX}"
     SPECIAL_FEDORA_CACHE_IMAGE_NAME: "xfedora-30-${_BUILT_IMAGE_SUFFIX}"

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -61,7 +61,7 @@ PACKER_VER="1.4.2"
 # Base-images rarely change, define them here so they're out of the way.
 export PACKER_BUILDS="${PACKER_BUILDS:-ubuntu-18,ubuntu-19,fedora-30,xfedora-30,fedora-29}"
 # Google-maintained base-image names
-export UBUNTU_BASE_IMAGE="ubuntu-1904-disco-v20190724"
+export UBUNTU_BASE_IMAGE="ubuntu-1910-eoan-v20200211"
 export PRIOR_UBUNTU_BASE_IMAGE="ubuntu-1804-bionic-v20190722a"
 # Manually produced base-image names (see $SCRIPT_BASE/README.md)
 export FEDORA_BASE_IMAGE="fedora-cloud-base-30-1-2-1565360543"

--- a/contrib/cirrus/packer/ubuntu_setup.sh
+++ b/contrib/cirrus/packer/ubuntu_setup.sh
@@ -32,105 +32,151 @@ $BIGTO $SUDOAPTGET update
 echo "Upgrading all packages"
 $BIGTO $SUDOAPTGET upgrade
 
-echo "Adding PPAs"
-$LILTO $SUDOAPTGET install software-properties-common
-$LILTO $SUDOAPTADD ppa:projectatomic/ppa
-$LILTO $SUDOAPTADD ppa:criu/ppa
+echo "Installing deps to add third-party repositories and automation tooling"
+$LILTO $SUDOAPTGET install software-properties-common git curl
+
+$LILTO ooe.sh $SUDOAPTADD ppa:criu/ppa
+
+# Install newer version of golang
 if [[ "$OS_RELEASE_VER" -eq "18" ]]
 then
-    $LILTO $SUDOAPTADD ppa:longsleep/golang-backports
+    $LILTO ooe.sh $SUDOAPTADD ppa:longsleep/golang-backports
 fi
 
-$LILTO $SUDOAPTGET update
+echo "Configuring/Instaling deps from Open build server"
+VERSION_ID=$(source /etc/os-release; echo $VERSION_ID)
+echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_$VERSION_ID/ /" \
+    | ooe.sh sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+ooe.sh curl -L -o /tmp/Release.key "https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${VERSION_ID}/Release.key"
+ooe.sh sudo apt-key add - < /tmp/Release.key
+
+INSTALL_PACKAGES=(\
+    apparmor
+    aufs-tools
+    autoconf
+    automake
+    bash-completion
+    bison
+    build-essential
+    buildah
+    bzip2
+    conmon
+    containernetworking-plugins
+    containers-common
+    coreutils
+    cri-o-runc
+    criu
+    curl
+    dnsmasq
+    e2fslibs-dev
+    emacs-nox
+    file
+    gawk
+    gcc
+    gettext
+    git
+    go-md2man
+    golang
+    iproute2
+    iptables
+    jq
+    libaio-dev
+    libapparmor-dev
+    libcap-dev
+    libdevmapper-dev
+    libdevmapper1.02.1
+    libfuse-dev
+    libfuse2
+    libglib2.0-dev
+    libgpgme11-dev
+    liblzma-dev
+    libnet1
+    libnet1-dev
+    libnl-3-dev
+    libprotobuf-c-dev
+    libprotobuf-dev
+    libseccomp-dev
+    libseccomp2
+    libselinux-dev
+    libsystemd-dev
+    libtool
+    libudev-dev
+    libvarlink
+    lsof
+    make
+    netcat
+    openssl
+    pkg-config
+    podman
+    protobuf-c-compiler
+    protobuf-compiler
+    python-future
+    python-minimal
+    python-protobuf
+    python3-dateutil
+    python3-pip
+    python3-psutil
+    python3-pytoml
+    python3-setuptools
+    rsync
+    runc
+    scons
+    skopeo
+    slirp4netns
+    socat
+    sudo
+    unzip
+    vim
+    wget
+    xz-utils
+    yum-utils
+    zip
+    zlib1g-dev
+)
+
+if [[ $OS_RELEASE_VER -ge 19 ]]
+then
+    INSTALL_PACKAGES+=(\
+        bats
+        btrfs-progs
+        fuse3
+        libbtrfs-dev
+        libfuse3-dev
+    )
+else
+    echo "Downloading version of bats with fix for a \$IFS related bug in 'run' command"
+    cd /tmp
+    BATS_URL='http://launchpadlibrarian.net/438140887/bats_1.1.0+git104-g1c83a1b-1_all.deb'
+    curl -L -O "$BATS_URL"
+    cd -
+    INSTALL_PACKAGES+=(\
+        /tmp/$(basename $BATS_URL)
+        btrfs-tools
+    )
+fi
+
+# Do this at the last possible moment to avoid dpkg lock conflicts
+echo "Upgrading all packages"
+$BIGTO ooe.sh $SUDOAPTGET upgrade
 
 echo "Installing general testing and system dependencies"
-$BIGTO $SUDOAPTGET install \
-    apparmor \
-    aufs-tools \
-    autoconf \
-    automake \
-    bash-completion \
-    bats \
-    bison \
-    btrfs-tools \
-    build-essential \
-    containernetworking-plugins \
-    containers-common \
-    cri-o-runc \
-    criu \
-    curl \
-    e2fslibs-dev \
-    emacs-nox \
-    file \
-    gawk \
-    gcc \
-    gettext \
-    go-md2man \
-    golang \
-    iproute2 \
-    iptables \
-    jq \
-    libaio-dev \
-    libapparmor-dev \
-    libcap-dev \
-    libdevmapper-dev \
-    libdevmapper1.02.1 \
-    libfuse-dev \
-    libfuse2 \
-    libglib2.0-dev \
-    libgpgme11-dev \
-    liblzma-dev \
-    libnet1 \
-    libnet1-dev \
-    libnl-3-dev \
-    libvarlink \
-    libprotobuf-c-dev \
-    libprotobuf-dev \
-    libseccomp-dev \
-    libseccomp2 \
-    libsystemd-dev \
-    libtool \
-    libudev-dev \
-    lsof \
-    make \
-    netcat \
-    pkg-config \
-    podman \
-    protobuf-c-compiler \
-    protobuf-compiler \
-    python-future \
-    python-minimal \
-    python-protobuf \
-    python3-dateutil \
-    python3-pip \
-    python3-psutil \
-    python3-pytoml \
-    python3-setuptools \
-    skopeo \
-    slirp4netns \
-    socat \
-    unzip \
-    vim \
-    xz-utils \
-    zip
+# Necessary to update cache of newly added repos
+$LILTO ooe.sh $SUDOAPTGET update
+$BIGTO ooe.sh $SUDOAPTGET install ${INSTALL_PACKAGES[@]}
 
-if [[ "$OS_RELEASE_VER" -ge "19" ]]
+export GOPATH="$(mktemp -d)"
+trap "sudo rm -rf $GOPATH" EXIT
+echo "Installing cataonit and libseccomp.sudo"
+cd $GOSRC
+ooe.sh sudo hack/install_catatonit.sh
+ooe.sh sudo make install.libseccomp.sudo
+
+CRIO_RUNC_PATH="/usr/lib/cri-o-runc/sbin/runc"
+if sudo dpkg -L cri-o-runc | grep -m 1 -q "$CRIO_RUNC_PATH"
 then
-    echo "Installing Ubuntu > 18 packages"
-    $LILTO $SUDOAPTGET install fuse3 libfuse3-dev libbtrfs-dev
+    echo "Linking $CRIO_RUNC_PATH to /usr/bin/runc for ease of testing."
+    sudo ln -f "$CRIO_RUNC_PATH" "/usr/bin/runc"
 fi
-
-if [[ "$OS_RELEASE_VER" -eq "18" ]]
-then
-    echo "Forced Ubuntu 18 kernel to enable cgroup swap accounting."
-    SEDCMD='s/^GRUB_CMDLINE_LINUX="(.*)"/GRUB_CMDLINE_LINUX="\1 cgroup_enable=memory swapaccount=1"/g'
-    ooe.sh sudo sed -re "$SEDCMD" -i /etc/default/grub.d/*
-    ooe.sh sudo sed -re "$SEDCMD" -i /etc/default/grub
-    ooe.sh sudo update-grub
-fi
-
-sudo /tmp/libpod/hack/install_catatonit.sh
-ooe.sh sudo make -C /tmp/libpod install.libseccomp.sudo
 
 ubuntu_finalize
 


### PR DESCRIPTION
Also, since 19.04 is EOL, update to Ubuntu 19.10 + Backport use of OBS packages.

Signed-off-by: Chris Evich <cevich@redhat.com>