### PR TITLE
Ensure that containers in pods properly set hostname

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -50,7 +50,7 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 		"Drop capabilities from the container",
 	)
 	createFlags.String(
-		"cgroupns", containerConfig.CgroupNS(),
+		"cgroupns", "",
 		"cgroup namespace to use",
 	)
 	createFlags.StringVar(
@@ -244,7 +244,7 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 		"Keep STDIN open even if not attached",
 	)
 	createFlags.String(
-		"ipc", containerConfig.IPCNS(),
+		"ipc", "",
 		"IPC namespace to use",
 	)
 	createFlags.StringVar(
@@ -325,7 +325,7 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 	)
 	// markFlagHidden(createFlags, "override-os")
 	createFlags.String(
-		"pid", containerConfig.PidNS(),
+		"pid", "",
 		"PID namespace to use",
 	)
 	createFlags.Int64Var(
@@ -454,11 +454,11 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 		"Username or UID (format: <name|uid>[:<group|gid>])",
 	)
 	createFlags.String(
-		"userns", containerConfig.Containers.UserNS,
+		"userns", "",
 		"User namespace to use",
 	)
 	createFlags.String(
-		"uts", containerConfig.Containers.UTSNS,
+		"uts", "",
 		"UTS namespace to use",
 	)
 	createFlags.StringArrayVar(

--- a/libpod/pod.go
+++ b/libpod/pod.go
@@ -171,6 +171,11 @@ func (p *Pod) SharesCgroup() bool {
 	return p.config.UsePodCgroupNS
 }
 
+// Hostname returns the hostname of the pod.
+func (p *Pod) Hostname() string {
+	return p.config.Hostname
+}
+
 // CgroupPath returns the path to the pod's CGroup
 func (p *Pod) CgroupPath() (string, error) {
 	p.lock.Lock()

--- a/libpod/pod_api.go
+++ b/libpod/pod_api.go
@@ -490,7 +490,7 @@ func (p *Pod) Inspect() (*define.InspectPodData, error) {
 		Namespace:        p.Namespace(),
 		Created:          p.CreatedTime(),
 		State:            podState,
-		Hostname:         "",
+		Hostname:         p.config.Hostname,
 		Labels:           p.Labels(),
 		CreateCgroup:     false,
 		CgroupParent:     p.CgroupParent(),

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -114,7 +114,7 @@ func MakeContainer(ctx context.Context, rt *libpod.Runtime, s *specgen.SpecGener
 	}
 	options = append(options, libpod.WithExitCommand(exitCommandArgs))
 
-	runtimeSpec, err := SpecGenToOCI(ctx, s, rt, rtc, newImage, finalMounts)
+	runtimeSpec, err := SpecGenToOCI(ctx, s, rt, rtc, newImage, finalMounts, pod)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -265,7 +265,7 @@ func GenerateNamespaceOptions(ctx context.Context, s *specgen.SpecGenerator, rt 
 	return toReturn, nil
 }
 
-func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt *libpod.Runtime) error {
+func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt *libpod.Runtime, pod *libpod.Pod) error {
 	// PID
 	switch s.PidNS.NSMode {
 	case specgen.Path:
@@ -326,6 +326,8 @@ func specConfigureNamespaces(s *specgen.SpecGenerator, g *generate.Generator, rt
 	hostname := s.Hostname
 	if hostname == "" {
 		switch {
+		case s.UtsNS.NSMode == specgen.FromPod:
+			hostname = pod.Hostname()
 		case s.UtsNS.NSMode == specgen.FromContainer:
 			utsCtr, err := rt.LookupContainer(s.UtsNS.Value)
 			if err != nil {

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -118,7 +118,7 @@ func makeCommand(ctx context.Context, s *specgen.SpecGenerator, img *image.Image
 	return finalCommand, nil
 }
 
-func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runtime, rtc *config.Config, newImage *image.Image, mounts []spec.Mount) (*spec.Spec, error) {
+func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runtime, rtc *config.Config, newImage *image.Image, mounts []spec.Mount, pod *libpod.Pod) (*spec.Spec, error) {
 	var (
 		inUserNS bool
 	)
@@ -300,7 +300,7 @@ func SpecGenToOCI(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.Runt
 	}
 
 	// NAMESPACES
-	if err := specConfigureNamespaces(s, &g, rt); err != nil {
+	if err := specConfigureNamespaces(s, &g, rt, pod); err != nil {
 		return nil, err
 	}
 	configSpec := g.Config


### PR DESCRIPTION
When we moved to the new Namespace types in Specgen, we made a distinction between taking a namespace from a pod, and taking it from another container. Due to this new distinction, some code
that previously worked for both `--pod=$ID` and `--uts=container:$ID` has accidentally become conditional on only the latter case. This happened for Hostname - we weren't properly setting it in cases where the container joined a pod. Fortunately, this is an easy fix once we know to check the condition.

Also, ensure that `podman pod inspect` actually prints hostname.

Fixes #6494