### PR TITLE
Modify py test to start stop system service for each test

### DIFF
--- a/test/dockerpy/README.md
+++ b/test/dockerpy/README.md
@@ -6,11 +6,6 @@ Running tests
 =============
 To run the tests locally in your sandbox:
 
-#### Make sure that the Podman system service is running to do so
-
-```
-sudo podman --log-level=debug system service -t0 unix:/run/podman/podman.sock
-```
 #### Run the entire test
 
 ```

--- a/test/dockerpy/common.py
+++ b/test/dockerpy/common.py
@@ -1,6 +1,68 @@
 import docker
+import subprocess
+import os
+import sys
+import time
 from docker import Client
+from . import constant
 
+alpineDict = {
+      "name":        "docker.io/library/alpine:latest",
+		"shortName":   "alpine",
+		"tarballName": "alpine.tar"}
 
 def get_client():
-   return docker.Client(base_url="unix:/run/podman/podman.sock")
+   client = docker.Client(base_url="http://localhost:8080",timeout=15)
+   return client
+
+client = get_client()
+
+def podman():
+    binary = os.getenv("PODMAN_BINARY")
+    if binary is None:
+        binary = "bin/podman"
+    return binary
+
+def restore_image_from_cache():
+   client.load_image(constant.ImageCacheDir+alpineDict["tarballName"])
+
+def run_top_container():
+   client.pull(constant.ALPINE)
+   c = client.create_container(constant.ALPINE,name=constant.TOP)
+   client.start(container=c.get("Id"))
+
+def enable_sock(TestClass):
+   TestClass.podman = subprocess.Popen(
+      [
+            podman(), "system", "service", "tcp:localhost:8080",
+            "--log-level=debug", "--time=0"
+      ],
+      shell=False,
+      stdin=subprocess.DEVNULL,
+      stdout=subprocess.DEVNULL,
+      stderr=subprocess.DEVNULL,
+   )
+   time.sleep(2)
+
+def terminate_connection(TestClass):
+   TestClass.podman.terminate()
+   stdout, stderr = TestClass.podman.communicate(timeout=0.5)
+   if stdout:
+      print("\nService Stdout:\n" + stdout.decode('utf-8'))
+   if stderr:
+      print("\nService Stderr:\n" + stderr.decode('utf-8'))
+
+   if TestClass.podman.returncode > 0:
+      sys.stderr.write("podman exited with error code {}\n".format(
+            TestClass.podman.returncode))
+      sys.exit(2)
+
+def remove_all_containers():
+   containers = client.containers(quiet=True)
+   for c in containers:
+      client.remove_container(container=c.get("Id"), force=True)
+
+def remove_all_images():
+   allImages = client.images()
+   for image in allImages:
+      client.remove_image(image,force=True)

--- a/test/dockerpy/constant.py
+++ b/test/dockerpy/constant.py
@@ -9,3 +9,5 @@ ALPINEAMD64ID     = "961769676411f082461f9ef46626dd7a2d1e2b2a38e6a44364bcbecf51e
 ALPINEARM64DIGEST = "docker.io/library/alpine@sha256:db7f3dcef3d586f7dd123f107c93d7911515a5991c4b9e51fa2a43e46335a43e"
 ALPINEARM64ID     = "915beeae46751fc564998c79e73a1026542e945ca4f73dc841d09ccc6c2c0672"
 infra             = "k8s.gcr.io/pause:3.2"
+TOP               = "top"
+ImageCacheDir = "/tmp/podman/imagecachedir"

--- a/test/dockerpy/containers.py
+++ b/test/dockerpy/containers.py
@@ -1,0 +1,46 @@
+
+import unittest
+import docker
+import requests
+import os
+from docker import Client
+from . import constant
+from . import common
+
+client = common.get_client()
+
+class TestContainers(unittest.TestCase):
+
+    podman = None
+
+    def setUp(self):
+        super().setUp()
+        common.run_top_container()
+
+    def tearDown(self):
+        common.remove_all_containers()
+        common.remove_all_images()
+        return super().tearDown()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        common.enable_sock(cls)
+
+    @classmethod
+    def tearDownClass(cls):
+        common.terminate_connection(cls)
+        return super().tearDownClass()
+
+    def test_inspect_container(self):
+        # Inspect bogus container
+        with self.assertRaises(requests.HTTPError):
+            client.inspect_container("dummy")
+        # Inspect valid container
+        container = client.inspect_container(constant.TOP)
+        self.assertIn(constant.TOP , container["Name"])
+
+
+if __name__ == '__main__':
+    # Setup temporary space
+    unittest.main()

--- a/test/dockerpy/images.py
+++ b/test/dockerpy/images.py
@@ -11,18 +11,28 @@ client = common.get_client()
 
 class TestImages(unittest.TestCase):
 
+    podman = None
     def setUp(self):
         super().setUp()
         client.pull(constant.ALPINE)
 
     def tearDown(self):
-        allImages = client.images()
-        for image in allImages:
-            client.remove_image(image,force=True)
+        common.remove_all_images()
         return super().tearDown()
 
-# Inspect Image
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        common.enable_sock(cls)
 
+
+    @classmethod
+    def tearDownClass(cls):
+        common.terminate_connection(cls)
+        return super().tearDownClass()
+
+
+# Inspect Image
 
     def test_inspect_image(self):
         # Check for error with wrong image name
@@ -79,8 +89,8 @@ class TestImages(unittest.TestCase):
         for i in response:
             # Alpine found
             if "docker.io/library/alpine" in i["Name"]:
-                self.assertTrue(True, msg="Image found")
-        self.assertFalse(False,msg="Image not found")
+                self.assertTrue
+        self.assertFalse
 
 # Image Exist (No docker-py support yet)
 
@@ -105,19 +115,22 @@ class TestImages(unittest.TestCase):
         alpine_image = client.inspect_image(constant.ALPINE)
         for h in imageHistory:
             if h["Id"] in alpine_image["Id"]:
-                self.assertTrue(True,msg="Image History validated")
-        self.assertFalse(False,msg="Unable to get image history")
+                self.assertTrue
+        self.assertFalse
 
 # Prune Image (No docker-py support yet)
 
 # Export Image
 
     def test_export_image(self):
-        file = "/tmp/alpine-latest.tar"
+        client.pull(constant.BB)
+        file = os.path.join(constant.ImageCacheDir , "busybox.tar")
+        if not os.path.exists(constant.ImageCacheDir):
+            os.makedirs(constant.ImageCacheDir)
         # Check for error with wrong image name
         with self.assertRaises(requests.HTTPError):
             client.get_image("dummy")
-        response = client.get_image(constant.ALPINE)
+        response = client.get_image(constant.BB)
         image_tar = open(file,mode="wb")
         image_tar.write(response.data)
         image_tar.close()
@@ -125,6 +138,13 @@ class TestImages(unittest.TestCase):
 
 # Import|Load Image
 
+    def test_import_image(self):
+        allImages = client.images()
+        self.assertEqual(len(allImages), 1)
+        file = os.path.join(constant.ImageCacheDir , "busybox.tar")
+        client.import_image_from_file(filename=file)
+        allImages = client.images()
+        self.assertEqual(len(allImages), 2)
 
 if __name__ == '__main__':
     # Setup temporary space


### PR DESCRIPTION
Start-stop system service for each test class to make it easy to integrate to CI
Adds more tests
Add some common methods shared between images and containers test.

Signed-off-by: Sujil02 <sushah@redhat.com>