### PR TITLE
fix api fails with 'strconv.ParseUint: parsing "tcp": invalid syntax'

### DIFF
--- a/pkg/api/handlers/compat/containers.go
+++ b/pkg/api/handlers/compat/containers.go
@@ -465,8 +465,11 @@ func LibpodToContainerJSON(l *libpod.Container, sz bool) (*types.ContainerJSON, 
 
 	ports := make(nat.PortSet)
 	for p := range inspect.HostConfig.PortBindings {
-		splitp := strings.Split(p, "/")
-		port, err := nat.NewPort(splitp[0], splitp[1])
+		splitp := strings.SplitN(p, "/", 2)
+		if len(splitp) != 2 {
+			return nil, errors.Errorf("PORT/PROTOCOL Format required for %q", p)
+		}
+		port, err := nat.NewPort(splitp[1], splitp[0])
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
fix https://github.com/containers/libpod/issues/6511
https://github.com/containers/libpod/blob/master/pkg/api/handlers/compat/containers.go#L466-L471
https://github.com/containers/libpod/blob/1fcb6788a5d7471a7ca6215a40e36e21812a0f6e/pkg/api/handlers/compat/containers.go#L466-L471
`nat.NewPort`
https://github.com/docker/go-connections/blob/480d0b58242613178844e8ffabde7a5d55658f0d/nat/nat.go#L34
the first arg should be protocol，such as `splitp` is `[]string{"80","tcp"}`,
```
nat.NewPort(splitp[0], splitp[1])  ==> nat.NewPort(splitp[1], splitp[0])
```