### PR TITLE
Fix error handling problem in APIv2 network remove

### DIFF
--- a/pkg/api/handlers/compat/networks.go
+++ b/pkg/api/handlers/compat/networks.go
@@ -285,7 +285,7 @@ func RemoveNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !exists {
-		utils.Error(w, "network not found", http.StatusNotFound, err)
+		utils.Error(w, "network not found", http.StatusNotFound, network.ErrNetworkNotFound)
 		return
 	}
 	if err := network.RemoveNetwork(config, name); err != nil {


### PR DESCRIPTION
Fix a bug with APIv2 compat network remove to log an ErrNetworkNotFound instead of nil
The endpoint uses network.Exists which returns 'false, nil' if the network doesn't exist.
The endpoint used to pass that 'nil' to utils.Error (api/handlers) which resulted in nil dereferencing.
It now calls utils.Error with the error object ErrNetworkNotFound.

Signed-off-by: Maximilian Müller <maxm123@techie.com>