### PR TITLE
Ensure that image/container inspect are specialized

### DIFF
--- a/cmd/podman/containers/inspect.go
+++ b/cmd/podman/containers/inspect.go
@@ -26,9 +26,15 @@ func init() {
 		Command: inspectCmd,
 		Parent:  containerCmd,
 	})
-	inspectOpts = inspect.AddInspectFlagSet(inspectCmd)
+	inspectOpts = new(entities.InspectOptions)
+	flags := inspectCmd.Flags()
+	flags.BoolVarP(&inspectOpts.Size, "size", "s", false, "Display total file size")
+	flags.StringVarP(&inspectOpts.Format, "format", "f", "json", "Format the output to a Go template or json")
+	flags.BoolVarP(&inspectOpts.Latest, "latest", "l", false, "Act on the latest container Podman is aware of")
 }
 
 func inspectExec(cmd *cobra.Command, args []string) error {
+	// Force container type
+	inspectOpts.Type = inspect.ContainerType
 	return inspect.Inspect(args, *inspectOpts)
 }

--- a/cmd/podman/images/inspect.go
+++ b/cmd/podman/images/inspect.go
@@ -27,11 +27,12 @@ func init() {
 		Command: inspectCmd,
 		Parent:  imageCmd,
 	})
-	inspectOpts = inspect.AddInspectFlagSet(inspectCmd)
+	inspectOpts = new(entities.InspectOptions)
 	flags := inspectCmd.Flags()
-	_ = flags.MarkHidden("latest") // Shared with container-inspect but not wanted here.
+	flags.StringVarP(&inspectOpts.Format, "format", "f", "json", "Format the output to a Go template or json")
 }
 
 func inspectExec(cmd *cobra.Command, args []string) error {
+	inspectOpts.Type = inspect.ImageType
 	return inspect.Inspect(args, *inspectOpts)
 }


### PR DESCRIPTION
We are currently able to inspect images with `podman container inspect` and containers with `podman image inspect` and neither of those seem correct. This ensures that the appropriate flags, and only the appropriate flags, are available for each specialized exec, and they can only inspect the specific type they were intended to.