### PR TITLE
govern remote attach and start

### DIFF
--- a/pkg/bindings/test/attach_test.go
+++ b/pkg/bindings/test/attach_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Podman containers attach", func() {
 		go func() {
 			defer GinkgoRecover()
 
-			err := containers.Attach(bt.conn, id, nil, bindings.PTrue, bindings.PTrue, nil, stdout, stderr)
+			err := containers.Attach(bt.conn, id, nil, bindings.PTrue, bindings.PTrue, nil, stdout, stderr, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 		}()
 
@@ -98,7 +98,7 @@ var _ = Describe("Podman containers attach", func() {
 		go func() {
 			defer GinkgoRecover()
 
-			err := containers.Attach(bt.conn, ctnr.ID, nil, bindings.PFalse, bindings.PTrue, stdin, stdout, stderr)
+			err := containers.Attach(bt.conn, ctnr.ID, nil, bindings.PFalse, bindings.PTrue, stdin, stdout, stderr, nil)
 			Expect(err).ShouldNot(HaveOccurred())
 		}()
 

--- a/test/e2e/commit_test.go
+++ b/test/e2e/commit_test.go
@@ -217,7 +217,6 @@ var _ = Describe("Podman commit", func() {
 	})
 
 	It("podman commit container check env variables", func() {
-		Skip(v2remotefail)
 		s := podmanTest.Podman([]string{"run", "--name", "test1", "-e", "TEST=1=1-01=9.01", "-it", "alpine", "true"})
 		s.WaitWithDefaultTimeout()
 		Expect(s.ExitCode()).To(Equal(0))


### PR DESCRIPTION
fixes a race where container would start before attach could occur resulting in an error.

Signed-off-by: Brent Baude <bbaude@redhat.com>