### PR TITLE
Turn off 'noexec' option by default for named volumes

### DIFF
--- a/pkg/util/mountOpts_linux.go
+++ b/pkg/util/mountOpts_linux.go
@@ -7,7 +7,7 @@ import (
 )
 
 func getDefaultMountOptions(path string) (defaultMountOptions, error) {
-	opts := defaultMountOptions{true, true, true}
+	opts := defaultMountOptions{false, true, true}
 	if path == "" {
 		return opts, nil
 	}

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Podman create", func() {
 		session = podmanTest.Podman([]string{"logs", "test_tmpfs"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(ContainSubstring("/create/test rw,nosuid,nodev,noexec,relatime - tmpfs"))
+		Expect(session.OutputToString()).To(ContainSubstring("/create/test rw,nosuid,nodev,relatime - tmpfs"))
 	})
 
 	It("podman create --pod automatically", func() {

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Podman run with volumes", func() {
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", "type=tmpfs,target=" + dest, ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
-		Expect(session.OutputToString()).To(ContainSubstring(dest + " rw,nosuid,nodev,noexec,relatime - tmpfs"))
+		Expect(session.OutputToString()).To(ContainSubstring(dest + " rw,nosuid,nodev,relatime - tmpfs"))
 
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", "type=tmpfs,target=/etc/ssl,tmpcopyup", ALPINE, "ls", "/etc/ssl"})
 		session.WaitWithDefaultTimeout()

--- a/test/system/160-volumes.bats
+++ b/test/system/160-volumes.bats
@@ -115,7 +115,8 @@ echo "got here -$rand-"
 EOF
     chmod 755 $mountpoint/myscript
 
-    # By default, volumes are mounted noexec. This should fail.
+    # By default, volumes are mounted exec, but we have manually added the
+    # noexec option. This should fail.
     # ARGH. Unfortunately, runc (used for cgroups v1) produces a different error
     local expect_rc=126
     local expect_msg='.* OCI runtime permission denied.*'
@@ -125,12 +126,12 @@ EOF
         expect_msg='.* exec user process caused.*permission denied'
     fi
 
-    run_podman ${expect_rc} run --rm --volume $myvolume:/vol:z $IMAGE /vol/myscript
+    run_podman ${expect_rc} run --rm --volume $myvolume:/vol:noexec,z $IMAGE /vol/myscript
     is "$output" "$expect_msg" "run on volume, noexec"
 
-    # With exec, it should pass
-    run_podman run --rm -v $myvolume:/vol:z,exec $IMAGE /vol/myscript
-    is "$output" "got here -$rand-" "script in volume is runnable with exec"
+    # With the default, it should pass
+    run_podman run --rm -v $myvolume:/vol:z $IMAGE /vol/myscript
+    is "$output" "got here -$rand-" "script in volume is runnable with default (exec)"
 
     # Clean up
     run_podman volume rm $myvolume


### PR DESCRIPTION
We previously enforced this for security reasons, but as Dan has explained on several occasions, it's not very valuable there (it's trivially easy to bypass) and it does seriously annoy folks trying to use named volumes. Flip the default from 'on' to 'off'.