### PR TITLE
When stopping containers locally, ensure cleanup runs

### DIFF
--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -179,6 +179,12 @@ func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []strin
 			report.Err = err
 			reports = append(reports, &report)
 			continue
+		} else if err := con.Cleanup(ctx); err != nil {
+			// Only if no error, proceed to cleanup to ensure all
+			// mounts are removed before we exit.
+			report.Err = err
+			reports = append(reports, &report)
+			continue
 		}
 		reports = append(reports, &report)
 	}


### PR DESCRIPTION
The cleanup process was already running and ensuring that mounts and networking configuration was cleaned up on container stop, but this was async from the actual `podman stop` command which breaks some expectations - the container is still mounted at the end of `podman stop` and will be cleaned up soon, but not immediately. Fortunately, it's a trivial change to resolve this.

Fixes #5747