### PR TITLE
Follow logs using event channel

### DIFF
--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/containers/libpod/libpod/define"
@@ -108,8 +109,8 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 					break
 				}
 				if state != define.ContainerStateRunning && state != define.ContainerStatePaused {
-					err := t.Stop()
-					if err != nil {
+					err := t.StopAtEOF()
+					if err != nil && fmt.Sprintf("%v", err) != "tail: stop at eof" {
 						logrus.Error(err)
 					}
 					break

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -88,9 +88,9 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 		go func() {
 			readOpts := events.ReadOptions{
 				EventChannel: eventChannel,
-				Filters: []string{"type=container"},
-				FromStart: false,
-				Stream: true,
+				Filters:      []string{"type=container"},
+				FromStart:    false,
+				Stream:       true,
 			}
 			eventsError := c.runtime.Events(readOpts)
 			if eventsError != nil {

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -103,16 +103,19 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 			for {
 				state, err := c.State()
 				if err != nil {
-					t.Stop()
+					tailError := t.StopAtEOF()
+					if tailError != nil && fmt.Sprintf("%v", tailError) != "tail: stop at eof" {
+						logrus.Error(tailError)
+					}
 					if errors.Cause(err) != define.ErrNoSuchCtr {
 						logrus.Error(err)
 					}
 					break
 				}
 				if state != define.ContainerStateRunning && state != define.ContainerStatePaused {
-					err := t.StopAtEOF()
-					if err != nil && fmt.Sprintf("%v", err) != "tail: stop at eof" {
-						logrus.Error(err)
+					tailError := t.StopAtEOF()
+					if tailError != nil && fmt.Sprintf("%v", tailError) != "tail: stop at eof" {
+						logrus.Error(tailError)
 					}
 					break
 				}

--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -102,10 +102,11 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 		go func() {
 			for {
 				state, err := c.State()
-				if err != nil && errors.Cause(err) != define.ErrNoSuchCtr {
-					logrus.Error(err)
-					break
-				} else if err != nil {
+				if err != nil {
+					t.Stop()
+					if errors.Cause(err) != define.ErrNoSuchCtr {
+						logrus.Error(err)
+					}
 					break
 				}
 				if state != define.ContainerStateRunning && state != define.ContainerStatePaused {
@@ -114,9 +115,8 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 						logrus.Error(err)
 					}
 					break
-				} else {
-					<-eventChannel
 				}
+				<-eventChannel
 			}
 		}()
 	}

--- a/libpod/logs/log.go
+++ b/libpod/logs/log.go
@@ -73,7 +73,7 @@ func GetLogFile(path string, options *LogOptions) (*tail.Tail, []*LogLine, error
 		Whence: whence,
 	}
 
-	t, err := tail.TailFile(path, tail.Config{MustExist: true, Poll: true, Follow: options.Follow, Location: &seek, Logger: tail.DiscardingLogger})
+	t, err := tail.TailFile(path, tail.Config{MustExist: true, Poll: false, Follow: options.Follow, Location: &seek, Logger: tail.DiscardingLogger})
 	return t, logTail, err
 }
 

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -311,4 +311,16 @@ var _ = Describe("Podman logs", func() {
 		logs.WaitWithDefaultTimeout()
 		Expect(logs).To(Not(Exit(0)))
 	})
+
+	It("follow output stopped container", func() {
+		containerName := "logs-f"
+
+		logc := podmanTest.Podman([]string{"run", "--name", containerName, "-d", ALPINE})
+		logc.WaitWithDefaultTimeout()
+		Expect(logc).To(Exit(0))
+
+		results := podmanTest.Podman([]string{"logs", "-f", containerName})
+		results.WaitWithDefaultTimeout()
+		Expect(results).To(Exit(0))
+	})
 })


### PR DESCRIPTION
Changes method for following logs to use an event
channel rather than a sleep timer to help prevent
race conditions.

Close #6531

Signed-off-by: jgallucci32 <john.gallucci.iv@gmail.com>