### PR TITLE
APIv2: Return `StatusCreated` from volume creation

### DIFF
--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -73,7 +73,7 @@ func CreateVolume(w http.ResponseWriter, r *http.Request) {
 		UID:        config.UID,
 		GID:        config.GID,
 	}
-	utils.WriteResponse(w, http.StatusOK, volResponse)
+	utils.WriteResponse(w, http.StatusCreated, volResponse)
 }
 
 func InspectVolume(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The swagdoc in `register_volumes.go` already correctly notes that a 201
should be returned upon success, so we only need to change the handler
to match the spec.