### PR TITLE
[1.9] CI: force registry:2.6

### DIFF
--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -180,6 +180,12 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 			errors.Wrapf(err, "Failed to parse parameters for %s", r.URL.String()))
 		return
 	}
+	name := utils.GetName(r)
+	newImage, err := runtime.ImageRuntime().NewFromLocal(name)
+	if err != nil {
+		utils.ImageNotFound(w, name, err)
+		return
+	}
 	switch query.Format {
 	case define.OCIArchive, define.V2s2Archive:
 		tmpfile, err := ioutil.TempFile("", "api.tar")
@@ -203,13 +209,6 @@ func ExportImage(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, "unknown format", http.StatusInternalServerError, errors.Errorf("unknown format %q", query.Format))
 		return
 	}
-	name := utils.GetName(r)
-	newImage, err := runtime.ImageRuntime().NewFromLocal(name)
-	if err != nil {
-		utils.ImageNotFound(w, name, err)
-		return
-	}
-
 	if err := newImage.Save(r.Context(), name, query.Format, output, []string{}, false, query.Compress); err != nil {
 		utils.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest, err)
 		return

--- a/test/e2e/config_amd64.go
+++ b/test/e2e/config_amd64.go
@@ -8,6 +8,6 @@ var (
 	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, registry, infra, labels, healthcheck}
 	nginx                    = "quay.io/libpod/alpine_nginx:latest"
 	BB_GLIBC                 = "docker.io/library/busybox:glibc"
-	registry                 = "docker.io/library/registry:2"
+	registry                 = "docker.io/library/registry:2.6"
 	labels                   = "quay.io/libpod/alpine_labels:latest"
 )

--- a/test/e2e/images_test.go
+++ b/test/e2e/images_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Podman images", func() {
 			Skip("Does not work on remote client")
 		}
 		dockerfile := `FROM docker.io/library/alpine:latest
-RUN apk update && apk add man
+RUN apk update && apk add strace
 `
 		podmanTest.BuildImage(dockerfile, "foobar.com/before:latest", "false")
 		result := podmanTest.Podman([]string{"images", "-q", "-f", "before=foobar.com/before:latest"})

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Podman login and logout", func() {
 			}
 		}
 
-		session := podmanTest.Podman([]string{"run", "--entrypoint", "htpasswd", "registry:2", "-Bbn", "podmantest", "test"})
+		session := podmanTest.Podman([]string{"run", "--entrypoint", "htpasswd", "registry:2.6", "-Bbn", "podmantest", "test"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -84,7 +84,7 @@ var _ = Describe("Podman login and logout", func() {
 			strings.Join([]string{authPath, "/auth"}, ":"), "-e", "REGISTRY_AUTH=htpasswd", "-e",
 			"REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm", "-e", "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd",
 			"-v", strings.Join([]string{certPath, "/certs"}, ":"), "-e", "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt",
-			"-e", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key", "registry:2"})
+			"-e", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key", "registry:2.6"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 
@@ -228,7 +228,7 @@ var _ = Describe("Podman login and logout", func() {
 			strings.Join([]string{authPath, "/auth"}, ":"), "-e", "REGISTRY_AUTH=htpasswd", "-e",
 			"REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm", "-e", "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd",
 			"-v", strings.Join([]string{certPath, "/certs"}, ":"), "-e", "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt",
-			"-e", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key", "registry:2"})
+			"-e", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key", "registry:2.6"})
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 

--- a/test/endpoint/config.go
+++ b/test/endpoint/config.go
@@ -10,7 +10,7 @@ var (
 	CACHE_IMAGES             = []string{ALPINE, BB, fedoraMinimal, nginx, redis, registry, infra, labels}
 	nginx                    = "quay.io/libpod/alpine_nginx:latest"
 	BB_GLIBC                 = "docker.io/library/busybox:glibc"
-	registry                 = "docker.io/library/registry:2"
+	registry                 = "docker.io/library/registry:2.6"
 	labels                   = "quay.io/libpod/alpine_labels:latest"
 )
 

--- a/test/system/150-login.bats
+++ b/test/system/150-login.bats
@@ -61,9 +61,9 @@ function setup() {
     mkdir -p ${PODMAN_LOGIN_WORKDIR}/runroot
     PODMAN_LOGIN_ARGS="--root ${PODMAN_LOGIN_WORKDIR}/root --runroot ${PODMAN_LOGIN_WORKDIR}/runroot"
     # Give it three tries, to compensate for flakes
-    run_podman ${PODMAN_LOGIN_ARGS} pull registry:2 ||
-        run_podman ${PODMAN_LOGIN_ARGS} pull registry:2 ||
-        run_podman ${PODMAN_LOGIN_ARGS} pull registry:2
+    run_podman ${PODMAN_LOGIN_ARGS} pull registry:2.6 ||
+        run_podman ${PODMAN_LOGIN_ARGS} pull registry:2.6 ||
+        run_podman ${PODMAN_LOGIN_ARGS} pull registry:2.6
 
     # Registry image needs a cert. Self-signed is good enough.
     CERT=$AUTHDIR/domain.crt
@@ -77,7 +77,7 @@ function setup() {
     # Store credentials where container will see them
     if [ ! -e $AUTHDIR/htpasswd ]; then
         run_podman ${PODMAN_LOGIN_ARGS} run --rm                  \
-                   --entrypoint htpasswd registry:2               \
+                   --entrypoint htpasswd registry:2.6             \
                    -Bbn ${PODMAN_LOGIN_USER} ${PODMAN_LOGIN_PASS} \
                    > $AUTHDIR/htpasswd
 
@@ -97,7 +97,7 @@ function setup() {
                -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
                -e REGISTRY_HTTP_TLS_CERTIFICATE=/auth/domain.crt \
                -e REGISTRY_HTTP_TLS_KEY=/auth/domain.key \
-               registry:2
+               registry:2.6
 }
 
 # END   first "test" - start a registry for use by other tests


### PR DESCRIPTION
For using the `registry:2.6` image. 2.7 and beyond dropped the
`htpasswd` binary from the rootfs which parts of our CI depends
on.

While this is not a sustainable solution (assuming `htpasswd` is gone
for ever), it unblocks the CI for now.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>