### PR TITLE
libpod: fix check for slirp4netns netns

### DIFF
--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -79,7 +79,8 @@ func (c *Container) prepare() error {
 	go func() {
 		defer wg.Done()
 		// Set up network namespace if not already set up
-		if c.config.CreateNetNS && c.state.NetNS == nil && !c.config.PostConfigureNetNS {
+		noNetNS := c.state.NetNS == nil
+		if c.config.CreateNetNS && noNetNS && !c.config.PostConfigureNetNS {
 			netNS, networkStatus, createNetNSErr = c.runtime.createNetNS(c)
 			if createNetNSErr != nil {
 				return
@@ -94,7 +95,7 @@ func (c *Container) prepare() error {
 		}
 
 		// handle rootless network namespace setup
-		if c.state.NetNS != nil && c.config.NetMode.IsSlirp4netns() && !c.config.PostConfigureNetNS {
+		if noNetNS && c.config.NetMode.IsSlirp4netns() && !c.config.PostConfigureNetNS {
 			createNetNSErr = c.runtime.setupRootlessNetNS(c)
 		}
 	}()


### PR DESCRIPTION
fix the check for c.state.NetNS == nil.  Its value is changed in the
first code block, so the condition is always true in the second one
and we end up running slirp4netns twice.

Closes: https://github.com/containers/libpod/issues/6538

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>