### PR TITLE
specgen: fix order for setting rlimits

### DIFF
--- a/pkg/specgen/generate/oci.go
+++ b/pkg/specgen/generate/oci.go
@@ -52,10 +52,14 @@ func addRlimits(s *specgen.SpecGenerator, g *generate.Generator) error {
 			if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlimit); err != nil {
 				logrus.Warnf("failed to return RLIMIT_NOFILE ulimit %q", err)
 			}
-			current = rlimit.Cur
-			max = rlimit.Max
+			if rlimit.Cur < current {
+				current = rlimit.Cur
+			}
+			if rlimit.Max < max {
+				max = rlimit.Max
+			}
 		}
-		g.AddProcessRlimits("RLIMIT_NOFILE", current, max)
+		g.AddProcessRlimits("RLIMIT_NOFILE", max, current)
 	}
 	if !nprocSet {
 		max := kernelMax
@@ -65,10 +69,14 @@ func addRlimits(s *specgen.SpecGenerator, g *generate.Generator) error {
 			if err := unix.Getrlimit(unix.RLIMIT_NPROC, &rlimit); err != nil {
 				logrus.Warnf("failed to return RLIMIT_NPROC ulimit %q", err)
 			}
-			current = rlimit.Cur
-			max = rlimit.Max
+			if rlimit.Cur < current {
+				current = rlimit.Cur
+			}
+			if rlimit.Max < max {
+				max = rlimit.Max
+			}
 		}
-		g.AddProcessRlimits("RLIMIT_NPROC", current, max)
+		g.AddProcessRlimits("RLIMIT_NPROC", max, current)
 	}
 
 	return nil


### PR DESCRIPTION
Also make sure that the limits we set for rootless are not higher than
what we'd set for root containers.

Rootless containers failed to start when the calling user already
had ulimit (e.g. on NOFILE) set.

This is basically a cherry-pick of 76f8efc0d0d into specgen

Signed-off-by: Ralf Haferkamp <rhafer@suse.com>