### PR TITLE
generate systemd: improve pod-flags filter

### DIFF
--- a/pkg/systemd/generate/common.go
+++ b/pkg/systemd/generate/common.go
@@ -1,6 +1,8 @@
 package generate
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 )
 
@@ -42,6 +44,9 @@ func filterPodFlags(command []string) []string {
 		s := command[i]
 		if s == "--pod" || s == "--pod-id-file" {
 			i++
+			continue
+		}
+		if strings.HasPrefix(s, "--pod=") || strings.HasPrefix(s, "--pod-id-file=") {
 			continue
 		}
 		processed = append(processed, s)

--- a/pkg/systemd/generate/common_test.go
+++ b/pkg/systemd/generate/common_test.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,12 +15,16 @@ func TestFilterPodFlags(t *testing.T) {
 		{[]string{"podman", "pod", "create"}},
 		{[]string{"podman", "pod", "create", "--name", "foo"}},
 		{[]string{"podman", "pod", "create", "--pod-id-file", "foo"}},
+		{[]string{"podman", "pod", "create", "--pod-id-file=foo"}},
 		{[]string{"podman", "run", "--pod", "foo"}},
+		{[]string{"podman", "run", "--pod=foo"}},
 	}
 
 	for _, test := range tests {
 		processed := filterPodFlags(test.input)
-		assert.NotContains(t, processed, "--pod-id-file")
-		assert.NotContains(t, processed, "--pod")
+		for _, s := range processed {
+			assert.False(t, strings.HasPrefix(s, "--pod-id-file"))
+			assert.False(t, strings.HasPrefix(s, "--pod"))
+		}
 	}
 }


### PR DESCRIPTION
When generating systemd units for pods, we need to remove certain
pod-related flags from the containers' create commands.  Make sure
to account for all the syntax including a single argument with key and
value being split by `=`.

Fixes: #6766
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>