### PR TITLE
Add support for `readonly` option to --mount

### DIFF
--- a/cmd/podman/common/volumes.go
+++ b/cmd/podman/common/volumes.go
@@ -209,9 +209,29 @@ func getBindMount(args []string) (spec.Mount, error) {
 		switch kv[0] {
 		case "bind-nonrecursive":
 			newMount.Options = append(newMount.Options, "bind")
+		case "readonly", "read-only":
+			if setRORW {
+				return newMount, errors.Wrapf(optionArgError, "cannot pass 'readonly', 'ro', or 'rw' options more than once")
+			}
+			setRORW = true
+			switch len(kv) {
+			case 1:
+				newMount.Options = append(newMount.Options, "ro")
+			case 2:
+				switch strings.ToLower(kv[1]) {
+				case "true":
+					newMount.Options = append(newMount.Options, "ro")
+				case "false":
+					// RW is default, so do nothing
+				default:
+					return newMount, errors.Wrapf(optionArgError, "readonly must be set to true or false, instead received %q", kv[1])
+				}
+			default:
+				return newMount, errors.Wrapf(optionArgError, "badly formatted option %q", val)
+			}
 		case "ro", "rw":
 			if setRORW {
-				return newMount, errors.Wrapf(optionArgError, "cannot pass 'ro' or 'rw' options more than once")
+				return newMount, errors.Wrapf(optionArgError, "cannot pass 'readonly', 'ro', or 'rw' options more than once")
 			}
 			setRORW = true
 			// Can be formatted as one of:

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -502,7 +502,7 @@ Current supported mount TYPES are `bind`, `volume`, and `tmpfs`.
 
               · dst, destination, target: mount destination spec.
 
-              · ro, read-only: true or false (default).
+              · ro, readonly: true or false (default).
 
        Options specific to bind:
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -511,7 +511,7 @@ Current supported mount TYPEs are **bind**, **volume**, and **tmpfs**.
 
 	      · dst, destination, target: mount destination spec.
 
-	      · ro, read-only: true or false (default).
+	      · ro, readonly: true or false (default).
 
        Options specific to bind:
 

--- a/test/e2e/run_volume_test.go
+++ b/test/e2e/run_volume_test.go
@@ -106,6 +106,11 @@ var _ = Describe("Podman run with volumes", func() {
 		Expect(session.ExitCode()).To(Equal(0))
 		Expect(session.OutputToString()).To(ContainSubstring(dest + " ro"))
 
+		session = podmanTest.Podman([]string{"run", "--rm", "--mount", mount + ",readonly", ALPINE, "grep", dest, "/proc/self/mountinfo"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring(dest + " ro"))
+
 		session = podmanTest.Podman([]string{"run", "--rm", "--mount", mount + ",shared", ALPINE, "grep", dest, "/proc/self/mountinfo"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))


### PR DESCRIPTION
This is just an alias to the `ro` option, but it's already in the manpages (and Docker) so we might as well add support for it.

Fixes #6379