### PR TITLE
podman images --format json: pretty print

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -141,8 +141,12 @@ func writeJSON(imageS []*entities.ImageSummary) error {
 		imgs = append(imgs, h)
 	}
 
-	enc := json.NewEncoder(os.Stdout)
-	return enc.Encode(imgs)
+	prettyJSON, err := json.MarshalIndent(imgs, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(prettyJSON))
+	return nil
 }
 
 func writeTemplate(imageS []*entities.ImageSummary) error {


### PR DESCRIPTION
Pretty print the JSON output when listing images.  We regressed on that
during v2 development. The indentation is now identical to the one of
Podman v1.9.3.

Fixes: #6687
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>