### PR TITLE
fix `ps --last=N`

### DIFF
--- a/pkg/ps/ps.go
+++ b/pkg/ps/ps.go
@@ -23,7 +23,7 @@ func GetContainerLists(runtime *libpod.Runtime, options entities.ContainerListOp
 		filterFuncs []libpod.ContainerFilter
 		pss         []entities.ListContainer
 	)
-	all := options.All
+	all := options.All || options.Last > 0
 	if len(options.Filters) > 0 {
 		for k, v := range options.Filters {
 			for _, val := range v {


### PR DESCRIPTION
Fix `ps --last=N` to also include non-running containers. Also add an
e2e test to prevent us from regressing in the future.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>