### PR TITLE
Fix build on OS X

### DIFF
--- a/cmd/podman/pods/top.go
+++ b/cmd/podman/pods/top.go
@@ -9,17 +9,15 @@ import (
 
 	"github.com/containers/libpod/cmd/podman/registry"
 	"github.com/containers/libpod/pkg/domain/entities"
-	"github.com/containers/psgo"
+	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 var (
-	topDescription = fmt.Sprintf(`Specify format descriptors to alter the output.
+	topDescription = `Specify format descriptors to alter the output.
 
-	You may run "podman pod top -l pid pcpu seccomp" to print the process ID, the CPU percentage and the seccomp mode of each process of the latest pod.
-  Format Descriptors:
-    %s`, strings.Join(psgo.ListDescriptors(), ","))
+  You may run "podman pod top -l pid pcpu seccomp" to print the process ID, the CPU percentage and the seccomp mode of each process of the latest pod.`
 
 	topOptions = entities.PodTopOptions{}
 
@@ -43,6 +41,12 @@ func init() {
 		Parent:  podCmd,
 	})
 
+	descriptors, err := util.GetContainerPidInformationDescriptors()
+	if err == nil {
+		topDescription = fmt.Sprintf("%s\n\n  Format Descriptors:\n    %s", topDescription, strings.Join(descriptors, ","))
+		topCommand.Long = topDescription
+	}
+
 	flags := topCommand.Flags()
 	flags.SetInterspersed(false)
 	flags.BoolVar(&topOptions.ListDescriptors, "list-descriptors", false, "")
@@ -56,7 +60,11 @@ func init() {
 
 func top(cmd *cobra.Command, args []string) error {
 	if topOptions.ListDescriptors {
-		fmt.Println(strings.Join(psgo.ListDescriptors(), "\n"))
+		descriptors, err := util.GetContainerPidInformationDescriptors()
+		if err != nil {
+			return err
+		}
+		fmt.Println(strings.Join(descriptors, "\n"))
 		return nil
 	}
 

--- a/cmd/podman/root.go
+++ b/cmd/podman/root.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log/syslog"
 	"os"
 	"path"
 	"runtime/pprof"
@@ -17,7 +16,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	logrusSyslog "github.com/sirupsen/logrus/hooks/syslog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -188,21 +186,6 @@ func loggingHook() {
 
 	if logrus.IsLevelEnabled(logrus.InfoLevel) {
 		logrus.Infof("%s filtering at log level %s", os.Args[0], logrus.GetLevel())
-	}
-}
-
-func syslogHook() {
-	if !useSyslog {
-		return
-	}
-
-	hook, err := logrusSyslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
-	if err != nil {
-		fmt.Fprint(os.Stderr, "Failed to initialize syslog hook: "+err.Error())
-		os.Exit(1)
-	}
-	if err == nil {
-		logrus.AddHook(hook)
 	}
 }
 

--- a/cmd/podman/syslog_linux.go
+++ b/cmd/podman/syslog_linux.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"log/syslog"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	logrusSyslog "github.com/sirupsen/logrus/hooks/syslog"
+)
+
+func syslogHook() {
+	if !useSyslog {
+		return
+	}
+
+	hook, err := logrusSyslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
+	if err != nil {
+		fmt.Fprint(os.Stderr, "Failed to initialize syslog hook: "+err.Error())
+		os.Exit(1)
+	}
+	if err == nil {
+		logrus.AddHook(hook)
+	}
+}

--- a/cmd/podman/syslog_unsupported.go
+++ b/cmd/podman/syslog_unsupported.go
@@ -1,0 +1,17 @@
+// +build !linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func syslogHook() {
+	if !useSyslog {
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "Logging to Syslog is not supported on Windows")
+	os.Exit(1)
+}


### PR DESCRIPTION
We disabled the OS X and Windows cross-building tests. This, predictably, led us to regress a bit in our ability to build for both of these.

This fixes the build on OS X and fixes one obvious Windows bug. Unfortunately, we're dragging in all of `pkg/spec` somewhere on Windows, and things are blowing up spectacularly because of it (plus a few uses of the `syscall` package in the bindings).

I've giving up for the day. This fixes OS X, but does not fully enable the cross-build CI (need Windows fixes for that).