### PR TITLE
unflake rmi tests

### DIFF
--- a/test/e2e/rmi_test.go
+++ b/test/e2e/rmi_test.go
@@ -137,12 +137,12 @@ var _ = Describe("Podman rmi", func() {
 		Expect(session).Should(Exit(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(1))
 
-		session = podmanTest.PodmanNoCache([]string{"images", "-q", "-a"})
+		session = podmanTest.PodmanNoCache([]string{"images", "--sort", "created", "--format", "{{.Id}}", "--all"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(Exit(0))
 		Expect(len(session.OutputToStringArray())).To(Equal(2),
 			"Output from 'podman images -q -a':'%s'", session.Out.Contents())
-		untaggedImg := session.OutputToStringArray()[0]
+		untaggedImg := session.OutputToStringArray()[1]
 
 		session = podmanTest.PodmanNoCache([]string{"rmi", "-f", untaggedImg})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
Make sure to always get the older image that the previously committed one
depends on.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>