### PR TITLE
system tests: invoke with abs path to podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ remoteintegration: varlink_generate test-binaries ginkgo-remote
 localsystem:
 	# Wipe existing config, database, and cache: start with clean slate.
 	$(RM) -rf ${HOME}/.local/share/containers ${HOME}/.config/containers
-	if timeout -v 1 true; then PODMAN=./bin/podman bats test/system/; else echo "Skipping $@: 'timeout -v' unavailable'"; fi
+	if timeout -v 1 true; then PODMAN=$(shell pwd)/bin/podman bats test/system/; else echo "Skipping $@: 'timeout -v' unavailable'"; fi
 
 .PHONY: remotesystem
 remotesystem:
@@ -378,7 +378,7 @@ remotesystem:
 			echo "Error: ./bin/podman system service did not come up on $$SOCK_FILE" >&2;\
 			exit 1;\
 		fi;\
-		env PODMAN="./bin/podman-remote --url $$PODMAN_SOCKET" bats test/system/ ;\
+		env PODMAN="$(shell pwd)/bin/podman-remote --url $$PODMAN_SOCKET" bats test/system/ ;\
 		rc=$$?;\
 		kill %1;\
 		rm -f $$SOCK_FILE;\

--- a/contrib/cirrus/logformatter
+++ b/contrib/cirrus/logformatter
@@ -231,6 +231,10 @@ END_HTML
         if ($looks_like_bats) {
             my $css;
 
+            # Readability: /long/path/to/podman -> podman (hover for full path)
+            $line =~ s{^(#\s+(#|\$)\s+)(\S+/)(podman\S*)\s}
+                      {$1<span title="$3$4">$4</span> };
+
             if    ($line =~ /^ok\s.*\s# skip/) { $css = 'skipped' }
             elsif ($line =~ /^ok\s/)           { $css = 'passed'  }
             elsif ($line =~ /^not\s+ok\s/)     { $css = 'failed'  }

--- a/contrib/cirrus/logformatter.t
+++ b/contrib/cirrus/logformatter.t
@@ -88,12 +88,16 @@ __END__
 ok 1 hi
 ok 2 bye # skip no reason
 not ok 3 fail
+# $ /path/to/podman foo -bar
+# #| FAIL: exit code is 123; expected 321
 ok 4 blah
 >>>
 1..4
 <span class='bats-passed'><a name='t--00001'>ok 1 hi</a></span>
 <span class='bats-skipped'><a name='t--00002'>ok 2 bye # skip no reason</a></span>
 <span class='bats-failed'><a name='t--00003'>not ok 3 fail</a></span>
+<span class='bats-log'># $ <span title="/path/to/podman">podman</span> foo -bar</span>
+<span class='bats-log-esm'># #| FAIL: exit code is 123; expected 321</span>
 <span class='bats-passed'><a name='t--00004'>ok 4 blah</a></span>
 <hr/><span class='bats-summary'>Summary: <span class='bats-passed'>2 Passed</span>, <span class='bats-failed'>1 Failed</span>, <span class='bats-skipped'>1 Skipped</span>. Total tests: 4</span>
 

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -2,12 +2,6 @@
 
 # Podman command to run; may be podman-remote
 PODMAN=${PODMAN:-podman}
-# If it's a relative path, convert to absolute; otherwise tests can't cd out
-if [[ "$PODMAN" =~ / ]]; then
-    if [[ ! "$PODMAN" =~ ^/ ]]; then
-        PODMAN=$(realpath $PODMAN)
-    fi
-fi
 
 # Standard image to use for most tests
 PODMAN_TEST_IMAGE_REGISTRY=${PODMAN_TEST_IMAGE_REGISTRY:-"quay.io"}
@@ -21,6 +15,12 @@ IMAGE=$PODMAN_TEST_IMAGE_FQN
 
 # Default timeout for a podman command.
 PODMAN_TIMEOUT=${PODMAN_TIMEOUT:-60}
+
+# Prompt to display when logging podman commands; distinguish root/rootless
+_LOG_PROMPT='$'
+if [ $(id -u) -eq 0 ]; then
+    _LOG_PROMPT='#'
+fi
 
 ###############################################################################
 # BEGIN setup/teardown tools
@@ -138,7 +138,7 @@ function run_podman() {
     esac
 
     # stdout is only emitted upon error; this echo is to help a debugger
-    echo "\$ $PODMAN $*"
+    echo "$_LOG_PROMPT $PODMAN $*"
     # BATS hangs if a subprocess remains and keeps FD 3 open; this happens
     # if podman crashes unexpectedly without cleaning up subprocesses.
     run timeout --foreground -v --kill=10 $PODMAN_TIMEOUT $PODMAN "$@" 3>/dev/null


### PR DESCRIPTION
Reversion of one part of #6679: my handling of 'realpath'
would not work when $PODMAN is 'podman-remote --url etc'.
Trying to handle that case got unmaintainable; so instead
let's just force 'make {local,remote}system' to invoke
with a full PODMAN path. This breaks down if someone
runs the tests with a manual 'bats' invocation, but I
think I'm the only one who ever does that.

Since podman path will now be very long in the logs,
add code to logformatter to abbreviate it like we do
for the ginkgo logs.

And, one thing that has bugged me for a long time:
in the error logs, show a different prompt ('#' vs '$')
to distinguish root vs rootless. This should make it
much easier to see at-a-glance whether a log file
is root or not. Add tests for it.

Signed-off-by: Ed Santiago <santiago@redhat.com>