### PR TITLE
Fix default AppArmor profile to contain version suffix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,3 +67,5 @@ require (
 	k8s.io/apimachinery v0.18.4
 	k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
 )
+
+replace github.com/containers/common v0.14.0 => github.com/openSUSE/containers-common v0.1.4-0.20200623120750-c01f6534bad2

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,6 @@ github.com/containernetworking/plugins v0.8.6 h1:npZTLiMa4CRn6m5P9+1Dz4O1j0UeFbm
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containers/buildah v1.15.0 h1:p9cYJwcQ5Fnv0iBeHAFwHR0K+kcv7LbyAjUtc+HjYsc=
 github.com/containers/buildah v1.15.0/go.mod h1:j0AY2kWpmaOPPV5GKDJY9dMtekk5WMmMhcB+z0OW+vc=
-github.com/containers/common v0.14.0 h1:hiZFDPf6ajKiDmojN5f5X3gboKPO73NLrYb0RXfrQiA=
-github.com/containers/common v0.14.0/go.mod h1:9olhlE+WhYof1npnMJdyRMX14/yIUint6zyHzcyRVAg=
 github.com/containers/conmon v2.0.18+incompatible h1:rjwjNnE756NuXcdE/uUmj4kDbrykslPuBMHI31wh43E=
 github.com/containers/conmon v2.0.18+incompatible/go.mod h1:hgwZ2mtuDrppv78a/cOBNiCm6O0UMWGx1mu7P00nu5I=
 github.com/containers/image/v5 v5.4.4/go.mod h1:g7cxNXitiLi6pEr9/L9n/0wfazRuhDKXU15kV86N8h8=
@@ -315,6 +313,8 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/openSUSE/containers-common v0.1.4-0.20200623120750-c01f6534bad2 h1:FO7pwVzlsAgqz9o2eUBRBoSDyzr6VfVZeYp42HR+s3k=
+github.com/openSUSE/containers-common v0.1.4-0.20200623120750-c01f6534bad2/go.mod h1:9olhlE+WhYof1npnMJdyRMX14/yIUint6zyHzcyRVAg=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/libpod/container_internal_linux.go
+++ b/libpod/container_internal_linux.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containers/libpod/pkg/resolvconf"
 	"github.com/containers/libpod/pkg/rootless"
 	"github.com/containers/libpod/pkg/util"
+	"github.com/containers/libpod/version"
 	"github.com/containers/storage/pkg/archive"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/user"
@@ -245,6 +246,10 @@ func (c *Container) generateSpec(ctx context.Context) (*spec.Spec, error) {
 
 	// Apply AppArmor checks and load the default profile if needed.
 	if !c.config.Privileged {
+		// Default profiles should be suffixed with podmans version number
+		if c.config.Spec.Process.ApparmorProfile == apparmor.Profile {
+			c.config.Spec.Process.ApparmorProfile += "-" + version.Version
+		}
 		updatedProfile, err := apparmor.CheckProfileAndLoadDefault(c.config.Spec.Process.ApparmorProfile)
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/containers/common/pkg/apparmor/apparmor_linux.go
+++ b/vendor/github.com/containers/common/pkg/apparmor/apparmor_linux.go
@@ -255,9 +255,13 @@ func CheckProfileAndLoadDefault(name string) (string, error) {
 		}
 	}
 
-	// If the specified name is not empty or is not a default libpod one,
-	// ignore it and return the name.
-	if name != "" && !strings.HasPrefix(name, ProfilePrefix) {
+	if name == "" {
+		name = Profile
+	}
+
+	// If the specified name is not a default one, ignore it and return the
+	// name.
+	if !strings.HasPrefix(name, ProfilePrefix) && !strings.HasPrefix(name, Profile) {
 		isLoaded, err := IsLoaded(name)
 		if err != nil {
 			return "", err
@@ -268,7 +272,6 @@ func CheckProfileAndLoadDefault(name string) (string, error) {
 		return name, nil
 	}
 
-	name = Profile
 	// To avoid expensive redundant loads on each invocation, check
 	// if it's loaded before installing it.
 	isLoaded, err := IsLoaded(name)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/containers/buildah/pkg/secrets
 github.com/containers/buildah/pkg/supplemented
 github.com/containers/buildah/pkg/umask
 github.com/containers/buildah/util
-# github.com/containers/common v0.14.0
+# github.com/containers/common v0.14.0 => github.com/openSUSE/containers-common v0.1.4-0.20200623120750-c01f6534bad2
 github.com/containers/common/pkg/apparmor
 github.com/containers/common/pkg/auth
 github.com/containers/common/pkg/capabilities


### PR DESCRIPTION
The default AppArmor profile is now `container-default-$VERSION`, which
was previously only `container-default`.

Requires https://github.com/containers/common/pull/185
Fixes https://github.com/containers/libpod/issues/6724