### PR TITLE
[CI:DOCS] Update man pages for --ip with CNI networks

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -383,9 +383,10 @@ Not implemented
 
 **--ip**=*ip*
 
-Specify a static IP address for the container, for example '10.88.64.128'.
-Can only be used if no additional CNI networks to join were specified via '--network=<network-name>', and if the container is not joining another container's network namespace via '--network=container:<name|id>'.
-The address must be within the default CNI network's pool (default 10.88.0.0/16).
+Specify a static IP address for the container, for example **10.88.64.128**.
+This option can only be used if the container is joined to only a single network - i.e., `--network=_network-name_` is used at most once -
+and if the container is not joining another container's network namespace via `--network=container:_id_`.
+The address must be within the CNI network's IP address pool (default **10.88.0.0/16**).
 
 **--ipc**=*ipc*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -395,9 +395,9 @@ Not implemented.
 **--ip**=*ip*
 
 Specify a static IP address for the container, for example **10.88.64.128**.
-Can only be used if no additional CNI networks to join were specified via **--network=**_network-name_,
-and if the container is not joining another container's network namespace via **--network=container:**_id_.
-The address must be within the default CNI network's pool (default **10.88.0.0/16**).
+This option can only be used if the container is joined to only a single network - i.e., `--network=_network-name_` is used at most once
+and if the container is not joining another container's network namespace via `--network=container:_id_`.
+The address must be within the CNI network's IP address pool (default **10.88.0.0/16**).
 
 **--ipc**=*mode*
 


### PR DESCRIPTION
Originally, we did not allow this, and the manpage reflects that.
We added support with 1.7.0, but did not update the manpage. Fix
the manpages so they are once again accurate.

Signed-off-by: Matthew Heon <mheon@redhat.com>
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>