### PR TITLE
Re-add PODMAN_USERNS environment variable

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/libpod/cmd/podman/registry"
@@ -464,7 +465,7 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 		"Username or UID (format: <name|uid>[:<group|gid>])",
 	)
 	createFlags.String(
-		"userns", "",
+		"userns", os.Getenv("PODMAN_USERNS"),
 		"User namespace to use",
 	)
 	createFlags.String(


### PR DESCRIPTION
This was lost during the Podman 2.0 migration. Turns out to be a very easy fix, fortunately - we want to use the environment var if not explicitly overridden.
