### PR TITLE
fix podman cp can create an extra directory when the source is the container's root directory

### DIFF
--- a/test/e2e/build/Dockerfile.test-cp-root-dir
+++ b/test/e2e/build/Dockerfile.test-cp-root-dir
@@ -1,0 +1,2 @@
+FROM scratch
+COPY Dockerfile.test-cp-root-dir /


### PR DESCRIPTION
(Edited, moving comment from @zhangguanzhang to here)

Fixes: #6596
Example of the issue: 

```
$ mkdir test
$ ls
drwxr-xr-x  2 root root         6 Jun 15 16:54 test
$ cat >Dockerfile<<EOF
FROM scratch
COPY Dockerfile /
EOF
$ podman build -t podman-test:1.0.0 .
STEP 1: FROM scratch
STEP 2: COPY Dockerfile /
STEP 3: COMMIT podman-test:1.0.0
--> 839962c7269
839962c7269777d5f50d68428d5def260b6842f7c0607978b8567668f2a8c067

$ podman create podman-test:1.0.0 dummy
53914c7a1191e96b7fee0fcb9b152480640c392321edadfe657c10afda1431a2
$ podman cp 539:/   non_dir
$ ls non_dir
Dockerfile
```
If you copy the container's root directory to an existing directory, It creates an extra layer of the directory called `merged`
```
$ podman cp 539:/ test
$ ls -l  test
total 0
drwxr-xr-x 2 root root 24 Jun 15 23:30 merged
$ ls -l  test/merged/
total 4
-rw-r--r-- 1 root root 31 Jun 13 22:50 Dockerfile
```

Signed-off-by: zhangguanzhang zhangguanzhang@qq.com