### PR TITLE
[CI:DOCS] Revert "Change Varlink systemd unit to use `system service`"

### DIFF
--- a/contrib/varlink/io.podman.service
+++ b/contrib/varlink/io.podman.service
@@ -6,7 +6,7 @@ Documentation=man:podman-varlink(1)
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/podman system service --varlink --timeout=60000 unix:%t/podman/io.podman
+ExecStart=/usr/bin/podman varlink unix:%t/podman/io.podman --timeout=60000
 TimeoutStopSec=30
 KillMode=process
 


### PR DESCRIPTION
This reverts commit 1bc992bfc3a983b4d9ab53f778a545d83bcde94d.

We originally thought `podman varlink` was entirely removed, but that was not true. We originally thought that `podman system service --varlink` worked the same as `podman varlink` but that was also not true. `system service` is broken when used under systemd units, and `podman varlink` still exists and works. Revert the change to `podman system service` to fix socket-activated Varlink under systemd.