### PR TITLE
The string field of Built was missing from server

### DIFF
--- a/pkg/bindings/system/system.go
+++ b/pkg/bindings/system/system.go
@@ -125,6 +125,7 @@ func Version(ctx context.Context) (*entities.SystemVersionReport, error) {
 		Version:    component.Version.Version,
 		GoVersion:  component.GoVersion,
 		GitCommit:  component.GitCommit,
+		BuiltTime:  time.Unix(b.Unix(), 0).Format(time.ANSIC),
 		Built:      b.Unix(),
 		OsArch:     fmt.Sprintf("%s/%s", component.Os, component.Arch),
 	}


### PR DESCRIPTION
It should match the client version, but was empty

Used here:

```
cmd/podman/system/version.go-   if version.GitCommit != "" {
cmd/podman/system/version.go-           fmt.Fprintf(writer, "Git Commit:\t%s\n", version.GitCommit)
cmd/podman/system/version.go-   }
cmd/podman/system/version.go:   fmt.Fprintf(writer, "Built:\t%s\n", version.BuiltTime)
cmd/podman/system/version.go-   fmt.Fprintf(writer, "OS/Arch:\t%s\n", version.OsArch)
```