### PR TITLE
Fix EOM for SendFile

### DIFF
--- a/pkg/varlinkapi/transfers.go
+++ b/pkg/varlinkapi/transfers.go
@@ -4,6 +4,7 @@ package varlinkapi
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -39,7 +40,7 @@ func (i *VarlinkAPI) SendFile(call iopodman.VarlinkCall, ftype string, length in
 
 	logrus.Debugf("successfully received %s", outputFile.Name())
 	// Send an ACK to the client
-	call.Call.Writer.WriteString(outputFile.Name())
+	call.Call.Writer.WriteString(fmt.Sprintf("%s:", outputFile.Name()))
 	call.Call.Writer.Flush()
 	return nil
 


### PR DESCRIPTION
To terminate a connection of varlink, say after sending a file, we need to send a message containing a delimiter of ':' so the client knows to hang up.

Fixes: #6237

Signed-off-by: Brent Baude <bbaude@redhat.com>