### PR TITLE
Allow security-opts to be parsed even if container is --privileged

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -796,10 +796,9 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 
 	if config.Privileged {
 		config.LabelOpts = label.DisableSecOpt()
-	} else {
-		if err := parseSecurityOpt(config, c.StringArray("security-opt"), runtime); err != nil {
-			return nil, err
-		}
+	}
+	if err := parseSecurityOpt(config, c.StringArray("security-opt"), runtime); err != nil {
+		return nil, err
 	}
 	config.SecurityOpts = c.StringArray("security-opt")
 	warnings, err := verifyContainerResources(config, false)


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>