### PR TITLE
Stop following logs using timers

### DIFF
--- a/libpod/container_log.go
+++ b/libpod/container_log.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/libpod/libpod/define"
 	"github.com/containers/libpod/libpod/logs"
+	"github.com/hpcloud/tail/watch"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -88,8 +89,8 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 		go func() {
 			for {
 				state, err := c.State()
+				time.Sleep(watch.POLL_DURATION)
 				if err != nil {
-					time.Sleep(250 * time.Millisecond)
 					tailError := t.StopAtEOF()
 					if tailError != nil && fmt.Sprintf("%v", tailError) != "tail: stop at eof" {
 						logrus.Error(tailError)
@@ -100,14 +101,12 @@ func (c *Container) readFromLogFile(options *logs.LogOptions, logChannel chan *l
 					break
 				}
 				if state != define.ContainerStateRunning && state != define.ContainerStatePaused {
-					time.Sleep(250 * time.Millisecond)
 					tailError := t.StopAtEOF()
 					if tailError != nil && fmt.Sprintf("%v", tailError) != "tail: stop at eof" {
 						logrus.Error(tailError)
 					}
 					break
 				}
-				time.Sleep(250 * time.Millisecond)
 			}
 		}()
 	}

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -311,4 +311,16 @@ var _ = Describe("Podman logs", func() {
 		logs.WaitWithDefaultTimeout()
 		Expect(logs).To(Not(Exit(0)))
 	})
+
+	It("follow output stopped container", func() {
+		containerName := "logs-f"
+
+		logc := podmanTest.Podman([]string{"run", "--name", containerName, "-d", ALPINE})
+		logc.WaitWithDefaultTimeout()
+		Expect(logc).To(Exit(0))
+
+		results := podmanTest.Podman([]string{"logs", "-f", containerName})
+		results.WaitWithDefaultTimeout()
+		Expect(results).To(Exit(0))
+	})
 })

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -315,7 +315,7 @@ var _ = Describe("Podman logs", func() {
 	It("follow output stopped container", func() {
 		containerName := "logs-f"
 
-		logc := podmanTest.Podman([]string{"run", "--name", containerName, "-d", ALPINE})
+		logc := podmanTest.Podman([]string{"run", "--name", containerName, "-d", ALPINE, "true"})
 		logc.WaitWithDefaultTimeout()
 		Expect(logc).To(Exit(0))
 


### PR DESCRIPTION
This incorporates code from PR #6591 and #6614 but does not use
event channels to detect container state and rather uses timers
with a defined wait duration before calling `t.StopAtEOF()` to
ensure the last log entry is output before a container exits.

The polling interval is set to 250 milliseconds based on polling
interval defined in hpcloud/tail here:
https://github.com/hpcloud/tail/blob/v1.0.0/watch/polling.go#L117

Close #6531

Co-authored-by: Qi Wang <qiwan@redhat.com>
Signed-off-by: jgallucci32 <john.gallucci.iv@gmail.com>