### PR TITLE
systemd generate: allow manual restart of container units in pods

### DIFF
--- a/pkg/systemd/generate/containers.go
+++ b/pkg/systemd/generate/containers.go
@@ -69,8 +69,6 @@ type containerInfo struct {
 
 const containerTemplate = headerTemplate + `
 {{- if .BoundToServices}}
-RefuseManualStart=yes
-RefuseManualStop=yes
 BindsTo={{- range $index, $value := .BoundToServices -}}{{if $index}} {{end}}{{ $value }}.service{{end}}
 After={{- range $index, $value := .BoundToServices -}}{{if $index}} {{end}}{{ $value }}.service{{end}}
 {{- end}}

--- a/pkg/systemd/generate/containers_test.go
+++ b/pkg/systemd/generate/containers_test.go
@@ -88,8 +88,6 @@ Description=Podman container-foobar.service
 Documentation=man:podman-generate-systemd(1)
 Wants=network.target
 After=network-online.target
-RefuseManualStart=yes
-RefuseManualStop=yes
 BindsTo=a.service b.service c.service pod.service
 After=a.service b.service c.service pod.service
 


### PR DESCRIPTION
Allow manual restarts of container units that are part of a pod.
This allows for configuring these containers for auto updates.

Fixes: #6770
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>