### PR TITLE
Remove github.com/libpod/libpod from cmd/pkg/podman

### DIFF
--- a/cmd/podman/networks/create.go
+++ b/cmd/podman/networks/create.go
@@ -5,7 +5,7 @@ import (
 	"net"
 
 	"github.com/containers/libpod/cmd/podman/registry"
-	"github.com/containers/libpod/libpod"
+	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/containers/libpod/pkg/network"
 	"github.com/pkg/errors"
@@ -65,8 +65,8 @@ func networkCreate(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
 		return errors.Errorf("only one network can be created at a time")
 	}
-	if len(args) > 0 && !libpod.NameRegex.MatchString(args[0]) {
-		return libpod.RegexError
+	if len(args) > 0 && !define.NameRegex.MatchString(args[0]) {
+		return define.RegexError
 	}
 
 	if len(args) > 0 {

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -3,6 +3,9 @@ package define
 import (
 	"bufio"
 	"io"
+	"regexp"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -10,6 +13,13 @@ var (
 	DefaultSHMLockPath = "/libpod_lock"
 	// DefaultRootlessSHMLockPath is the default path for rootless SHM locks
 	DefaultRootlessSHMLockPath = "/libpod_rootless_lock"
+
+	// NameRegex is a regular expression to validate container/pod names.
+	// This must NOT be changed from outside of Libpod. It should be a
+	// constant, but Go won't let us do that.
+	NameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+	// RegexError is thrown in presence of an invalid container/pod name.
+	RegexError = errors.Wrapf(ErrInvalidArg, "names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*")
 )
 
 const (

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"regexp"
 	"syscall"
 
 	"github.com/containers/common/pkg/config"
@@ -18,15 +17,6 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/pkg/errors"
-)
-
-var (
-	// NameRegex is a regular expression to validate container/pod names.
-	// This must NOT be changed from outside of Libpod. It should be a
-	// constant, but Go won't let us do that.
-	NameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
-	// RegexError is thrown in presence of an invalid container/pod name.
-	RegexError = errors.Wrapf(define.ErrInvalidArg, "names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*")
 )
 
 // Runtime Creation Options
@@ -665,8 +655,8 @@ func WithName(name string) CtrCreateOption {
 		}
 
 		// Check the name against a regex
-		if !NameRegex.MatchString(name) {
-			return RegexError
+		if !define.NameRegex.MatchString(name) {
+			return define.RegexError
 		}
 
 		ctr.config.Name = name
@@ -1383,8 +1373,8 @@ func WithVolumeName(name string) VolumeCreateOption {
 		}
 
 		// Check the name against a regex
-		if !NameRegex.MatchString(name) {
-			return RegexError
+		if !define.NameRegex.MatchString(name) {
+			return define.RegexError
 		}
 		volume.config.Name = name
 
@@ -1502,8 +1492,8 @@ func WithPodName(name string) PodCreateOption {
 		}
 
 		// Check the name against a regex
-		if !NameRegex.MatchString(name) {
-			return RegexError
+		if !define.NameRegex.MatchString(name) {
+			return define.RegexError
 		}
 
 		pod.config.Name = name
@@ -1520,8 +1510,8 @@ func WithPodHostname(hostname string) PodCreateOption {
 		}
 
 		// Check the hostname against a regex
-		if !NameRegex.MatchString(hostname) {
-			return RegexError
+		if !define.NameRegex.MatchString(hostname) {
+			return define.RegexError
 		}
 
 		pod.config.Hostname = hostname


### PR DESCRIPTION
By moving a couple of variables from libpod/libpod to libpod/libpod/define
I am able shrink the podman-remote-* executables by another megabyte.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>