### PR TITLE
add socket information to podman info

### DIFF
--- a/docs/source/markdown/podman-info.1.md
+++ b/docs/source/markdown/podman-info.1.md
@@ -71,6 +71,9 @@ host:
       commit: 3e425f80a8c931f88e6d94a8c831b9d5aa481657
       spec: 1.0.1-dev
   os: linux
+  remoteSocket:
+    exists: false
+    path: /run/user/1000/podman/podman.sock
   rootless: true
   slirp4netns:
     executable: /bin/slirp4netns
@@ -179,6 +182,10 @@ Run podman info with JSON formatted response:
       "version": "runc version 1.0.0-rc8+dev\ncommit: 3e425f80a8c931f88e6d94a8c831b9d5aa481657\nspec: 1.0.1-dev"
     },
     "os": "linux",
+    "remoteSocket": {
+      "path": "/run/user/1000/podman/podman.sock",
+      "exists": false
+    },
     "rootless": true,
     "slirp4netns": {
       "executable": "/bin/slirp4netns",

--- a/libpod/define/info.go
+++ b/libpod/define/info.go
@@ -27,6 +27,7 @@ type HostInfo struct {
 	MemTotal       int64                  `json:"memTotal"`
 	OCIRuntime     *OCIRuntimeInfo        `json:"ociRuntime"`
 	OS             string                 `json:"os"`
+	RemoteSocket   *RemoteSocket          `json:"remoteSocket,omitempty"`
 	Rootless       bool                   `json:"rootless"`
 	RuntimeInfo    map[string]interface{} `json:"runtimeInfo,omitempty"`
 	Slirp4NetNS    SlirpInfo              `json:"slirp4netns,omitempty"`
@@ -34,6 +35,12 @@ type HostInfo struct {
 	SwapTotal      int64                  `json:"swapTotal"`
 	Uptime         string                 `json:"uptime"`
 	Linkmode       string                 `json:"linkmode"`
+}
+
+// RemoteSocket describes information about the API socket
+type RemoteSocket struct {
+	Path   string `json:"path,omitempty"`
+	Exists bool   `json:"exists,omitempty"`
 }
 
 // SlirpInfo describes the slirp exectuable that


### PR DESCRIPTION
this is step 1 to self-discovery of remote ssh connections.  we add a remotesocket struct to info to detect what the socket path might be.

Signed-off-by: Brent Baude <bbaude@redhat.com>