### PR TITLE
images --no-trunc: fix ID formatting

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -234,11 +234,7 @@ func imageListFormat(flags listFlagType) (string, string) {
 	}
 
 	hdr += "\tIMAGE ID"
-	if flags.noTrunc {
-		row += "\tsha256:{{.ID}}"
-	} else {
-		row += "\t{{.ID}}"
-	}
+	row += "\t{{.ID}}"
 
 	hdr += "\tCREATED\tSIZE"
 	row += "\t{{.Created}}\t{{.Size}}"


### PR DESCRIPTION
Remove the redundant `sha256:` prefix from the image IDs.

Fixes: #6459
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>