### PR TITLE
Makefile: allow customizable GO_BUILD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ PRE_COMMIT = $(shell command -v bin/venv/bin/pre-commit ~/.local/bin/pre-commit 
 
 SOURCES = $(shell find . -path './.*' -prune -o -name "*.go")
 
-GO_BUILD=$(GO) build
+GO_BUILD ?= $(GO) build
 # Go module support: set `-mod=vendor` to use the vendored sources
 ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
-	GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
+	GO_BUILD ?= GO111MODULE=on $(GO) build -mod=vendor
 endif
 
 BUILDTAGS_CROSS ?= containers_image_openpgp exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_overlay


### PR DESCRIPTION
This will let me use a customizable GO_BUILD so that I can run build
targets for deb packages

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@rhatdan @baude @mheon @vrothberg PTAL.