### PR TITLE
podman untag: error if tag doesn't exist

### DIFF
--- a/completions/bash/podman
+++ b/completions/bash/podman
@@ -1572,6 +1572,11 @@ _podman_image_tag() {
      _podman_tag
 }
 
+
+_podman_image_untag() {
+     _podman_untag
+}
+
 _podman_image() {
     local boolean_options="
 	--help
@@ -1593,6 +1598,7 @@ _podman_image() {
 	 sign
 	 tag
 	 trust
+	 untag
      "
      local aliases="
 	 list
@@ -2444,6 +2450,23 @@ _podman_stats() {
 }
 
 _podman_tag() {
+    local options_with_args="
+    "
+    local boolean_options="
+	--help
+	-h
+    "
+    case "$cur" in
+	-*)
+	    COMPREPLY=($(compgen -W "$boolean_options $options_with_args" -- "$cur"))
+	    ;;
+	*)
+	    __podman_complete_images
+	    ;;
+    esac
+}
+
+_podman_untag() {
     local options_with_args="
     "
     local boolean_options="
@@ -3588,6 +3611,7 @@ _podman_podman() {
     umount
     unmount
     unpause
+    untag
     varlink
     version
     volume

--- a/docs/source/markdown/podman-untag.1.md
+++ b/docs/source/markdown/podman-untag.1.md
@@ -4,14 +4,12 @@
 podman\-untag - Removes one or more names from a locally-stored image
 
 ## SYNOPSIS
-**podman untag** *image*[:*tag*] [*target-names*[:*tag*]] [*options*]
+**podman untag** [*options*] *image* [*name*[:*tag*]...]
 
-**podman image untag** *image*[:*tag*] [target-names[:*tag*]] [*options*]
+**podman image untag** [*options*] *image* [*name*[:*tag*]...]
 
 ## DESCRIPTION
-Removes one or all names of an image. A name refers to the entire image name,
-including the optional *tag* after the `:`. If no target image names are
-specified, `untag` will remove all tags for the image at once.
+Remove one or more names from an image in the local storage.  The image can be referred to by ID or reference.  If a no name is specified, all names are removed the image.  If a specified name is a short name and does not include a registry `localhost/` will be prefixed (e.g., `fedora` -> `localhost/fedora`). If a specified name does not include a tag `:latest` will be appended (e.g., `localhost/fedora` -> `localhost/fedora:latest`).
 
 ## OPTIONS
 

--- a/libpod/define/errors.go
+++ b/libpod/define/errors.go
@@ -17,6 +17,9 @@ var (
 	// ErrNoSuchImage indicates the requested image does not exist
 	ErrNoSuchImage = image.ErrNoSuchImage
 
+	// ErrNoSuchTag indicates the requested image tag does not exist
+	ErrNoSuchTag = image.ErrNoSuchTag
+
 	// ErrNoSuchVolume indicates the requested volume does not exist
 	ErrNoSuchVolume = errors.New("no such volume")
 

--- a/libpod/image/errors.go
+++ b/libpod/image/errors.go
@@ -12,4 +12,6 @@ var (
 	ErrNoSuchPod = errors.New("no such pod")
 	// ErrNoSuchImage indicates the requested image does not exist
 	ErrNoSuchImage = errors.New("no such image")
+	// ErrNoSuchTag indicates the requested image tag does not exist
+	ErrNoSuchTag = errors.New("no such tag")
 )

--- a/libpod/image/image.go
+++ b/libpod/image/image.go
@@ -559,15 +559,24 @@ func (i *Image) TagImage(tag string) error {
 	return nil
 }
 
-// UntagImage removes a tag from the given image
+// UntagImage removes the specified tag from the image.
+// If the tag does not exist, ErrNoSuchTag is returned.
 func (i *Image) UntagImage(tag string) error {
 	if err := i.reloadImage(); err != nil {
 		return err
 	}
+
+	// Normalize the tag as we do with TagImage.
+	ref, err := NormalizedTag(tag)
+	if err != nil {
+		return err
+	}
+	tag = ref.String()
+
 	var newTags []string
 	tags := i.Names()
 	if !util.StringInSlice(tag, tags) {
-		return nil
+		return errors.Wrapf(ErrNoSuchTag, "%q", tag)
 	}
 	for _, t := range tags {
 		if tag != t {

--- a/test/system/020-tag.bats
+++ b/test/system/020-tag.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# helper function for "podman tag/untag" test
+function _tag_and_check() {
+    local tag_as="$1"
+    local check_as="$2"
+
+    run_podman tag $IMAGE $tag_as
+    run_podman image exists $check_as
+    run_podman untag $IMAGE $check_as
+    run_podman 1 image exists $check_as
+}
+
+@test "podman tag/untag" {
+	# Test a fully-qualified image reference.
+	_tag_and_check registry.com/image:latest registry.com/image:latest
+
+	# Test a reference without tag and make sure ":latest" is appended.
+	_tag_and_check registry.com/image registry.com/image:latest
+
+	# Test a tagged short image and make sure "localhost/" is prepended.
+	_tag_and_check image:latest localhost/image:latest
+
+	# Test a short image without tag and make sure "localhost/" is
+	# prepended and ":latest" is appended.
+	_tag_and_check image localhost/image:latest
+
+	# Test error case.
+	run_podman 125 untag $IMAGE registry.com/foo:bar
+	is "$output" "Error: \"registry.com/foo:bar\": no such tag"
+}
+
+# vim: filetype=sh


### PR DESCRIPTION
Throw an error if a specified tag does not exist.  Also make sure that
the user input is normalized as we already do for `podman tag`.

To prevent regressions, add a set of end-to-end and systemd tests.

Last but not least, update the docs and add bash completions.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>