### PR TITLE
Do not share container log driver for exec

### DIFF
--- a/contrib/cirrus/setup_environment.sh
+++ b/contrib/cirrus/setup_environment.sh
@@ -50,6 +50,7 @@ case "${OS_RELEASE_ID}" in
 	    if [[ "$OS_RELEASE_VER" == "20" ]]; then
 		    apt-get install -y python-is-python3
 	    fi
+	    apt-get upgrade -y conmon
         ;;
     fedora)
         # All SELinux distros need this for systemd-in-a-container

--- a/docs/source/markdown/podman-create.1.md
+++ b/docs/source/markdown/podman-create.1.md
@@ -419,7 +419,7 @@ Not implemented
 
 **--log-driver**="*k8s-file*"
 
-Logging driver for the container.  Currently available options are *k8s-file* and *journald*, with *json-file* aliased to *k8s-file* for scripting compatibility.
+Logging driver for the container.  Currently available options are *k8s-file*, *journald*, and *none*, with *json-file* aliased to *k8s-file* for scripting compatibility.
 
 **--log-opt**=*path*
 

--- a/docs/source/markdown/podman-run.1.md
+++ b/docs/source/markdown/podman-run.1.md
@@ -432,7 +432,7 @@ Not implemented.
 
 **--log-driver**="*driver*"
 
-Logging driver for the container. Currently available options are **k8s-file** and **journald**, with **json-file** aliased to **k8s-file** for scripting compatibility.
+Logging driver for the container. Currently available options are **k8s-file**, **journald**, and **none**, with **json-file** aliased to **k8s-file** for scripting compatibility.
 
 **--log-opt**=*name*=*value*
 

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -22,12 +22,21 @@ func (r *Runtime) Log(containers []*Container, options *logs.LogOptions, logChan
 
 // ReadLog reads a containers log based on the input options and returns loglines over a channel.
 func (c *Container) ReadLog(options *logs.LogOptions, logChannel chan *logs.LogLine) error {
-	// TODO Skip sending logs until journald logs can be read
-	// TODO make this not a magic string
-	if c.LogDriver() == define.JournaldLogging {
+	switch c.LogDriver() {
+	case define.NoLogging:
+		return errors.Wrapf(define.ErrNoLogs, "this container is using the 'none' log driver, cannot read logs")
+	case define.JournaldLogging:
+		// TODO Skip sending logs until journald logs can be read
 		return c.readFromJournal(options, logChannel)
+	case define.JSONLogging:
+		// TODO provide a separate implementation of this when Conmon
+		// has support.
+		fallthrough
+	case define.KubernetesLogging, "":
+		return c.readFromLogFile(options, logChannel)
+	default:
+		return errors.Wrapf(define.ErrInternal, "unrecognized log driver %q, cannot read logs", c.LogDriver())
 	}
-	return c.readFromLogFile(options, logChannel)
 }
 
 func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *logs.LogLine) error {

--- a/libpod/define/config.go
+++ b/libpod/define/config.go
@@ -72,3 +72,6 @@ const KubernetesLogging = "k8s-file"
 
 // JSONLogging is the string conmon expects when specifying to use the json logging format
 const JSONLogging = "json-file"
+
+// NoLogging is the string conmon expects when specifying to use no log driver whatsoever
+const NoLogging = "none"

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -79,6 +79,9 @@ var (
 	// ErrNoCgroups indicates that the container does not have its own
 	// CGroup.
 	ErrNoCgroups = errors.New("this container does not have a cgroup")
+	// ErrNoLogs indicates that this container is not creating a log so log
+	// operations cannot be performed on it
+	ErrNoLogs = errors.New("this container is not logging output")
 
 	// ErrRootless indicates that the given command cannot but run without
 	// root.

--- a/libpod/oci_conmon_exec_linux.go
+++ b/libpod/oci_conmon_exec_linux.go
@@ -392,7 +392,7 @@ func (r *ConmonOCIRuntime) startExec(c *Container, sessionID string, options *Ex
 		return nil, nil, err
 	}
 
-	args := r.sharedConmonArgs(c, sessionID, c.execBundlePath(sessionID), c.execPidPath(sessionID), c.execLogPath(sessionID), c.execExitFileDir(sessionID), ociLog, "")
+	args := r.sharedConmonArgs(c, sessionID, c.execBundlePath(sessionID), c.execPidPath(sessionID), c.execLogPath(sessionID), c.execExitFileDir(sessionID), ociLog, define.NoLogging, "")
 
 	if options.PreserveFDs > 0 {
 		args = append(args, formatRuntimeOpts("--preserve-fds", fmt.Sprintf("%d", options.PreserveFDs))...)

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -993,7 +993,7 @@ func WithLogDriver(driver string) CtrCreateOption {
 		switch driver {
 		case "":
 			return errors.Wrapf(define.ErrInvalidArg, "log driver must be set")
-		case define.JournaldLogging, define.KubernetesLogging, define.JSONLogging:
+		case define.JournaldLogging, define.KubernetesLogging, define.JSONLogging, define.NoLogging:
 			break
 		default:
 			return errors.Wrapf(define.ErrInvalidArg, "invalid log driver")

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -321,7 +321,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		ctrNamedVolumes = append(ctrNamedVolumes, newVol)
 	}
 
-	if ctr.config.LogPath == "" && ctr.config.LogDriver != define.JournaldLogging {
+	if ctr.config.LogPath == "" && ctr.config.LogDriver != define.JournaldLogging && ctr.config.LogDriver != define.NoLogging {
 		ctr.config.LogPath = filepath.Join(ctr.config.StaticDir, "ctr.log")
 	}
 

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -25,10 +25,6 @@ var _ = Describe("Podman exec", func() {
 		podmanTest = PodmanTestCreate(tempdir)
 		podmanTest.Setup()
 		podmanTest.SeedImages()
-		// HACK: Remove this once we get Conmon 2.0.17 on Ubuntu
-		if podmanTest.Host.Distribution == "ubuntu" {
-			Skip("Unable to perform test on Ubuntu distributions due to too-old Conmon (need 2.0.17)")
-		}
 	})
 
 	AfterEach(func() {

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -300,4 +300,15 @@ var _ = Describe("Podman logs", func() {
 		results.WaitWithDefaultTimeout()
 		Expect(results).To(Exit(0))
 	})
+
+	It("podman logs with log-driver=none errors", func() {
+		ctrName := "logsctr"
+		logc := podmanTest.Podman([]string{"run", "--name", ctrName, "-d", "--log-driver", "none", ALPINE, "top"})
+		logc.WaitWithDefaultTimeout()
+		Expect(logc).To(Exit(0))
+
+		logs := podmanTest.Podman([]string{"logs", "-f", ctrName})
+		logs.WaitWithDefaultTimeout()
+		Expect(logs).To(Not(Exit(0)))
+	})
 })


### PR DESCRIPTION
When the container uses journald logging, we don't want to automatically use the same driver for its exec sessions. If we do we will pollute the journal (particularly in the case of healthchecks) with large amounts of undesired logs. Instead, force exec sessions logs to file for now; we can add a log-driver
flag later (we'll probably want to add a `podman logs` command that reads exec session logs at the same time).

Fixes #6555