### PR TITLE
Fix sorting of json formatted list of images

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -158,12 +158,6 @@ func ps(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if len(listOpts.Sort) > 0 {
-		listContainers, err = entities.SortPsOutput(listOpts.Sort, listContainers)
-		if err != nil {
-			return err
-		}
-	}
 	if listOpts.Format == "json" {
 		return jsonOut(listContainers)
 	}

--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -130,12 +130,16 @@ func writeJSON(imageS []*entities.ImageSummary) error {
 		CreatedAt string
 	}
 
-	imgs := make([]image, 0, len(imageS))
-	for _, e := range imageS {
+	imgReporters := getImagesReporters(imageS)
+	sort.Slice(imgReporters, sortFunc(listFlag.sort, imgReporters))
+
+	imgs := make([]image, 0, len(imgReporters))
+	for _, e := range imgReporters {
 		var h image
-		h.ImageSummary = *e
-		h.Created = units.HumanDuration(time.Since(e.Created)) + " ago"
-		h.CreatedAt = e.Created.Format(time.RFC3339Nano)
+
+		h.ImageSummary = e.ImageSummary
+		h.Created = e.Created()
+		h.CreatedAt = e.ImageSummary.Created.Format(time.RFC3339Nano)
 		h.RepoTags = nil
 
 		imgs = append(imgs, h)

--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -145,8 +145,13 @@ func writeJSON(imageS []*entities.ImageSummary) error {
 		imgs = append(imgs, h)
 	}
 
-	enc := json.NewEncoder(os.Stdout)
-	return enc.Encode(imgs)
+	byteOutput, err := json.MarshalIndent(imgs, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(byteOutput))
+
+	return nil
 }
 
 func writeTemplate(imageS []*entities.ImageSummary) error {


### PR DESCRIPTION
The JSON formatted output of `podman images` was not sorted when a sorting option was specified. This was due to the fact that sorting in `cmd/podman/images/list.go` relies on the `imageReporter` type that wasn't used in the JSON-related function.

With this getting of imageReporters is split into a separate function that is used by both Go templates and JSON parts of the listing.

The output of `podman images --format json` used to be pretty-printed which stopped to be the case with V2. This behaviour is returned with this PR.

Extra: I encountered a redundancy in `cmd/podman/containers/ps.go` where sorting of a list of containers was done twice in a row which naturally does not have an effect. The duplication is removed with this.

PS: No unit tests, yet!

Fixes #6593 