### PR TITLE
Fix inspect to display multiple label: changes

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -520,7 +520,7 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 			case "label":
 				// TODO selinux opts and label opts are the same thing
 				s.ContainerSecurityConfig.SelinuxOpts = append(s.ContainerSecurityConfig.SelinuxOpts, con[1])
-				s.Annotations[define.InspectAnnotationLabel] = con[1]
+				s.Annotations[define.InspectAnnotationLabel] = strings.Join(s.ContainerSecurityConfig.SelinuxOpts, ",label=")
 			case "apparmor":
 				s.ContainerSecurityConfig.ApparmorProfile = con[1]
 				s.Annotations[define.InspectAnnotationApparmor] = con[1]


### PR DESCRIPTION
If the user runs a container like

podman run --security-opt seccomp=unconfined --security-opt label=type:spc_t --security-opt label=level:s0 ...

Podman inspect was only showing the second option

This change will show

            "SecurityOpt": [
                "label=type:spc_t,label=level:s0:c60",
                "seccomp=unconfined"
            ],

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>