### PR TITLE
Add <return> to lines returned in podman-remote logs

### DIFF
--- a/pkg/domain/infra/tunnel/containers.go
+++ b/pkg/domain/infra/tunnel/containers.go
@@ -370,7 +370,7 @@ func (ic *ContainerEngine) ContainerLogs(_ context.Context, nameOrIDs []string, 
 		case <-ctx.Done():
 			return err
 		case line := <-outCh:
-			_, _ = io.WriteString(options.Writer, line)
+			_, _ = io.WriteString(options.Writer, line+"\n")
 		}
 	}
 }


### PR DESCRIPTION
Every line is sent back individually over the APIv2 as
logs, but we are not adding the '\n' to give us line breaks.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>