### PR TITLE
[CI:DOCS] Fix readthedocs link

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -1,7 +1,7 @@
 # Podman Documentation
 
 The online man pages and other documents regarding Podman can be found at
-[Read The Docs](https://podman.readthedocs.io/en/latest/index.html).  The man pages
+[Read The Docs](https://podman.readthedocs.io).  The man pages
 can be found under the [Commands](https://podman.readthedocs.io/en/latest/Commands.html)
 link on that page.
 


### PR DESCRIPTION
Touch up the link to the docs on readthedocs.  Using the fully
specified link like this will cause a CORS issue in many browsers.

Plus we're working on a Spanish variant of the site, so we probably
should point to the English variant.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>