### PR TITLE
V2 Implement terminal handling in bindings attach

### DIFF
--- a/pkg/api/handlers/compat/resize.go
+++ b/pkg/api/handlers/compat/resize.go
@@ -1,0 +1,68 @@
+package compat
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/pkg/api/handlers/utils"
+	"github.com/gorilla/schema"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+func ResizeTTY(w http.ResponseWriter, r *http.Request) {
+	runtime := r.Context().Value("runtime").(*libpod.Runtime)
+	decoder := r.Context().Value("decoder").(*schema.Decoder)
+
+	// /containers/{id}/resize
+	query := struct {
+		height uint16 `schema:"h"`
+		width  uint16 `schema:"w"`
+	}{
+		// override any golang type defaults
+	}
+
+	if err := decoder.Decode(&query, r.URL.Query()); err != nil {
+		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest,
+			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
+		return
+	}
+
+	sz := remotecommand.TerminalSize{
+		Width:  query.width,
+		Height: query.height,
+	}
+
+	var status int
+	name := utils.GetName(r)
+	switch {
+	case strings.Contains(r.URL.Path, "/containers/"):
+		ctnr, err := runtime.LookupContainer(name)
+		if err != nil {
+			utils.ContainerNotFound(w, name, err)
+			return
+		}
+		if err := ctnr.AttachResize(sz); err != nil {
+			utils.InternalServerError(w, errors.Wrapf(err, "cannot resize container"))
+			return
+		}
+		// This is not a 204, even though we write nothing, for compatibility
+		// reasons.
+		status = http.StatusOK
+	case strings.Contains(r.URL.Path, "/exec/"):
+		ctnr, err := runtime.GetExecSessionContainer(name)
+		if err != nil {
+			utils.SessionNotFound(w, name, err)
+			return
+		}
+		if err := ctnr.ExecResize(name, sz); err != nil {
+			utils.InternalServerError(w, errors.Wrapf(err, "cannot resize session"))
+			return
+		}
+		// This is not a 204, even though we write nothing, for compatibility
+		// reasons.
+		status = http.StatusCreated
+	}
+	utils.WriteResponse(w, status, "")
+}

--- a/pkg/api/handlers/utils/errors.go
+++ b/pkg/api/handlers/utils/errors.go
@@ -63,6 +63,14 @@ func PodNotFound(w http.ResponseWriter, name string, err error) {
 	Error(w, msg, http.StatusNotFound, err)
 }
 
+func SessionNotFound(w http.ResponseWriter, name string, err error) {
+	if errors.Cause(err) != define.ErrNoSuchExecSession {
+		InternalServerError(w, err)
+	}
+	msg := fmt.Sprintf("No such exec session: %s", name)
+	Error(w, msg, http.StatusNotFound, err)
+}
+
 func ContainerNotRunning(w http.ResponseWriter, containerID string, err error) {
 	msg := fmt.Sprintf("Container %s is not running", containerID)
 	Error(w, msg, http.StatusConflict, err)

--- a/pkg/api/server/register_containers.go
+++ b/pkg/api/server/register_containers.go
@@ -584,9 +584,9 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/containers/{name}/resize"), s.APIHandler(compat.ResizeContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/containers/{name}/resize"), s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
-	r.HandleFunc("/containers/{name}/resize", s.APIHandler(compat.ResizeContainer)).Methods(http.MethodPost)
+	r.HandleFunc("/containers/{name}/resize", s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
 	// swagger:operation GET /containers/{name}/export compat exportContainer
 	// ---
 	// tags:
@@ -1259,7 +1259,7 @@ func (s *APIServer) registerContainersHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchContainer"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/libpod/containers/{name}/resize"), s.APIHandler(compat.ResizeContainer)).Methods(http.MethodPost)
+	r.HandleFunc(VersionedPath("/libpod/containers/{name}/resize"), s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
 	// swagger:operation GET /libpod/containers/{name}/export libpod libpodExportContainer
 	// ---
 	// tags:

--- a/pkg/api/server/register_exec.go
+++ b/pkg/api/server/register_exec.go
@@ -145,9 +145,9 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchExecInstance"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/exec/{id}/resize"), s.APIHandler(compat.UnsupportedHandler)).Methods(http.MethodPost)
+	r.Handle(VersionedPath("/exec/{id}/resize"), s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
 	// Added non version path to URI to support docker non versioned paths
-	r.Handle("/exec/{id}/resize", s.APIHandler(compat.UnsupportedHandler)).Methods(http.MethodPost)
+	r.Handle("/exec/{id}/resize", s.APIHandler(compat.ResizeTTY)).Methods(http.MethodPost)
 	// swagger:operation GET /exec/{id}/json compat inspectExec
 	// ---
 	// tags:


### PR DESCRIPTION
* Add support for /exec/{id}/resize
* Add support for ErrSessionNotFound
* Resize container TTY as stdin changes size
* Refactor all resize functions into one handler

Signed-off-by: Jhon Honce <jhonce@redhat.com>