### PR TITLE
Cirrus: Change DEST_BRANCH to v2.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ env:
     #### Global variables used for all tasks
     ####
     # Name of the ultimate destination branch for this CI run, PR or post-merge.
-    DEST_BRANCH: "master"
+    DEST_BRANCH: "v2.0"
     # Overrides default location (/tmp/cirrus) for repo clone
     GOPATH: "/var/tmp/go"
     GOBIN: "${GOPATH}/bin"
@@ -102,7 +102,7 @@ gating_task:
         # Note: Image has dual purpose, see contrib/gate/README.md
         # The entrypoint.sh script ensures a prestine copy of $SRCPATH is
         # available at $GOSRC before executing make instructions.
-        image: "quay.io/libpod/gate:master"
+        image: "quay.io/libpod/gate:$DEST_BRANCH"
         cpu: 8
         memory: 12
 
@@ -256,7 +256,7 @@ varlink_api_task:
     # Runs within Cirrus's "community cluster"
     container:
         # Note: Image has dual purpose, see contrib/gate/README.md
-        image: "quay.io/libpod/gate:master"
+        image: "quay.io/libpod/gate:$DEST_BRANCH"
         cpu: 4
         memory: 12
 
@@ -343,7 +343,7 @@ meta_task:
         - "build_without_cgo"
 
     container:
-        image: "quay.io/libpod/imgts:master"  # see contrib/imgts
+        image: "quay.io/libpod/imgts:$DEST_BRANCH"  # see contrib/imgts
         cpu: 1
         memory: 1
 
@@ -366,32 +366,6 @@ meta_task:
 
     # Cirrus-CI ignores entrypoint defined in image
     script: '$CIRRUS_WORKING_DIR/$SCRIPT_BASE/update_meta.sh |& ${TIMESTAMP}'
-
-
-# Remove old and disused images based on labels set by meta_task
-image_prune_task:
-
-    # This should ONLY ever run from the master branch, and never
-    # anywhere else so it's behavior is always consistent, even
-    # as new branches are created.
-    only_if: $CIRRUS_BRANCH == "master"
-
-    depends_on:
-        - "meta"
-
-    container:
-        image: "quay.io/libpod/imgprune:master"  # see contrib/imgprune
-        cpu: 1
-        memory: 1
-
-    env:
-        <<: *meta_env_vars
-        GCPJSON: ENCRYPTED[4c11d8e09c904c30fc70eecb95c73dec0ddf19976f9b981a0f80f3f6599e8f990bcef93c253ac0277f200850d98528e7]
-        GCPNAME: ENCRYPTED[7f54557ba6e5a437f11283a53e71baec9ca546f48a9835538cc54d297f79968eb1337d4596a1025b14f9d1c5723fbd29]
-
-    timeout_in: 10m
-
-    script: '/usr/local/bin/entrypoint.sh |& ${TIMESTAMP}'
 
 
 # This task does the unit and integration testing for every platform
@@ -738,7 +712,6 @@ success_task:
         - "build_without_cgo"
         - "container_image_build"
         - "meta"
-        - "image_prune"
         - "testing"
         - "rpmbuild"
         - "special_testing_rootless"
@@ -758,7 +731,7 @@ success_task:
 
     container:
         # Note: Image has dual purpose, see contrib/gate/README.md
-        image: "quay.io/libpod/gate:master"
+        image: "quay.io/libpod/gate:$DEST_BRANCH"
         cpu: 1
         memory: 1
 

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -56,7 +56,7 @@ fi
 # Defaults when not running under CI
 export CI="${CI:-false}"
 CIRRUS_CI="${CIRRUS_CI:-false}"
-DEST_BRANCH="${DEST_BRANCH:-master}"
+DEST_BRANCH="${DEST_BRANCH:-v2.0}"
 CONTINUOUS_INTEGRATION="${CONTINUOUS_INTEGRATION:-false}"
 CIRRUS_REPO_NAME=${CIRRUS_REPO_NAME:-libpod}
 CIRRUS_BASE_SHA=${CIRRUS_BASE_SHA:-unknown$(date +%s)}  # difficult to reliably discover


### PR DESCRIPTION
Also remove job that only runs on 'master', and reference most container
image names using the v2.0 branch tag.

Signed-off-by: Chris Evich <cevich@redhat.com>