### PR TITLE
RHEL8 and Centos8 don't have oci-runtime yet

### DIFF
--- a/contrib/spec/podman.spec.in
+++ b/contrib/spec/podman.spec.in
@@ -80,8 +80,12 @@ Requires: iptables
 %if 0%{?rhel} <= 7
 Requires: container-selinux
 %else
+%if 0%{?rhel} || 0%{?centos}
+Requires: runc
+%else
 Requires: oci-runtime
 Recommends: crun
+%endif
 Recommends: container-selinux
 Recommends: slirp4netns
 Recommends: fuse-overlayfs


### PR DESCRIPTION
For the time being we need to just require runc
this should fix rdoproject.org/github-check

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>