### PR TITLE
podman-registry: fix lost credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ localunit: test/goecho/goecho varlink_generate
 	ginkgo \
 		-r \
 		$(TESTFLAGS) \
-		--skipPackage test/e2e,pkg/apparmor,test/endpoint,pkg/bindings \
+		--skipPackage test/e2e,pkg/apparmor,test/endpoint,pkg/bindings,hack \
 		--cover \
 		--covermode atomic \
 		--tags "$(BUILDTAGS)" \
@@ -326,7 +326,7 @@ localunit: test/goecho/goecho varlink_generate
 
 .PHONY: ginkgo
 ginkgo:
-	ginkgo -v $(TESTFLAGS) -tags "$(BUILDTAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes 3 -debug test/e2e/.
+	ginkgo -v $(TESTFLAGS) -tags "$(BUILDTAGS)" $(GINKGOTIMEOUT) -cover -flakeAttempts 3 -progress -trace -noColor -nodes 3 -debug test/e2e/. hack/.
 
 .PHONY: ginkgo-remote
 ginkgo-remote:

--- a/hack/podman-registry
+++ b/hack/podman-registry
@@ -14,7 +14,7 @@ PODMAN_REGISTRY_PASS=
 PODMAN_REGISTRY_PORT=
 
 # Podman binary to run
-PODMAN=${PODMAN:-$(type -p podman)}
+PODMAN=${PODMAN:-$(dirname $0)/../bin/podman}
 
 # END   defaults
 ###############################################################################
@@ -176,11 +176,16 @@ function do_start() {
               -out ${AUTHDIR}/domain.crt                               \
               -subj "/C=US/ST=Foo/L=Bar/O=Red Hat, Inc./CN=localhost"
 
-    # Store credentials where container will see them
-    must_pass podman run --rm                                        \
-              --entrypoint htpasswd ${PODMAN_REGISTRY_IMAGE}         \
-              -Bbn ${PODMAN_REGISTRY_USER} ${PODMAN_REGISTRY_PASS}   \
-              > $AUTHDIR/htpasswd
+    # Store credentials where container will see them. We can't run
+    # this one via must_pass because we need its stdout.
+    podman run --rm                                               \
+           --entrypoint htpasswd ${PODMAN_REGISTRY_IMAGE}         \
+           -Bbn ${PODMAN_REGISTRY_USER} ${PODMAN_REGISTRY_PASS}   \
+           > $AUTHDIR/htpasswd
+    if [ $? -ne 0 ]; then
+        rm -rf ${PODMAN_REGISTRY_WORKDIR}
+        die "Command failed: podman run [htpasswd]"
+    fi
 
     # In case someone needs to debug
     echo "${PODMAN_REGISTRY_USER}:${PODMAN_REGISTRY_PASS}" \


### PR DESCRIPTION
must_pass(), added in #6375, eats the credentials generated
via 'podman run --entrypoint htpasswd'. Run that podman
instance directly, and add explicit error check.

The error and stdout/stderr handling here has gotten
cumbersome. There must be something I'm missing that
could make it all simpler.

Also: when setting $PODMAN, default to the locally built
one -- there may not be one in $PATH.

Signed-off-by: Ed Santiago <santiago@redhat.com>