### PR TITLE
Add support for the unless-stopped restart policy

### DIFF
--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -676,6 +676,7 @@ Valid values are:
 - `no`                       : Do not restart containers on exit
 - `on-failure[:max_retries]` : Restart containers when they exit with a non-0 exit code, retrying indefinitely or until the optional max_retries count is hit
 - `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
+- `unless-stopped`           : Identical to **always**
 
 Please note that restart will not restart containers after a system reboot.
 If this functionality is required in your environment, you can invoke Podman from a systemd unit file, or create an init script for whichever init system is in use.

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -682,11 +682,10 @@ Restart policy will not take effect if a container is stopped via the **podman k
 
 Valid _policy_ values are:
 
-- **no**: Do not restart containers on exit;
-- **on-failure**[:*max_retries*]: Restart containers when they exit
-with a non-zero exit code, retrying indefinitely or until the optional
-*max_retries* count is hit;
-- **always**: Restart containers when they exit, regardless of status, retrying indefinitely.
+- `no`                       : Do not restart containers on exit
+- `on-failure[:max_retries]` : Restart containers when they exit with a non-zero exit code, retrying indefinitely or until the optional *max_retries* count is hit
+- `always`                   : Restart containers when they exit, regardless of status, retrying indefinitely
+- `unless-stopped`           : Identical to **always**
 
 Please note that restart will not restart containers after a system reboot.
 If this functionality is required in your environment, you can invoke Podman from a **systemd.unit**(5) file, or create an init script for whichever init system is in use.

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -97,6 +97,10 @@ const (
 	// RestartPolicyOnFailure restarts the container on non-0 exit code,
 	// with an optional maximum number of retries.
 	RestartPolicyOnFailure = "on-failure"
+	// RestartPolicyUnlessStopped unconditionally restarts unless stopped
+	// by the user. It is identical to Always except with respect to
+	// handling of system restart, which Podman does not yet support.
+	RestartPolicyUnlessStopped = "unless-stopped"
 )
 
 // Container is a single OCI container.

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1285,7 +1285,7 @@ func WithRestartPolicy(policy string) CtrCreateOption {
 		}
 
 		switch policy {
-		case RestartPolicyNone, RestartPolicyNo, RestartPolicyOnFailure, RestartPolicyAlways:
+		case RestartPolicyNone, RestartPolicyNo, RestartPolicyOnFailure, RestartPolicyAlways, RestartPolicyUnlessStopped:
 			ctr.config.RestartPolicy = policy
 		default:
 			return errors.Wrapf(define.ErrInvalidArg, "%q is not a valid restart policy", policy)

--- a/pkg/specgen/generate/container_create.go
+++ b/pkg/specgen/generate/container_create.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/containers/common/pkg/config"
 	"github.com/containers/libpod/libpod"
-	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/image"
 	"github.com/containers/libpod/pkg/specgen"
 	"github.com/containers/libpod/pkg/util"
@@ -251,9 +250,6 @@ func createContainerOptions(ctx context.Context, rt *libpod.Runtime, s *specgen.
 	// Default used if not overridden on command line
 
 	if s.RestartPolicy != "" {
-		if s.RestartPolicy == "unless-stopped" {
-			return nil, errors.Wrapf(define.ErrInvalidArg, "the unless-stopped restart policy is not supported")
-		}
 		if s.RestartRetries != nil {
 			options = append(options, libpod.WithRestartRetries(*s.RestartRetries))
 		}

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -401,6 +401,20 @@ var _ = Describe("Podman create", func() {
 		Expect(session.ExitCode()).To(Not(Equal(0)))
 	})
 
+	It("podman create with --restart-policy unless-stopped", func() {
+		ctrName := "testctr"
+		unlessStopped := "unless-stopped"
+		session := podmanTest.Podman([]string{"create", "-t", "--restart", unlessStopped, "--name", ctrName, ALPINE, "/bin/sh"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", ctrName})
+		inspect.WaitWithDefaultTimeout()
+		data := inspect.InspectContainerToJSON()
+		Expect(len(data)).To(Equal(1))
+		Expect(data[0].HostConfig.RestartPolicy.Name).To(Equal(unlessStopped))
+	})
+
 	It("podman create with -m 1000000 sets swap to 2000000", func() {
 		numMem := 1000000
 		ctrName := "testCtr"


### PR DESCRIPTION
We initially believed that implementing this required support for restarting containers after reboot, but this is not the case. The unless-stopped restart policy acts identically to the always restart policy except in cases related to reboot (which we do not support yet), but it does not require that support for us to implement it.

Changes themselves are quite simple, we need a new restart policy constant, we need to remove existing checks that block creation of containers when unless-stopped was used, and we need to update the manpages.

Fixes #6508