### PR TITLE
Add support for format {{.Label}}

### DIFF
--- a/cmd/podman/pods/ps.go
+++ b/cmd/podman/pods/ps.go
@@ -178,6 +178,11 @@ func (l ListPodReporter) Created() string {
 	return units.HumanDuration(time.Since(l.ListPodsReport.Created)) + " ago"
 }
 
+// Labels returns a map of the pod's labels
+func (l ListPodReporter) Labels() map[string]string {
+	return l.ListPodsReport.Labels
+}
+
 // NumberofContainers returns an int representation for
 // the number of containers belonging to the pod
 func (l ListPodReporter) NumberOfContainers() int {

--- a/pkg/api/handlers/utils/pods.go
+++ b/pkg/api/handlers/utils/pods.go
@@ -66,6 +66,7 @@ func GetPods(w http.ResponseWriter, r *http.Request) ([]*entities.ListPodsReport
 			Namespace: pod.Namespace(),
 			Status:    status,
 			InfraId:   infraId,
+			Labels:    pod.Labels(),
 		}
 		for _, ctr := range ctrs {
 			state, err := ctr.State()

--- a/pkg/domain/entities/pods.go
+++ b/pkg/domain/entities/pods.go
@@ -29,6 +29,7 @@ type ListPodsReport struct {
 	Name       string
 	Namespace  string
 	Status     string
+	Labels     map[string]string
 }
 
 type ListPodContainer struct {

--- a/pkg/domain/infra/abi/pods.go
+++ b/pkg/domain/infra/abi/pods.go
@@ -360,6 +360,7 @@ func (ic *ContainerEngine) PodPs(ctx context.Context, options entities.PodPSOpti
 			Name:       p.Name(),
 			Namespace:  p.Namespace(),
 			Status:     status,
+			Labels:     p.Labels(),
 		})
 	}
 	return reports, nil

--- a/test/e2e/pod_ps_test.go
+++ b/test/e2e/pod_ps_test.go
@@ -243,4 +243,20 @@ var _ = Describe("Podman ps", func() {
 		infra.WaitWithDefaultTimeout()
 		Expect(len(infra.OutputToString())).To(BeZero())
 	})
+
+	It("podman pod ps format with labels", func() {
+		_, ec, _ := podmanTest.CreatePod("")
+		Expect(ec).To(Equal(0))
+
+		_, ec1, _ := podmanTest.CreatePodWithLabels("", map[string]string{
+			"io.podman.test.label": "value1",
+			"io.podman.test.key":   "irrelevant-value",
+		})
+		Expect(ec1).To(Equal(0))
+
+		session := podmanTest.Podman([]string{"pod", "ps", "--format", "{{.Labels}}"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(ContainSubstring("value1"))
+	})
 })


### PR DESCRIPTION
the pod ps man page says .Label is valid go template format. i dont think the function was actually ever implemented.

Fixes #6448

Signed-off-by: Brent Baude <bbaude@redhat.com>