### PR TITLE
Fix --init and --init-path

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -563,6 +563,8 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	// we dont think these are in the spec
 	// init - initbinary
 	// initpath
+	s.Init = c.Init
+	s.InitPath = c.InitPath
 	s.Stdin = c.Interactive
 	// quiet
 	// DeviceCgroupRules: c.StringSlice("device-cgroup-rule"),

--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -112,7 +112,7 @@ func makeCommand(ctx context.Context, s *specgen.SpecGenerator, img *image.Image
 		if initPath == "" {
 			return nil, errors.Errorf("no path to init binary found but container requested an init")
 		}
-		finalCommand = append([]string{initPath, "--"}, finalCommand...)
+		finalCommand = append([]string{"/dev/init", "--"}, finalCommand...)
 	}
 
 	return finalCommand, nil

--- a/pkg/specgen/generate/storage.go
+++ b/pkg/specgen/generate/storage.go
@@ -314,8 +314,8 @@ func addContainerInitBinary(s *specgen.SpecGenerator, path string) (spec.Mount, 
 	if !s.PidNS.IsPrivate() {
 		return mount, fmt.Errorf("cannot add init binary as PID 1 (PID namespace isn't private)")
 	}
-	if s.Systemd == "true" || s.Systemd == "always" {
-		return mount, fmt.Errorf("cannot use container-init binary with systemd")
+	if s.Systemd == "always" {
+		return mount, fmt.Errorf("cannot use container-init binary with systemd=always")
 	}
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return mount, errors.Wrap(err, "container-init binary not found on the host")

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -151,12 +151,36 @@ var _ = Describe("Podman run", func() {
 		session := podmanTest.Podman([]string{"run", "--init", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		result := podmanTest.Podman([]string{"inspect", "-l"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		conData := result.InspectContainerToJSON()
+		Expect(conData[0].Path).To(Equal("/dev/init"))
+		Expect(conData[0].Config.Annotations["io.podman.annotations.init"]).To(Equal("TRUE"))
 	})
 
 	It("podman run a container with --init and --init-path", func() {
 		session := podmanTest.Podman([]string{"run", "--init", "--init-path", "/usr/libexec/podman/catatonit", ALPINE, "ls"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
+		result := podmanTest.Podman([]string{"inspect", "-l"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		conData := result.InspectContainerToJSON()
+		Expect(conData[0].Path).To(Equal("/dev/init"))
+		Expect(conData[0].Config.Annotations["io.podman.annotations.init"]).To(Equal("TRUE"))
+	})
+
+	It("podman run a container without --init", func() {
+		session := podmanTest.Podman([]string{"run", ALPINE, "ls"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		result := podmanTest.Podman([]string{"inspect", "-l"})
+		result.WaitWithDefaultTimeout()
+		Expect(result.ExitCode()).To(Equal(0))
+		conData := result.InspectContainerToJSON()
+		Expect(conData[0].Path).To(Equal("ls"))
+		Expect(conData[0].Config.Annotations["io.podman.annotations.init"]).To(Equal("FALSE"))
 	})
 
 	It("podman run seccomp test", func() {


### PR DESCRIPTION
This passes init and init-path through to specgen, and I've tested it works after fixing the command injection.
