### PR TITLE
V2 enable remote logs and testing

### DIFF
--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	ErrLostSync = errors.New("lost synchronization with attach multiplexed result")
+	ErrLostSync = errors.New("lost synchronization with multiplexed stream")
 )
 
 // List obtains a list of containers in local storage.  All parameters to this method are optional.
@@ -485,7 +485,7 @@ func Attach(ctx context.Context, nameOrId string, detachKeys *string, logs, stre
 					return err
 				}
 			case fd == 3:
-				return fmt.Errorf("error from daemon in stream: %s", frame)
+				return errors.New("error from service in stream: " + string(frame))
 			default:
 				return fmt.Errorf("unrecognized input header: %d", fd)
 			}
@@ -507,7 +507,7 @@ func DemuxHeader(r io.Reader, buffer []byte) (fd, sz int, err error) {
 
 	fd = int(buffer[0])
 	if fd < 0 || fd > 3 {
-		err = ErrLostSync
+		err = errors.Wrapf(ErrLostSync, fmt.Sprintf(`channel "%d" found, 0-3 supported`, fd))
 		return
 	}
 
@@ -528,7 +528,6 @@ func DemuxFrame(r io.Reader, buffer []byte, length int) (frame []byte, err error
 		err = io.ErrUnexpectedEOF
 		return
 	}
-
 	return buffer[0:length], nil
 }
 

--- a/pkg/bindings/test/containers_test.go
+++ b/pkg/bindings/test/containers_test.go
@@ -378,9 +378,9 @@ var _ = Describe("Podman containers ", func() {
 			containers.Logs(bt.conn, r.ID, opts, stdoutChan, nil)
 		}()
 		o := <-stdoutChan
-		o = strings.ReplaceAll(o, "\r", "")
+		o = strings.TrimSpace(o)
 		_, err = time.Parse(time.RFC1123Z, o)
-		Expect(err).To(BeNil())
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 
 	It("podman top", func() {

--- a/test/e2e/libpod_suite_remote_test.go
+++ b/test/e2e/libpod_suite_remote_test.go
@@ -89,10 +89,17 @@ func (p *PodmanTestIntegration) StartRemoteService() {
 	if os.Geteuid() == 0 {
 		os.MkdirAll("/run/podman", 0755)
 	}
+
+	args := []string{}
+	if _, found := os.LookupEnv("DEBUG_SERVICE"); found {
+		args = append(args, "--log-level", "debug")
+	}
 	remoteSocket := p.RemoteSocket
-	args := []string{"system", "service", "--timeout", "0", remoteSocket}
+	args = append(args, "system", "service", "--timeout", "0", remoteSocket)
 	podmanOptions := getRemoteOptions(p, args)
 	command := exec.Command(p.PodmanBinary, podmanOptions...)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
 	fmt.Printf("Running: %s %s\n", p.PodmanBinary, strings.Join(podmanOptions, " "))
 	command.Start()
 	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Podman logs", func() {
@@ -19,7 +20,6 @@ var _ = Describe("Podman logs", func() {
 	)
 
 	BeforeEach(func() {
-		SkipIfRemote() // v2remotefail
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)
@@ -36,97 +36,99 @@ var _ = Describe("Podman logs", func() {
 
 	})
 
-	It("podman logs for container", func() {
+	It("all lines", func() {
 		logc := podmanTest.Podman([]string{"run", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
-		cid := logc.OutputToString()
+		Expect(logc).To(Exit(0))
 
+		cid := logc.OutputToString()
 		results := podmanTest.Podman([]string{"logs", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(3))
 	})
 
-	It("podman logs tail two lines", func() {
+	It("tail two lines", func() {
 		logc := podmanTest.Podman([]string{"run", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		results := podmanTest.Podman([]string{"logs", "--tail", "2", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(2))
 	})
 
-	It("podman logs tail zero lines", func() {
+	It("tail zero lines", func() {
 		logc := podmanTest.Podman([]string{"run", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		results := podmanTest.Podman([]string{"logs", "--tail", "0", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(0))
 	})
 
-	It("podman logs tail 99 lines", func() {
+	It("tail 99 lines", func() {
 		logc := podmanTest.Podman([]string{"run", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		results := podmanTest.Podman([]string{"logs", "--tail", "99", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(3))
 	})
 
-	It("podman logs tail 2 lines with timestamps", func() {
+	It("tail 2 lines with timestamps", func() {
 		logc := podmanTest.Podman([]string{"run", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		results := podmanTest.Podman([]string{"logs", "--tail", "2", "-t", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(2))
 	})
 
-	It("podman logs latest with since time", func() {
+	It("since time 2017-08-07", func() {
 		logc := podmanTest.Podman([]string{"run", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		results := podmanTest.Podman([]string{"logs", "--since", "2017-08-07T10:10:09.056611202-04:00", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(3))
 	})
 
-	It("podman logs latest with since duration", func() {
+	It("since duration 10m", func() {
 		logc := podmanTest.Podman([]string{"run", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		results := podmanTest.Podman([]string{"logs", "--since", "10m", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(3))
 	})
 
-	It("podman logs latest and container name should fail", func() {
+	It("latest and container name should fail", func() {
+		SkipIfRemote() // -l not supported
 		results := podmanTest.Podman([]string{"logs", "-l", "foobar"})
 		results.WaitWithDefaultTimeout()
 		Expect(results).To(ExitWithError())
 	})
 
-	It("podman logs two containers and should display short container IDs", func() {
+	It("two containers showing short container IDs", func() {
+		SkipIfRemote() // remote does not support multiple containers
 		log1 := podmanTest.Podman([]string{"run", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		log1.WaitWithDefaultTimeout()
 		Expect(log1.ExitCode()).To(Equal(0))
@@ -139,7 +141,7 @@ var _ = Describe("Podman logs", func() {
 
 		results := podmanTest.Podman([]string{"logs", cid1, cid2})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).Should(Exit(0))
 
 		output := results.OutputToStringArray()
 		Expect(len(output)).To(Equal(6))
@@ -149,23 +151,24 @@ var _ = Describe("Podman logs", func() {
 	It("podman logs on a created container should result in 0 exit code", func() {
 		session := podmanTest.Podman([]string{"create", "-dt", "--name", "log", ALPINE})
 		session.WaitWithDefaultTimeout()
-		Expect(session.ExitCode()).To(BeZero())
+		Expect(session).To(Exit(0))
 
 		results := podmanTest.Podman([]string{"logs", "log"})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(BeZero())
+		Expect(results).To(Exit(0))
 	})
 
-	It("podman journald logs for container with container tag", func() {
+	It("using journald for container with container tag", func() {
+		SkipIfRemote()
 		Skip("need to verify images have correct packages for journald")
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "--log-opt=tag={{.ImageName}}", "-d", ALPINE, "sh", "-c", "echo podman; sleep 0.1; echo podman; sleep 0.1; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		wait := podmanTest.Podman([]string{"wait", "-l"})
 		wait.WaitWithDefaultTimeout()
-		Expect(wait.ExitCode()).To(BeZero())
+		Expect(wait).To(Exit(0))
 
 		cmd := exec.Command("journalctl", "--no-pager", "-o", "json", "--output-fields=CONTAINER_TAG", "-u", fmt.Sprintf("libpod-conmon-%s.scope", cid))
 		out, err := cmd.CombinedOutput()
@@ -173,17 +176,18 @@ var _ = Describe("Podman logs", func() {
 		Expect(string(out)).To(ContainSubstring("alpine"))
 	})
 
-	It("podman journald logs for container name", func() {
+	It("using journald for container name", func() {
 		Skip("need to verify images have correct packages for journald")
+		SkipIfRemote()
 		containerName := "inside-journal"
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "-d", "--name", containerName, ALPINE, "sh", "-c", "echo podman; sleep 0.1; echo podman; sleep 0.1; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		wait := podmanTest.Podman([]string{"wait", "-l"})
 		wait.WaitWithDefaultTimeout()
-		Expect(wait.ExitCode()).To(BeZero())
+		Expect(wait).To(Exit(0))
 
 		cmd := exec.Command("journalctl", "--no-pager", "-o", "json", "--output-fields=CONTAINER_NAME", "-u", fmt.Sprintf("libpod-conmon-%s.scope", cid))
 		out, err := cmd.CombinedOutput()
@@ -191,98 +195,97 @@ var _ = Describe("Podman logs", func() {
 		Expect(string(out)).To(ContainSubstring(containerName))
 	})
 
-	It("podman journald logs for container", func() {
+	It("using journald for container", func() {
 		Skip("need to verify images have correct packages for journald")
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		results := podmanTest.Podman([]string{"logs", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(3))
 	})
 
-	It("podman journald logs tail two lines", func() {
+	It("using journald tail two lines", func() {
 		Skip("need to verify images have correct packages for journald")
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
-
 		results := podmanTest.Podman([]string{"logs", "--tail", "2", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(2))
 	})
 
-	It("podman journald logs tail 99 lines", func() {
+	It("using journald tail 99 lines", func() {
 		Skip("need to verify images have correct packages for journald")
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		results := podmanTest.Podman([]string{"logs", "--tail", "99", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(3))
 	})
 
-	It("podman journald logs tail 2 lines with timestamps", func() {
+	It("using journald tail 2 lines with timestamps", func() {
 		Skip("need to verify images have correct packages for journald")
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		results := podmanTest.Podman([]string{"logs", "--tail", "2", "-t", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(2))
 	})
 
-	It("podman journald logs latest with since time", func() {
+	It("using journald since time 2017-08-07", func() {
 		Skip("need to verify images have correct packages for journald")
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		results := podmanTest.Podman([]string{"logs", "--since", "2017-08-07T10:10:09.056611202-04:00", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(3))
 	})
 
-	It("podman journald logs latest with since duration", func() {
+	It("using journald with duration 10m", func() {
 		Skip("need to verify images have correct packages for journald")
 		logc := podmanTest.Podman([]string{"run", "--log-driver", "journald", "-dt", ALPINE, "sh", "-c", "echo podman; echo podman; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 		cid := logc.OutputToString()
 
 		results := podmanTest.Podman([]string{"logs", "--since", "10m", cid})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 		Expect(len(results.OutputToStringArray())).To(Equal(3))
 	})
 
-	It("podman logs -f two lines", func() {
+	It("streaming output", func() {
 		containerName := "logs-f-rm"
 
 		logc := podmanTest.Podman([]string{"run", "--rm", "--name", containerName, "-dt", ALPINE, "sh", "-c", "echo podman; sleep 1; echo podman"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 
 		results := podmanTest.Podman([]string{"logs", "-f", containerName})
 		results.WaitWithDefaultTimeout()
-		Expect(results.ExitCode()).To(Equal(0))
+		Expect(results).To(Exit(0))
 
 		// Verify that the cleanup process worked correctly and we can recreate a container with the same name
 		logc = podmanTest.Podman([]string{"run", "--rm", "--name", containerName, "-dt", ALPINE, "true"})
 		logc.WaitWithDefaultTimeout()
-		Expect(logc.ExitCode()).To(Equal(0))
+		Expect(logc).To(Exit(0))
 	})
 })


### PR DESCRIPTION
* wire up bindings and handler for obtaining logs remotely
* enable debug logging from podman in e2e test using DEBUG and
  DEBUG_SERVICE env variables
* Fix error in streaming log frames
* enable remote logs test

Signed-off-by: Jhon Honce <jhonce@redhat.com>