### PR TITLE
Merged request to fix -f to stop following logs

### DIFF
--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -83,7 +83,11 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 					break
 				}
 				if state != define.ContainerStateRunning && state != define.ContainerStatePaused {
-					t.StopAtEOF()
+					err := t.Stop()
+					if err != nil {
+						logrus.Error(err)
+						break
+					}
 					break
 				}
 				time.Sleep(1 * time.Second)

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -30,6 +30,13 @@ func (c *Container) ReadLog(options *logs.LogOptions, logChannel chan *logs.LogL
 }
 
 func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *logs.LogLine) error {
+	state, err := c.State()
+	if err != nil {
+		return err
+	}
+	if state != define.ContainerStateRunning && state != define.ContainerStatePaused {
+		options.Follow = false
+	}
 	t, tailLog, err := logs.GetLogFile(c.LogPath(), options)
 	if err != nil {
 		// If the log file does not exist, this is not fatal.
@@ -68,6 +75,14 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 			nll.CName = c.Name()
 			if nll.Since(options.Since) {
 				logChannel <- nll
+			}
+			state, err := c.State()
+			if err != nil {
+				logrus.Error(err)
+				break
+			}
+			if options.Follow && state != define.ContainerStateRunning && state != define.ContainerStatePaused {
+				t.Kill(err)
 			}
 		}
 		options.WaitGroup.Done()

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -88,7 +88,6 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 					err := t.Stop()
 					if err != nil {
 						logrus.Error(err)
-						break
 					}
 					break
 				}

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -78,8 +78,10 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 		if options.Follow {
 			for {
 				state, err := c.State()
-				if err != nil {
+				if err != nil && errors.Cause(err) != define.ErrNoSuchCtr {
 					logrus.Error(err)
+					break
+				} else if err != nil {
 					break
 				}
 				if state != define.ContainerStateRunning && state != define.ContainerStatePaused {

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -288,4 +288,16 @@ var _ = Describe("Podman logs", func() {
 		logc.WaitWithDefaultTimeout()
 		Expect(logc).To(Exit(0))
 	})
+
+	It("follow output stopped container", func() {
+		containerName := "logs-f"
+
+		logc := podmanTest.Podman([]string{"run", "--name", containerName, "-d", ALPINE})
+		logc.WaitWithDefaultTimeout()
+		Expect(logc).To(Exit(0))
+
+		results := podmanTest.Podman([]string{"logs", "-f", containerName})
+		results.WaitWithDefaultTimeout()
+		Expect(results).To(Exit(0))
+	})
 })


### PR DESCRIPTION
This is a MERGED request from @QiWang19 and myself. It contains the test cases developed by her in addition to the modifications made to handle multiple cases. Close #6531

Fixes an issue with the first PR where a container would exit while following logs and the log tail continued to follow. This creates a subroutine which checks the state of the container and instructs the tailLog to stop when it reaches EOF.

Tested the following conditions:
* Tail and follow logs of running container
* Tail and follow logs of stopped container
* Tail and follow logs of running container which exits after some time