### PR TITLE
Fix podman inspect on overlapping/missing objects

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -625,7 +625,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 			if retries < 0 {
 				return errors.Errorf("must specify restart policy retry count as a number greater than 0")
 			}
-			var retriesUint uint = uint(retries)
+			var retriesUint = uint(retries)
 			s.RestartRetries = &retriesUint
 		default:
 			return errors.Errorf("invalid restart policy: may specify retries at most once")

--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -40,7 +40,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	anchorDir, err := extractTarFile(r, w)
+	anchorDir, err := extractTarFile(r)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
@@ -241,7 +241,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		})
 }
 
-func extractTarFile(r *http.Request, w http.ResponseWriter) (string, error) {
+func extractTarFile(r *http.Request) (string, error) {
 	// build a home for the request body
 	anchorDir, err := ioutil.TempDir("", "libpod_builder")
 	if err != nil {

--- a/pkg/domain/entities/engine_container.go
+++ b/pkg/domain/entities/engine_container.go
@@ -24,7 +24,7 @@ type ContainerEngine interface {
 	ContainerExists(ctx context.Context, nameOrID string) (*BoolReport, error)
 	ContainerExport(ctx context.Context, nameOrID string, options ContainerExportOptions) error
 	ContainerInit(ctx context.Context, namesOrIds []string, options ContainerInitOptions) ([]*ContainerInitReport, error)
-	ContainerInspect(ctx context.Context, namesOrIds []string, options InspectOptions) ([]*ContainerInspectReport, error)
+	ContainerInspect(ctx context.Context, namesOrIds []string, options InspectOptions) ([]*ContainerInspectReport, []error, error)
 	ContainerKill(ctx context.Context, namesOrIds []string, options KillOptions) ([]*KillReport, error)
 	ContainerList(ctx context.Context, options ContainerListOptions) ([]ListContainer, error)
 	ContainerLogs(ctx context.Context, containers []string, options ContainerLogsOptions) error

--- a/pkg/domain/entities/engine_image.go
+++ b/pkg/domain/entities/engine_image.go
@@ -13,7 +13,7 @@ type ImageEngine interface {
 	Exists(ctx context.Context, nameOrID string) (*BoolReport, error)
 	History(ctx context.Context, nameOrID string, opts ImageHistoryOptions) (*ImageHistoryReport, error)
 	Import(ctx context.Context, opts ImageImportOptions) (*ImageImportReport, error)
-	Inspect(ctx context.Context, namesOrIDs []string, opts InspectOptions) ([]*ImageInspectReport, error)
+	Inspect(ctx context.Context, namesOrIDs []string, opts InspectOptions) ([]*ImageInspectReport, []error, error)
 	List(ctx context.Context, opts ImageListOptions) ([]*ImageSummary, error)
 	Load(ctx context.Context, opts ImageLoadOptions) (*ImageLoadReport, error)
 	Prune(ctx context.Context, opts ImagePruneOptions) (*ImagePruneReport, error)


### PR DESCRIPTION
This started as a small fix to `podman inspect` where a container and image, with the same name/tag, were present, and `podman inspect` was run on that name. `podman inspect` in 1.9 (and `docker inspect`) will give you the container; in v2.0, we gave the image. This was an easy fix (just reorder how we check for image/container).

Unfortunately, in the process of testing this fix, I determined that we regressed in a different area. When you run inspect on a number of containers, some of which do not exist, `podman inspect` should return an array of inspect results for the objects that exist, then print a number of errors, one for each object that could not be found. We were bailing after the first error, and not printing output for the containers that succeeded. (For reference, this applied to images as well). This required a much more substantial set of changes to properly handle - signatures for the inspect functions in ContainerEngine and ImageEngine, plus the implementations of these interfaces, plus the actual inspect frontend code needed to be adjusted to use this.

Fixes #6556
