### PR TITLE
Remove reference to "upcoming" RHEL 7.7

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -247,7 +247,7 @@ cannot find newuidmap: exec: "newuidmap": executable file not found in $PATH
 
 #### Solution
 
-Install a version of shadow-utils that includes these executables.  Note RHEL 7 and CentOS 7 will not have support for this until RHEL7.7 is released.
+Install a version of shadow-utils that includes these executables.  Note that for RHEL and CentOS 7, at least the 7.7 release must be installed for support to be available.
 
 ### 11) rootless setup user: invalid argument
 


### PR DESCRIPTION
7.7 has been released for a while now, so change troubleshooting reference to indicate that.

Fixes #6349