### PR TITLE
Fix conflicts between privileged and other flags

### DIFF
--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -156,10 +156,6 @@ func replaceContainer(name string) error {
 }
 
 func createInit(c *cobra.Command) error {
-	if c.Flag("privileged").Changed && c.Flag("security-opt").Changed {
-		logrus.Warn("setting security options with --privileged has no effect")
-	}
-
 	if c.Flag("shm-size").Changed {
 		cliVals.ShmSize = c.Flag("shm-size").Value.String()
 	}

--- a/pkg/specgen/container_validate.go
+++ b/pkg/specgen/container_validate.go
@@ -61,10 +61,6 @@ func (s *SpecGenerator) Validate() error {
 	//
 	// ContainerSecurityConfig
 	//
-	// groups and privileged are exclusive
-	if len(s.Groups) > 0 && s.Privileged {
-		return exclusiveOptions("Groups", "privileged")
-	}
 	// capadd and privileged are exclusive
 	if len(s.CapAdd) > 0 && s.Privileged {
 		return exclusiveOptions("CapAdd", "privileged")

--- a/pkg/specgen/specgen.go
+++ b/pkg/specgen/specgen.go
@@ -207,6 +207,7 @@ type ContainerSecurityConfig struct {
 	// - Adds all devices on the system to the container.
 	// - Adds all capabilities to the container.
 	// - Disables Seccomp, SELinux, and Apparmor confinement.
+	//   (Though SELinux can be manually re-enabled).
 	// TODO: this conflicts with things.
 	// TODO: this does more.
 	Privileged bool `json:"privileged,omitempty"`


### PR DESCRIPTION
The `--privileged` flag does not conflict with `--group-add` (this one was breaking Toolbox) and does not conflict with most parts of `--security-opt` (this was breaking Openstack).