### PR TITLE
Allow to change the generated systemd unit name prefix

### DIFF
--- a/cmd/podman/generate/systemd.go
+++ b/cmd/podman/generate/systemd.go
@@ -39,6 +39,9 @@ func init() {
 	flags.UintVarP(&systemdTimeout, "time", "t", containerConfig.Engine.StopTimeout, "Stop timeout override")
 	flags.StringVar(&systemdOptions.RestartPolicy, "restart-policy", "on-failure", "Systemd restart-policy")
 	flags.BoolVarP(&systemdOptions.New, "new", "", false, "Create a new container instead of starting an existing one")
+	flags.StringVar(&systemdOptions.ContainerPrefix, "container-prefix", "container", "Systemd unit name prefix for containers")
+	flags.StringVar(&systemdOptions.PodPrefix, "pod-prefix", "pod", "Systemd unit name prefix for pods")
+	flags.StringVar(&systemdOptions.Separator, "separator", "-", "Systemd unit name seperator between name/id and prefix")
 	flags.SetNormalizeFunc(utils.AliasFlags)
 }
 

--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -2838,7 +2838,10 @@ _podman_generate_systemd() {
     local options_with_args="
     --restart-policy
     -t
-    --time"
+    --time
+	--container-prefix
+	--pod-prefix
+	--separator"
 
     local boolean_options="
     -h

--- a/docs/source/markdown/podman-generate-systemd.1.md
+++ b/docs/source/markdown/podman-generate-systemd.1.md
@@ -40,6 +40,18 @@ Override the default stop timeout for the container with the given value.
 Set the systemd restart policy.  The restart-policy must be one of: "no", "on-success", "on-failure", "on-abnormal",
 "on-watchdog", "on-abort", or "always".  The default policy is *on-failure*.
 
+**--container-prefix**=*prefix*
+
+Set the systemd unit name prefix for containers. The default is *container*.
+
+**--pod-prefix**=*prefix*
+
+Set the systemd unit name prefix for pods. The default is *pod*.
+
+**--separator**=*separator*
+
+Set the systemd unit name seperator between the name/id of a container/pod and the prefix. The default is *-*.
+
 ## Examples
 
 ### Generate and print a systemd unit file for a container

--- a/pkg/domain/entities/generate.go
+++ b/pkg/domain/entities/generate.go
@@ -14,6 +14,12 @@ type GenerateSystemdOptions struct {
 	RestartPolicy string
 	// StopTimeout - time when stopping the container.
 	StopTimeout *uint
+	// ContainerPrefix - systemd unit name prefix for containers
+	ContainerPrefix string
+	// PodPrefix - systemd unit name prefix for pods
+	PodPrefix string
+	// Separator - systemd unit name seperator between name/id and prefix
+	Separator string
 }
 
 // GenerateSystemdReport

--- a/pkg/domain/infra/abi/generate.go
+++ b/pkg/domain/infra/abi/generate.go
@@ -159,14 +159,14 @@ func (ic *ContainerEngine) generateSystemdgenContainerInfo(nameOrID string, pod 
 func generateServiceName(ctr *libpod.Container, pod *libpod.Pod, options entities.GenerateSystemdOptions) (string, string) {
 	var kind, name, ctrName string
 	if pod == nil {
-		kind = "container"
+		kind = options.ContainerPrefix //defaults to container
 		name = ctr.ID()
 		if options.Name {
 			name = ctr.Name()
 		}
 		ctrName = name
 	} else {
-		kind = "pod"
+		kind = options.PodPrefix //defaults to pod
 		name = pod.ID()
 		ctrName = ctr.ID()
 		if options.Name {
@@ -174,7 +174,7 @@ func generateServiceName(ctr *libpod.Container, pod *libpod.Pod, options entitie
 			ctrName = ctr.Name()
 		}
 	}
-	return ctrName, fmt.Sprintf("%s-%s", kind, name)
+	return ctrName, fmt.Sprintf("%s%s%s", kind, options.Separator, name)
 }
 
 func (ic *ContainerEngine) GenerateKube(ctx context.Context, nameOrID string, options entities.GenerateKubeOptions) (*entities.GenerateKubeReport, error) {


### PR DESCRIPTION
I often generate my systemd units with `podman gernerate systemd` but I dont like the default unit prefixes _"container-"_/_"pod-"_, so I have to change them manually in a extra step.
This PR allows to change the created systemd unit names with a custom prefix and a custom separator with the following flags:
- --container-prefix
- --pod-prefix
- --separator
The current behavior does not change!

If a user dont want any prefix he could do now `podman generate systemd -f -n --container-prefix "" --pod-prefix "" --separator "" POD/CONTAINER`
If you want to change the separator you can do `podman generate systemd -f -n --separator "_" POD/CONTAINER`