### PR TITLE
Fix breakage in upstream CI

### DIFF
--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Podman images", func() {
 	It("podman images filter before image", func() {
 		SkipIfRemote()
 		dockerfile := `FROM docker.io/library/alpine:latest
-RUN apk update && apk add man
+RUN apk update && apk add less
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "before=foobar.com/before:latest"})


### PR DESCRIPTION
Alpine 3.12 seems to have renamed the `man` package - it no longer exists. Switch man-db, which I believe is the same thing.