### PR TITLE
Enable detached exec for remote

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -46,6 +46,9 @@ case "${OS_RELEASE_ID}" in
 
         workaround_bfq_bug
 
+	# HACK: Need Conmon 2.0.17, currently in updates-testing on F31.
+	dnf update -y --enablerepo=updates-testing conmon
+
         if [[ "$ADD_SECOND_PARTITION" == "true" ]]; then
             bash "$SCRIPT_BASE/add_second_partition.sh"
         fi

--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -33,7 +33,7 @@
 # People want conmon packaged with the copr rpm
 %global import_path_conmon      github.com/containers/conmon
 %global git_conmon      https://%{import_path_conmon}
-%global commit_conmon   d532caebc788fafdd2a305b68cd1983b4039bea4
+%global commit_conmon   41877362fc4685d55e0473d2e4a1cbe5e1debee0
 %global shortcommit_conmon %(c=%{commit_conmon}; echo ${c:0:7})
 
 Name: podman

--- a/libpod/container_exec.go
+++ b/libpod/container_exec.go
@@ -69,6 +69,10 @@ type ExecConfig struct {
 	// The ID of the exec session, and the ID of the container the exec
 	// session is a part of (in that order).
 	ExitCommand []string `json:"exitCommand,omitempty"`
+	// ExitCommandDelay is a delay (in seconds) between the container
+	// exiting, and the exit command being executed. If set to 0, there is
+	// no delay. If set, ExitCommand must also be set.
+	ExitCommandDelay uint `json:"exitCommandDelay,omitempty"`
 }
 
 // ExecSession contains information on a single exec session attached to a given
@@ -164,6 +168,9 @@ func (c *Container) ExecCreate(config *ExecConfig) (string, error) {
 	}
 	if len(config.Command) == 0 {
 		return "", errors.Wrapf(define.ErrInvalidArg, "must provide a non-empty command to start an exec session")
+	}
+	if config.ExitCommandDelay > 0 && len(config.ExitCommand) == 0 {
+		return "", errors.Wrapf(define.ErrInvalidArg, "must provide a non-empty exit command if giving an exit command delay")
 	}
 
 	// Verify that we are in a good state to continue
@@ -984,6 +991,7 @@ func prepareForExec(c *Container, session *ExecSession) (*ExecOptions, error) {
 	opts.PreserveFDs = session.Config.PreserveFDs
 	opts.DetachKeys = session.Config.DetachKeys
 	opts.ExitCommand = session.Config.ExitCommand
+	opts.ExitCommandDelay = session.Config.ExitCommandDelay
 
 	return opts, nil
 }

--- a/libpod/oci.go
+++ b/libpod/oci.go
@@ -172,6 +172,9 @@ type ExecOptions struct {
 	// ExitCommand is a command that will be run after the exec session
 	// exits.
 	ExitCommand []string
+	// ExitCommandDelay is a delay (in seconds) between the exec session
+	// exiting, and the exit command being invoked.
+	ExitCommandDelay uint
 }
 
 // HTTPAttachStreams informs the HTTPAttach endpoint which of the container's

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -421,12 +421,14 @@ func (r *ConmonOCIRuntime) startExec(c *Container, sessionID string, options *Ex
 		for _, arg := range options.ExitCommand[1:] {
 			args = append(args, []string{"--exit-command-arg", arg}...)
 		}
+		if options.ExitCommandDelay > 0 {
+			args = append(args, []string{"--exit-delay", fmt.Sprintf("%d", options.ExitCommandDelay)}...)
+		}
 	}
 
 	logrus.WithFields(logrus.Fields{
 		"args": args,
 	}).Debugf("running conmon: %s", r.conmonPath)
-	// TODO: Need to pass this back so we can wait on it.
 	execCmd := exec.Command(r.conmonPath, args...)
 
 	// TODO: This is commented because it doesn't make much sense in HTTP

--- a/pkg/api/server/register_exec.go
+++ b/pkg/api/server/register_exec.go
@@ -13,7 +13,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	// tags:
 	//   - exec (compat)
 	// summary: Create an exec instance
-	// description: Run a command inside a running container.
+	// description: Create an exec session to run a command inside a running container. Exec sessions will be automatically removed 5 minutes after they exit.
 	// parameters:
 	//  - in: path
 	//    name: name
@@ -153,7 +153,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	// tags:
 	//   - exec (compat)
 	// summary: Inspect an exec instance
-	// description: Return low-level information about an exec instance. Stale (stopped) exec sessions will be auto-removed after inspect runs.
+	// description: Return low-level information about an exec instance.
 	// parameters:
 	//  - in: path
 	//    name: id
@@ -182,7 +182,7 @@ func (s *APIServer) registerExecHandlers(r *mux.Router) error {
 	// tags:
 	//   - exec
 	// summary: Create an exec instance
-	// description: Run a command inside a running container.
+	// description: Create an exec session to run a command inside a running container. Exec sessions will be automatically removed 5 minutes after they exit.
 	// parameters:
 	//  - in: path
 	//    name: name

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -613,12 +613,11 @@ func (ic *ContainerEngine) ContainerExecDetached(ctx context.Context, nameOrId s
 	if err != nil {
 		return "", errors.Wrapf(err, "error retrieving Libpod configuration to build exec exit command")
 	}
-	podmanPath, err := os.Executable()
-	if err != nil {
-		return "", errors.Wrapf(err, "error retrieving executable to build exec exit command")
-	}
 	// TODO: Add some ability to toggle syslog
-	exitCommandArgs := generate.CreateExitCommandArgs(storageConfig, runtimeConfig, podmanPath, false, true, true)
+	exitCommandArgs, err := generate.CreateExitCommandArgs(storageConfig, runtimeConfig, false, true, true)
+	if err != nil {
+		return "", errors.Wrapf(err, "error constructing exit command for exec session")
+	}
 	execConfig.ExitCommand = exitCommandArgs
 
 	// Create and start the exec session

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -25,6 +25,10 @@ var _ = Describe("Podman exec", func() {
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
 		podmanTest.SeedImages()
+		// HACK: Remove this once we get Conmon 2.0.17 on Ubuntu
+		if podmanTest.Host.Distribution == "ubuntu" {
+			Skip("Unable to perform test on Ubuntu distributions due to too-old Conmon (need 2.0.17)")
+		}
 	})
 
 	AfterEach(func() {
@@ -284,7 +288,6 @@ var _ = Describe("Podman exec", func() {
 	})
 
 	It("podman exec --detach", func() {
-		Skip(v2remotefail)
 		ctrName := "testctr"
 		ctr := podmanTest.Podman([]string{"run", "-t", "-i", "-d", "--name", ctrName, ALPINE, "top"})
 		ctr.WaitWithDefaultTimeout()


### PR DESCRIPTION
The biggest obstacle here was cleanup - we needed a way to remove detached exec sessions after they exited, but there's no way to tell if an exec session will be attached or detached when it's created, and that's when we must add the exit command that would do the removal. The solution was adding a delay to the exit command (5 minutes), which gives sufficient time for attached exec sessions to retrieve the exit code of the session after it exits, but still guarantees that they will be removed, even for detached sessions. This requires Conmon 2.0.17, which has the new `--exit-delay` flag.

As part of the exit command rework, we can drop the hack we were using to clean up exec sessions (remove them as part of inspect). This is a lot cleaner, and I'm a lot happier about it.

Otherwise, this is just plumbing - we need a bindings call for detached exec, and that needed to be added to the tunnel mode backend for entities.