### PR TITLE
Fix ssh-agent support

### DIFF
--- a/cmd/podman/system/connection.go
+++ b/cmd/podman/system/connection.go
@@ -42,7 +42,7 @@ var (
 		RunE:               connection,
 		Example: `podman system connection server.fubar.com
   podman system connection --identity ~/.ssh/dev_rsa ssh://root@server.fubar.com:2222
-  podman system connection --identity ~/.ssh/dev_rsa -port 22 root@server.fubar.com`,
+  podman system connection --identity ~/.ssh/dev_rsa --port 22 root@server.fubar.com`,
 	}
 
 	cOpts = struct {
@@ -202,7 +202,7 @@ func getUDS(cmd *cobra.Command, uri *url.URL) (string, error) {
 		return "", errors.Wrapf(err, "failed to parse 'podman info' results")
 	}
 
-	if info.Host.RemoteSocket == nil || !info.Host.RemoteSocket.Exists {
+	if info.Host.RemoteSocket == nil || len(info.Host.RemoteSocket.Path) == 0 {
 		return "", fmt.Errorf("remote podman %q failed to report its UDS socket", uri.Host)
 	}
 	return info.Host.RemoteSocket.Path, nil

--- a/pkg/bindings/connection.go
+++ b/pkg/bindings/connection.go
@@ -181,12 +181,15 @@ func pingNewConnection(ctx context.Context) error {
 
 func sshClient(_url *url.URL, secure bool, passPhrase string, identity string) (Connection, error) {
 	authMethods := []ssh.AuthMethod{}
-	auth, err := terminal.PublicKey(identity, []byte(passPhrase))
-	if err != nil {
-		return Connection{}, errors.Wrapf(err, "failed to parse identity %q", identity)
+
+	if len(identity) > 0 {
+		auth, err := terminal.PublicKey(identity, []byte(passPhrase))
+		if err != nil {
+			return Connection{}, errors.Wrapf(err, "failed to parse identity %q", identity)
+		}
+		logrus.Debugf("public key signer enabled for identity %q", identity)
+		authMethods = append(authMethods, auth)
 	}
-	logrus.Debugf("public key signer enabled for identity %q", identity)
-	authMethods = append(authMethods, auth)
 
 	if sock, found := os.LookupEnv("SSH_AUTH_SOCK"); found {
 		logrus.Debugf("Found SSH_AUTH_SOCK %q, ssh-agent signer enabled", sock)


### PR DESCRIPTION
* An identity of "" implies ssh-agent and user/password to be used
* Fixed example
* Fixed issue where info.Host.RemoteSocket.Exists == false while info.Host.RemoteSocket.Path existed

Signed-off-by: Jhon Honce <jhonce@redhat.com>