### PR TITLE
enable building without `varlink` tag

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -268,7 +268,7 @@ varlink_api_task:
     timeout_in: 10m
 
     api_md_script:
-        - '/usr/local/bin/entrypoint.sh varlink_api_generate |& ${TIMESTAMP}'
+        - '/usr/local/bin/entrypoint.sh BUILDTAGS="varlink" varlink_api_generate |& ${TIMESTAMP}'
         - 'cd ${GOSRC} && ./hack/tree_status.sh |& ${TIMESTAMP}'
 
     on_failure:

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -5,12 +5,6 @@
 %bcond_without doc
 %bcond_without debug
 
-%if 0%{?fedora} >= 28
-%bcond_without varlink
-%else
-%bcond_with varlink
-%endif
-
 %if %{with debug}
 %global _find_debuginfo_dwz_opts %{nil}
 %global _dwz_low_mem_die_limit 0
@@ -387,9 +381,7 @@ popd
 ln -s vendor src
 export GO111MODULE=off
 export GOPATH=$(pwd)/_build:$(pwd):$(pwd):%{gopath}
-export BUILDTAGS="varlink selinux seccomp systemd $(%{hackdir}/hack/btrfs_installed_tag.sh) $(%{hackdir}/hack/btrfs_tag.sh) $(%{hackdir}/hack/libdm_tag.sh) exclude_graphdriver_devicemapper"
-
-GOPATH=$GOPATH go generate ./pkg/varlink/...
+export BUILDTAGS="selinux seccomp systemd $(%{hackdir}/hack/btrfs_installed_tag.sh) $(%{hackdir}/hack/btrfs_tag.sh) $(%{hackdir}/hack/libdm_tag.sh) exclude_graphdriver_devicemapper"
 
 %if %{with doc}
 BUILDTAGS=$BUILDTAGS make binaries docs
@@ -503,15 +495,10 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/vendor:%{gopath}
 %{_datadir}/zsh/site-functions/*
 %{_libexecdir}/%{name}/conmon
 %config(noreplace) %{_sysconfdir}/cni/net.d/87-%{name}-bridge.conflist
-%{_unitdir}/io.podman.service
-%{_unitdir}/io.podman.socket
-%{_usr}/lib/systemd/user/io.podman.service
-%{_usr}/lib/systemd/user/io.podman.socket
 %{_unitdir}/podman.service
 %{_unitdir}/podman.socket
 %{_usr}/lib/systemd/user/podman.service
 %{_usr}/lib/systemd/user/podman.socket
-%{_usr}/lib/tmpfiles.d/%{name}.conf
 
 %if 0%{?with_devel}
 %files -n libpod-devel -f devel.file-list

--- a/test/endpoint/commit.go
+++ b/test/endpoint/commit.go
@@ -1,3 +1,5 @@
+// +build varlink
+
 package endpoint
 
 import (

--- a/test/endpoint/config.go
+++ b/test/endpoint/config.go
@@ -1,3 +1,5 @@
+// +build varlink
+
 package endpoint
 
 import "encoding/json"

--- a/test/endpoint/endpoint.go
+++ b/test/endpoint/endpoint.go
@@ -1,3 +1,5 @@
+// +build varlink
+
 package endpoint
 
 import (

--- a/test/endpoint/endpoint_suite_test.go
+++ b/test/endpoint/endpoint_suite_test.go
@@ -1,3 +1,5 @@
+// +build varlink
+
 package endpoint
 
 import (

--- a/test/endpoint/exists_test.go
+++ b/test/endpoint/exists_test.go
@@ -1,3 +1,5 @@
+// +build varlink
+
 package endpoint
 
 import (

--- a/test/endpoint/pull_test.go
+++ b/test/endpoint/pull_test.go
@@ -1,3 +1,5 @@
+// +build varlink
+
 package endpoint
 
 import (

--- a/test/endpoint/setup.go
+++ b/test/endpoint/setup.go
@@ -1,3 +1,5 @@
+// +build varlink
+
 package endpoint
 
 import (

--- a/test/endpoint/version_test.go
+++ b/test/endpoint/version_test.go
@@ -1,3 +1,5 @@
+// +build varlink
+
 package endpoint
 
 import (


### PR DESCRIPTION
default build without `varlink` tag
    
Issue gh#6286 was already fixed in a prior commit but the Makefile still
ran some varlink steps by default.
    
This commit makes any varlink build steps dependent on the varlink
build tag and also makes the contrib rpm spec file independent of
varlink.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>