### PR TITLE
Fix handling of systemd.

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -424,7 +424,7 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 		"Sysctl options",
 	)
 	createFlags.StringVar(
-		&cf.SystemdD,
+		&cf.Systemd,
 		"systemd", "true",
 		`Run container in systemd mode ("true"|"false"|"always")`,
 	)

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -85,7 +85,7 @@ type ContainerCLIOpts struct {
 	SubUIDName        string
 	SubGIDName        string
 	Sysctl            []string
-	SystemdD          string
+	Systemd           string
 	TmpFS             []string
 	TTY               bool
 	UIDMap            []string

--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -38,7 +38,7 @@ func (s *SpecGenerator) Validate() error {
 	}
 	// systemd values must be true, false, or always
 	if len(s.ContainerBasicConfig.Systemd) > 0 && !util.StringInSlice(strings.ToLower(s.ContainerBasicConfig.Systemd), SystemDValues) {
-		return errors.Wrapf(ErrInvalidSpecConfig, "SystemD values must be one of %s", strings.Join(SystemDValues, ","))
+		return errors.Wrapf(ErrInvalidSpecConfig, "--systemd values must be one of %q", strings.Join(SystemDValues, ", "))
 	}
 
 	//

--- a/test/e2e/systemd_test.go
+++ b/test/e2e/systemd_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containers/libpod/pkg/cgroups"
 	. "github.com/containers/libpod/test/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -82,13 +81,6 @@ WantedBy=multi-user.target
 	})
 
 	It("podman run container with systemd PID1", func() {
-		cgroupsv2, err := cgroups.IsCgroup2UnifiedMode()
-		Expect(err).To(BeNil())
-		if cgroupsv2 {
-			// TODO: Find a way to enable this for v2
-			Skip("systemd test does not work in cgroups V2 mode yet")
-		}
-
 		systemdImage := "fedora"
 		pull := podmanTest.Podman([]string{"pull", systemdImage})
 		pull.WaitWithDefaultTimeout()


### PR DESCRIPTION
Systemd enablement has to happen on the server side, since we need
check if the image is running systemd.

Also need to make sure user setting the StopSignal is not overriden on the
server side. But if not set and using systemd, we set it correctly.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>