### PR TITLE
Poll on events for file reading

### DIFF
--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -202,5 +202,5 @@ func (e EventLogFile) getTail(options ReadOptions) (*tail.Tail, error) {
 	if len(options.Until) > 0 {
 		stream = false
 	}
-	return tail.TailFile(e.options.LogFilePath, tail.Config{ReOpen: reopen, Follow: stream, Location: &seek, Logger: tail.DiscardingLogger})
+	return tail.TailFile(e.options.LogFilePath, tail.Config{ReOpen: reopen, Follow: stream, Location: &seek, Logger: tail.DiscardingLogger, Poll: true})
 }


### PR DESCRIPTION
When multiple connections are monitoring events via the remote API, the inotify in the hpcloud library seems unable to consistently send events.  Switching from inotify to poll seems to clear this up.

Fixes: #6664

Signed-off-by: Brent Baude <bbaude@redhat.com>