### PR TITLE
Removes remote system reset functionality. skip e2e test for remote.

### DIFF
--- a/pkg/api/handlers/libpod/system.go
+++ b/pkg/api/handlers/libpod/system.go
@@ -71,16 +71,6 @@ func SystemPrune(w http.ResponseWriter, r *http.Request) {
 	utils.WriteResponse(w, http.StatusOK, systemPruneReport)
 }
 
-// SystemReset Resets podman storage back to default state
-func SystemReset(w http.ResponseWriter, r *http.Request) {
-	err := r.Context().Value("runtime").(*libpod.Runtime).Reset(r.Context())
-	if err != nil {
-		utils.InternalServerError(w, err)
-		return
-	}
-	utils.WriteResponse(w, http.StatusOK, nil)
-}
-
 func DiskUsage(w http.ResponseWriter, r *http.Request) {
 	// Options are only used by the CLI
 	options := entities.SystemDfOptions{}

--- a/pkg/api/server/register_system.go
+++ b/pkg/api/server/register_system.go
@@ -27,20 +27,6 @@ func (s *APIServer) registerSystemHandlers(r *mux.Router) error {
 	//   500:
 	//     $ref: "#/responses/InternalError"
 	r.Handle(VersionedPath("/libpod/system/prune"), s.APIHandler(libpod.SystemPrune)).Methods(http.MethodPost)
-	// swagger:operation POST /libpod/system/reset libpod resetSystem
-	// ---
-	// tags:
-	//   - system
-	// summary: Reset podman storage
-	// description: All containers will be stopped and removed, and all images, volumes and container content will be removed.
-	// produces:
-	// - application/json
-	// responses:
-	//   200:
-	//     description: no error
-	//   500:
-	//     $ref: "#/responses/InternalError"
-	r.Handle(VersionedPath("/libpod/system/reset"), s.APIHandler(libpod.SystemReset)).Methods(http.MethodPost)
 	// swagger:operation GET /libpod/system/df libpod df
 	// ---
 	// tags:

--- a/pkg/bindings/system/system.go
+++ b/pkg/bindings/system/system.go
@@ -122,19 +122,6 @@ func Version(ctx context.Context) (*entities.SystemVersionReport, error) {
 	return &report, err
 }
 
-// Reset removes all unused system data.
-func Reset(ctx context.Context) error {
-	conn, err := bindings.GetClient(ctx)
-	if err != nil {
-		return err
-	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/system/reset", nil)
-	if err != nil {
-		return err
-	}
-	return response.Process(response)
-}
-
 // DiskUsage returns information about image, container, and volume disk
 // consumption
 func DiskUsage(ctx context.Context) (*entities.SystemDfReport, error) {

--- a/pkg/bindings/test/system_test.go
+++ b/pkg/bindings/test/system_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/libpod/pkg/bindings"
 	"github.com/containers/libpod/pkg/bindings/containers"
-	"github.com/containers/libpod/pkg/bindings/images"
 	"github.com/containers/libpod/pkg/bindings/pods"
 	"github.com/containers/libpod/pkg/bindings/system"
 	"github.com/containers/libpod/pkg/bindings/volumes"
@@ -149,46 +148,5 @@ var _ = Describe("Podman system", func() {
 			ToNot(ContainElement("docker.io/library/alpine:latest"))
 		// Volume should be pruned now as flag set true
 		Expect(len(systemPruneResponse.VolumePruneReport)).To(Equal(1))
-	})
-
-	It("podman system reset", func() {
-		// Adding an unused volume should work
-		_, err := volumes.Create(bt.conn, entities.VolumeCreateOptions{})
-		Expect(err).To(BeNil())
-
-		vols, err := volumes.List(bt.conn, nil)
-		Expect(err).To(BeNil())
-		Expect(len(vols)).To(Equal(1))
-
-		// Start a pod and leave it running
-		_, err = pods.Start(bt.conn, newpod)
-		Expect(err).To(BeNil())
-
-		imageSummary, err := images.List(bt.conn, nil, nil)
-		Expect(err).To(BeNil())
-		// Since in the begin context images are created
-		Expect(len(imageSummary)).To(Equal(3))
-
-		err = system.Reset(bt.conn)
-		Expect(err).To(BeNil())
-
-		// re-establish connection
-		s = bt.startAPIService()
-		time.Sleep(1 * time.Second)
-
-		// No pods
-		podSummary, err := pods.List(bt.conn, nil)
-		Expect(err).To(BeNil())
-		Expect(len(podSummary)).To(Equal(0))
-
-		// No images
-		imageSummary, err = images.List(bt.conn, bindings.PTrue, nil)
-		Expect(err).To(BeNil())
-		Expect(len(imageSummary)).To(Equal(0))
-
-		// no volumes
-		vols, err = volumes.List(bt.conn, nil)
-		Expect(err).To(BeNil())
-		Expect(len(vols)).To(BeZero())
 	})
 })

--- a/pkg/domain/infra/tunnel/system.go
+++ b/pkg/domain/infra/tunnel/system.go
@@ -27,11 +27,6 @@ func (ic *ContainerEngine) SystemPrune(ctx context.Context, options entities.Sys
 	return system.Prune(ic.ClientCxt, &options.All, &options.Volume)
 }
 
-// Reset removes all storage
-func (ic *SystemEngine) Reset(ctx context.Context) error {
-	return system.Reset(ic.ClientCxt)
-}
-
 func (ic *ContainerEngine) SystemDf(ctx context.Context, options entities.SystemDfOptions) (*entities.SystemDfReport, error) {
 	return system.DiskUsage(ic.ClientCxt)
 }

--- a/test/e2e/system_reset_test.go
+++ b/test/e2e/system_reset_test.go
@@ -34,7 +34,7 @@ var _ = Describe("podman system reset", func() {
 	})
 
 	It("podman system reset", func() {
-		Skip(v2remotefail)
+		SkipIfRemote()
 		// system reset will not remove additional store images, so need to grab length
 
 		session := podmanTest.Podman([]string{"rmi", "--force", "--all"})


### PR DESCRIPTION
As system reset too dangerous for remote use, deleting the functionality
and removing the bindings test for reset.

Signed-off-by: Sujil02 <sushah@redhat.com>