### PR TITLE
APIv2:fix: Remove `/json` from compat network EPs

### DIFF
--- a/pkg/api/server/register_networks.go
+++ b/pkg/api/server/register_networks.go
@@ -32,7 +32,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/InternalError"
 	r.HandleFunc(VersionedPath("/networks/{name}"), s.APIHandler(compat.RemoveNetwork)).Methods(http.MethodDelete)
 	r.HandleFunc("/networks/{name}", s.APIHandler(compat.RemoveNetwork)).Methods(http.MethodDelete)
-	// swagger:operation GET /networks/{name}/json compat compatInspectNetwork
+	// swagger:operation GET /networks/{name} compat compatInspectNetwork
 	// ---
 	// tags:
 	//  - networks (compat)
@@ -53,9 +53,9 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/NoSuchNetwork"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/networks/{name}/json"), s.APIHandler(compat.InspectNetwork)).Methods(http.MethodGet)
-	r.HandleFunc("/networks/{name}/json", s.APIHandler(compat.InspectNetwork)).Methods(http.MethodGet)
-	// swagger:operation GET /networks/json compat compatListNetwork
+	r.HandleFunc(VersionedPath("/networks/{name}"), s.APIHandler(compat.InspectNetwork)).Methods(http.MethodGet)
+	r.HandleFunc("/networks/{name}", s.APIHandler(compat.InspectNetwork)).Methods(http.MethodGet)
+	// swagger:operation GET /networks compat compatListNetwork
 	// ---
 	// tags:
 	//  - networks (compat)
@@ -68,7 +68,7 @@ func (s *APIServer) registerNetworkHandlers(r *mux.Router) error {
 	//     $ref: "#/responses/CompatNetworkList"
 	//   500:
 	//     $ref: "#/responses/InternalError"
-	r.HandleFunc(VersionedPath("/networks/json"), s.APIHandler(compat.ListNetworks)).Methods(http.MethodGet)
+	r.HandleFunc(VersionedPath("/networks"), s.APIHandler(compat.ListNetworks)).Methods(http.MethodGet)
 	r.HandleFunc("/networks", s.APIHandler(compat.ListNetworks)).Methods(http.MethodGet)
 	// swagger:operation POST /networks/create compat compatCreateNetwork
 	// ---


### PR DESCRIPTION
Just a trivial fix to make the network endpoints match the docker enginer API spec. Hopefully the current endpoint URLs aren't considered part of the API since they've already landed in podman 2.0, and we can fix them now. If we need to, we can just add the correct endpoints paths and leave the `/json` ones vestigial.

 AFAICT all of the other registered endpoints in the APIv2 compat layer which include a `/json` suffix are correct.