### PR TITLE
Fix leak of empty tarball

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -181,6 +181,12 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
 		return
 	}
+	name := utils.GetName(r)
+	newImage, err := runtime.ImageRuntime().NewFromLocal(name)
+	if err != nil {
+		utils.ImageNotFound(w, name, err)
+		return
+	}
 	switch query.Format {
 	case define.OCIArchive, define.V2s2Archive:
 		tmpfile, err := ioutil.TempFile("", "api.tar")
@@ -204,13 +210,6 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "unknown format", http.StatusInternalServerError, errors.Errorf("unknown format %q", query.Format))
 		return
 	}
-	name := utils.GetName(r)
-	newImage, err := runtime.ImageRuntime().NewFromLocal(name)
-	if err != nil {
-		utils.ImageNotFound(w, name, err)
-		return
-	}
-
 	if err := newImage.Save(r.Context(), name, query.Format, output, []string{}, false, query.Compress); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, err)
 		return

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Podman images", func() {
 	It("podman images filter before image", func() {
 		SkipIfRemote()
 		dockerfile := `FROM docker.io/library/alpine:latest
-RUN apk update && apk add man
+RUN apk update && apk add strace
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "before=foobar.com/before:latest"})


### PR DESCRIPTION
In cases of trying to export an image, if the image was not found, we leaked an empty tarball or directory depending on the format.

Fixes: #6409

Signed-off-by: Brent Baude <bbaude@redhat.com>