### PR TITLE
utils: drop default mapping when running uid!=0

### DIFF
--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -419,12 +419,6 @@ func ParseIDMapping(mode namespaces.UsernsMode, uidMapSlice, gidMapSlice []strin
 	if len(uidMapSlice) == 0 && len(gidMapSlice) != 0 {
 		uidMapSlice = gidMapSlice
 	}
-	if len(uidMapSlice) == 0 && subUIDMap == "" && os.Getuid() != 0 {
-		uidMapSlice = []string{fmt.Sprintf("0:%d:1", os.Getuid())}
-	}
-	if len(gidMapSlice) == 0 && subGIDMap == "" && os.Getuid() != 0 {
-		gidMapSlice = []string{fmt.Sprintf("0:%d:1", os.Getgid())}
-	}
 
 	if subUIDMap != "" && subGIDMap != "" {
 		mappings, err := idtools.NewIDMappings(subUIDMap, subGIDMap)


### PR DESCRIPTION
this is a leftover from the first implementation of rootless.  This
code is never hit by podman rootless anymore as podman automatically
creates a user namespace now.

Fixes an issue with podman remote when used with uid != 0.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>