### PR TITLE
BATS and APIv2: more tests and tweaks

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -19,7 +19,7 @@ t GET libpod/containers/json 200 length=0
 
 t GET libpod/containers/json?all=true 200 \
   length=1 \
-  .[0].Id~[0-9a-f]\\{12\\} \
+  .[0].Id~[0-9a-f]\\{64\\} \
   .[0].Image=$IMAGE \
   .[0].Command[0]="true" \
   .[0].State~\\\(exited\\\|stopped\\\) \
@@ -33,7 +33,7 @@ t DELETE libpod/containers/$cid 204
 CNAME=myfoo
 podman run --name $CNAME $IMAGE -td top
 t GET libpod/containers/json?all=true 200 \
-  .[0].Id~[0-9a-f]\\{12\\}
+  .[0].Id~[0-9a-f]\\{64\\}
 cid=$(jq -r '.[0].Id' <<<"$output")
 
 # No such container
@@ -45,7 +45,7 @@ t POST "libpod/commit?container=$CNAME&$cparam"  '' 500
 
 # Commit a new image from the container
 t POST "libpod/commit?container=$CNAME" '' 200 \
-  .Id~[0-9a-f]\\{12\\}
+  .Id~[0-9a-f]\\{64\\}
 iid=$(jq -r '.Id' <<<"$output")
 t GET libpod/images/$iid/json 200 \
   .RepoTags[0]=null \

--- a/test/system/200-pod.bats
+++ b/test/system/200-pod.bats
@@ -73,6 +73,12 @@ function teardown() {
     run_podman run -d --pod $podname $IMAGE nc -l -p $port
     cid1="$output"
 
+    # (While we're here, test the 'Pod' field of 'podman ps'. Expect two ctrs)
+    run_podman ps --format '{{.Pod}}'
+    newline="
+"
+    is "$output" "${podid:0:12}${newline}${podid:0:12}" "sdfdsf"
+
     # Talker: send the message via common port on localhost
     message=$(random_string 15)
     run_podman run --rm --pod $podname $IMAGE \

--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# tests for podman healthcheck
+#
+#
+
+load helpers
+
+
+# Helper function: run 'podman inspect' and check various given fields
+function _check_health {
+    local testname="$1"
+    local tests="$2"
+
+    run_podman inspect --format json healthcheck_c
+
+    parse_table "$tests" | while read field expect;do
+        # (kludge to deal with parse_table and empty strings)
+        if [ "$expect" = "''" ]; then expect=""; fi
+
+        actual=$(jq -r ".[0].State.Healthcheck.$field" <<<"$output")
+        is "$actual" "$expect" "$testname - .State.Healthcheck.$field"
+    done
+}
+
+
+@test "podman healthcheck" {
+
+    # Create an image with a healthcheck script; said script will
+    # pass until the file /uh-oh gets created (by us, via exec)
+    cat >${PODMAN_TMPDIR}/healthcheck <<EOF
+#!/bin/sh
+
+if test -e /uh-oh; then
+    echo "Uh-oh on stdout!"
+    echo "Uh-oh on stderr!" >&2
+    exit 1
+else
+    echo "Life is Good on stdout"
+    echo "Life is Good on stderr" >&2
+    exit 0
+fi
+EOF
+
+    cat >${PODMAN_TMPDIR}/entrypoint <<EOF
+#!/bin/sh
+
+while :; do
+    sleep 1
+done
+EOF
+
+    cat >${PODMAN_TMPDIR}/Containerfile <<EOF
+FROM $IMAGE
+
+COPY healthcheck /healthcheck
+COPY entrypoint  /entrypoint
+
+RUN  chmod 755 /healthcheck /entrypoint
+
+CMD ["/entrypoint"]
+EOF
+
+    run_podman build -t healthcheck_i ${PODMAN_TMPDIR}
+
+    # Run that healthcheck image.
+    run_podman run -d --name healthcheck_c \
+               --health-cmd /healthcheck   \
+               --health-interval 1s        \
+               --health-retries 3          \
+               healthcheck_i
+
+    # We can't check for 'starting' because a 1-second interval is too
+    # short; it could run healthcheck before we get to our first check.
+    #
+    # So, just force a healthcheck run, then confirm that it's running.
+    run_podman healthcheck run healthcheck_c
+    is "$output" "healthy" "output from 'podman healthcheck run'"
+
+    _check_health "All healthy" "
+Status           | healthy
+FailingStreak    | 0
+Log[-1].ExitCode | 0
+Log[-1].Output   |
+"
+
+    # Force a failure
+    run_podman exec healthcheck_c touch /uh-oh
+    sleep 2
+
+    _check_health "First failure" "
+Status           | healthy
+FailingStreak    | [123]
+Log[-1].ExitCode | 1
+Log[-1].Output   |
+"
+
+    # After three successive failures, container should no longer be healthy
+    sleep 5
+    _check_health "Three or more failures" "
+Status           | unhealthy
+FailingStreak    | [3456]
+Log[-1].ExitCode | 1
+Log[-1].Output   |
+"
+
+    # healthcheck should now fail, with exit status 1 and 'unhealthy' output
+    run_podman 1 healthcheck run healthcheck_c
+    is "$output" "unhealthy" "output from 'podman healthcheck run'"
+
+    # Clean up
+    run_podman rm -f healthcheck_c
+    run_podman rmi   healthcheck_i
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
 - (minor): apiv2 tests: check for full ID

   Observation made while reviewing #6461: tests were checking
   only for a 12-character container/image ID in return value.
   It's actually 64, and we should test for that. This should
   also minimize confusion in a future maintainer.

 - podman pause/unpause: new test

   Runs a 'date/sleep' loop, pauses container, sleeps 3s,
   restarts, then confirms that there's a 3- to 6-second
   gap in the logs for the container.

 - podman healthcheck: new test

   run a container with healthcheck, test both healthy
   and unhealthy conditions

 - podman pod: check '{{.Pod}}' field in podman ps

   Hey, as long as we have a pod with two running
   containers, might as well confirm that 'podman ps'
   returns the expected pod ID.

Signed-off-by: Ed Santiago <santiago@redhat.com>