### PR TITLE
Set stop signal to 15 when not explicitly set

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -535,7 +535,6 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 
 	s.SeccompPolicy = c.SeccompPolicy
 
-	// TODO: should parse out options
 	s.VolumesFrom = c.VolumesFrom
 
 	// Only add read-only tmpfs mounts in case that we are read-only and the
@@ -547,22 +546,10 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	s.Mounts = mounts
 	s.Volumes = volumes
 
-	// TODO any idea why this was done
-	// devices := rtc.Containers.Devices
-	// TODO conflict on populate?
-	//
-	// if c.Changed("device") {
-	//	devices = append(devices, c.StringSlice("device")...)
-	// }
-
 	for _, dev := range c.Devices {
 		s.Devices = append(s.Devices, specs.LinuxDevice{Path: dev})
 	}
 
-	// TODO things i cannot find in spec
-	// we dont think these are in the spec
-	// init - initbinary
-	// initpath
 	s.Init = c.Init
 	s.InitPath = c.InitPath
 	s.Stdin = c.Interactive
@@ -586,11 +573,6 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 		}
 		s.Rlimits = append(s.Rlimits, rl)
 	}
-
-	// Tmpfs:         c.StringArray("tmpfs"),
-
-	// TODO how to handle this?
-	// Syslog:        c.Bool("syslog"),
 
 	logOpts := make(map[string]string)
 	for _, o := range c.LogOptions {

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -83,6 +83,8 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 			return nil, errors.Wrapf(err, "converting containers.conf ShmSize %s to an int", r.config.Containers.ShmSize)
 		}
 		ctr.config.ShmSize = size
+		ctr.config.StopSignal = 15
+		ctr.config.StopTimeout = r.config.Engine.StopTimeout
 	} else {
 		// This is a restore from an imported checkpoint
 		ctr.restoreFromCheckpoint = true
@@ -106,8 +108,6 @@ func (r *Runtime) initContainerVariables(rSpec *spec.Spec, config *ContainerConf
 	ctr.config.CreatedTime = time.Now()
 
 	ctr.state.BindMounts = make(map[string]string)
-
-	ctr.config.StopTimeout = r.config.Engine.StopTimeout
 
 	ctr.config.OCIRuntime = r.defaultOCIRuntime.Name()
 

--- a/test/e2e/create_test.go
+++ b/test/e2e/create_test.go
@@ -458,4 +458,17 @@ var _ = Describe("Podman create", func() {
 			Expect(session.ExitCode()).To(Equal(0))
 		}
 	})
+
+	It("podman create sets default stop signal 15", func() {
+		ctrName := "testCtr"
+		session := podmanTest.Podman([]string{"create", "--name", ctrName, ALPINE, "/bin/sh"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		inspect := podmanTest.Podman([]string{"inspect", ctrName})
+		inspect.WaitWithDefaultTimeout()
+		data := inspect.InspectContainerToJSON()
+		Expect(len(data)).To(Equal(1))
+		Expect(data[0].Config.StopSignal).To(Equal(uint(15)))
+	})
 })


### PR DESCRIPTION
When going through the output of `podman inspect` to try and identify another issue, I noticed that Podman 2.0 was setting
StopSignal to 0 on containers by default. After chasing it through the command line and SpecGen, I determined that we were
actually not setting a default in Libpod, which is strange because I swear we used to do that. I re-added the disappeared default and now all is well again.

Also, while I was looking for the bug in SpecGen, I found a bunch of TODOs that have already been done. Eliminate the comments for these.