### PR TITLE
container stats: fix --no-stream race

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -1087,6 +1087,7 @@ func (ic *ContainerEngine) Shutdown(_ context.Context) {
 }
 
 func (ic *ContainerEngine) ContainerStats(ctx context.Context, namesOrIds []string, options entities.ContainerStatsOptions) error {
+	defer close(options.StatChan)
 	containerFunc := ic.Libpod.GetRunningContainers
 	switch {
 	case len(namesOrIds) > 0:


### PR DESCRIPTION
Fix a race in `podman container stats` by waiting for the client to
consume the data in the channel.  This requires a `sync.WaitGroup` (or
semaphore) in the client and to also close the channel the backend.

Fixes: #6405
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@baude PTAL