### PR TITLE
[1.9] CI: disable bindings tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -535,32 +535,6 @@ special_testing_cross_task:
         type: "application/octet-stream"
 
 
-special_testing_bindings_task:
-
-    depends_on:
-        - "gating"
-        - "varlink_api"
-        - "vendor"
-
-    only_if: >-
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:IMG.*' &&
-        $CIRRUS_CHANGE_MESSAGE !=~ '.*CI:DOCS.*'
-
-    env:
-        SPECIALMODE: 'bindings'  # See docs
-
-    timeout_in: 40m
-
-    setup_environment_script: '$SCRIPT_BASE/setup_environment.sh |& ${TIMESTAMP}'
-    integration_test_script: '$SCRIPT_BASE/integration_test.sh |& ${TIMESTAMP} | ${LOGFORMAT} integration_test'
-
-    on_failure:
-        failed_branch_script: '$CIRRUS_WORKING_DIR/$SCRIPT_BASE/notice_branch_failure.sh'
-
-    always:
-        <<: *standardlogs
-
-
 special_testing_endpoint_task:
 
     depends_on:
@@ -746,7 +720,6 @@ success_task:
         - "special_testing_in_podman"
         - "special_testing_cross"
         - "special_testing_endpoint"
-        - "special_testing_bindings"
         - "test_build_cache_images"
         - "verify_test_built_images"
         - "docs"


### PR DESCRIPTION
Disable the bindings tests in the CI.  They primarilly targetted Podman
v2 development and pretty flaky and make backporting a bit harder.
So let's just silence them for the 1.9 branch.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>