### PR TITLE
Add parallel execution code for container operations

### DIFF
--- a/pkg/parallel/parallel.go
+++ b/pkg/parallel/parallel.go
@@ -1,0 +1,44 @@
+package parallel
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
+)
+
+var (
+	// Maximum number of jobs that will be used.
+	// Set a low, but non-zero, default. We'll be overriding it by default
+	// anyways.
+	numThreads uint = 8
+	// Semaphore to control thread creation and ensure numThreads is
+	// respected.
+	jobControl *semaphore.Weighted
+	// Lock to control changing the semaphore - we don't want to do it
+	// while anyone is using it.
+	jobControlLock sync.RWMutex
+)
+
+// SetMaxThreads sets the number of threads that will be used for parallel jobs.
+func SetMaxThreads(threads uint) error {
+	if threads == 0 {
+		return errors.New("must give a non-zero number of threads to execute with")
+	}
+
+	jobControlLock.Lock()
+	defer jobControlLock.Unlock()
+
+	numThreads = threads
+	jobControl = semaphore.NewWeighted(int64(threads))
+	logrus.Infof("Setting parallel job count to %d", threads)
+
+	return nil
+}
+
+// GetMaxThreads returns the current number of threads that will be used for
+// parallel jobs.
+func GetMaxThreads() uint {
+	return numThreads
+}

--- a/pkg/parallel/parallel_linux.go
+++ b/pkg/parallel/parallel_linux.go
@@ -1,0 +1,57 @@
+package parallel
+
+import (
+	"context"
+	"sync"
+
+	"github.com/containers/libpod/libpod"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// ParallelContainerOp performs the given function on the given set of
+// containers, using a number of parallel threads.
+// If no error is returned, each container specified in ctrs will have an entry
+// in the resulting map; containers with no error will be set to nil.
+func ParallelContainerOp(ctx context.Context, ctrs []*libpod.Container, applyFunc func(*libpod.Container) error) (map[*libpod.Container]error, error) {
+	jobControlLock.RLock()
+	defer jobControlLock.RUnlock()
+
+	// We could use a sync.Map but given Go's lack of generic I'd rather
+	// just use a lock on a normal map...
+	// The expectation is that most of the time is spent in applyFunc
+	// anyways.
+	var (
+		errMap  map[*libpod.Container]error = make(map[*libpod.Container]error)
+		errLock sync.Mutex
+		allDone sync.WaitGroup
+	)
+
+	for _, ctr := range ctrs {
+		// Block until a thread is available
+		if err := jobControl.Acquire(ctx, 1); err != nil {
+			return nil, errors.Wrapf(err, "error acquiring job control semaphore")
+		}
+
+		allDone.Add(1)
+
+		c := ctr
+		go func() {
+			logrus.Debugf("Launching job on container %s", c.ID())
+
+			err := applyFunc(c)
+			errLock.Lock()
+			errMap[c] = err
+			errLock.Unlock()
+
+			allDone.Done()
+			jobControl.Release(1)
+		}()
+	}
+
+	allDone.Wait()
+
+	return errMap, nil
+}
+
+// TODO: Add an Enqueue() function that returns a promise


### PR DESCRIPTION
This code will run container operations in parallel, up to a given maximum number of threads. Currently, it has only been enabled for local `podman rm` as a proof of concept.