### PR TITLE
search: allow wildcards

### DIFF
--- a/libpod/image/search.go
+++ b/libpod/image/search.go
@@ -64,13 +64,16 @@ type SearchFilter struct {
 // SearchImages searches images based on term and the specified SearchOptions
 // in all registries.
 func SearchImages(term string, options SearchOptions) ([]SearchResult, error) {
-	// Check if search term has a registry in it
-	registry, err := sysreg.GetRegistry(term)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error getting registry from %q", term)
-	}
-	if registry != "" {
-		term = term[len(registry)+1:]
+	registry := ""
+
+	// Try to extract a registry from the specified search term.  We
+	// consider everything before the first slash to be the registry.  Note
+	// that we cannot use the reference parser from the containers/image
+	// library as the search term may container arbitrary input such as
+	// wildcards.  See bugzilla.redhat.com/show_bug.cgi?id=1846629.
+	if spl := strings.SplitN(term, "/", 2); len(spl) > 1 {
+		registry = spl[0]
+		term = spl[1]
 	}
 
 	registries, err := getRegistries(registry)

--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -3,12 +3,10 @@ package registries
 import (
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/containers/image/v5/pkg/sysregistriesv2"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/libpod/pkg/rootless"
-	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 )
 
@@ -76,18 +74,4 @@ func GetInsecureRegistries() ([]string, error) {
 		}
 	}
 	return insecureRegistries, nil
-}
-
-// GetRegistry returns the registry name from a string if specified
-func GetRegistry(image string) (string, error) {
-	// It is possible to only have the registry name in the format "myregistry/"
-	// if so, just trim the "/" from the end and return the registry name
-	if strings.HasSuffix(image, "/") {
-		return strings.TrimSuffix(image, "/"), nil
-	}
-	imgRef, err := reference.Parse(image)
-	if err != nil {
-		return "", err
-	}
-	return reference.Domain(imgRef.(reference.Named)), nil
 }

--- a/test/e2e/search_test.go
+++ b/test/e2e/search_test.go
@@ -400,4 +400,16 @@ registries = ['{{.Host}}:{{.Port}}']`
 		search.WaitWithDefaultTimeout()
 		Expect(search.ExitCode()).To(Not(Equal(0)))
 	})
+
+	It("podman search with wildcards", func() {
+		search := podmanTest.Podman([]string{"search", "--limit", "30", "registry.redhat.io/*"})
+		search.WaitWithDefaultTimeout()
+		Expect(search.ExitCode()).To(Equal(0))
+		Expect(len(search.OutputToStringArray())).To(Equal(31))
+
+		search = podmanTest.Podman([]string{"search", "registry.redhat.io/*openshift*"})
+		search.WaitWithDefaultTimeout()
+		Expect(search.ExitCode()).To(Equal(0))
+		Expect(len(search.OutputToStringArray()) > 1).To(BeTrue())
+	})
 })


### PR DESCRIPTION
Allow trailing wildcards in the search term.  Note that not all
registries support wildcards and it may only work with v1 registries.
Hence, we just strip `*` before parsing the domain of the input.

Fixes: bugzilla.redhat.com/show_bug.cgi?id=1846629
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@mtrmac @rhatdan @TomSweeneyRedHat  @QiWang19 PTAL