### PR TITLE
[CI:DOCS] Add quick start directions to APIv2 Dock

### DIFF
--- a/pkg/api/server/docs.go
+++ b/pkg/api/server/docs.go
@@ -4,6 +4,24 @@
 // only as experimental as this point.  The endpoints, parameters, inputs, and
 // return values can all change.
 //
+// To start the service and keep it running for 5,000 seconds (-t 0 runs forever):
+//    podman system service -t 5000 &
+//
+// You can then use cURL on the socket using requests documented below.
+//
+// NOTE: if you install the package podman-docker, it will create a symbolic
+// link for /var/run/docker.sock to /run/podman/podman.sock
+//
+// See podman-service(1) for more information.
+//
+//  Quick Examples:
+//   'podman info'
+//      curl --unix-socket /run/podman/podman.sock http://d/v1.0.0/libpod/info
+//   'podman pull quay.io/containers/podman'
+//      curl -XPOST --unix-socket /run/podman/podman.sock -v 'http://d/v1.0.0/images/create?fromImage=quay.io%2Fcontainers%2Fpodman'
+//   'podman list images'
+//      curl --unix-socket /run/podman/podman.sock -v 'http://d/v1.0.0/libpod/images/json' | jq
+//
 // Terms Of Service:
 //
 //     Schemes: http, https


### PR DESCRIPTION
Adds some quick start up directions to the top of the
API v2 documentation and a few examples.
This strongly leverages comments from @jgallucci32 in #6535.

Fixes: #6535

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>