### PR TITLE
Get proper exit code when running or starting a container.

### DIFF
--- a/test/e2e/run_exit_test.go
+++ b/test/e2e/run_exit_test.go
@@ -62,7 +62,6 @@ var _ = Describe("Podman run exit", func() {
 	})
 
 	It("podman run exit 50", func() {
-		Skip(v2remotefail)
 		result := podmanTest.Podman([]string{"run", ALPINE, "sh", "-c", "exit 50"})
 		result.WaitWithDefaultTimeout()
 		Expect(result.ExitCode()).To(Equal(50))


### PR DESCRIPTION
When we finish running a container, we need to call wait in order
to get the exit code from the container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>