### PR TITLE
Add podman network to bash command completions

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1018,14 +1018,15 @@ _podman_network_create() {
 	    ;;
     esac
 }
+
 _podman_network_inspect() {
     local options_with_args="
+	--format
+	-f
      "
     local boolean_options="
 	--help
 	-h
-	--format
-	-f
     "
     _complete_ "$options_with_args" "$boolean_options"
 
@@ -1038,15 +1039,15 @@ _podman_network_inspect() {
 
 _podman_network_ls() {
     local options_with_args="
+	--format
+	-f
+	--filter
      "
     local boolean_options="
     --help
     -h
 	--quiet
 	-q
-	--format
-	-f
-	-- filter
     "
     _complete_ "$options_with_args" "$boolean_options"
 
@@ -3565,6 +3566,7 @@ _podman_podman() {
     logs
     manifest
     mount
+    network
     pause
     pod
     port


### PR DESCRIPTION
network commands were not supported in command completions.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>