### PR TITLE
Fix event cleanup when client closes connection

### DIFF
--- a/cmd/podman/system/events.go
+++ b/cmd/podman/system/events.go
@@ -53,9 +53,8 @@ func init() {
 
 func eventsCmd(cmd *cobra.Command, args []string) error {
 	var (
-		err         error
-		eventsError error
-		tmpl        *template.Template
+		err  error
+		tmpl *template.Template
 	)
 	if strings.Join(strings.Fields(eventFormat), "") == "{{json.}}" {
 		eventFormat = formats.JSONString
@@ -69,42 +68,49 @@ func eventsCmd(cmd *cobra.Command, args []string) error {
 	if len(eventOptions.Since) > 0 || len(eventOptions.Until) > 0 {
 		eventOptions.FromStart = true
 	}
+
+	eventContext, eventCancel := context.WithCancel(registry.Context())
 	eventChannel := make(chan *events.Event)
 	eventOptions.EventChan = eventChannel
+	defer close(eventChannel)
+	errChannel := make(chan error)
+	defer close(errChannel)
 
 	go func() {
-		eventsError = registry.ContainerEngine().Events(context.Background(), eventOptions)
+		errChannel <- registry.ContainerEngine().Events(eventContext, eventOptions)
+		eventCancel()
 	}()
-	if eventsError != nil {
-		return eventsError
-	}
 
 	w := bufio.NewWriter(os.Stdout)
-	for event := range eventChannel {
-		switch {
-		case eventFormat == formats.JSONString:
-			jsonStr, err := event.ToJSONString()
-			if err != nil {
-				return errors.Wrapf(err, "unable to format json")
+	for {
+		select {
+		case event := <-eventChannel:
+			switch {
+			case eventFormat == formats.JSONString:
+				jsonStr, err := event.ToJSONString()
+				if err != nil {
+					return errors.Wrapf(err, "unable to format json")
+				}
+				if _, err := w.Write([]byte(jsonStr)); err != nil {
+					return err
+				}
+			case len(eventFormat) > 0:
+				if err := tmpl.Execute(w, event); err != nil {
+					return err
+				}
+			default:
+				if _, err := w.Write([]byte(event.ToHumanReadable())); err != nil {
+					return err
+				}
 			}
-			if _, err := w.Write([]byte(jsonStr)); err != nil {
+			if _, err := w.Write([]byte("\n")); err != nil {
 				return err
 			}
-		case len(eventFormat) > 0:
-			if err := tmpl.Execute(w, event); err != nil {
+			if err := w.Flush(); err != nil {
 				return err
 			}
-		default:
-			if _, err := w.Write([]byte(event.ToHumanReadable())); err != nil {
-				return err
-			}
-		}
-		if _, err := w.Write([]byte("\n")); err != nil {
-			return err
-		}
-		if err := w.Flush(); err != nil {
+		case err := <-errChannel:
 			return err
 		}
 	}
-	return nil
 }

--- a/libpod/events.go
+++ b/libpod/events.go
@@ -1,6 +1,7 @@
 package libpod
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/containers/libpod/libpod/events"
@@ -75,12 +76,12 @@ func (v *Volume) newVolumeEvent(status events.Status) {
 
 // Events is a wrapper function for everyone to begin tailing the events log
 // with options
-func (r *Runtime) Events(options events.ReadOptions) error {
+func (r *Runtime) Events(ctx context.Context, options events.ReadOptions) error {
 	eventer, err := r.newEventer()
 	if err != nil {
 		return err
 	}
-	return eventer.Read(options)
+	return eventer.Read(ctx, options)
 }
 
 // GetEvents reads the event log and returns events based on input filters
@@ -98,7 +99,7 @@ func (r *Runtime) GetEvents(filters []string) ([]*events.Event, error) {
 		return nil, err
 	}
 	go func() {
-		readErr = eventer.Read(options)
+		readErr = eventer.Read(context.Background(), options)
 	}()
 	if readErr != nil {
 		return nil, readErr

--- a/libpod/events/config.go
+++ b/libpod/events/config.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"time"
 
 	"github.com/pkg/errors"
@@ -52,7 +53,7 @@ type Eventer interface {
 	// Write an event to a backend
 	Write(event Event) error
 	// Read an event from the backend
-	Read(options ReadOptions) error
+	Read(ctx context.Context, options ReadOptions) error
 	// String returns the type of event logger
 	String() string
 }

--- a/libpod/events/events.go
+++ b/libpod/events/events.go
@@ -202,5 +202,6 @@ func (e EventLogFile) getTail(options ReadOptions) (*tail.Tail, error) {
 	if len(options.Until) > 0 {
 		stream = false
 	}
-	return tail.TailFile(e.options.LogFilePath, tail.Config{ReOpen: reopen, Follow: stream, Location: &seek, Logger: tail.DiscardingLogger, Poll: true})
+	return tail.TailFile(e.options.LogFilePath,
+		tail.Config{ReOpen: reopen, Follow: stream, Location: &seek, Logger: tail.DiscardingLogger, Poll: true})
 }

--- a/libpod/events/journal_linux.go
+++ b/libpod/events/journal_linux.go
@@ -3,6 +3,7 @@
 package events
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -53,7 +54,7 @@ func (e EventJournalD) Write(ee Event) error {
 }
 
 // Read reads events from the journal and sends qualified events to the event channel
-func (e EventJournalD) Read(options ReadOptions) error {
+func (e EventJournalD) Read(_ context.Context, options ReadOptions) error {
 	defer close(options.EventChannel)
 	eventOptions, err := generateEventOptions(options.Filters, options.Since, options.Until)
 	if err != nil {

--- a/libpod/events/nullout.go
+++ b/libpod/events/nullout.go
@@ -1,5 +1,9 @@
 package events
 
+import (
+	"context"
+)
+
 // EventToNull is an eventer type that only performs write operations
 // and only writes to /dev/null. It is meant for unittests only
 type EventToNull struct{}
@@ -10,7 +14,7 @@ func (e EventToNull) Write(ee Event) error {
 }
 
 // Read does nothing. Do not use it.
-func (e EventToNull) Read(options ReadOptions) error {
+func (e EventToNull) Read(_ context.Context, options ReadOptions) error {
 	return nil
 }
 

--- a/pkg/domain/infra/abi/events.go
+++ b/pkg/domain/infra/abi/events.go
@@ -9,5 +9,5 @@ import (
 
 func (ic *ContainerEngine) Events(ctx context.Context, opts entities.EventsOptions) error {
 	readOpts := events.ReadOptions{FromStart: opts.FromStart, Stream: opts.Stream, Filters: opts.Filter, EventChannel: opts.EventChan, Since: opts.Since, Until: opts.Until}
-	return ic.Libpod.Events(readOpts)
+	return ic.Libpod.Events(ctx, readOpts)
 }

--- a/pkg/varlinkapi/events.go
+++ b/pkg/varlinkapi/events.go
@@ -3,6 +3,7 @@
 package varlinkapi
 
 import (
+	"context"
 	"time"
 
 	"github.com/containers/libpod/libpod/events"
@@ -27,7 +28,7 @@ func (i *VarlinkAPI) GetEvents(call iopodman.VarlinkCall, filter []string, since
 	eventChannel := make(chan *events.Event)
 	go func() {
 		readOpts := events.ReadOptions{FromStart: fromStart, Stream: stream, Filters: filter, EventChannel: eventChannel}
-		eventsError = i.Runtime.Events(readOpts)
+		eventsError = i.Runtime.Events(context.Background(), readOpts)
 	}()
 	if eventsError != nil {
 		return call.ReplyErrorOccurred(eventsError.Error())


### PR DESCRIPTION
* Refactor channel close to happen in code that creates channel
* Add context to allow stopping the publishing of events

Signed-off-by: Jhon Honce <jhonce@redhat.com>