### PR TITLE
libpod: specify mappings to the storage

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containers/libpod/pkg/selinux"
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/mount"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
@@ -359,6 +360,25 @@ func (c *Container) setupStorageMapping(dest, from *storage.IDMappingOptions) {
 				}
 			}
 			dest.AutoUserNsOpts.InitialSize = initialSize + 1
+		}
+	} else if c.config.Spec.Linux != nil {
+		dest.UIDMap = nil
+		for _, r := range c.config.Spec.Linux.UIDMappings {
+			u := idtools.IDMap{
+				ContainerID: int(r.ContainerID),
+				HostID:      int(r.HostID),
+				Size:        int(r.Size),
+			}
+			dest.UIDMap = append(dest.UIDMap, u)
+		}
+		dest.GIDMap = nil
+		for _, r := range c.config.Spec.Linux.GIDMappings {
+			g := idtools.IDMap{
+				ContainerID: int(r.ContainerID),
+				HostID:      int(r.HostID),
+				Size:        int(r.Size),
+			}
+			dest.GIDMap = append(dest.GIDMap, g)
 		}
 	}
 }

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -89,6 +89,13 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("podman --userns=keep-id root owns /usr", func() {
+		session := podmanTest.Podman([]string{"run", "--userns=keep-id", "alpine", "stat", "-c%u", "/usr"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		Expect(session.OutputToString()).To(Equal("0"))
+	})
+
 	It("podman --userns=keep-id --user root:root", func() {
 		session := podmanTest.Podman([]string{"run", "--userns=keep-id", "--user", "root:root", "alpine", "id", "-u"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
specify the mappings in the container configuration to the storage
when creating the container so that the correct mappings can be
configured.

Regression introduced with Podman 2.0.

Closes: https://github.com/containers/libpod/issues/6735

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>