### PR TITLE
check --user range for rootless containers

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -325,6 +325,11 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 	}
 
 	if c.config.User != "" {
+		if rootless.IsRootless() {
+			if err := util.CheckRootlessUIDRange(execUser.Uid); err != nil {
+				return nil, err
+			}
+		}
 		// User and Group must go together
 		g.SetProcessUID(uint32(execUser.Uid))
 		g.SetProcessGID(uint32(execUser.Gid))

--- a/pkg/util/utils_unsupported.go
+++ b/pkg/util/utils_unsupported.go
@@ -10,3 +10,8 @@ import (
 func FindDeviceNodes() (map[string]string, error) {
 	return nil, errors.Errorf("not supported on non-Linux OSes")
 }
+
+// CheckRootlessUIDRange is not implemented anywhere except Linux.
+func CheckRootlessUIDRange(uid int) error {
+	return nil
+}


### PR DESCRIPTION
Check --user range if it's a uid for rootless containers. Returns error if it is out of the range. From https://github.com/containers/libpod/issues/6431#issuecomment-636124686

Signed-off-by: Qi Wang <qiwan@redhat.com>