### PR TITLE
podman: create scope only if --cgroup-manager=systemd

### DIFF
--- a/pkg/domain/infra/abi/system.go
+++ b/pkg/domain/infra/abi/system.go
@@ -72,11 +72,9 @@ func (ic *ContainerEngine) SetupRootless(_ context.Context, cmd *cobra.Command) 
 				return err
 			}
 			unitName := fmt.Sprintf("podman-%d.scope", os.Getpid())
-			if err := utils.RunUnderSystemdScope(os.Getpid(), "user.slice", unitName); err != nil {
-				if conf.Engine.CgroupManager == config.SystemdCgroupsManager {
+			if conf.Engine.CgroupManager == config.SystemdCgroupsManager {
+				if err := utils.RunUnderSystemdScope(os.Getpid(), "user.slice", unitName); err != nil {
 					logrus.Warnf("Failed to add podman to systemd sandbox cgroup: %v", err)
-				} else {
-					logrus.Debugf("Failed to add podman to systemd sandbox cgroup: %v", err)
 				}
 			}
 		}


### PR DESCRIPTION
drop check for current cgroup ownership if the cgroup manager is not
set to systemd.

Closes: https://github.com/containers/libpod/issues/4483

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>