### PR TITLE
Cirrus: Fix Success Deps

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -237,9 +237,6 @@ build_each_commit_task:
 # Update metadata on VM images referenced by this repository state
 meta_task:
 
-    depends_on:
-        - "gating"
-
     container:
         image: "quay.io/libpod/imgts:latest"  # see contrib/imgts
         cpu: 1

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -432,9 +432,9 @@ success_task:
         - "gating"
         - "varlink_api"
         - "vendor"
-        - "build_each_commit_task"
+        - "build_each_commit"
         - "testing"
-        - "rootless_testing_task"
+        - "rootless_testing"
         - "optional_testing"
 
     env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -430,12 +430,14 @@ success_task:
 
     depends_on:  # ignores any dependent task conditions
         - "gating"
+        - "vendor"
         - "varlink_api"
         - "vendor"
         - "build_each_commit"
         - "testing"
-        - "rootless_testing"
+        - "special_testing"
         - "optional_testing"
+        - "cache_images"
 
     env:
         CIRRUS_WORKING_DIR: "/usr/src/libpod"


### PR DESCRIPTION
Cirrus-CI recently began failing if dependencies (incorrectly) mentioned the `_task` suffix.  Easy fix.