### PR TITLE
Enable IPv6 port binding

### DIFF
--- a/cmd/podman/common/util.go
+++ b/cmd/podman/common/util.go
@@ -71,14 +71,44 @@ func createPortBindings(ports []string) ([]specgen.PortMapping, error) {
 			return nil, errors.Errorf("invalid port format - protocol can only be specified once")
 		}
 
-		splitPort := strings.Split(splitProto[0], ":")
+		remainder := splitProto[0]
+		haveV6 := false
+
+		// Check for an IPv6 address in brackets
+		splitV6 := strings.Split(remainder, "]")
+		switch len(splitV6) {
+		case 1:
+			// Do nothing, proceed as before
+		case 2:
+			// We potentially have an IPv6 address
+			haveV6 = true
+			if !strings.HasPrefix(splitV6[0], "[") {
+				return nil, errors.Errorf("invalid port format - IPv6 addresses must be enclosed by []")
+			}
+			if !strings.HasPrefix(splitV6[1], ":") {
+				return nil, errors.Errorf("invalid port format - IPv6 address must be followed by a colon (':')")
+			}
+			ipNoPrefix := strings.TrimPrefix(splitV6[0], "[")
+			hostIP = &ipNoPrefix
+			remainder = strings.TrimPrefix(splitV6[1], ":")
+		default:
+			return nil, errors.Errorf("invalid port format - at most one IPv6 address can be specified in a --publish")
+		}
+
+		splitPort := strings.Split(remainder, ":")
 		switch len(splitPort) {
 		case 1:
+			if haveV6 {
+				return nil, errors.Errorf("invalid port format - must provide host and destination port if specifying an IP")
+			}
 			ctrPort = splitPort[0]
 		case 2:
 			hostPort = &(splitPort[0])
 			ctrPort = splitPort[1]
 		case 3:
+			if haveV6 {
+				return nil, errors.Errorf("invalid port format - when v6 address specified, must be [ipv6]:hostPort:ctrPort")
+			}
 			hostIP = &(splitPort[0])
 			hostPort = &(splitPort[1])
 			ctrPort = splitPort[2]

--- a/test/e2e/run_networking_test.go
+++ b/test/e2e/run_networking_test.go
@@ -129,6 +129,32 @@ var _ = Describe("Podman run networking", func() {
 		Expect(inspectOut[0].NetworkSettings.Ports[0].HostIP).To(Equal("127.0.0.1"))
 	})
 
+	It("podman run -p [::1]:8080:80/udp", func() {
+		name := "testctr"
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "[::1]:8080:80/udp", "--name", name, ALPINE, "/bin/sh"})
+		session.WaitWithDefaultTimeout()
+		inspectOut := podmanTest.InspectContainer(name)
+		Expect(len(inspectOut)).To(Equal(1))
+		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports[0].HostPort).To(Equal(int32(8080)))
+		Expect(inspectOut[0].NetworkSettings.Ports[0].ContainerPort).To(Equal(int32(80)))
+		Expect(inspectOut[0].NetworkSettings.Ports[0].Protocol).To(Equal("udp"))
+		Expect(inspectOut[0].NetworkSettings.Ports[0].HostIP).To(Equal("::1"))
+	})
+
+	It("podman run -p [::1]:8080:80/tcp", func() {
+		name := "testctr"
+		session := podmanTest.Podman([]string{"create", "-t", "-p", "[::1]:8080:80/tcp", "--name", name, ALPINE, "/bin/sh"})
+		session.WaitWithDefaultTimeout()
+		inspectOut := podmanTest.InspectContainer(name)
+		Expect(len(inspectOut)).To(Equal(1))
+		Expect(len(inspectOut[0].NetworkSettings.Ports)).To(Equal(1))
+		Expect(inspectOut[0].NetworkSettings.Ports[0].HostPort).To(Equal(int32(8080)))
+		Expect(inspectOut[0].NetworkSettings.Ports[0].ContainerPort).To(Equal(int32(80)))
+		Expect(inspectOut[0].NetworkSettings.Ports[0].Protocol).To(Equal("tcp"))
+		Expect(inspectOut[0].NetworkSettings.Ports[0].HostIP).To(Equal("::1"))
+	})
+
 	It("podman run --expose 80 -P", func() {
 		name := "testctr"
 		session := podmanTest.Podman([]string{"create", "-t", "--expose", "80", "-P", "--name", name, ALPINE, "/bin/sh"})


### PR DESCRIPTION
Two areas needed tweaking to accomplish this: port parsing and binding ports on the host.

Parsing is an obvious problem - we have to accomodate an IPv6 address enclosed by [] as well as a normal IPv4 address. It was slightly complicated by the fact that we previously just counted the number of colons in the whole port definition (a thousand curses on whoever in the IPv6 standard body decided to reuse colons for address separators), but did not end up being that bad.

Libpod also (optionally) binds ports on the host to prevent their reuse by host processes. This code was IPv4 only for TCP, and bound to both for UDP (which I'm fairly certain is not correct, and has been adjusted). This just needed protocols adjusted to read "tcp4"/"tcp6" and "udp4"/"udp6" based on what we wanted to bind to.

Fixes #5715