### PR TITLE
[CI:DOCS] Image tree endpoint should return 404

### DIFF
--- a/pkg/api/server/register_images.go
+++ b/pkg/api/server/register_images.go
@@ -698,7 +698,7 @@ func (s *APIServer) registerImagesHandlers(r *mux.Router) error {
 	// responses:
 	//   200:
 	//     $ref: '#/responses/LibpodImageTreeResponse'
-	//   401:
+	//   404:
 	//     $ref: '#/responses/NoSuchImage'
 	//   500:
 	//     $ref: '#/responses/InternalError'


### PR DESCRIPTION
when trying to get an image tree for a missing image, it should return a 404.  doc fix only.

Fixes: #6289

Signed-off-by: Brent Baude <bbaude@redhat.com>