### PR TITLE
test.apiv2: add testing for displaying image history and exporting image

### DIFF
--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -33,4 +33,27 @@ t GET images/$iid/json 200 \
 
 #t POST images/create fromImage=alpine 201 foo
 
+# Display the image history
+t GET libpod/images/nonesuch/history 404
+
+for i in $iid ${iid:0:12} $PODMAN_TEST_IMAGE_NAME; do
+  t GET libpod/images/$i/history 200 \
+    .[0].Id=$iid \
+    .[0].Created~[0-9]\\{10\\} \
+    .[0].Tags=null \
+    .[0].Size=0 \
+    .[0].Comment=
+done
+
+# Export an image on the local
+t GET libpod/images/nonesuch/get 404
+t GET libpod/images/$iid/get?format=foo 500
+t GET libpod/images/$PODMAN_TEST_IMAGE_NAME/get?compress=bar 400
+
+for i in $iid ${iid:0:12} $PODMAN_TEST_IMAGE_NAME; do
+  t GET "libpod/images/$i/get"                200 '[POSIX tar archive]'
+  t GET "libpod/images/$i/get?compress=true"  200 '[POSIX tar archive]'
+  t GET "libpod/images/$i/get?compress=false" 200 '[POSIX tar archive]'
+done
+
 # vim: filetype=sh

--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -207,13 +207,21 @@ function t() {
     fi
 
     cat $WORKDIR/curl.headers.out >>$LOG 2>/dev/null || true
-    output=$(< $WORKDIR/curl.result.out)
 
-    # Log results. If JSON, filter through jq for readability
-    if egrep -qi '^Content-Type: application/json' $WORKDIR/curl.headers.out; then
-        jq . <<<"$output" >>$LOG
-    else
+    # Log results, if text. If JSON, filter through jq for readability.
+    content_type=$(sed -ne 's/^Content-Type:[ ]\+//pi' <$WORKDIR/curl.headers.out)
+
+    if [[ $content_type =~ /octet ]]; then
+        output="[$(file --brief $WORKDIR/curl.result.out)]"
         echo "$output" >>$LOG
+    else
+        output=$(< $WORKDIR/curl.result.out)
+
+        if [[ $content_type =~ application/json ]]; then
+            jq . <<<"$output" >>$LOG
+        else
+            echo "$output" >>$LOG
+        fi
     fi
 
     # Test return code
@@ -232,6 +240,7 @@ function t() {
         return
     fi
 
+    local i
     for i; do
         case "$i" in
             # Exact match on json field


### PR DESCRIPTION
test/apiv2/10-images.at: add testing for displaying image history and
                         exporting image
test/apiv2/test-apiv2: directy return when the output option is a tar file
                       not log file

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>

Test result as follows.
```
ok 63 [10-images] GET libpod/images/4fab981df737963d83b548a3a6f4e7b43f718eb88567ba5ec7921f636a93d7bc/history : status=200
ok 64 [10-images] GET libpod/images/4fab981df737963d83b548a3a6f4e7b43f718eb88567ba5ec7921f636a93d7bc/history : .[0].Id=4fab981df737963d83b548a3a6f4e7b43f718eb88567ba5ec7921f636a93d7bc
ok 65 [10-images] GET libpod/images/4fab981df737963d83b548a3a6f4e7b43f718eb88567ba5ec7921f636a93d7bc/history : .[0].Created~[0-9]\{10\}
ok 66 [10-images] GET libpod/images/4fab981df737963d83b548a3a6f4e7b43f718eb88567ba5ec7921f636a93d7bc/history : .[0].Tags=null
ok 67 [10-images] GET libpod/images/4fab981df737963d83b548a3a6f4e7b43f718eb88567ba5ec7921f636a93d7bc/history : .[0].Size=0
ok 68 [10-images] GET libpod/images/4fab981df737963d83b548a3a6f4e7b43f718eb88567ba5ec7921f636a93d7bc/history : .[0].Comment=
ok 69 [10-images] GET libpod/images/4fab981df737/history : status=200
ok 70 [10-images] GET libpod/images/4fab981df737/history : .[0].Id=4fab981df737963d83b548a3a6f4e7b43f718eb88567ba5ec7921f636a93d7bc
ok 71 [10-images] GET libpod/images/4fab981df737/history : .[0].Created~[0-9]\{10\}
ok 72 [10-images] GET libpod/images/4fab981df737/history : .[0].Tags=null
ok 73 [10-images] GET libpod/images/4fab981df737/history : .[0].Size=0
ok 74 [10-images] GET libpod/images/4fab981df737/history : .[0].Comment=
ok 75 [10-images] GET libpod/images/alpine_labels/history : status=200
ok 76 [10-images] GET libpod/images/alpine_labels/history : .[0].Id=4fab981df737963d83b548a3a6f4e7b43f718eb88567ba5ec7921f636a93d7bc
ok 77 [10-images] GET libpod/images/alpine_labels/history : .[0].Created~[0-9]\{10\}
ok 78 [10-images] GET libpod/images/alpine_labels/history : .[0].Tags=null
ok 79 [10-images] GET libpod/images/alpine_labels/history : .[0].Size=0
ok 80 [10-images] GET libpod/images/alpine_labels/history : .[0].Comment=
ok 81 [10-images] GET libpod/images/nonesuch/get : status=404
ok 82 [10-images] GET libpod/images/4fab981df737963d83b548a3a6f4e7b43f718eb88567ba5ec7921f636a93d7bc/get?format=foo : status=500
ok 83 [10-images] GET libpod/images/alpine_labels/get?compress=bar : status=400
```