### PR TITLE
Properly follow linked namespace container for stats

### DIFF
--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -550,7 +550,7 @@ func getContainerNetNS(ctr *Container) (string, error) {
 		if err = c.syncContainer(); err != nil {
 			return "", err
 		}
-		return c.state.NetNS.Path(), nil
+		return getContainerNetNS(c)
 	}
 	return "", nil
 }

--- a/test/e2e/pod_stats_test.go
+++ b/test/e2e/pod_stats_test.go
@@ -178,4 +178,21 @@ var _ = Describe("Podman pod stats", func() {
 		Expect(stats).To(ExitWithError())
 	})
 
+	It("podman stats on net=host post", func() {
+		// --net=host not supported for rootless pods at present
+		SkipIfRootless()
+		podName := "testPod"
+		podCreate := podmanTest.Podman([]string{"pod", "create", "--net=host", "--name", podName})
+		podCreate.WaitWithDefaultTimeout()
+		Expect(podCreate.ExitCode()).To(Equal(0))
+
+		ctrRun := podmanTest.Podman([]string{"run", "-d", "--pod", podName, ALPINE, "top"})
+		ctrRun.WaitWithDefaultTimeout()
+		Expect(ctrRun.ExitCode()).To(Equal(0))
+
+		stats := podmanTest.Podman([]string{"pod", "stats", "--format", "json", "--no-stream", podName})
+		stats.WaitWithDefaultTimeout()
+		Expect(stats.ExitCode()).To(Equal(0))
+		Expect(stats.IsJSONOutputValid()).To(BeTrue())
+	})
 })


### PR DESCRIPTION
Podman containers can specify that they get their network namespace from another container. This is automatic in pods, but any container can do it.

The problem is that these containers are not guaranteed to have a network namespace of their own; it is perfectly valid to join the network namespace of a --net=host container, and both containers will end up in the host namespace. The code for obtaining network stats did not account for this, and could cause segfaults as a result. Fortunately, the fix is simple - the function we use to get said stats already performs appropriate checks, so we just need to recursively call it.

Fixes #5652