### PR TITLE
Add containers.conf default file for windows and MAC Installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,6 +478,7 @@ podman-remote-release-%.zip:
 	cp release.txt "$(TMPDIR)/"
 	cp ./bin/podman-remote-$*$(BINSFX) "$(TMPDIR)/$(SUBDIR)/podman$(BINSFX)"
 	cp -r ./docs/build/remote/$* "$(TMPDIR)/$(SUBDIR)/docs/"
+	cp ./contrib/remote/containers.conf "$(TMPDIR)/$(SUBDIR)/"
 	cd "$(TMPDIR)/$(SUBDIR)" && \
 		zip --recurse-paths "$(CURDIR)/$@" "./release.txt" "./"
 	-rm -rf "$(TMPDIR)"

--- a/contrib/remote/containers.conf
+++ b/contrib/remote/containers.conf
@@ -1,0 +1,11 @@
+# The containers configuration file specifies all of the available configuration
+# command-line options/flags for container engine tools like Podman
+# but in a TOML format that can be easily modified and versioned.
+
+[engine]
+
+# Default Remote URI to access the Podman service.
+# Examples:
+#  remote rootless ssh://engineering.lab.company.com/run/user/1000/podman/podman.sock
+#  remote rootfull ssh://root@10.10.1.136:22/run/podman/podman.sock
+# remote_uri= ""


### PR DESCRIPTION
We want to add this configuration file so that users can descover
how to configure the permanent connection to a remote podman instance.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>