### PR TITLE
Print container state when erroring that it is improper

### DIFF
--- a/pkg/api/handlers/compat/containers_attach.go
+++ b/pkg/api/handlers/compat/containers_attach.go
@@ -94,7 +94,7 @@ func AttachContainer(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else if !(state == define.ContainerStateCreated || state == define.ContainerStateRunning) {
-		utils.InternalServerError(w, errors.Wrapf(define.ErrCtrStateInvalid, "can only attach to created or running containers"))
+		utils.InternalServerError(w, errors.Wrapf(define.ErrCtrStateInvalid, "can only attach to created or running containers - currently in state %s", state.String()))
 		return
 	}
 


### PR DESCRIPTION
This is a nice little convenience - lets people know why we won't let them attach to a container.