### PR TITLE
podman run/create: support all transports

### DIFF
--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -125,10 +125,13 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	imageName := args[0]
 	if !cliVals.RootFS {
-		if err := pullImage(args[0]); err != nil {
+		name, err := pullImage(args[0])
+		if err != nil {
 			return err
 		}
+		imageName = name
 	}
 
 	if cliVals.Replace {
@@ -166,7 +169,7 @@ func run(cmd *cobra.Command, args []string) error {
 	runOpts.Detach = cliVals.Detach
 	runOpts.DetachKeys = cliVals.DetachKeys
 	cliVals.PreserveFDs = runOpts.PreserveFDs
-	s := specgen.NewSpecGenerator(args[0], cliVals.RootFS)
+	s := specgen.NewSpecGenerator(imageName, cliVals.RootFS)
 	if err := common.FillOutSpecGen(s, &cliVals, args); err != nil {
 		return err
 	}
@@ -196,7 +199,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	if runRmi {
-		_, rmErrors := registry.ImageEngine().Remove(registry.GetContext(), []string{args[0]}, entities.ImageRemoveOptions{})
+		_, rmErrors := registry.ImageEngine().Remove(registry.GetContext(), []string{imageName}, entities.ImageRemoveOptions{})
 		if len(rmErrors) > 0 {
 			logrus.Errorf("%s", errors.Wrapf(errorhandling.JoinErrors(rmErrors), "failed removing image"))
 		}

--- a/test/system/030-run.bats
+++ b/test/system/030-run.bats
@@ -201,4 +201,17 @@ echo $rand        |   0 | $rand
        "podman will not overwrite existing cidfile"
 }
 
+@test "podman run docker-archive" {
+	tmpdir=$PODMAN_TMPDIR/run-archive
+	mkdir -p $tmpdir
+	archive=$tmpdir/archive.tar
+
+	run_podman save $IMAGE -o $archive
+
+	run_podman run docker-archive:$archive ls
+
+	# Also make sure create eats the archive as well
+	run_podman create docker-archive:$archive ls
+}
+
 # vim: filetype=sh


### PR DESCRIPTION
Support all image transports in podman run/create.  It seems we
regressed with v2 on that.

Fixes: #6744
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>