### PR TITLE
Ensure signal validation happens first in pod kill

### DIFF
--- a/pkg/api/handlers/libpod/pods.go
+++ b/pkg/api/handlers/libpod/pods.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containers/libpod/pkg/util"
 	"github.com/gorilla/schema"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func PodCreate(w http.ResponseWriter, r *http.Request) {
@@ -375,6 +376,7 @@ func PodKill(w http.ResponseWriter, r *http.Request) {
 	sig, err := util.ParseSignal(signal)
 	if err != nil {
 		utils.InternalServerError(w, errors.Wrapf(err, "unable to parse signal value"))
+		return
 	}
 	name := utils.GetName(r)
 	pod, err := runtime.LookupPod(name)
@@ -382,6 +384,7 @@ func PodKill(w http.ResponseWriter, r *http.Request) {
 		utils.PodNotFound(w, name, err)
 		return
 	}
+	logrus.Debugf("Killing pod %s with signal %d", pod.ID(), sig)
 	podStates, err := pod.Status()
 	if err != nil {
 		utils.Error(w, "Something went wrong.", http.StatusInternalServerError, err)

--- a/pkg/domain/infra/tunnel/pods.go
+++ b/pkg/domain/infra/tunnel/pods.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containers/libpod/pkg/bindings/pods"
 	"github.com/containers/libpod/pkg/domain/entities"
 	"github.com/containers/libpod/pkg/specgen"
+	"github.com/containers/libpod/pkg/util"
 	"github.com/pkg/errors"
 )
 
@@ -19,6 +20,12 @@ func (ic *ContainerEngine) PodKill(ctx context.Context, namesOrIds []string, opt
 	var (
 		reports []*entities.PodKillReport
 	)
+
+	_, err := util.ParseSignal(options.Signal)
+	if err != nil {
+		return nil, err
+	}
+
 	foundPods, err := getPodsByContext(ic.ClientCxt, options.All, namesOrIds)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes an error in the system tests, which expect that when you try and kill a nonexistent pod with an incorrect signal, you receive an error about the signal, not the pod.

At the same time, fix a missing return statement in the bindings, which could also have caused us grief.

Fixes #6540
