### PR TITLE
Ensure umask is set appropriately for 'system service'

### DIFF
--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -173,6 +173,10 @@ func (s *APIServer) Serve() error {
 		}()
 	}
 
+	// Before we start serving, ensure umask is properly set for container
+	// creation.
+	_ = syscall.Umask(0022)
+
 	go func() {
 		err := s.Server.Serve(s.Listener)
 		if err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
We need a umask of 0022 to ensure containers are created correctly, but we set a different one prior to starting the server (to ensure the unix socket has the right permissions). Thus, we need to set the umask after the socket has been bound, but before the server begins accepting requests.

Fixes #6787
