### PR TITLE
Add parallel operation to `podman stop`

### DIFF
--- a/cmd/podman/containers/stop.go
+++ b/cmd/podman/containers/stop.go
@@ -85,9 +85,8 @@ func stop(cmd *cobra.Command, args []string) error {
 	var (
 		errs utils.OutputErrors
 	)
-	stopOptions.Timeout = containerConfig.Engine.StopTimeout
 	if cmd.Flag("time").Changed {
-		stopOptions.Timeout = stopTimeout
+		stopOptions.Timeout = &stopTimeout
 	}
 
 	responses, err := registry.ContainerEngine().ContainerStop(context.Background(), args, stopOptions)

--- a/pkg/domain/entities/containers.go
+++ b/pkg/domain/entities/containers.go
@@ -84,7 +84,7 @@ type StopOptions struct {
 	CIDFiles []string
 	Ignore   bool
 	Latest   bool
-	Timeout  uint
+	Timeout  *uint
 }
 
 type StopReport struct {

--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -100,7 +100,7 @@ func (ic *ContainerEngine) ContainerStop(ctx context.Context, namesOrIds []strin
 	}
 	for _, c := range ctrs {
 		report := entities.StopReport{Id: c.ID}
-		if err = containers.Stop(ic.ClientCxt, c.ID, &options.Timeout); err != nil {
+		if err = containers.Stop(ic.ClientCxt, c.ID, options.Timeout); err != nil {
 			// These first two are considered non-fatal under the right conditions
 			if errors.Cause(err).Error() == define.ErrCtrStopped.Error() {
 				logrus.Debugf("Container %s is already stopped", c.ID)


### PR DESCRIPTION
This is the other command that benefits greatly from being run in parallel, due to the potential 15-second timeout for containers that ignore SIGTERM.

While we're at it, also clean up how stop timeout is set. This needs to be an optional parameter, so that the value set when the container is created with `--stop-timeout` will be respected.
