### PR TITLE
libpod/containers/json: alias last -> limit

### DIFF
--- a/pkg/bindings/containers/containers.go
+++ b/pkg/bindings/containers/containers.go
@@ -35,7 +35,7 @@ func List(ctx context.Context, filters map[string][]string, all *bool, last *int
 		params.Set("all", strconv.FormatBool(*all))
 	}
 	if last != nil {
-		params.Set("last", strconv.Itoa(*last))
+		params.Set("limit", strconv.Itoa(*last))
 	}
 	if pod != nil {
 		params.Set("pod", strconv.FormatBool(*pod))

--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -26,6 +26,27 @@ t GET libpod/containers/json?all=true 200 \
   .[0].ExitCode=0 \
   .[0].IsInfra=false
 
+# Make sure `limit` works.
+t GET libpod/containers/json?limit=1 200 \
+  length=1 \
+  .[0].Id~[0-9a-f]\\{64\\} \
+  .[0].Image=$IMAGE \
+  .[0].Command[0]="true" \
+  .[0].State~\\\(exited\\\|stopped\\\) \
+  .[0].ExitCode=0 \
+  .[0].IsInfra=false
+
+# Make sure `last` works, which is an alias for `limit`.
+# See https://github.com/containers/libpod/issues/6413.
+t GET libpod/containers/json?last=1 200 \
+  length=1 \
+  .[0].Id~[0-9a-f]\\{64\\} \
+  .[0].Image=$IMAGE \
+  .[0].Command[0]="true" \
+  .[0].State~\\\(exited\\\|stopped\\\) \
+  .[0].ExitCode=0 \
+  .[0].IsInfra=false
+
 cid=$(jq -r '.[0].Id' <<<"$output")
 
 t DELETE libpod/containers/$cid 204


### PR DESCRIPTION
Support both `last` and `limit` for in the containers listing endpoint.
We intended to use `limit` which is also mentioned in the docs, but the
implementation ended up using `last` as the http parameter; likely being
caused by the CLI using `--last`.  To avoid any regression, we decided
for supporting both and aliasing `last`.

Fixes: #6413
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>