### PR TITLE
Add tests for --privileged with other flags

### DIFF
--- a/test/e2e/run_selinux_test.go
+++ b/test/e2e/run_selinux_test.go
@@ -177,4 +177,13 @@ var _ = Describe("Podman run", func() {
 		Expect(session.OutputToString()).To(Equal(session1.OutputToString()))
 	})
 
+	It("podman run --privileged and --security-opt SELinux options", func() {
+		session := podmanTest.Podman([]string{"run", "-it", "--privileged", "--security-opt", "label=type:spc_t", "--security-opt", "label=level:s0:c1,c2", ALPINE, "cat", "/proc/self/attr/current"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		match, _ := session.GrepString("spc_t")
+		Expect(match).To(BeTrue())
+		match2, _ := session.GrepString("s0:c1,c2")
+		Expect(match2).To(BeTrue())
+	})
 })

--- a/test/e2e/run_test.go
+++ b/test/e2e/run_test.go
@@ -1039,4 +1039,12 @@ USER mail`
 		session.WaitWithDefaultTimeout()
 		Expect(session.ExitCode()).To(Equal(0))
 	})
+
+	It("podman run --privileged and --group-add", func() {
+		groupName := "kvm"
+		session := podmanTest.Podman([]string{"run", "-t", "-i", "--group-add", groupName, "--privileged", fedoraMinimal, "groups"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(strings.Contains(session.OutputToString(), groupName)).To(BeTrue())
+	})
 })


### PR DESCRIPTION
With Podman v2.0, we broke (or thought we were going to break) using `--privileged` with `--group-add` and `--security-opt` (specifically using `--security-opt` for SELinux config).