### PR TITLE
Fix a segfault in `podman inspect -l` w/ no containers

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -44,8 +44,10 @@ func getContainersAndInputByContext(all, latest bool, names []string, runtime *l
 		ctrs, err = runtime.GetAllContainers()
 	case latest:
 		ctr, err = runtime.GetLatestContainer()
-		rawInput = append(rawInput, ctr.ID())
-		ctrs = append(ctrs, ctr)
+		if err == nil {
+			rawInput = append(rawInput, ctr.ID())
+			ctrs = append(ctrs, ctr)
+		}
 	default:
 		for _, n := range names {
 			ctr, e := runtime.LookupContainer(n)

--- a/test/e2e/inspect_test.go
+++ b/test/e2e/inspect_test.go
@@ -171,4 +171,12 @@ var _ = Describe("Podman inspect", func() {
 		Expect(imageData[0].HealthCheck.Interval).To(BeNumerically("==", 60000000000))
 		Expect(imageData[0].HealthCheck.Test).To(Equal([]string{"CMD-SHELL", "curl -f http://localhost/ || exit 1"}))
 	})
+
+	It("podman inspect --latest with no container fails", func() {
+		SkipIfRemote()
+
+		session := podmanTest.Podman([]string{"inspect", "--latest"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Not(Equal(0)))
+	})
 })


### PR DESCRIPTION
We also need to rework container/image inspect to be separate, but that can happen in another PR.

Fixes #6472