### PR TITLE
remote manifest test

### DIFF
--- a/pkg/api/handlers/libpod/manifests.go
+++ b/pkg/api/handlers/libpod/manifests.go
@@ -151,6 +151,7 @@ func ManifestPush(w http.ResponseWriter, r *http.Request) {
 	}
 	sc := image.GetSystemContext(rtc.Engine.SignaturePolicyPath, "", false)
 	opts := manifests.PushOptions{
+		Store:              runtime.GetStore(),
 		ImageListSelection: copy2.CopySpecificImages,
 		SystemContext:      sc,
 	}

--- a/pkg/bindings/manifests/manifests.go
+++ b/pkg/bindings/manifests/manifests.go
@@ -112,17 +112,17 @@ func Push(ctx context.Context, name string, destination *string, all *bool) (str
 	params := url.Values{}
 	params.Set("image", name)
 	if destination != nil {
-		dest = name
+		dest = *destination
 	}
 	params.Set("destination", dest)
 	if all != nil {
 		params.Set("all", strconv.FormatBool(*all))
 	}
-	response, err := conn.DoRequest(nil, http.MethodPost, "/manifests/%s/push", params, name)
+	_, err = conn.DoRequest(nil, http.MethodPost, "/manifests/%s/push", params, name)
 	if err != nil {
 		return "", err
 	}
-	return idr.ID, response.Process(&idr)
+	return idr.ID, err
 }
 
 // There is NO annotate endpoint.  this binding could never work

--- a/test/e2e/manifest_test.go
+++ b/test/e2e/manifest_test.go
@@ -155,7 +155,6 @@ var _ = Describe("Podman manifest", func() {
 	})
 
 	It("podman manifest push", func() {
-		Skip(v2remotefail)
 		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
@@ -185,7 +184,8 @@ var _ = Describe("Podman manifest", func() {
 	})
 
 	It("podman manifest push purge", func() {
-		Skip(v2remotefail)
+		// remote does not support --purge
+		SkipIfRemote()
 		session := podmanTest.Podman([]string{"manifest", "create", "foo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))


### PR DESCRIPTION
Enable remove manifest tests. Skip --purge test because remote does not support it.

Signed-off-by: Qi Wang <qiwan@redhat.com>