### PR TITLE
[CI:DOCS] Change Varlink systemd unit to use `system service`

### DIFF
--- a/contrib/varlink/io.podman.service
+++ b/contrib/varlink/io.podman.service
@@ -6,7 +6,7 @@ Documentation=man:podman-varlink(1)
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/podman varlink unix:%t/podman/io.podman --timeout=60000
+ExecStart=/usr/bin/podman system service --varlink --timeout=60000 unix:%t/podman/io.podman
 TimeoutStopSec=30
 KillMode=process
 


### PR DESCRIPTION
We completely removed `podman varlink`, which broke the systemd unit file used by the Varlink code. Change that to use the new `podman system service --varlink` command which replaced it.

Also needs a slight reorder of args to make things work happily on my system.
