### PR TITLE
Allow recursive dependency start with Init()

### DIFF
--- a/pkg/api/handlers/compat/containers_attach.go
+++ b/pkg/api/handlers/compat/containers_attach.go
@@ -89,7 +89,7 @@ func AttachContainer(w http.ResponseWriter, r *http.Request) {
 	}
 	// For Docker compatibility, we need to re-initialize containers in these states.
 	if state == define.ContainerStateConfigured || state == define.ContainerStateExited {
-		if err := ctr.Init(r.Context()); err != nil {
+		if err := ctr.Init(r.Context(), ctr.PodID() != ""); err != nil {
 			utils.Error(w, "Container in wrong state", http.StatusConflict, errors.Wrapf(err, "error preparing container %s for attach", ctr.ID()))
 			return
 		}

--- a/pkg/api/handlers/libpod/containers.go
+++ b/pkg/api/handlers/libpod/containers.go
@@ -294,7 +294,7 @@ func InitContainer(w http.ResponseWriter, r *http.Request) {
 		utils.ContainerNotFound(w, name, err)
 		return
 	}
-	err = ctr.Init(r.Context())
+	err = ctr.Init(r.Context(), ctr.PodID() != "")
 	if errors.Cause(err) == define.ErrCtrStateInvalid {
 		utils.Error(w, "container already initialized", http.StatusNotModified, err)
 		return

--- a/pkg/domain/infra/abi/containers.go
+++ b/pkg/domain/infra/abi/containers.go
@@ -999,7 +999,7 @@ func (ic *ContainerEngine) ContainerInit(ctx context.Context, namesOrIds []strin
 	reports := make([]*entities.ContainerInitReport, 0, len(ctrs))
 	for _, ctr := range ctrs {
 		report := entities.ContainerInitReport{Id: ctr.ID()}
-		err := ctr.Init(ctx)
+		err := ctr.Init(ctx, ctr.PodID() != "")
 
 		// If we're initializing all containers, ignore invalid state errors
 		if options.All && errors.Cause(err) == define.ErrCtrStateInvalid {

--- a/pkg/varlinkapi/containers.go
+++ b/pkg/varlinkapi/containers.go
@@ -385,7 +385,7 @@ func (i *VarlinkAPI) InitContainer(call iopodman.VarlinkCall, name string) error
 	if err != nil {
 		return call.ReplyContainerNotFound(name, err.Error())
 	}
-	if err := ctr.Init(getContext()); err != nil {
+	if err := ctr.Init(getContext(), false); err != nil {
 		if errors.Cause(err) == define.ErrCtrStateInvalid {
 			return call.ReplyInvalidState(ctr.ID(), err.Error())
 		}
@@ -557,7 +557,7 @@ func (i *VarlinkAPI) GetAttachSockets(call iopodman.VarlinkCall, name string) er
 	// If the container hasn't been run, we need to run init
 	// so the conmon sockets get created.
 	if status == define.ContainerStateConfigured || status == define.ContainerStateStopped {
-		if err := ctr.Init(getContext()); err != nil {
+		if err := ctr.Init(getContext(), false); err != nil {
 			return call.ReplyErrorOccurred(err.Error())
 		}
 	}


### PR DESCRIPTION
As part of APIv2 Attach, we need to be able to attach to freshly created containers (in ContainerStateConfigured). This isn't something Libpod is interested in supporting, so we use Init() to get the container into ContainerStateCreated, in which attach is possible. Problem: Init() will fail if dependencies are not started, so a fresh container in a fresh pod will fail. The simplest solution is to extend the existing recursive start code from Start() to Init(), allowing dependency containers to be
started when we initialize the container (optionally, controlled via bool).

Also, update some comments in container_api.go to make it more clear how some of our major API calls work.

Fixes #6646