### PR TITLE
Fix handling of old oci hooks

### DIFF
--- a/pkg/hooks/0.1.0/hook.go
+++ b/pkg/hooks/0.1.0/hook.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/containers/libpod/pkg/hooks"
 	current "github.com/containers/libpod/pkg/hooks/1.0.0"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -32,8 +31,9 @@ type Hook struct {
 	HasBindMounts *bool `json:"hasbindmounts,omitempty"`
 }
 
-func read(content []byte) (hook *current.Hook, err error) {
+func Read(content []byte) (hook *current.Hook, err error) {
 	var raw Hook
+
 	if err = json.Unmarshal(content, &raw); err != nil {
 		return nil, err
 	}
@@ -85,9 +85,4 @@ func read(content []byte) (hook *current.Hook, err error) {
 	}
 
 	return hook, nil
-}
-
-func init() {
-	hooks.Readers[""] = read
-	hooks.Readers[Version] = read
 }

--- a/pkg/hooks/0.1.0/hook_test.go
+++ b/pkg/hooks/0.1.0/hook_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGood(t *testing.T) {
-	hook, err := read([]byte("{\"hook\": \"/a/b/c\", \"stages\": [\"prestart\"], \"cmds\": [\"sh\"]}"))
+	hook, err := Read([]byte("{\"hook\": \"/a/b/c\", \"stages\": [\"prestart\"], \"cmds\": [\"sh\"]}"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +27,7 @@ func TestGood(t *testing.T) {
 }
 
 func TestInvalidJSON(t *testing.T) {
-	_, err := read([]byte("{"))
+	_, err := Read([]byte("{"))
 	if err == nil {
 		t.Fatal("unexpected success")
 	}
@@ -35,7 +35,7 @@ func TestInvalidJSON(t *testing.T) {
 }
 
 func TestArguments(t *testing.T) {
-	hook, err := read([]byte("{\"hook\": \"/a/b/c\", \"arguments\": [\"d\", \"e\"], \"stages\": [\"prestart\"], \"cmds\": [\"sh\"]}"))
+	hook, err := Read([]byte("{\"hook\": \"/a/b/c\", \"arguments\": [\"d\", \"e\"], \"stages\": [\"prestart\"], \"cmds\": [\"sh\"]}"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestArguments(t *testing.T) {
 }
 
 func TestEmptyObject(t *testing.T) {
-	_, err := read([]byte("{}"))
+	_, err := Read([]byte("{}"))
 	if err == nil {
 		t.Fatal("unexpected success")
 	}
@@ -62,7 +62,7 @@ func TestEmptyObject(t *testing.T) {
 }
 
 func TestNoStages(t *testing.T) {
-	_, err := read([]byte("{\"hook\": \"/a/b/c\"}"))
+	_, err := Read([]byte("{\"hook\": \"/a/b/c\"}"))
 	if err == nil {
 		t.Fatal("unexpected success")
 	}
@@ -70,7 +70,7 @@ func TestNoStages(t *testing.T) {
 }
 
 func TestStage(t *testing.T) {
-	hook, err := read([]byte("{\"hook\": \"/a/b/c\", \"stage\": [\"prestart\"]}"))
+	hook, err := Read([]byte("{\"hook\": \"/a/b/c\", \"stage\": [\"prestart\"]}"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestStage(t *testing.T) {
 }
 
 func TestStagesAndStage(t *testing.T) {
-	_, err := read([]byte("{\"hook\": \"/a/b/c\", \"stages\": [\"prestart\"], \"stage\": [\"prestart\"]}"))
+	_, err := Read([]byte("{\"hook\": \"/a/b/c\", \"stages\": [\"prestart\"], \"stage\": [\"prestart\"]}"))
 	if err == nil {
 		t.Fatal("unexpected success")
 	}
@@ -93,7 +93,7 @@ func TestStagesAndStage(t *testing.T) {
 }
 
 func TestCmd(t *testing.T) {
-	hook, err := read([]byte("{\"hook\": \"/a/b/c\", \"stage\": [\"prestart\"], \"cmd\": [\"sh\"]}"))
+	hook, err := Read([]byte("{\"hook\": \"/a/b/c\", \"stage\": [\"prestart\"], \"cmd\": [\"sh\"]}"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestCmd(t *testing.T) {
 }
 
 func TestCmdsAndCmd(t *testing.T) {
-	_, err := read([]byte("{\"hook\": \"/a/b/c\", \"stages\": [\"prestart\"], \"cmds\": [\"sh\"], \"cmd\": [\"true\"]}"))
+	_, err := Read([]byte("{\"hook\": \"/a/b/c\", \"stages\": [\"prestart\"], \"cmds\": [\"sh\"], \"cmd\": [\"true\"]}"))
 	if err == nil {
 		t.Fatal("unexpected success")
 	}
@@ -119,7 +119,7 @@ func TestCmdsAndCmd(t *testing.T) {
 }
 
 func TestAnnotations(t *testing.T) {
-	hook, err := read([]byte("{\"hook\": \"/a/b/c\", \"stage\": [\"prestart\"], \"annotations\": [\"a\", \"b\"]}"))
+	hook, err := Read([]byte("{\"hook\": \"/a/b/c\", \"stage\": [\"prestart\"], \"annotations\": [\"a\", \"b\"]}"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestAnnotations(t *testing.T) {
 }
 
 func TestAnnotation(t *testing.T) {
-	hook, err := read([]byte("{\"hook\": \"/a/b/c\", \"stage\": [\"prestart\"], \"annotation\": [\"a\", \"b\"]}"))
+	hook, err := Read([]byte("{\"hook\": \"/a/b/c\", \"stage\": [\"prestart\"], \"annotation\": [\"a\", \"b\"]}"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestAnnotation(t *testing.T) {
 }
 
 func TestAnnotationsAndAnnotation(t *testing.T) {
-	_, err := read([]byte("{\"hook\": \"/a/b/c\", \"stages\": [\"prestart\"], \"annotations\": [\"a\"], \"annotation\": [\"b\"]}"))
+	_, err := Read([]byte("{\"hook\": \"/a/b/c\", \"stages\": [\"prestart\"], \"annotations\": [\"a\"], \"annotation\": [\"b\"]}"))
 	if err == nil {
 		t.Fatal("unexpected success")
 	}
@@ -163,7 +163,7 @@ func TestAnnotationsAndAnnotation(t *testing.T) {
 }
 
 func TestHasBindMounts(t *testing.T) {
-	hook, err := read([]byte("{\"hook\": \"/a/b/c\", \"stage\": [\"prestart\"], \"hasbindmounts\": true}"))
+	hook, err := Read([]byte("{\"hook\": \"/a/b/c\", \"stage\": [\"prestart\"], \"hasbindmounts\": true}"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/hooks/read.go
+++ b/pkg/hooks/read.go
@@ -3,12 +3,12 @@ package hooks
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
+	old "github.com/containers/libpod/pkg/hooks/0.1.0"
 	current "github.com/containers/libpod/pkg/hooks/1.0.0"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -49,7 +49,7 @@ func read(content []byte) (hook *current.Hook, err error) {
 	}
 	reader, ok := Readers[ver.Version]
 	if !ok {
-		return nil, fmt.Errorf("unrecognized hook version: %q", ver.Version)
+		return nil, errors.Errorf("unrecognized hook version: %q", ver.Version)
 	}
 
 	hook, err = reader(content)
@@ -95,4 +95,6 @@ func ReadDir(path string, extensionStages []string, hooks map[string]*current.Ho
 
 func init() {
 	Readers[current.Version] = current.Read
+	Readers[old.Version] = old.Read
+	Readers[""] = old.Read
 }


### PR DESCRIPTION
Podman is blowing up with oci-umount hook, because
it was never rewritten to support the v1.0.0 value.

This PR adds support for the older version and cleans
up the hook handling.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>