### PR TITLE
container: move volume chown after spec generation

### DIFF
--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1854,8 +1854,8 @@ func (c *Container) unmount(force bool) error {
 // this should be from chrootarchive.
 // Container MUST be mounted before calling.
 func (c *Container) copyWithTarFromImage(source, dest string) error {
-	a := archive.NewDefaultArchiver()
-
+	mappings := idtools.NewIDMappingsFromMaps(c.config.IDMappings.UIDMap, c.config.IDMappings.GIDMap)
+	a := archive.NewArchiver(mappings)
 	if err := c.copyOwnerAndPerms(source, dest); err != nil {
 		return err
 	}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -1497,6 +1497,19 @@ func WithVolumeGID(gid int) VolumeCreateOption {
 	}
 }
 
+// WithVolumeNeedsChown sets the NeedsChown flag for the volume.
+func WithVolumeNeedsChown() VolumeCreateOption {
+	return func(volume *Volume) error {
+		if volume.valid {
+			return define.ErrVolumeFinalized
+		}
+
+		volume.state.NeedsChown = true
+
+		return nil
+	}
+}
+
 // withSetAnon sets a bool notifying libpod that this volume is anonymous and
 // should be removed when containers using it are removed and volumes are
 // specified for removal.

--- a/libpod/runtime_ctr.go
+++ b/libpod/runtime_ctr.go
@@ -309,7 +309,7 @@ func (r *Runtime) setupContainer(ctx context.Context, ctr *Container) (_ *Contai
 		logrus.Debugf("Creating new volume %s for container", vol.Name)
 
 		// The volume does not exist, so we need to create it.
-		volOptions := []VolumeCreateOption{WithVolumeName(vol.Name), WithVolumeUID(ctr.RootUID()), WithVolumeGID(ctr.RootGID())}
+		volOptions := []VolumeCreateOption{WithVolumeName(vol.Name), WithVolumeUID(ctr.RootUID()), WithVolumeGID(ctr.RootGID()), WithVolumeNeedsChown()}
 		if isAnonymous {
 			volOptions = append(volOptions, withSetAnon())
 		}

--- a/libpod/volume_inspect.go
+++ b/libpod/volume_inspect.go
@@ -65,8 +65,15 @@ func (v *Volume) Inspect() (*InspectVolumeData, error) {
 	for k, v := range v.config.Options {
 		data.Options[k] = v
 	}
-	data.UID = v.config.UID
-	data.GID = v.config.GID
+	var err error
+	data.UID, err = v.UID()
+	if err != nil {
+		return nil, err
+	}
+	data.GID, err = v.GID()
+	if err != nil {
+		return nil, err
+	}
 	data.Anonymous = v.config.IsAnon
 
 	return data, nil

--- a/pkg/api/handlers/libpod/volumes.go
+++ b/pkg/api/handlers/libpod/volumes.go
@@ -86,6 +86,17 @@ func InspectVolume(w http.ResponseWriter, r *http.Request) {
 		utils.VolumeNotFound(w, name, err)
 		return
 	}
+	var uid, gid int
+	uid, err = vol.UID()
+	if err != nil {
+		utils.Error(w, "Error fetching volume UID", http.StatusInternalServerError, err)
+		return
+	}
+	gid, err = vol.GID()
+	if err != nil {
+		utils.Error(w, "Error fetching volume GID", http.StatusInternalServerError, err)
+		return
+	}
 	volResponse := entities.VolumeConfigResponse{
 		Name:       vol.Name(),
 		Driver:     vol.Driver(),
@@ -94,8 +105,8 @@ func InspectVolume(w http.ResponseWriter, r *http.Request) {
 		Labels:     vol.Labels(),
 		Scope:      vol.Scope(),
 		Options:    vol.Options(),
-		UID:        vol.UID(),
-		GID:        vol.GID(),
+		UID:        uid,
+		GID:        gid,
 	}
 	utils.WriteResponse(w, http.StatusOK, volResponse)
 }
@@ -130,6 +141,17 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 	}
 	volumeConfigs := make([]*entities.VolumeListReport, 0, len(vols))
 	for _, v := range vols {
+		var uid, gid int
+		uid, err = v.UID()
+		if err != nil {
+			utils.Error(w, "Error fetching volume UID", http.StatusInternalServerError, err)
+			return
+		}
+		gid, err = v.GID()
+		if err != nil {
+			utils.Error(w, "Error fetching volume GID", http.StatusInternalServerError, err)
+			return
+		}
 		config := entities.VolumeConfigResponse{
 			Name:       v.Name(),
 			Driver:     v.Driver(),
@@ -138,8 +160,8 @@ func ListVolumes(w http.ResponseWriter, r *http.Request) {
 			Labels:     v.Labels(),
 			Scope:      v.Scope(),
 			Options:    v.Options(),
-			UID:        v.UID(),
-			GID:        v.GID(),
+			UID:        uid,
+			GID:        gid,
 		}
 		volumeConfigs = append(volumeConfigs, &entities.VolumeListReport{VolumeConfigResponse: config})
 	}

--- a/pkg/domain/infra/abi/volumes.go
+++ b/pkg/domain/infra/abi/volumes.go
@@ -95,6 +95,15 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 	}
 	reports := make([]*entities.VolumeInspectReport, 0, len(vols))
 	for _, v := range vols {
+		var uid, gid int
+		uid, err = v.UID()
+		if err != nil {
+			return nil, err
+		}
+		gid, err = v.GID()
+		if err != nil {
+			return nil, err
+		}
 		config := entities.VolumeConfigResponse{
 			Name:       v.Name(),
 			Driver:     v.Driver(),
@@ -103,8 +112,8 @@ func (ic *ContainerEngine) VolumeInspect(ctx context.Context, namesOrIds []strin
 			Labels:     v.Labels(),
 			Scope:      v.Scope(),
 			Options:    v.Options(),
-			UID:        v.UID(),
-			GID:        v.GID(),
+			UID:        uid,
+			GID:        gid,
 		}
 		reports = append(reports, &entities.VolumeInspectReport{VolumeConfigResponse: &config})
 	}
@@ -141,6 +150,15 @@ func (ic *ContainerEngine) VolumeList(ctx context.Context, opts entities.VolumeL
 	}
 	reports := make([]*entities.VolumeListReport, 0, len(vols))
 	for _, v := range vols {
+		var uid, gid int
+		uid, err = v.UID()
+		if err != nil {
+			return nil, err
+		}
+		gid, err = v.GID()
+		if err != nil {
+			return nil, err
+		}
 		config := entities.VolumeConfigResponse{
 			Name:       v.Name(),
 			Driver:     v.Driver(),
@@ -149,8 +167,8 @@ func (ic *ContainerEngine) VolumeList(ctx context.Context, opts entities.VolumeL
 			Labels:     v.Labels(),
 			Scope:      v.Scope(),
 			Options:    v.Options(),
-			UID:        v.UID(),
-			GID:        v.GID(),
+			UID:        uid,
+			GID:        gid,
 		}
 		reports = append(reports, &entities.VolumeListReport{VolumeConfigResponse: config})
 	}

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -245,4 +245,31 @@ var _ = Describe("Podman UserNS support", func() {
 		ok, _ := session.GrepString("4998")
 		Expect(ok).To(BeTrue())
 	})
+
+	It("podman --user with volume", func() {
+		tests := []struct {
+			uid, gid, arg, vol string
+		}{
+			{"0", "0", "0:0", "vol-0"},
+			{"1000", "0", "1000", "vol-1"},
+			{"1000", "1000", "1000:1000", "vol-2"},
+		}
+
+		for _, tt := range tests {
+			session := podmanTest.Podman([]string{"run", "-d", "--user", tt.arg, "--mount", "type=volume,src=" + tt.vol + ",dst=/home/user", "alpine", "top"})
+			session.WaitWithDefaultTimeout()
+			Expect(session.ExitCode()).To(Equal(0))
+
+			inspectUID := podmanTest.Podman([]string{"volume", "inspect", "--format", "{{ .UID }}", tt.vol})
+			inspectUID.WaitWithDefaultTimeout()
+			Expect(inspectUID.ExitCode()).To(Equal(0))
+			Expect(inspectUID.OutputToString()).To(Equal(tt.uid))
+
+			// Make sure we're defaulting to 0.
+			inspectGID := podmanTest.Podman([]string{"volume", "inspect", "--format", "{{ .GID }}", tt.vol})
+			inspectGID.WaitWithDefaultTimeout()
+			Expect(inspectGID.ExitCode()).To(Equal(0))
+			Expect(inspectGID.OutputToString()).To(Equal(tt.gid))
+		}
+	})
 })


### PR DESCRIPTION
move the chown for newly created volumes after the spec generation so the correct UID/GID are known.

Closes: https://github.com/containers/libpod/issues/5698

Alternative to: github.com/containers/libpod/pull/6730

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
