### PR TITLE
Bump required go version to 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/libpod
 
-go 1.12
+go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1


### PR DESCRIPTION
Recent versions of libpod use features from github.com/pkg/errors
that are only available when building with go 1.13 or newer.
