### PR TITLE
Account for non-default port number in image name

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -188,7 +188,7 @@ func writeTemplate(imageS []*entities.ImageSummary) error {
 }
 
 func tokenRepoTag(tag string) (string, string) {
-	tokens := strings.SplitN(tag, ":", 2)
+	tokens := strings.Split(tag, ":")
 	switch len(tokens) {
 	case 0:
 		return tag, ""
@@ -196,6 +196,8 @@ func tokenRepoTag(tag string) (string, string) {
 		return tokens[0], ""
 	case 2:
 		return tokens[0], tokens[1]
+	case 3:
+		return tokens[0] + ":" + tokens[1], tokens[2]
 	default:
 		return "<N/A>", ""
 	}


### PR DESCRIPTION
Previously, if an image was tagged with the format
$REGISTRY:$PORT/$REPO:$TAG,
then `podman images` would display "$PORT/$REPO:$TAG" under the "TAG"
field.

This commit correctly displays $REGISTRY:$PORT/$REPO under the
"REPOSITORY" field while the "TAG" field only displays $TAG.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

Fixes: gh#6665


@baude @mheon @rhatdan @vrothberg @jwhonce PTAL