### PR TITLE
replace error-prone non-ASCII quotes in template config

### DIFF
--- a/vendor/github.com/containers/common/pkg/config/containers.conf
+++ b/vendor/github.com/containers/common/pkg/config/containers.conf
@@ -92,7 +92,7 @@
 # Ulimits has limits for non privileged container engines.
 #
 # default_ulimits = [
-#  “nofile”=”1280:2560”,
+#  "nofile"="1280:2560",
 # ]
 
 # List of default DNS options to be added to /etc/resolv.conf inside of the container.
@@ -105,7 +105,7 @@
 
 # Set default DNS servers.
 # This option can be used to override the DNS configuration passed to the
-# container. The special value “none” can be specified to disable creation of
+# container. The special value "none" can be specified to disable creation of
 # /etc/resolv.conf in the container.
 # The /etc/resolv.conf file in the image will be used without changes.
 #
@@ -125,7 +125,7 @@
 # Path to OCI hooks directories for automatically executed hooks.
 #
 # hooks_dir = [
-# “/usr/share/containers/oci/hooks.d”,
+#     "/usr/share/containers/oci/hooks.d",
 # ]
 
 # Default proxy environment variables passed into the container.
@@ -220,7 +220,7 @@
 # userns = "host"
 
 # Number of UIDs to allocate for the automatic container creation.
-# UIDs are allocated from the “container” UIDs listed in
+# UIDs are allocated from the "container" UIDs listed in
 # /etc/subuid & /etc/subgid
 #
 # userns_size=65536
@@ -241,7 +241,7 @@
 [engine]
 
 # Cgroup management implementation used for the runtime.
-# Valid options “systemd” or “cgroupfs”
+# Valid options "systemd" or "cgroupfs"
 #
 # cgroup_manager = "systemd"
 


### PR DESCRIPTION
while browsing the config file template that ships with fedora32, I came across
odd-looking non-ASCII quotes and I figured I'd propose to clean this up