### PR TITLE
auto-update: use image's arch

### DIFF
--- a/pkg/api/handlers/compat/images_build.go
+++ b/pkg/api/handlers/compat/images_build.go
@@ -40,7 +40,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	anchorDir, err := extractTarFile(r, w)
+	anchorDir, err := extractTarFile(r)
 	if err != nil {
 		utils.InternalServerError(w, err)
 		return
@@ -241,7 +241,7 @@ func BuildImage(w http.ResponseWriter, r *http.Request) {
 		})
 }
 
-func extractTarFile(r *http.Request, w http.ResponseWriter) (string, error) {
+func extractTarFile(r *http.Request) (string, error) {
 	// build a home for the request body
 	anchorDir, err := ioutil.TempDir("", "libpod_builder")
 	if err != nil {

--- a/pkg/autoupdate/autoupdate.go
+++ b/pkg/autoupdate/autoupdate.go
@@ -251,8 +251,19 @@ func newerImageAvailable(runtime *libpod.Runtime, img *image.Image, origName str
 		return false, err
 	}
 
+	data, err := img.Inspect(context.Background())
+	if err != nil {
+		return false, err
+	}
+
 	sys := runtime.SystemContext()
 	sys.AuthFilePath = options.Authfile
+
+	// We need to account for the arch that the image uses.  It seems
+	// common on ARM to tweak this option to pull the correct image.  See
+	// github.com/containers/libpod/issues/6613.
+	sys.ArchitectureChoice = data.Architecture
+
 	remoteImg, err := remoteRef.NewImage(context.Background(), sys)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Use the architecture of the local image when looking for a new image on
a registry.  It seems to be common practice on ARM to tweak the
architecture choice to pull the correct image.

Fixes: #6613
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>