### PR TITLE
Don't ignore --user flag in rootless --userns keepid

### DIFF
--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -153,9 +153,7 @@ func namespaceOptions(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.
 	// User
 	switch s.UserNS.NSMode {
 	case specgen.KeepID:
-		if rootless.IsRootless() {
-			s.User = ""
-		} else {
+		if !rootless.IsRootless() {
 			// keep-id as root doesn't need a user namespace
 			s.UserNS.NSMode = specgen.Host
 		}

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -89,6 +89,13 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("podman --userns=keep-id --user root:root", func() {
+		session := podmanTest.Podman([]string{"run", "--userns=keep-id", "--user", "root:root", "alpine", "id", "-u"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("0"))
+	})
+
 	It("podman --userns=auto", func() {
 		u, err := user.Current()
 		Expect(err).To(BeNil())


### PR DESCRIPTION
Currently podman run --userns keep-id --user root:root fedora id

The --user flag is ignored.  Removing this makes the code work correctly.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

Fixes: https://github.com/containers/libpod/issues/6652