### PR TITLE
[CI:DOCS]Add swagger.yaml to docs/

### DIFF
--- a/docs/source/Reference.rst
+++ b/docs/source/Reference.rst
@@ -3,7 +3,7 @@
 Reference
 =========
 
-To see full screen version please visit: `API documentation <https://docs.podman.io/en/latest/_static/api.html>`_
+To see full screen version please visit: `API documentation <_static/api.html>`_
 
 .. raw:: html
 

--- a/docs/source/_static/api.html
+++ b/docs/source/_static/api.html
@@ -18,7 +18,7 @@
     </style>
   </head>
   <body>
-    <redoc spec-url='https://storage.googleapis.com/libpod-master-releases/swagger-latest-master.yaml'></redoc>
+    <redoc spec-url='https://github.com/containers/libpod/tree/v2.0/docs/swagger.yaml'></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
 </html>

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,0 +1,11942 @@
+basePath: /
+consumes:
+- application/json
+- application/x-tar
+definitions:
+  Address:
+    description: Address represents an IP address
+    properties:
+      Addr:
+        type: string
+      PrefixLen:
+        format: int64
+        type: integer
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/network
+  AuthenticateOKBody:
+    description: AuthenticateOKBody authenticate o k body
+    properties:
+      IdentityToken:
+        description: An opaque token used to authenticate a user after a successful
+          login
+        type: string
+      Status:
+        description: The status of the authentication
+        type: string
+    required:
+    - IdentityToken
+    - Status
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/registry
+  AutoUserNsOptions:
+    properties:
+      AdditionalGIDMappings:
+        description: |-
+          AdditionalGIDMappings specified additional GID mappings to include in
+          the generated user namespace.
+        items:
+          $ref: '#/definitions/IDMap'
+        type: array
+      AdditionalUIDMappings:
+        description: |-
+          AdditionalUIDMappings specified additional UID mappings to include in
+          the generated user namespace.
+        items:
+          $ref: '#/definitions/IDMap'
+        type: array
+      GroupFile:
+        description: GroupFile to use if the container uses a volume.
+        type: string
+      InitialSize:
+        description: |-
+          InitialSize defines the minimum size for the user namespace.
+          The created user namespace will have at least this size.
+        format: uint32
+        type: integer
+      PasswdFile:
+        description: PasswdFile to use if the container uses a volume.
+        type: string
+      Size:
+        description: |-
+          Size defines the size for the user namespace.  If it is set to a
+          value bigger than 0, the user namespace will have exactly this size.
+          If it is not set, some heuristics will be used to find its size.
+        format: uint32
+        type: integer
+    title: AutoUserNsOptions defines how to automatically create a user namespace.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/containers/storage
+  CgroupConfig:
+    description: CgroupConfig configures the cgroup namespace for the container
+    properties:
+      CgroupMode:
+        $ref: '#/definitions/CgroupMode'
+      CgroupParent:
+        type: string
+      Cgroupns:
+        type: string
+      Cgroups:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/spec
+  CgroupMode:
+    title: CgroupMode represents cgroup mode in the container.
+    type: string
+    x-go-package: github.com/containers/libpod/pkg/namespaces
+  CgroupSpec:
+    title: CgroupSpec represents the cgroup to use for the container.
+    type: string
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  CgroupnsMode:
+    description: CgroupnsMode represents the cgroup namespace mode of the container
+    type: string
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  Change:
+    description: |-
+      It describes changes of the files in the path respect to the
+      parent layers. The change could be modify, add, delete.
+      This is used for layer diff.
+    properties:
+      Kind:
+        $ref: '#/definitions/ChangeType'
+      Path:
+        type: string
+    title: Change represents a change, it wraps the change type and path.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/containers/storage/pkg/archive
+  ChangeType:
+    format: int64
+    title: ChangeType represents the change type.
+    type: integer
+    x-go-package: github.com/containers/libpod/vendor/github.com/containers/storage/pkg/archive
+  Config:
+    description: |-
+      It should hold only portable information about the container.
+      Here, "portable" means "independent from the host we are running on".
+      Non-portable information *should* appear in HostConfig.
+      All fields added to this struct must be marked `omitempty` to keep getting
+      predictable hashes from the old `v1Compatibility` configuration.
+    properties:
+      ArgsEscaped:
+        type: boolean
+      AttachStderr:
+        type: boolean
+      AttachStdin:
+        type: boolean
+      AttachStdout:
+        type: boolean
+      Cmd:
+        $ref: '#/definitions/StrSlice'
+      Domainname:
+        type: string
+      Entrypoint:
+        $ref: '#/definitions/StrSlice'
+      Env:
+        items:
+          type: string
+        type: array
+      ExposedPorts:
+        $ref: '#/definitions/PortSet'
+      Healthcheck:
+        $ref: '#/definitions/HealthConfig'
+      Hostname:
+        type: string
+      Image:
+        type: string
+      Labels:
+        additionalProperties:
+          type: string
+        type: object
+      MacAddress:
+        type: string
+      NetworkDisabled:
+        type: boolean
+      OnBuild:
+        items:
+          type: string
+        type: array
+      OpenStdin:
+        type: boolean
+      Shell:
+        $ref: '#/definitions/StrSlice'
+      StdinOnce:
+        type: boolean
+      StopSignal:
+        type: string
+      StopTimeout:
+        format: int64
+        type: integer
+      Tty:
+        type: boolean
+      User:
+        type: string
+      Volumes:
+        additionalProperties:
+          type: object
+        type: object
+      WorkingDir:
+        type: string
+    title: Config contains the configuration data about a container.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  ConfigReference:
+    description: ConfigReference specifies the source which provides a network's configuration
+    properties:
+      Network:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/network
+  ConmonInfo:
+    description: ConmonInfo describes the conmon executable being used
+    properties:
+      package:
+        type: string
+        x-go-name: Package
+      path:
+        type: string
+        x-go-name: Path
+      version:
+        type: string
+        x-go-name: Version
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  ContainerBasicConfig:
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        description: |-
+          Annotations are key-value options passed into the container runtime
+          that can be used to trigger special behavior.
+          Optional.
+        type: object
+        x-go-name: Annotations
+      command:
+        description: |-
+          Command is the container's command.
+          If not given and Image is specified, this will be populated by the
+          image's configuration.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: Command
+      conmon_pid_file:
+        description: |-
+          ConmonPidFile is a path at which a PID file for Conmon will be
+          placed.
+          If not given, a default location will be used.
+          Optional.
+        type: string
+        x-go-name: ConmonPidFile
+      entrypoint:
+        description: |-
+          Entrypoint is the container's entrypoint.
+          If not given and Image is specified, this will be populated by the
+          image's configuration.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: Entrypoint
+      env:
+        additionalProperties:
+          type: string
+        description: |-
+          Env is a set of environment variables that will be set in the
+          container.
+          Optional.
+        type: object
+        x-go-name: Env
+      hostname:
+        description: |-
+          Hostname is the container's hostname. If not set, the hostname will
+          not be modified (if UtsNS is not private) or will be set to the
+          container ID (if UtsNS is private).
+          Conflicts with UtsNS if UtsNS is not set to private.
+          Optional.
+        type: string
+        x-go-name: Hostname
+      labels:
+        additionalProperties:
+          type: string
+        description: |-
+          Labels are key-value pairs that are used to add metadata to
+          containers.
+          Optional.
+        type: object
+        x-go-name: Labels
+      log_configuration:
+        $ref: '#/definitions/LogConfig'
+      name:
+        description: |-
+          Name is the name the container will be given.
+          If no name is provided, one will be randomly generated.
+          Optional.
+        type: string
+        x-go-name: Name
+      namespace:
+        description: |-
+          Namespace is the libpod namespace the container will be placed in.
+          Optional.
+        type: string
+        x-go-name: Namespace
+      oci_runtime:
+        description: |-
+          OCIRuntime is the name of the OCI runtime that will be used to create
+          the container.
+          If not specified, the default will be used.
+          Optional.
+        type: string
+        x-go-name: OCIRuntime
+      pidns:
+        $ref: '#/definitions/Namespace'
+      pod:
+        description: |-
+          Pod is the ID of the pod the container will join.
+          Optional.
+        type: string
+        x-go-name: Pod
+      remove:
+        description: |-
+          Remove indicates if the container should be removed once it has been started
+          and exits
+        type: boolean
+        x-go-name: Remove
+      restart_policy:
+        description: |-
+          RestartPolicy is the container's restart policy - an action which
+          will be taken when the container exits.
+          If not given, the default policy, which does nothing, will be used.
+          Optional.
+        type: string
+        x-go-name: RestartPolicy
+      restart_tries:
+        description: |-
+          RestartRetries is the number of attempts that will be made to restart
+          the container.
+          Only available when RestartPolicy is set to "on-failure".
+          Optional.
+        format: uint64
+        type: integer
+        x-go-name: RestartRetries
+      stdin:
+        description: Stdin is whether the container will keep its STDIN open.
+        type: boolean
+        x-go-name: Stdin
+      stop_signal:
+        $ref: '#/definitions/Signal'
+      stop_timeout:
+        description: |-
+          StopTimeout is a timeout between the container's stop signal being
+          sent and SIGKILL being sent.
+          If not provided, the default will be used.
+          If 0 is used, stop signal will not be sent, and SIGKILL will be sent
+          instead.
+          Optional.
+        format: uint64
+        type: integer
+        x-go-name: StopTimeout
+      sysctl:
+        additionalProperties:
+          type: string
+        description: Sysctl sets kernel parameters for the container
+        type: object
+        x-go-name: Sysctl
+      systemd:
+        description: |-
+          Systemd is whether the container will be started in systemd mode.
+          Valid options are "true", "false", and "always".
+          "true" enables this mode only if the binary run in the container is
+          sbin/init or systemd. "always" unconditionally enables systemd mode.
+          "false" unconditionally disables systemd mode.
+          If enabled, mounts and stop signal will be modified.
+          If set to "always" or set to "true" and conditionally triggered,
+          conflicts with StopSignal.
+          If not specified, "false" will be assumed.
+          Optional.
+        type: string
+        x-go-name: Systemd
+      terminal:
+        description: |-
+          Terminal is whether the container will create a PTY.
+          Optional.
+        type: boolean
+        x-go-name: Terminal
+      utsns:
+        $ref: '#/definitions/Namespace'
+    title: ContainerBasicConfig contains the basic parts of a container.
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  ContainerCgroupConfig:
+    description: |-
+      ContainerCgroupConfig contains configuration information about a container's
+      cgroups.
+    properties:
+      cgroup_parent:
+        description: |-
+          CgroupParent is the container's CGroup parent.
+          If not set, the default for the current cgroup driver will be used.
+          Optional.
+        type: string
+        x-go-name: CgroupParent
+      cgroupns:
+        $ref: '#/definitions/Namespace'
+      cgroups_mode:
+        description: |-
+          CgroupsMode sets a policy for how cgroups will be created in the
+          container, including the ability to disable creation entirely.
+        type: string
+        x-go-name: CgroupsMode
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  ContainerChangeResponseItem:
+    description: ContainerChangeResponseItem change item in response to ContainerChanges
+      operation
+    properties:
+      Kind:
+        description: Kind of change
+        format: uint8
+        type: integer
+      Path:
+        description: Path to file that has changed
+        type: string
+    required:
+    - Kind
+    - Path
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  ContainerCreateCreatedBody:
+    description: ContainerCreateCreatedBody OK response to ContainerCreate operation
+    properties:
+      Id:
+        description: The ID of the created container
+        type: string
+        x-go-name: ID
+      Warnings:
+        description: Warnings encountered when creating the container
+        items:
+          type: string
+        type: array
+    required:
+    - Id
+    - Warnings
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  ContainerHealthCheckConfig:
+    description: |-
+      ContainerHealthCheckConfig describes a container healthcheck with attributes
+      like command, retries, interval, start period, and timeout.
+    properties:
+      healthconfig:
+        $ref: '#/definitions/Schema2HealthConfig'
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  ContainerNamedVolume:
+    description: |-
+      ContainerNamedVolume is a named volume that will be mounted into the
+      container. Each named volume is a libpod Volume present in the state.
+    properties:
+      dest:
+        description: Dest is the mount's destination
+        type: string
+        x-go-name: Dest
+      options:
+        description: Options are fstab style mount options
+        items:
+          type: string
+        type: array
+        x-go-name: Options
+      volumeName:
+        description: |-
+          Name is the name of the volume to mount in.
+          Must resolve to a valid volume present in this Podman.
+        type: string
+        x-go-name: Name
+    type: object
+    x-go-package: github.com/containers/libpod/libpod
+  ContainerNetworkConfig:
+    description: |-
+      ContainerNetworkConfig contains information on a container's network
+      configuration.
+    properties:
+      cni_networks:
+        description: |-
+          CNINetworks is a list of CNI networks to join the container to.
+          If this list is empty, the default CNI network will be joined
+          instead. If at least one entry is present, we will not join the
+          default network (unless it is part of this list).
+          Only available if NetNS is set to bridge.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: CNINetworks
+      dns_option:
+        description: |-
+          DNSOptions is a set of DNS options that will be used in the
+          container's resolv.conf, replacing the host's DNS options which are
+          used by default.
+          Conflicts with UseImageResolvConf.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: DNSOptions
+      dns_search:
+        description: |-
+          DNSSearch is a set of DNS search domains that will be used in the
+          container's resolv.conf, replacing the host's DNS search domains
+          which are used by default.
+          Conflicts with UseImageResolvConf.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: DNSSearch
+      dns_server:
+        description: |-
+          DNSServers is a set of DNS servers that will be used in the
+          container's resolv.conf, replacing the host's DNS Servers which are
+          used by default.
+          Conflicts with UseImageResolvConf.
+          Optional.
+        items:
+          $ref: '#/definitions/IP'
+        type: array
+        x-go-name: DNSServers
+      expose:
+        description: |-
+          Expose is a number of ports that will be forwarded to the container
+          if PublishExposedPorts is set.
+          Expose is a map of uint16 (port number) to a string representing
+          protocol. Allowed protocols are "tcp", "udp", and "sctp", or some
+          combination of the three separated by commas.
+          If protocol is set to "" we will assume TCP.
+          Only available if NetNS is set to Bridge or Slirp, and
+          PublishExposedPorts is set.
+          Optional.
+        x-go-name: Expose
+      hostadd:
+        description: |-
+          HostAdd is a set of hosts which will be added to the container's
+          etc/hosts file.
+          Conflicts with UseImageHosts.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: HostAdd
+      netns:
+        $ref: '#/definitions/Namespace'
+      portmappings:
+        description: |-
+          PortBindings is a set of ports to map into the container.
+          Only available if NetNS is set to bridge or slirp.
+          Optional.
+        items:
+          $ref: '#/definitions/PortMapping'
+        type: array
+        x-go-name: PortMappings
+      publish_image_ports:
+        description: |-
+          PublishExposedPorts will publish ports specified in the image to
+          random unused ports (guaranteed to be above 1024) on the host.
+          This is based on ports set in Expose below, and any ports specified
+          by the Image (if one is given).
+          Only available if NetNS is set to Bridge or Slirp.
+        type: boolean
+        x-go-name: PublishExposedPorts
+      static_ip:
+        $ref: '#/definitions/IP'
+      static_ipv6:
+        $ref: '#/definitions/IP'
+      static_mac:
+        $ref: '#/definitions/HardwareAddr'
+      use_image_hosts:
+        description: |-
+          UseImageHosts indicates that /etc/hosts should not be managed by
+          Podman, and instead sourced from the image.
+          Conflicts with HostAdd.
+        type: boolean
+        x-go-name: UseImageHosts
+      use_image_resolve_conf:
+        description: |-
+          UseImageResolvConf indicates that resolv.conf should not be managed
+          by Podman, but instead sourced from the image.
+          Conflicts with DNSServer, DNSSearch, DNSOption.
+        type: boolean
+        x-go-name: UseImageResolvConf
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  ContainerNode:
+    description: |-
+      ContainerNode stores information about the node that a container
+      is running on.  It's only available in Docker Swarm
+    properties:
+      Addr:
+        type: string
+      Cpus:
+        format: int64
+        type: integer
+      ID:
+        type: string
+      IP:
+        type: string
+        x-go-name: IPAddress
+      Labels:
+        additionalProperties:
+          type: string
+        type: object
+      Memory:
+        format: int64
+        type: integer
+      Name:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  ContainerResourceConfig:
+    properties:
+      oom_score_adj:
+        description: |-
+          OOMScoreAdj adjusts the score used by the OOM killer to determine
+          processes to kill for the container's process.
+          Optional.
+        format: int64
+        type: integer
+        x-go-name: OOMScoreAdj
+      r_limits:
+        description: |-
+          Rlimits are POSIX rlimits to apply to the container.
+          Optional.
+        items:
+          $ref: '#/definitions/POSIXRlimit'
+        type: array
+        x-go-name: Rlimits
+      resource_limits:
+        $ref: '#/definitions/LinuxResources'
+      throttleReadBpsDevice:
+        additionalProperties:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        description: IO read rate limit per cgroup per device, bytes per second
+        type: object
+        x-go-name: ThrottleReadBpsDevice
+      throttleReadIOPSDevice:
+        additionalProperties:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        description: IO read rate limit per cgroup per device, IO per second
+        type: object
+        x-go-name: ThrottleReadIOPSDevice
+      throttleWriteBpsDevice:
+        additionalProperties:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        description: IO write rate limit per cgroup per device, bytes per second
+        type: object
+        x-go-name: ThrottleWriteBpsDevice
+      throttleWriteIOPSDevice:
+        additionalProperties:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        description: IO write rate limit per cgroup per device, IO per second
+        type: object
+        x-go-name: ThrottleWriteIOPSDevice
+      weightDevice:
+        additionalProperties:
+          $ref: '#/definitions/LinuxWeightDevice'
+        description: Weight per cgroup per device, can override BlkioWeight
+        type: object
+        x-go-name: WeightDevice
+    title: ContainerResourceConfig contains information on container resource limits.
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  ContainerSecurityConfig:
+    description: |-
+      ContainerSecurityConfig is a container's security features, including
+      SELinux, Apparmor, and Seccomp.
+    properties:
+      apparmor_profile:
+        description: |-
+          ApparmorProfile is the name of the Apparmor profile the container
+          will use.
+          Optional.
+        type: string
+        x-go-name: ApparmorProfile
+      cap_add:
+        description: |-
+          CapAdd are capabilities which will be added to the container.
+          Conflicts with Privileged.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: CapAdd
+      cap_drop:
+        description: |-
+          CapDrop are capabilities which will be removed from the container.
+          Conflicts with Privileged.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: CapDrop
+      groups:
+        description: |-
+          Groups are a list of supplemental groups the container's user will
+          be granted access to.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: Groups
+      idmappings:
+        $ref: '#/definitions/IDMappingOptions'
+      no_new_privileges:
+        description: |-
+          NoNewPrivileges is whether the container will set the no new
+          privileges flag on create, which disables gaining additional
+          privileges (e.g. via setuid) in the container.
+        type: boolean
+        x-go-name: NoNewPrivileges
+      privileged:
+        description: |-
+          Privileged is whether the container is privileged.
+          Privileged does the following:
+          Adds all devices on the system to the container.
+          Adds all capabilities to the container.
+          Disables Seccomp, SELinux, and Apparmor confinement.
+          (Though SELinux can be manually re-enabled).
+          TODO: this conflicts with things.
+          TODO: this does more.
+        type: boolean
+        x-go-name: Privileged
+      read_only_filesystem:
+        description: |-
+          ReadOnlyFilesystem indicates that everything will be mounted
+          as read-only
+        type: boolean
+        x-go-name: ReadOnlyFilesystem
+      seccomp_policy:
+        description: |-
+          SeccompPolicy determines which seccomp profile gets applied
+          the container. valid values: empty,default,image
+        type: string
+        x-go-name: SeccompPolicy
+      seccomp_profile_path:
+        description: |-
+          SeccompProfilePath is the path to a JSON file containing the
+          container's Seccomp profile.
+          If not specified, no Seccomp profile will be used.
+          Optional.
+        type: string
+        x-go-name: SeccompProfilePath
+      selinux_opts:
+        description: |-
+          SelinuxProcessLabel is the process label the container will use.
+          If SELinux is enabled and this is not specified, a label will be
+          automatically generated if not specified.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: SelinuxOpts
+      user:
+        description: |-
+          User is the user the container will be run as.
+          Can be given as a UID or a username; if a username, it will be
+          resolved within the container, using the container's /etc/passwd.
+          If unset, the container will be run as root.
+          Optional.
+        type: string
+        x-go-name: User
+      userns:
+        $ref: '#/definitions/Namespace'
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  ContainerSize:
+    description: |-
+      ContainerSize holds the size of the container's root filesystem and top
+      read-write layer.
+    properties:
+      rootFsSize:
+        format: int64
+        type: integer
+        x-go-name: RootFsSize
+      rwSize:
+        format: int64
+        type: integer
+        x-go-name: RwSize
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/ps/define
+  ContainerState:
+    description: |-
+      ContainerState stores container's running state
+      it's part of ContainerJSONBase and will return by "inspect" command
+    properties:
+      Dead:
+        type: boolean
+      Error:
+        type: string
+      ExitCode:
+        format: int64
+        type: integer
+      FinishedAt:
+        type: string
+      Health:
+        $ref: '#/definitions/Health'
+      OOMKilled:
+        type: boolean
+      Paused:
+        type: boolean
+      Pid:
+        format: int64
+        type: integer
+      Restarting:
+        type: boolean
+      Running:
+        type: boolean
+      StartedAt:
+        type: string
+      Status:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  ContainerStorageConfig:
+    description: |-
+      ContainerStorageConfig contains information on the storage configuration of a
+      container.
+    properties:
+      devices:
+        description: |-
+          Devices are devices that will be added to the container.
+          Optional.
+        items:
+          $ref: '#/definitions/LinuxDevice'
+        type: array
+        x-go-name: Devices
+      image:
+        description: |-
+          Image is the image the container will be based on. The image will be
+          used as the container's root filesystem, and its environment vars,
+          volumes, and other configuration will be applied to the container.
+          Conflicts with Rootfs.
+          At least one of Image or Rootfs must be specified.
+        type: string
+        x-go-name: Image
+      image_volume_mode:
+        description: |-
+          ImageVolumeMode indicates how image volumes will be created.
+          Supported modes are "ignore" (do not create), "tmpfs" (create as
+          tmpfs), and "anonymous" (create as anonymous volumes).
+          The default if unset is anonymous.
+          Optional.
+        type: string
+        x-go-name: ImageVolumeMode
+      init:
+        description: |-
+          Init specifies that an init binary will be mounted into the
+          container, and will be used as PID1.
+        type: boolean
+        x-go-name: Init
+      init_path:
+        description: |-
+          InitPath specifies the path to the init binary that will be added if
+          Init is specified above. If not specified, the default set in the
+          Libpod config will be used. Ignored if Init above is not set.
+          Optional.
+        type: string
+        x-go-name: InitPath
+      ipcns:
+        $ref: '#/definitions/Namespace'
+      mounts:
+        description: |-
+          Mounts are mounts that will be added to the container.
+          These will supersede Image Volumes and VolumesFrom volumes where
+          there are conflicts.
+          Optional.
+        items:
+          $ref: '#/definitions/Mount'
+        type: array
+        x-go-name: Mounts
+      rootfs:
+        description: |-
+          Rootfs is the path to a directory that will be used as the
+          container's root filesystem. No modification will be made to the
+          directory, it will be directly mounted into the container as root.
+          Conflicts with Image.
+          At least one of Image or Rootfs must be specified.
+        type: string
+        x-go-name: Rootfs
+      rootfs_propagation:
+        description: |-
+          RootfsPropagation is the rootfs propagation mode for the container.
+          If not set, the default of rslave will be used.
+          Optional.
+        type: string
+        x-go-name: RootfsPropagation
+      shm_size:
+        description: |-
+          ShmSize is the size of the tmpfs to mount in at /dev/shm, in bytes.
+          Conflicts with ShmSize if IpcNS is not private.
+          Optional.
+        format: int64
+        type: integer
+        x-go-name: ShmSize
+      volumes:
+        description: |-
+          Volumes are named volumes that will be added to the container.
+          These will supersede Image Volumes and VolumesFrom volumes where
+          there are conflicts.
+          Optional.
+        items:
+          $ref: '#/definitions/NamedVolume'
+        type: array
+        x-go-name: Volumes
+      volumes_from:
+        description: |-
+          VolumesFrom is a set of containers whose volumes will be added to
+          this container. The name or ID of the container must be provided, and
+          may optionally be followed by a : and then one or more
+          comma-separated options. Valid options are 'ro', 'rw', and 'z'.
+          Options will be used for all volumes sourced from the container.
+        items:
+          type: string
+        type: array
+        x-go-name: VolumesFrom
+      work_dir:
+        description: |-
+          WorkDir is the container's working directory.
+          If unset, the default, /, will be used.
+          Optional.
+        type: string
+        x-go-name: WorkDir
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  ContainerStore:
+    description: |-
+      ContainerStore describes the quantity of containers in the
+      store by status
+    properties:
+      number:
+        format: int64
+        type: integer
+        x-go-name: Number
+      paused:
+        format: int64
+        type: integer
+        x-go-name: Paused
+      running:
+        format: int64
+        type: integer
+        x-go-name: Running
+      stopped:
+        format: int64
+        type: integer
+        x-go-name: Stopped
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  ContainerTopOKBody:
+    description: ContainerTopOKBody OK response to ContainerTop operation
+    properties:
+      Processes:
+        description: Each process running in the container, where each is process
+          is an array of values corresponding to the titles
+        items:
+          items:
+            type: string
+          type: array
+        type: array
+      Titles:
+        description: The ps column titles
+        items:
+          type: string
+        type: array
+    required:
+    - Processes
+    - Titles
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  ContainerUpdateOKBody:
+    description: ContainerUpdateOKBody OK response to ContainerUpdate operation
+    properties:
+      Warnings:
+        description: warnings
+        items:
+          type: string
+        type: array
+    required:
+    - Warnings
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  ContainerWaitOKBody:
+    description: ContainerWaitOKBody OK response to ContainerWait operation
+    properties:
+      Error:
+        $ref: '#/definitions/ContainerWaitOKBodyError'
+      StatusCode:
+        description: Exit code of the container
+        format: int64
+        type: integer
+    required:
+    - Error
+    - StatusCode
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  ContainerWaitOKBodyError:
+    description: ContainerWaitOKBodyError container waiting error, if any
+    properties:
+      Message:
+        description: Details of an error
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  ContainersPruneReport:
+    properties:
+      ContainersDeleted:
+        items:
+          type: string
+        type: array
+      SpaceReclaimed:
+        format: uint64
+        type: integer
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/api/handlers
+  CreateConfig:
+    description: CreateConfig is a pre OCI spec structure.  It represents user input
+      from varlink or the CLI
+    properties:
+      Annotations:
+        additionalProperties:
+          type: string
+        type: object
+      Args:
+        items:
+          type: string
+        type: array
+      BuiltinImgVolumes:
+        additionalProperties:
+          type: object
+        type: object
+      Cgroup:
+        $ref: '#/definitions/CgroupConfig'
+      CidFile:
+        type: string
+      Command:
+        items:
+          type: string
+        type: array
+      ConmonPidFile:
+        type: string
+      Detach:
+        type: boolean
+      Devices:
+        items:
+          type: string
+        type: array
+      Entrypoint:
+        items:
+          type: string
+        type: array
+      Env:
+        additionalProperties:
+          type: string
+        type: object
+      HealthCheck:
+        $ref: '#/definitions/Schema2HealthConfig'
+      Image:
+        type: string
+      ImageID:
+        type: string
+      ImageVolumeType:
+        type: string
+      Init:
+        type: boolean
+      InitPath:
+        type: string
+      Interactive:
+        type: boolean
+      Ipc:
+        $ref: '#/definitions/IpcConfig'
+      Labels:
+        additionalProperties:
+          type: string
+        type: object
+      LogDriver:
+        type: string
+      LogDriverOpt:
+        items:
+          type: string
+        type: array
+      Mounts:
+        items:
+          $ref: '#/definitions/Mount'
+        type: array
+      MountsFlag:
+        items:
+          type: string
+        type: array
+      Name:
+        type: string
+      NamedVolumes:
+        items:
+          $ref: '#/definitions/ContainerNamedVolume'
+        type: array
+      Network:
+        $ref: '#/definitions/NetworkConfig'
+      Pid:
+        $ref: '#/definitions/PidConfig'
+      Pod:
+        type: string
+      PodmanPath:
+        type: string
+      Quiet:
+        type: boolean
+      RawImageName:
+        type: string
+      Resources:
+        $ref: '#/definitions/CreateResourceConfig'
+      RestartPolicy:
+        type: string
+      Rm:
+        type: boolean
+      Rmi:
+        type: boolean
+      Rootfs:
+        type: string
+      Security:
+        $ref: '#/definitions/SecurityConfig'
+      StopSignal:
+        $ref: '#/definitions/Signal'
+      StopTimeout:
+        format: uint64
+        type: integer
+      Syslog:
+        type: boolean
+      Systemd:
+        type: boolean
+      Tmpfs:
+        items:
+          type: string
+        type: array
+      Tty:
+        type: boolean
+      User:
+        $ref: '#/definitions/UserConfig'
+      UserCommand:
+        items:
+          type: string
+        type: array
+      Uts:
+        $ref: '#/definitions/UtsConfig'
+      Volumes:
+        items:
+          type: string
+        type: array
+      VolumesFrom:
+        items:
+          type: string
+        type: array
+      WorkDir:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/spec
+  CreateResourceConfig:
+    description: |-
+      CreateResourceConfig represents resource elements in CreateConfig
+      structures
+    properties:
+      BlkioWeight:
+        format: uint16
+        type: integer
+      BlkioWeightDevice:
+        items:
+          type: string
+        type: array
+      CPUPeriod:
+        format: uint64
+        type: integer
+      CPUQuota:
+        format: int64
+        type: integer
+      CPURtPeriod:
+        format: uint64
+        type: integer
+      CPURtRuntime:
+        format: int64
+        type: integer
+      CPUShares:
+        format: uint64
+        type: integer
+      CPUs:
+        format: double
+        type: number
+      CPUsetCPUs:
+        type: string
+      CPUsetMems:
+        type: string
+      DeviceCgroupRules:
+        items:
+          type: string
+        type: array
+      DeviceReadBps:
+        items:
+          type: string
+        type: array
+      DeviceReadIOps:
+        items:
+          type: string
+        type: array
+      DeviceWriteBps:
+        items:
+          type: string
+        type: array
+      DeviceWriteIOps:
+        items:
+          type: string
+        type: array
+      DisableOomKiller:
+        type: boolean
+      KernelMemory:
+        format: int64
+        type: integer
+      Memory:
+        format: int64
+        type: integer
+      MemoryReservation:
+        format: int64
+        type: integer
+      MemorySwap:
+        format: int64
+        type: integer
+      MemorySwappiness:
+        format: int64
+        type: integer
+      OomScoreAdj:
+        format: int64
+        type: integer
+      PidsLimit:
+        format: int64
+        type: integer
+      ShmSize:
+        format: int64
+        type: integer
+      Ulimit:
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/spec
+  Data:
+    description: Data handles the data for a storage driver
+    properties:
+      Data:
+        additionalProperties:
+          type: string
+        type: object
+      Name:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/driver
+  DeviceMapping:
+    properties:
+      CgroupPermissions:
+        type: string
+      PathInContainer:
+        type: string
+      PathOnHost:
+        type: string
+    title: DeviceMapping represents the device mapping between the host and the container.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  DeviceRequest:
+    description: Used by GPU device drivers.
+    properties:
+      Capabilities:
+        items:
+          items:
+            type: string
+          type: array
+        type: array
+      Count:
+        format: int64
+        type: integer
+      DeviceIDs:
+        items:
+          type: string
+        type: array
+      Driver:
+        type: string
+      Options:
+        additionalProperties:
+          type: string
+        type: object
+    title: DeviceRequest represents a request for devices from a device driver.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  Digest:
+    description: |-
+      The following is an example of the contents of Digest types:
+
+      sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
+
+      This allows to abstract the digest behind this type and work only in those
+      terms.
+    title: |-
+      Digest allows simple protection of hex formatted digest strings, prefixed
+      by their algorithm. Strings of type Digest have some guarantee of being in
+      the correct format and it provides quick access to the components of a
+      digest string.
+    type: string
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/go-digest
+  DistributionInfo:
+    description: |-
+      DistributionInfo describes the host distribution
+      for libpod
+    properties:
+      distribution:
+        type: string
+        x-go-name: Distribution
+      version:
+        type: string
+        x-go-name: Version
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  Duration:
+    description: |-
+      A Duration represents the elapsed time between two instants
+      as an int64 nanosecond count. The representation limits the
+      largest representable duration to approximately 290 years.
+    format: int64
+    type: integer
+    x-go-package: time
+  EndpointIPAMConfig:
+    description: EndpointIPAMConfig represents IPAM configurations for the endpoint
+    properties:
+      IPv4Address:
+        type: string
+      IPv6Address:
+        type: string
+      LinkLocalIPs:
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/network
+  EndpointResource:
+    description: EndpointResource contains network resources allocated and used for
+      a container in a network
+    properties:
+      EndpointID:
+        type: string
+      IPv4Address:
+        type: string
+      IPv6Address:
+        type: string
+      MacAddress:
+        type: string
+      Name:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  EndpointSettings:
+    description: EndpointSettings stores the network endpoint details
+    properties:
+      Aliases:
+        items:
+          type: string
+        type: array
+      DriverOpts:
+        additionalProperties:
+          type: string
+        type: object
+      EndpointID:
+        type: string
+      Gateway:
+        type: string
+      GlobalIPv6Address:
+        type: string
+      GlobalIPv6PrefixLen:
+        format: int64
+        type: integer
+      IPAMConfig:
+        $ref: '#/definitions/EndpointIPAMConfig'
+      IPAddress:
+        type: string
+      IPPrefixLen:
+        format: int64
+        type: integer
+      IPv6Gateway:
+        type: string
+      Links:
+        items:
+          type: string
+        type: array
+      MacAddress:
+        type: string
+      NetworkID:
+        description: Operational data
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/network
+  ErrorResponse:
+    properties:
+      message:
+        description: The error message.
+        type: string
+        x-go-name: Message
+    required:
+    - message
+    title: ErrorResponse Represents an error.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  FileMode:
+    description: |-
+      The bits have the same definition on all systems, so that
+      information about files can be moved from one system
+      to another portably. Not all bits apply to all systems.
+      The only required bit is ModeDir for directories.
+    format: uint32
+    title: A FileMode represents a file's mode and permission bits.
+    type: integer
+    x-go-package: os
+  GraphDriverData:
+    properties:
+      Data:
+        additionalProperties:
+          type: string
+        description: data
+        type: object
+      Name:
+        description: name
+        type: string
+    required:
+    - Data
+    - Name
+    title: GraphDriverData Information about a container's graph driver.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  HardwareAddr:
+    items:
+      format: uint8
+      type: integer
+    title: A HardwareAddr represents a physical hardware address.
+    type: array
+    x-go-package: net
+  Health:
+    description: Health stores information about the container's healthcheck results
+    properties:
+      FailingStreak:
+        format: int64
+        type: integer
+      Log:
+        items:
+          $ref: '#/definitions/HealthcheckResult'
+        type: array
+      Status:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  HealthCheckLog:
+    description: HealthCheckLog describes the results of a single healthcheck
+    properties:
+      End:
+        description: End time as a string
+        type: string
+      ExitCode:
+        description: Exitcode is 0 or 1
+        format: int64
+        type: integer
+      Output:
+        description: Output is the stdout/stderr from the healthcheck command
+        type: string
+      Start:
+        description: Start time as string
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  HealthCheckResults:
+    description: HealthCheckResults describes the results/logs from a healthcheck
+    properties:
+      FailingStreak:
+        description: FailingStreak is the number of consecutive failed healthchecks
+        format: int64
+        type: integer
+      Log:
+        description: Log describes healthcheck attempts and results
+        items:
+          $ref: '#/definitions/HealthCheckLog'
+        type: array
+      Status:
+        description: Status healthy or unhealthy
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  HealthConfig:
+    properties:
+      Interval:
+        $ref: '#/definitions/Duration'
+      Retries:
+        description: |-
+          Retries is the number of consecutive failures needed to consider a container as unhealthy.
+          Zero means inherit.
+        format: int64
+        type: integer
+      StartPeriod:
+        $ref: '#/definitions/Duration'
+      Test:
+        description: |-
+          Test is the test to perform to check that the container is healthy.
+          An empty slice means to inherit the default.
+          The options are:
+          {} : inherit healthcheck
+          {"NONE"} : disable healthcheck
+          {"CMD", args...} : exec arguments directly
+          {"CMD-SHELL", command} : run command with system's default shell
+        items:
+          type: string
+        type: array
+      Timeout:
+        $ref: '#/definitions/Duration'
+    title: HealthConfig holds configuration settings for the HEALTHCHECK feature.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  HealthcheckResult:
+    description: HealthcheckResult stores information about a single run of a healthcheck
+      probe
+    properties:
+      End:
+        format: date-time
+        type: string
+      ExitCode:
+        format: int64
+        type: integer
+      Output:
+        type: string
+      Start:
+        format: date-time
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  History:
+    properties:
+      author:
+        description: Author is the author of the build point.
+        type: string
+        x-go-name: Author
+      comment:
+        description: Comment is a custom message set when creating the layer.
+        type: string
+        x-go-name: Comment
+      created:
+        description: Created is the combined date and time at which the layer was
+          created, formatted as defined by RFC 3339, section 5.6.
+        format: date-time
+        type: string
+        x-go-name: Created
+      created_by:
+        description: CreatedBy is the command which created the layer.
+        type: string
+        x-go-name: CreatedBy
+      empty_layer:
+        description: EmptyLayer is used to mark if the history item created a filesystem
+          diff.
+        type: boolean
+        x-go-name: EmptyLayer
+    title: History describes the history of a layer.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/image-spec/specs-go/v1
+  HistoryResponseItem:
+    description: HistoryResponseItem individual image layer information in response
+      to ImageHistory operation
+    properties:
+      Comment:
+        description: comment
+        type: string
+      Created:
+        description: created
+        format: int64
+        type: integer
+      CreatedBy:
+        description: created by
+        type: string
+      Id:
+        description: Id
+        type: string
+        x-go-name: ID
+      Size:
+        description: size
+        format: int64
+        type: integer
+      Tags:
+        description: tags
+        items:
+          type: string
+        type: array
+    required:
+    - Comment
+    - Created
+    - CreatedBy
+    - Id
+    - Size
+    - Tags
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/image
+  HostConfig:
+    description: |-
+      Here, "non-portable" means "dependent of the host we are running on".
+      Portable information *should* appear in Config.
+    properties:
+      AutoRemove:
+        type: boolean
+      Binds:
+        description: Applicable to all platforms
+        items:
+          type: string
+        type: array
+      BlkioDeviceReadBps:
+        items:
+          $ref: '#/definitions/ThrottleDevice'
+        type: array
+      BlkioDeviceReadIOps:
+        items:
+          $ref: '#/definitions/ThrottleDevice'
+        type: array
+      BlkioDeviceWriteBps:
+        items:
+          $ref: '#/definitions/ThrottleDevice'
+        type: array
+      BlkioDeviceWriteIOps:
+        items:
+          $ref: '#/definitions/ThrottleDevice'
+        type: array
+      BlkioWeight:
+        format: uint16
+        type: integer
+      BlkioWeightDevice:
+        items:
+          $ref: '#/definitions/WeightDevice'
+        type: array
+      CapAdd:
+        $ref: '#/definitions/StrSlice'
+      CapDrop:
+        $ref: '#/definitions/StrSlice'
+      Capabilities:
+        items:
+          type: string
+        type: array
+      Cgroup:
+        $ref: '#/definitions/CgroupSpec'
+      CgroupParent:
+        description: Applicable to UNIX platforms
+        type: string
+      CgroupnsMode:
+        $ref: '#/definitions/CgroupnsMode'
+      ConsoleSize:
+        description: Applicable to Windows
+        items:
+          format: uint64
+          type: integer
+        type: array
+      ContainerIDFile:
+        type: string
+      CpuCount:
+        description: Applicable to Windows
+        format: int64
+        type: integer
+        x-go-name: CPUCount
+      CpuPercent:
+        format: int64
+        type: integer
+        x-go-name: CPUPercent
+      CpuPeriod:
+        format: int64
+        type: integer
+        x-go-name: CPUPeriod
+      CpuQuota:
+        format: int64
+        type: integer
+        x-go-name: CPUQuota
+      CpuRealtimePeriod:
+        format: int64
+        type: integer
+        x-go-name: CPURealtimePeriod
+      CpuRealtimeRuntime:
+        format: int64
+        type: integer
+        x-go-name: CPURealtimeRuntime
+      CpuShares:
+        description: Applicable to all platforms
+        format: int64
+        type: integer
+        x-go-name: CPUShares
+      CpusetCpus:
+        type: string
+      CpusetMems:
+        type: string
+      DeviceCgroupRules:
+        items:
+          type: string
+        type: array
+      DeviceRequests:
+        items:
+          $ref: '#/definitions/DeviceRequest'
+        type: array
+      Devices:
+        items:
+          $ref: '#/definitions/DeviceMapping'
+        type: array
+      Dns:
+        items:
+          type: string
+        type: array
+        x-go-name: DNS
+      DnsOptions:
+        items:
+          type: string
+        type: array
+        x-go-name: DNSOptions
+      DnsSearch:
+        items:
+          type: string
+        type: array
+        x-go-name: DNSSearch
+      ExtraHosts:
+        items:
+          type: string
+        type: array
+      GroupAdd:
+        items:
+          type: string
+        type: array
+      IOMaximumBandwidth:
+        format: uint64
+        type: integer
+      IOMaximumIOps:
+        format: uint64
+        type: integer
+      Init:
+        description: Run a custom init inside the container, if null, use the daemon's
+          configured settings
+        type: boolean
+      IpcMode:
+        $ref: '#/definitions/IpcMode'
+      Isolation:
+        $ref: '#/definitions/Isolation'
+      KernelMemory:
+        format: int64
+        type: integer
+      KernelMemoryTCP:
+        format: int64
+        type: integer
+      Links:
+        items:
+          type: string
+        type: array
+      LogConfig:
+        $ref: '#/definitions/LogConfig'
+      MaskedPaths:
+        description: MaskedPaths is the list of paths to be masked inside the container
+          (this overrides the default set of paths)
+        items:
+          type: string
+        type: array
+      Memory:
+        format: int64
+        type: integer
+      MemoryReservation:
+        format: int64
+        type: integer
+      MemorySwap:
+        format: int64
+        type: integer
+      MemorySwappiness:
+        format: int64
+        type: integer
+      Mounts:
+        description: Mounts specs used by the container
+        items:
+          $ref: '#/definitions/Mount'
+        type: array
+      NanoCpus:
+        format: int64
+        type: integer
+        x-go-name: NanoCPUs
+      NetworkMode:
+        $ref: '#/definitions/NetworkMode'
+      OomKillDisable:
+        type: boolean
+      OomScoreAdj:
+        format: int64
+        type: integer
+      PidMode:
+        $ref: '#/definitions/PidMode'
+      PidsLimit:
+        format: int64
+        type: integer
+      PortBindings:
+        $ref: '#/definitions/PortMap'
+      Privileged:
+        type: boolean
+      PublishAllPorts:
+        type: boolean
+      ReadonlyPaths:
+        description: ReadonlyPaths is the list of paths to be set as read-only inside
+          the container (this overrides the default set of paths)
+        items:
+          type: string
+        type: array
+      ReadonlyRootfs:
+        type: boolean
+      RestartPolicy:
+        $ref: '#/definitions/RestartPolicy'
+      Runtime:
+        type: string
+      SecurityOpt:
+        items:
+          type: string
+        type: array
+      ShmSize:
+        format: int64
+        type: integer
+      StorageOpt:
+        additionalProperties:
+          type: string
+        type: object
+      Sysctls:
+        additionalProperties:
+          type: string
+        type: object
+      Tmpfs:
+        additionalProperties:
+          type: string
+        type: object
+      UTSMode:
+        $ref: '#/definitions/UTSMode'
+      Ulimits:
+        items:
+          $ref: '#/definitions/Ulimit'
+        type: array
+      UsernsMode:
+        $ref: '#/definitions/UsernsMode'
+      VolumeDriver:
+        type: string
+      VolumesFrom:
+        items:
+          type: string
+        type: array
+    title: HostConfig the non-portable Config structure of a container.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  HostInfo:
+    description: HostInfo describes the libpod host
+    properties:
+      arch:
+        type: string
+        x-go-name: Arch
+      buildahVersion:
+        type: string
+        x-go-name: BuildahVersion
+      cgroupVersion:
+        type: string
+        x-go-name: CGroupsVersion
+      conmon:
+        $ref: '#/definitions/ConmonInfo'
+      cpus:
+        format: int64
+        type: integer
+        x-go-name: CPUs
+      distribution:
+        $ref: '#/definitions/DistributionInfo'
+      eventLogger:
+        type: string
+        x-go-name: EventLogger
+      hostname:
+        type: string
+        x-go-name: Hostname
+      idMappings:
+        $ref: '#/definitions/IDMappings'
+      kernel:
+        type: string
+        x-go-name: Kernel
+      linkmode:
+        type: string
+        x-go-name: Linkmode
+      memFree:
+        format: int64
+        type: integer
+        x-go-name: MemFree
+      memTotal:
+        format: int64
+        type: integer
+        x-go-name: MemTotal
+      ociRuntime:
+        $ref: '#/definitions/OCIRuntimeInfo'
+      os:
+        type: string
+        x-go-name: OS
+      remoteSocket:
+        $ref: '#/definitions/RemoteSocket'
+      rootless:
+        type: boolean
+        x-go-name: Rootless
+      runtimeInfo:
+        additionalProperties:
+          type: object
+        type: object
+        x-go-name: RuntimeInfo
+      slirp4netns:
+        $ref: '#/definitions/SlirpInfo'
+      swapFree:
+        format: int64
+        type: integer
+        x-go-name: SwapFree
+      swapTotal:
+        format: int64
+        type: integer
+        x-go-name: SwapTotal
+      uptime:
+        type: string
+        x-go-name: Uptime
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  IDMap:
+    description: |-
+      IDMap contains a single entry for user namespace range remapping. An array
+      of IDMap entries represents the structure that will be provided to the Linux
+      kernel for creating a user namespace.
+    properties:
+      container_id:
+        format: int64
+        type: integer
+        x-go-name: ContainerID
+      host_id:
+        format: int64
+        type: integer
+        x-go-name: HostID
+      size:
+        format: int64
+        type: integer
+        x-go-name: Size
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/containers/storage/pkg/idtools
+  IDMappingOptions:
+    description: |-
+      IDMappingOptions are used for specifying how ID mapping should be set up for
+      a layer or container.
+    properties:
+      AutoUserNs:
+        type: boolean
+      AutoUserNsOpts:
+        $ref: '#/definitions/AutoUserNsOptions'
+      GIDMap:
+        items:
+          $ref: '#/definitions/IDMap'
+        type: array
+      HostGIDMapping:
+        type: boolean
+      HostUIDMapping:
+        description: |-
+          UIDMap and GIDMap are used for setting up a layer's root filesystem
+          for use inside of a user namespace where ID mapping is being used.
+          If HostUIDMapping/HostGIDMapping is true, no mapping of the
+          respective type will be used.  Otherwise, if UIDMap and/or GIDMap
+          contain at least one mapping, one or both will be used.  By default,
+          if neither of those conditions apply, if the layer has a parent
+          layer, the parent layer's mapping will be used, and if it does not
+          have a parent layer, the mapping which was passed to the Store
+          object when it was initialized will be used.
+        type: boolean
+      UIDMap:
+        items:
+          $ref: '#/definitions/IDMap'
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/containers/storage
+  IDMappings:
+    description: IDMappings describe the GID and UID mappings
+    properties:
+      gidmap:
+        items:
+          $ref: '#/definitions/IDMap'
+        type: array
+        x-go-name: GIDMap
+      uidmap:
+        items:
+          $ref: '#/definitions/IDMap'
+        type: array
+        x-go-name: UIDMap
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  IDResponse:
+    properties:
+      Id:
+        description: ID
+        type: string
+        x-go-name: ID
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/api/handlers
+  IP:
+    description: |-
+      Note that in this documentation, referring to an
+      IP address as an IPv4 address or an IPv6 address
+      is a semantic property of the address, not just the
+      length of the byte slice: a 16-byte slice can still
+      be an IPv4 address.
+    items:
+      format: uint8
+      type: integer
+    title: |-
+      An IP is a single IP address, a slice of bytes.
+      Functions in this package accept either 4-byte (IPv4)
+      or 16-byte (IPv6) slices as input.
+    type: array
+    x-go-package: net
+  IPAM:
+    description: IPAM represents IP Address Management
+    properties:
+      Config:
+        items:
+          $ref: '#/definitions/IPAMConfig'
+        type: array
+      Driver:
+        type: string
+      Options:
+        additionalProperties:
+          type: string
+        type: object
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/network
+  IPAMConfig:
+    description: IPAMConfig represents IPAM configurations
+    properties:
+      AuxiliaryAddresses:
+        additionalProperties:
+          type: string
+        type: object
+        x-go-name: AuxAddress
+      Gateway:
+        type: string
+      IPRange:
+        type: string
+      Subnet:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/network
+  IPMask:
+    description: See type IPNet and func ParseCIDR for details.
+    items:
+      format: uint8
+      type: integer
+    title: |-
+      An IPMask is a bitmask that can be used to manipulate
+      IP addresses for IP addressing and routing.
+    type: array
+    x-go-package: net
+  IPNet:
+    properties:
+      IP:
+        $ref: '#/definitions/IP'
+      Mask:
+        $ref: '#/definitions/IPMask'
+    title: An IPNet represents an IP network.
+    type: object
+    x-go-package: net
+  IdResponse:
+    description: IDResponse Response to an API call that returns just an Id
+    properties:
+      Id:
+        description: The id of the newly created object.
+        type: string
+        x-go-name: ID
+    required:
+    - Id
+    type: object
+    x-go-name: IDResponse
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  ImageConfig:
+    properties:
+      Cmd:
+        description: Cmd defines the default arguments to the entrypoint of the container.
+        items:
+          type: string
+        type: array
+      Entrypoint:
+        description: Entrypoint defines a list of arguments to use as the command
+          to execute when the container starts.
+        items:
+          type: string
+        type: array
+      Env:
+        description: Env is a list of environment variables to be used in a container.
+        items:
+          type: string
+        type: array
+      ExposedPorts:
+        additionalProperties:
+          type: object
+        description: ExposedPorts a set of ports to expose from a container running
+          this image.
+        type: object
+      Labels:
+        additionalProperties:
+          type: string
+        description: Labels contains arbitrary metadata for the container.
+        type: object
+      StopSignal:
+        description: StopSignal contains the system call signal that will be sent
+          to the container to exit.
+        type: string
+      User:
+        description: User defines the username or UID which the process in the container
+          should run as.
+        type: string
+      Volumes:
+        additionalProperties:
+          type: object
+        description: Volumes is a set of directories describing where the process
+          is likely write data specific to a container instance.
+        type: object
+      WorkingDir:
+        description: WorkingDir sets the current working directory of the entrypoint
+          process in the container.
+        type: string
+    title: ImageConfig defines the execution parameters which should be used as a
+      base when running a container using an image.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/image-spec/specs-go/v1
+  ImageDeleteResponse:
+    description: |-
+      ImageDeleteResponse is the response for removing an image from storage and containers
+      what was untagged vs actually removed
+    properties:
+      deleted:
+        type: string
+        x-go-name: Deleted
+      untagged:
+        items:
+          type: string
+        type: array
+        x-go-name: Untagged
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/image
+  ImageDeleteResponseItem:
+    description: ImageDeleteResponseItem image delete response item
+    properties:
+      Deleted:
+        description: The image ID of an image that was deleted
+        type: string
+      Untagged:
+        description: The image ID of an image that was untagged
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  ImageImportReport:
+    properties:
+      Id:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  ImageLayer:
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/api/handlers
+  ImageLoadReport:
+    properties:
+      Names:
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  ImageMetadata:
+    description: ImageMetadata contains engine-local data about the image
+    properties:
+      LastTagTime:
+        format: date-time
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  ImageStore:
+    description: |-
+      ImageStore describes the image store.  Right now only the number
+      of images present
+    properties:
+      number:
+        format: int64
+        type: integer
+        x-go-name: Number
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  ImageSummary:
+    description: ImageSummary image summary
+    properties:
+      Containers:
+        description: containers
+        format: int64
+        type: integer
+      Created:
+        description: created
+        format: int64
+        type: integer
+      Id:
+        description: Id
+        type: string
+        x-go-name: ID
+      Labels:
+        additionalProperties:
+          type: string
+        description: labels
+        type: object
+      ParentId:
+        description: parent Id
+        type: string
+        x-go-name: ParentID
+      RepoDigests:
+        description: repo digests
+        items:
+          type: string
+        type: array
+      RepoTags:
+        description: repo tags
+        items:
+          type: string
+        type: array
+      SharedSize:
+        description: shared size
+        format: int64
+        type: integer
+      Size:
+        description: size
+        format: int64
+        type: integer
+      VirtualSize:
+        description: virtual size
+        format: int64
+        type: integer
+    required:
+    - Containers
+    - Created
+    - Id
+    - Labels
+    - ParentId
+    - RepoDigests
+    - RepoTags
+    - SharedSize
+    - Size
+    - VirtualSize
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  Info:
+    description: |-
+      Info is the overall struct that describes the host system
+      running libpod/podman
+    properties:
+      host:
+        $ref: '#/definitions/HostInfo'
+      registries:
+        additionalProperties:
+          type: object
+        type: object
+        x-go-name: Registries
+      store:
+        $ref: '#/definitions/StoreInfo'
+      version:
+        $ref: '#/definitions/Version'
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectAdditionalNetwork:
+    description: |-
+      InspectAdditionalNetwork holds information about non-default CNI networks the
+      container has been connected to.
+      As with InspectNetworkSettings, many fields are unused and maintained only
+      for compatibility with Docker.
+    properties:
+      AdditionalMACAddresses:
+        description: |-
+          AdditionalMacAddresses is a set of additional MAC Addresses beyond
+          the first. CNI may configure more than one interface for a single
+          network, which can cause this.
+        items:
+          type: string
+        type: array
+        x-go-name: AdditionalMacAddresses
+      DriverOpts:
+        additionalProperties:
+          type: string
+        description: |-
+          DriverOpts is presently unused and maintained exclusively for
+          compatibility.
+        type: object
+      EndpointID:
+        description: EndpointID is unused, maintained exclusively for compatibility.
+        type: string
+      Gateway:
+        description: Gateway is the IP address of the gateway this network will use.
+        type: string
+      GlobalIPv6Address:
+        description: GlobalIPv6Address is the global-scope IPv6 Address for this network.
+        type: string
+      GlobalIPv6PrefixLen:
+        description: GlobalIPv6PrefixLen is the length of the subnet mask of this
+          network.
+        format: int64
+        type: integer
+      IPAMConfig:
+        additionalProperties:
+          type: string
+        description: |-
+          IPAMConfig is presently unused and maintained exclusively for
+          compatibility.
+        type: object
+      IPAddress:
+        description: IPAddress is the IP address for this network.
+        type: string
+      IPPrefixLen:
+        description: IPPrefixLen is the length of the subnet mask of this network.
+        format: int64
+        type: integer
+      IPv6Gateway:
+        description: IPv6Gateway is the IPv6 gateway this network will use.
+        type: string
+      Links:
+        description: |-
+          Links is presently unused and maintained exclusively for
+          compatibility.
+        items:
+          type: string
+        type: array
+      MacAddress:
+        description: MacAddress is the MAC address for the interface in this network.
+        type: string
+      NetworkID:
+        description: Name of the network we're connecting to.
+        type: string
+      SecondaryIPAddresses:
+        description: |-
+          SecondaryIPAddresses is a list of extra IP Addresses that the
+          container has been assigned in this network.
+        items:
+          type: string
+        type: array
+      SecondaryIPv6Addresses:
+        description: |-
+          SecondaryIPv6Addresses is a list of extra IPv6 Addresses that the
+          container has been assigned in this networ.
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectBlkioThrottleDevice:
+    description: |-
+      InspectBlkioThrottleDevice holds information about a speed cap for a device
+      node. This cap applies to a specific operation (read, write, etc) on the given
+      node.
+    properties:
+      Path:
+        description: Path is the path to the device this applies to.
+        type: string
+      Rate:
+        description: |-
+          Rate is the maximum rate. It is in either bytes per second or iops
+          per second, determined by where it is used - documentation will
+          indicate which is appropriate.
+        format: uint64
+        type: integer
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectBlkioWeightDevice:
+    description: |-
+      InspectBlkioWeightDevice holds information about the relative weight
+      of an individual device node. Weights are used in the I/O scheduler to give
+      relative priority to some accesses.
+    properties:
+      Path:
+        description: Path is the path to the device this applies to.
+        type: string
+      Weight:
+        description: |-
+          Weight is the relative weight the scheduler will use when scheduling
+          I/O.
+        format: uint16
+        type: integer
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectContainerConfig:
+    description: |-
+      InspectContainerConfig holds further data about how a container was initially
+      configured.
+    properties:
+      Annotations:
+        additionalProperties:
+          type: string
+        description: Container annotations
+        type: object
+      AttachStderr:
+        description: Unused, at present
+        type: boolean
+      AttachStdin:
+        description: Unused, at present
+        type: boolean
+      AttachStdout:
+        description: Unused, at present
+        type: boolean
+      Cmd:
+        description: Container command
+        items:
+          type: string
+        type: array
+      CreateCommand:
+        description: |-
+          CreateCommand is the full command plus arguments of the process the
+          container has been created with.
+        items:
+          type: string
+        type: array
+      Domainname:
+        description: Container domain name - unused at present
+        type: string
+        x-go-name: DomainName
+      Entrypoint:
+        description: Container entrypoint
+        type: string
+      Env:
+        description: Container environment variables
+        items:
+          type: string
+        type: array
+      Healthcheck:
+        $ref: '#/definitions/Schema2HealthConfig'
+      Hostname:
+        description: Container hostname
+        type: string
+      Image:
+        description: Container image
+        type: string
+      Labels:
+        additionalProperties:
+          type: string
+        description: Container labels
+        type: object
+      OnBuild:
+        description: On-build arguments - presently unused. More of Buildah's domain.
+        type: string
+      OpenStdin:
+        description: Whether the container leaves STDIN open
+        type: boolean
+      StdinOnce:
+        description: |-
+          Whether STDIN is only left open once.
+          Presently not supported by Podman, unused.
+        type: boolean
+      StopSignal:
+        description: Container stop signal
+        format: uint64
+        type: integer
+      Tty:
+        description: Whether the container creates a TTY
+        type: boolean
+      User:
+        description: User the container was launched with
+        type: string
+      Volumes:
+        additionalProperties:
+          type: object
+        description: Unused, at present. I've never seen this field populated.
+        type: object
+      WorkingDir:
+        description: Container working directory
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectContainerHostConfig:
+    description: |-
+      InspectContainerHostConfig holds information used when the container was
+      created.
+      It's very much a Docker-specific struct, retained (mostly) as-is for
+      compatibility. We fill individual fields as best as we can, inferring as much
+      as possible from the spec and container config.
+      Some things cannot be inferred. These will be populated by spec annotations
+      (if available).
+      Field names are fixed for compatibility and cannot be changed.
+      As such, silence lint warnings about them.
+      nolint
+    properties:
+      AutoRemove:
+        description: |-
+          AutoRemove is whether the container will be automatically removed on
+          exiting.
+          It is not handled directly within libpod and is stored in an
+          annotation.
+        type: boolean
+      Binds:
+        description: |-
+          Binds contains an array of user-added mounts.
+          Both volume mounts and named volumes are included.
+          Tmpfs mounts are NOT included.
+          In 'docker inspect' this is separated into 'Binds' and 'Mounts' based
+          on how a mount was added. We do not make this distinction and do not
+          include a Mounts field in inspect.
+          Format: <src>:<destination>[:<comma-separated options>]
+        items:
+          type: string
+        type: array
+      BlkioDeviceReadBps:
+        description: |-
+          BlkioDeviceReadBps is an array of I/O throttle parameters for
+          individual device nodes.
+          This specifically sets read rate cap in bytes per second for device
+          nodes.
+          As with BlkioWeightDevice, we pull the path from /sys/dev, and we
+          don't guarantee the path will be identical to the original (though
+          the node will be).
+        items:
+          $ref: '#/definitions/InspectBlkioThrottleDevice'
+        type: array
+      BlkioDeviceReadIOps:
+        description: |-
+          BlkioDeviceReadIOps is an array of I/O throttle parameters for
+          individual device nodes.
+          This specifically sets the read rate cap in iops per second for
+          device nodes.
+          As with BlkioWeightDevice, we pull the path from /sys/dev, and we
+          don't guarantee the path will be identical to the original (though
+          the node will be).
+        items:
+          $ref: '#/definitions/InspectBlkioThrottleDevice'
+        type: array
+      BlkioDeviceWriteBps:
+        description: |-
+          BlkioDeviceWriteBps is an array of I/O throttle parameters for
+          individual device nodes.
+          this specifically sets write rate cap in bytes per second for device
+          nodes.
+          as with BlkioWeightDevice, we pull the path from /sys/dev, and we
+          don't guarantee the path will be identical to the original (though
+          the node will be).
+        items:
+          $ref: '#/definitions/InspectBlkioThrottleDevice'
+        type: array
+      BlkioDeviceWriteIOps:
+        description: |-
+          BlkioDeviceWriteIOps is an array of I/O throttle parameters for
+          individual device nodes.
+          This specifically sets the write rate cap in iops per second for
+          device nodes.
+          As with BlkioWeightDevice, we pull the path from /sys/dev, and we
+          don't guarantee the path will be identical to the original (though
+          the node will be).
+        items:
+          $ref: '#/definitions/InspectBlkioThrottleDevice'
+        type: array
+      BlkioWeight:
+        description: |-
+          BlkioWeight indicates the I/O resources allocated to the container.
+          It is a relative weight in the scheduler for assigning I/O time
+          versus other CGroups.
+        format: uint16
+        type: integer
+      BlkioWeightDevice:
+        description: |-
+          BlkioWeightDevice is an array of I/O resource priorities for
+          individual device nodes.
+          Unfortunately, the spec only stores the device's Major/Minor numbers
+          and not the path, which is used here.
+          Fortunately, the kernel provides an interface for retrieving the path
+          of a given node by major:minor at /sys/dev/. However, the exact path
+          in use may not be what was used in the original CLI invocation -
+          though it is guaranteed that the device node will be the same, and
+          using the given path will be functionally identical.
+        items:
+          $ref: '#/definitions/InspectBlkioWeightDevice'
+        type: array
+      CapAdd:
+        description: |-
+          CapAdd is a list of capabilities added to the container.
+          It is not directly stored by Libpod, and instead computed from the
+          capabilities listed in the container's spec, compared against a set
+          of default capabilities.
+        items:
+          type: string
+        type: array
+      CapDrop:
+        description: |-
+          CapDrop is a list of capabilities removed from the container.
+          It is not directly stored by libpod, and instead computed from the
+          capabilities listed in the container's spec, compared against a set
+          of default capabilities.
+        items:
+          type: string
+        type: array
+      Cgroup:
+        description: |-
+          Cgroup contains the container's cgroup. It is presently not
+          populated.
+          TODO.
+        type: string
+      CgroupMode:
+        description: |-
+          CgroupMode is the configuration of the container's cgroup namespace.
+          Populated as follows:
+          private - a cgroup namespace has been created
+          host - No cgroup namespace created
+          container:<id> - Using another container's cgroup namespace
+          ns:<path> - A path to a cgroup namespace has been specified
+        type: string
+      CgroupParent:
+        description: |-
+          CgroupParent is the CGroup parent of the container.
+          Only set if not default.
+        type: string
+      Cgroups:
+        description: |-
+          Cgroups contains the container's CGroup mode.
+          Allowed values are "default" (container is creating CGroups) and
+          "disabled" (container is not creating CGroups).
+          This is Libpod-specific and not included in `docker inspect`.
+        type: string
+      ConsoleSize:
+        description: |-
+          ConsoleSize is an array of 2 integers showing the size of the
+          container's console.
+          It is only set if the container is creating a terminal.
+          TODO.
+        items:
+          format: uint64
+          type: integer
+        type: array
+      ContainerIDFile:
+        description: |-
+          ContainerIDFile is a file created during container creation to hold
+          the ID of the created container.
+          This is not handled within libpod and is stored in an annotation.
+        type: string
+      CpuCount:
+        description: CpuCount is Windows-only and not presently implemented.
+        format: uint64
+        type: integer
+      CpuPercent:
+        description: CpuPercent is Windows-only and not presently implemented.
+        format: uint64
+        type: integer
+      CpuPeriod:
+        description: |-
+          CpuPeriod is the length of a CPU period in microseconds.
+          It relates directly to CpuQuota.
+        format: uint64
+        type: integer
+      CpuQuota:
+        description: |-
+          CpuPeriod is the amount of time (in microseconds) that a container
+          can use the CPU in every CpuPeriod.
+        format: int64
+        type: integer
+      CpuRealtimePeriod:
+        description: |-
+          CpuRealtimePeriod is the length of time (in microseconds) of the CPU
+          realtime period. If set to 0, no time will be allocated to realtime
+          tasks.
+        format: uint64
+        type: integer
+      CpuRealtimeRuntime:
+        description: |-
+          CpuRealtimeRuntime is the length of time (in microseconds) allocated
+          for realtime tasks within every CpuRealtimePeriod.
+        format: int64
+        type: integer
+      CpuShares:
+        description: |-
+          CpuShares indicates the CPU resources allocated to the container.
+          It is a relative weight in the scheduler for assigning CPU time
+          versus other CGroups.
+        format: uint64
+        type: integer
+      CpusetCpus:
+        description: |-
+          CpusetCpus is the is the set of CPUs that the container will execute
+          on. Formatted as `0-3` or `0,2`. Default (if unset) is all CPUs.
+        type: string
+      CpusetMems:
+        description: |-
+          CpusetMems is the set of memory nodes the container will use.
+          Formatted as `0-3` or `0,2`. Default (if unset) is all memory nodes.
+        type: string
+      Devices:
+        description: |-
+          Devices is a list of device nodes that will be added to the
+          container.
+          These are stored in the OCI spec only as type, major, minor while we
+          display the host path. We convert this with /sys/dev, but we cannot
+          guarantee that the host path will be identical - only that the actual
+          device will be.
+        items:
+          $ref: '#/definitions/InspectDevice'
+        type: array
+      DiskQuota:
+        description: |-
+          DiskQuota is the maximum amount of disk space the container may use
+          (in bytes).
+          Presently not populated.
+          TODO.
+        format: uint64
+        type: integer
+      Dns:
+        description: |-
+          Dns is a list of DNS nameservers that will be added to the
+          container's resolv.conf
+        items:
+          type: string
+        type: array
+      DnsOptions:
+        description: |-
+          DnsOptions is a list of DNS options that will be set in the
+          container's resolv.conf
+        items:
+          type: string
+        type: array
+      DnsSearch:
+        description: |-
+          DnsSearch is a list of DNS search domains that will be set in the
+          container's resolv.conf
+        items:
+          type: string
+        type: array
+      ExtraHosts:
+        description: |-
+          ExtraHosts contains hosts that will be aded to the container's
+          etc/hosts.
+        items:
+          type: string
+        type: array
+      GroupAdd:
+        description: |-
+          GroupAdd contains groups that the user inside the container will be
+          added to.
+        items:
+          type: string
+        type: array
+      IOMaximumBandwidth:
+        description: IOMaximumBandwidth is Windows-only and not presently implemented.
+        format: uint64
+        type: integer
+      IOMaximumIOps:
+        description: IOMaximumIOps is Windows-only and not presently implemented.
+        format: uint64
+        type: integer
+      Init:
+        description: Init indicates whether the container has an init mounted into
+          it.
+        type: boolean
+      IpcMode:
+        description: |-
+          IpcMode represents the configuration of the container's IPC
+          namespace.
+          Populated as follows:
+          "" (empty string) - Default, an IPC namespace will be created
+          host - No IPC namespace created
+          container:<id> - Using another container's IPC namespace
+          ns:<path> - A path to an IPC namespace has been specified
+        type: string
+      Isolation:
+        description: |-
+          Isolation is presently unused and provided solely for Docker
+          compatibility.
+        type: string
+      KernelMemory:
+        description: |-
+          KernelMemory is the maximum amount of memory the kernel will devote
+          to the container.
+        format: int64
+        type: integer
+      Links:
+        description: Links is unused, and provided purely for Docker compatibility.
+        items:
+          type: string
+        type: array
+      LogConfig:
+        $ref: '#/definitions/InspectLogConfig'
+      Memory:
+        description: |-
+          Memory indicates the memory resources allocated to the container.
+          This is the limit (in bytes) of RAM the container may use.
+        format: int64
+        type: integer
+      MemoryReservation:
+        description: |-
+          MemoryReservation is the reservation (soft limit) of memory available
+          to the container. Soft limits are warnings only and can be exceeded.
+        format: int64
+        type: integer
+      MemorySwap:
+        description: |-
+          MemorySwap is the total limit for all memory available to the
+          container, including swap. 0 indicates that there is no limit to the
+          amount of memory available.
+        format: int64
+        type: integer
+      MemorySwappiness:
+        description: |-
+          MemorySwappiness is the willingness of the kernel to page container
+          memory to swap. It is an integer from 0 to 100, with low numbers
+          being more likely to be put into swap.
+          1, the default, will not set swappiness and use the system defaults.
+        format: int64
+        type: integer
+      NanoCpus:
+        description: |-
+          NanoCpus indicates number of CPUs allocated to the container.
+          It is an integer where one full CPU is indicated by 1000000000 (one
+          billion).
+          Thus, 2.5 CPUs (fractional portions of CPUs are allowed) would be
+          2500000000 (2.5 billion).
+          In 'docker inspect' this is set exclusively of two further options in
+          the output (CpuPeriod and CpuQuota) which are both used to implement
+          this functionality.
+          We can't distinguish here, so if CpuQuota is set to the default of
+          100000, we will set both CpuQuota, CpuPeriod, and NanoCpus. If
+          CpuQuota is not the default, we will not set NanoCpus.
+        format: int64
+        type: integer
+      NetworkMode:
+        description: |-
+          NetworkMode is the configuration of the container's network
+          namespace.
+          Populated as follows:
+          default - A network namespace is being created and configured via CNI
+          none - A network namespace is being created, not configured via CNI
+          host - No network namespace created
+          container:<id> - Using another container's network namespace
+          ns:<path> - A path to a network namespace has been specified
+        type: string
+      OomKillDisable:
+        description: |-
+          OomKillDisable indicates whether the kernel OOM killer is disabled
+          for the container.
+        type: boolean
+      OomScoreAdj:
+        description: |-
+          OOMScoreAdj is an adjustment that will be made to the container's OOM
+          score.
+        format: int64
+        type: integer
+      PidMode:
+        description: |-
+          PidMode represents the configuration of the container's PID
+          namespace.
+          Populated as follows:
+          "" (empty string) - Default, a PID namespace will be created
+          host - No PID namespace created
+          container:<id> - Using another container's PID namespace
+          ns:<path> - A path to a PID namespace has been specified
+        type: string
+      PidsLimit:
+        description: |-
+          PidsLimit is the maximum number of PIDs what may be created within
+          the container. 0, the default, indicates no limit.
+        format: int64
+        type: integer
+      PortBindings:
+        additionalProperties:
+          items:
+            $ref: '#/definitions/InspectHostPort'
+          type: array
+        description: |-
+          PortBindings contains the container's port bindings.
+          It is formatted as map[string][]InspectHostPort.
+          The string key here is formatted as <integer port number>/<protocol>
+          and represents the container port. A single container port may be
+          bound to multiple host ports (on different IPs).
+        type: object
+      Privileged:
+        description: |-
+          Privileged indicates whether the container is running with elevated
+          privileges.
+          This has a very specific meaning in the Docker sense, so it's very
+          difficult to decode from the spec and config, and so is stored as an
+          annotation.
+        type: boolean
+      PublishAllPorts:
+        description: |-
+          PublishAllPorts indicates whether image ports are being published.
+          This is not directly stored in libpod and is saved as an annotation.
+        type: boolean
+      ReadonlyRootfs:
+        description: ReadonlyRootfs is whether the container will be mounted read-only.
+        type: boolean
+      RestartPolicy:
+        $ref: '#/definitions/InspectRestartPolicy'
+      Runtime:
+        description: |-
+          Runtime is provided purely for Docker compatibility.
+          It is set unconditionally to "oci" as Podman does not presently
+          support non-OCI runtimes.
+        type: string
+      SecurityOpt:
+        description: |-
+          SecurityOpt is a list of security-related options that are set in the
+          container.
+        items:
+          type: string
+        type: array
+      ShmSize:
+        description: ShmSize is the size of the container's SHM device.
+        format: int64
+        type: integer
+      Tmpfs:
+        additionalProperties:
+          type: string
+        description: |-
+          Tmpfs is a list of tmpfs filesystems that will be mounted into the
+          container.
+          It is a map of destination path to options for the mount.
+        type: object
+      UTSMode:
+        description: |-
+          UTSMode represents the configuration of the container's UID
+          namespace.
+          Populated as follows:
+          "" (empty string) - Default, a UTS namespace will be created
+          host - no UTS namespace created
+          container:<id> - Using another container's UTS namespace
+          ns:<path> - A path to a UTS namespace has been specified
+        type: string
+      Ulimits:
+        description: Ulimits is a set of ulimits that will be set within the container.
+        items:
+          $ref: '#/definitions/InspectUlimit'
+        type: array
+      UsernsMode:
+        description: |-
+          UsernsMode represents the configuration of the container's user
+          namespace.
+          When running rootless, a user namespace is created outside of libpod
+          to allow some privileged operations. This will not be reflected here.
+          Populated as follows:
+          "" (empty string) - No user namespace will be created
+          private - The container will be run in a user namespace
+          container:<id> - Using another container's user namespace
+          ns:<path> - A path to a user namespace has been specified
+          TODO Rootless has an additional 'keep-id' option, presently not
+          reflected here.
+        type: string
+      VolumeDriver:
+        description: |-
+          VolumeDriver is presently unused and is retained for Docker
+          compatibility.
+        type: string
+      VolumesFrom:
+        description: |-
+          VolumesFrom is a list of containers which this container uses volumes
+          from. This is not handled directly within libpod and is stored in an
+          annotation.
+          It is formatted as an array of container names and IDs.
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectContainerState:
+    description: |-
+      InspectContainerState provides a detailed record of a container's current
+      state. It is returned as part of InspectContainerData.
+      As with InspectContainerData, many portions of this struct are matched to
+      Docker, but here we see more fields that are unused (nonsensical in the
+      context of Libpod).
+    properties:
+      ConmonPid:
+        format: int64
+        type: integer
+      Dead:
+        type: boolean
+      Error:
+        type: string
+      ExitCode:
+        format: int32
+        type: integer
+      FinishedAt:
+        format: date-time
+        type: string
+      Healthcheck:
+        $ref: '#/definitions/HealthCheckResults'
+      OOMKilled:
+        type: boolean
+      OciVersion:
+        type: string
+      Paused:
+        type: boolean
+      Pid:
+        format: int64
+        type: integer
+      Restarting:
+        type: boolean
+      Running:
+        type: boolean
+      StartedAt:
+        format: date-time
+        type: string
+      Status:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectDevice:
+    properties:
+      CgroupPermissions:
+        description: |-
+          CgroupPermissions is the permissions of the mounted device.
+          Presently not populated.
+          TODO.
+        type: string
+      PathInContainer:
+        description: PathInContainer is the path of the device within the container.
+        type: string
+      PathOnHost:
+        description: PathOnHost is the path of the device on the host.
+        type: string
+    title: InspectDevice is a single device that will be mounted into the container.
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectHostPort:
+    description: |-
+      InspectHostPort provides information on a port on the host that a container's
+      port is bound to.
+    properties:
+      HostIp:
+        description: |-
+          IP on the host we are bound to. "" if not specified (binding to all
+          IPs).
+        type: string
+        x-go-name: HostIP
+      HostPort:
+        description: |-
+          Port on the host we are bound to. No special formatting - just an
+          integer stuffed into a string.
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectLogConfig:
+    description: |-
+      InspectLogConfig holds information about a container's configured log driver
+      and is presently unused. It is retained for Docker compatibility.
+    properties:
+      Config:
+        additionalProperties:
+          type: string
+        type: object
+      Type:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectMount:
+    description: |-
+      InspectMount provides a record of a single mount in a container. It contains
+      fields for both named and normal volumes. Only user-specified volumes will be
+      included, and tmpfs volumes are not included even if the user specified them.
+    properties:
+      Destination:
+        description: |-
+          The destination directory for the volume. Specified as a path within
+          the container, as it would be passed into the OCI runtime.
+        type: string
+      Driver:
+        description: The driver used for the named volume. Empty for bind mounts.
+        type: string
+      Mode:
+        description: |-
+          Contains SELinux :z/:Z mount options. Unclear what, if anything, else
+          goes in here.
+        type: string
+      Name:
+        description: The name of the volume. Empty for bind mounts.
+        type: string
+      Options:
+        description: |-
+          All remaining mount options. Additional data, not present in the
+          original output.
+        items:
+          type: string
+        type: array
+      Propagation:
+        description: |-
+          Mount propagation for the mount. Can be empty if not specified, but
+          is always printed - no omitempty.
+        type: string
+      RW:
+        description: Whether the volume is read-write
+        type: boolean
+      Source:
+        description: The source directory for the volume.
+        type: string
+      Type:
+        description: |-
+          Whether the mount is a volume or bind mount. Allowed values are
+          "volume" and "bind".
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectNetworkSettings:
+    description: |-
+      InspectNetworkSettings holds information about the network settings of the
+      container.
+      Many fields are maintained only for compatibility with `docker inspect` and
+      are unused within Libpod.
+    properties:
+      AdditionalMACAddresses:
+        description: |-
+          AdditionalMacAddresses is a set of additional MAC Addresses beyond
+          the first. CNI may configure more than one interface for a single
+          network, which can cause this.
+        items:
+          type: string
+        type: array
+        x-go-name: AdditionalMacAddresses
+      Bridge:
+        type: string
+      EndpointID:
+        description: EndpointID is unused, maintained exclusively for compatibility.
+        type: string
+      Gateway:
+        description: Gateway is the IP address of the gateway this network will use.
+        type: string
+      GlobalIPv6Address:
+        description: GlobalIPv6Address is the global-scope IPv6 Address for this network.
+        type: string
+      GlobalIPv6PrefixLen:
+        description: GlobalIPv6PrefixLen is the length of the subnet mask of this
+          network.
+        format: int64
+        type: integer
+      HairpinMode:
+        type: boolean
+      IPAddress:
+        description: IPAddress is the IP address for this network.
+        type: string
+      IPPrefixLen:
+        description: IPPrefixLen is the length of the subnet mask of this network.
+        format: int64
+        type: integer
+      IPv6Gateway:
+        description: IPv6Gateway is the IPv6 gateway this network will use.
+        type: string
+      LinkLocalIPv6Address:
+        type: string
+      LinkLocalIPv6PrefixLen:
+        format: int64
+        type: integer
+      MacAddress:
+        description: MacAddress is the MAC address for the interface in this network.
+        type: string
+      Networks:
+        additionalProperties:
+          $ref: '#/definitions/InspectAdditionalNetwork'
+        description: |-
+          Networks contains information on non-default CNI networks this
+          container has joined.
+          It is a map of network name to network information.
+        type: object
+      Ports:
+        additionalProperties:
+          items:
+            $ref: '#/definitions/InspectHostPort'
+          type: array
+        type: object
+      SandboxID:
+        type: string
+      SandboxKey:
+        type: string
+      SecondaryIPAddresses:
+        description: |-
+          SecondaryIPAddresses is a list of extra IP Addresses that the
+          container has been assigned in this network.
+        items:
+          type: string
+        type: array
+      SecondaryIPv6Addresses:
+        description: |-
+          SecondaryIPv6Addresses is a list of extra IPv6 Addresses that the
+          container has been assigned in this networ.
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectPodContainerInfo:
+    properties:
+      Id:
+        description: ID is the ID of the container.
+        type: string
+        x-go-name: ID
+      Name:
+        description: Name is the name of the container.
+        type: string
+      State:
+        description: State is the current status of the container.
+        type: string
+    title: InspectPodContainerInfo contains information on a container in a pod.
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectPodInfraConfig:
+    description: |-
+      InspectPodInfraConfig contains the configuration of the pod's infra
+      container.
+    properties:
+      DNSOption:
+        description: |-
+          DNSOption is a set of DNS options that will be used by the infra
+          container's resolv.conf and shared with the remainder of the pod.
+        items:
+          type: string
+        type: array
+      DNSSearch:
+        description: |-
+          DNSSearch is a set of DNS search domains that will be used by the
+          infra container's resolv.conf and shared with the remainder of the
+          pod.
+        items:
+          type: string
+        type: array
+      DNSServer:
+        description: |-
+          DNSServer is a set of DNS Servers that will be used by the infra
+          container's resolv.conf and shared with the remainder of the pod.
+        items:
+          type: string
+        type: array
+      HostAdd:
+        description: |-
+          HostAdd adds a number of hosts to the infra container's resolv.conf
+          which will be shared with the rest of the pod.
+        items:
+          type: string
+        type: array
+      HostNetwork:
+        description: |-
+          HostNetwork is whether the infra container (and thus the whole pod)
+          will use the host's network and not create a network namespace.
+        type: boolean
+      NoManageHosts:
+        description: |-
+          NoManageHosts indicates that the pod will not manage /etc/hosts and
+          instead each container will handle their own.
+        type: boolean
+      NoManageResolvConf:
+        description: |-
+          NoManageResolvConf indicates that the pod will not manage resolv.conf
+          and instead each container will handle their own.
+        type: boolean
+      PortBindings:
+        description: |-
+          PortBindings are ports that will be forwarded to the infra container
+          and then shared with the pod.
+        items:
+          $ref: '#/definitions/PortMapping'
+        type: array
+      StaticIP:
+        $ref: '#/definitions/IP'
+      StaticMAC:
+        $ref: '#/definitions/HardwareAddr'
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectRestartPolicy:
+    properties:
+      MaximumRetryCount:
+        description: |-
+          MaximumRetryCount is the maximum number of retries allowed if the
+          "on-failure" restart policy is in use. Not used if "on-failure" is
+          not set.
+        format: uint64
+        type: integer
+      Name:
+        description: |-
+          Name contains the container's restart policy.
+          Allowable values are "no" or "" (take no action),
+          "on-failure" (restart on non-zero exit code, with an optional max
+          retry count), and "always" (always restart on container stop, unless
+          explicitly requested by API).
+          Note that this is NOT actually a name of any sort - the poor naming
+          is for Docker compatibility.
+        type: string
+    title: InspectRestartPolicy holds information about the container's restart policy.
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  InspectUlimit:
+    properties:
+      Hard:
+        description: Hard is the hard limit that will be applied.
+        format: uint64
+        type: integer
+      Name:
+        description: Name is the name (type) of the ulimit.
+        type: string
+      Soft:
+        description: Soft is the soft limit that will be applied.
+        format: uint64
+        type: integer
+    title: InspectUlimit is a ulimit that will be applied to the container.
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  IpcConfig:
+    description: IpcConfig configures the ipc namespace for the container
+    properties:
+      IpcMode:
+        $ref: '#/definitions/IpcMode'
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/spec
+  IpcMode:
+    title: IpcMode represents the container ipc stack.
+    type: string
+    x-go-package: github.com/containers/libpod/pkg/namespaces
+  Isolation:
+    description: |-
+      Isolation represents the isolation technology of a container. The supported
+      values are platform specific
+    type: string
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  LibpodContainersPruneReport:
+    properties:
+      error:
+        type: string
+        x-go-name: PruneError
+      id:
+        type: string
+        x-go-name: ID
+      space:
+        format: int64
+        type: integer
+        x-go-name: SpaceReclaimed
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/api/handlers
+  LibpodImagesPullReport:
+    properties:
+      id:
+        type: string
+        x-go-name: ID
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/api/handlers
+  LibpodImagesRemoveReport:
+    description: |-
+      LibpodImagesRemoveReport is the return type for image removal via the rest
+      api.
+    properties:
+      Deleted:
+        description: Deleted images.
+        items:
+          type: string
+        type: array
+      Errors:
+        description: Image removal requires is to return data and an error.
+        items:
+          type: string
+        type: array
+      ExitCode:
+        description: |-
+          ExitCode describes the exit codes as described in the `podman rmi`
+          man page.
+        format: int64
+        type: integer
+      Untagged:
+        description: Untagged images. Can be longer than Deleted.
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/api/handlers
+  LinuxBlockIO:
+    description: LinuxBlockIO for Linux cgroup 'blkio' resource management
+    properties:
+      leafWeight:
+        description: Specifies tasks' weight in the given cgroup while competing with
+          the cgroup's child cgroups, CFQ scheduler only
+        format: uint16
+        type: integer
+        x-go-name: LeafWeight
+      throttleReadBpsDevice:
+        description: IO read rate limit per cgroup per device, bytes per second
+        items:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        type: array
+        x-go-name: ThrottleReadBpsDevice
+      throttleReadIOPSDevice:
+        description: IO read rate limit per cgroup per device, IO per second
+        items:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        type: array
+        x-go-name: ThrottleReadIOPSDevice
+      throttleWriteBpsDevice:
+        description: IO write rate limit per cgroup per device, bytes per second
+        items:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        type: array
+        x-go-name: ThrottleWriteBpsDevice
+      throttleWriteIOPSDevice:
+        description: IO write rate limit per cgroup per device, IO per second
+        items:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        type: array
+        x-go-name: ThrottleWriteIOPSDevice
+      weight:
+        description: Specifies per cgroup weight
+        format: uint16
+        type: integer
+        x-go-name: Weight
+      weightDevice:
+        description: Weight per cgroup per device, can override BlkioWeight
+        items:
+          $ref: '#/definitions/LinuxWeightDevice'
+        type: array
+        x-go-name: WeightDevice
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxCPU:
+    description: LinuxCPU for Linux cgroup 'cpu' resource management
+    properties:
+      cpus:
+        description: CPUs to use within the cpuset. Default is to use any CPU available.
+        type: string
+        x-go-name: Cpus
+      mems:
+        description: List of memory nodes in the cpuset. Default is to use any available
+          memory node.
+        type: string
+        x-go-name: Mems
+      period:
+        description: CPU period to be used for hardcapping (in usecs).
+        format: uint64
+        type: integer
+        x-go-name: Period
+      quota:
+        description: CPU hardcap limit (in usecs). Allowed cpu time in a given period.
+        format: int64
+        type: integer
+        x-go-name: Quota
+      realtimePeriod:
+        description: CPU period to be used for realtime scheduling (in usecs).
+        format: uint64
+        type: integer
+        x-go-name: RealtimePeriod
+      realtimeRuntime:
+        description: How much time realtime scheduling may use (in usecs).
+        format: int64
+        type: integer
+        x-go-name: RealtimeRuntime
+      shares:
+        description: CPU shares (relative weight (ratio) vs. other cgroups with cpu
+          shares).
+        format: uint64
+        type: integer
+        x-go-name: Shares
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxDevice:
+    description: LinuxDevice represents the mknod information for a Linux special
+      device file
+    properties:
+      fileMode:
+        $ref: '#/definitions/FileMode'
+      gid:
+        description: Gid of the device.
+        format: uint32
+        type: integer
+        x-go-name: GID
+      major:
+        description: Major is the device's major number.
+        format: int64
+        type: integer
+        x-go-name: Major
+      minor:
+        description: Minor is the device's minor number.
+        format: int64
+        type: integer
+        x-go-name: Minor
+      path:
+        description: Path to the device.
+        type: string
+        x-go-name: Path
+      type:
+        description: Device type, block, char, etc.
+        type: string
+        x-go-name: Type
+      uid:
+        description: UID of the device.
+        format: uint32
+        type: integer
+        x-go-name: UID
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxDeviceCgroup:
+    description: LinuxDeviceCgroup represents a device rule for the whitelist controller
+    properties:
+      access:
+        description: Cgroup access permissions format, rwm.
+        type: string
+        x-go-name: Access
+      allow:
+        description: Allow or deny
+        type: boolean
+        x-go-name: Allow
+      major:
+        description: Major is the device's major number.
+        format: int64
+        type: integer
+        x-go-name: Major
+      minor:
+        description: Minor is the device's minor number.
+        format: int64
+        type: integer
+        x-go-name: Minor
+      type:
+        description: Device type, block, char, etc.
+        type: string
+        x-go-name: Type
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxHugepageLimit:
+    description: LinuxHugepageLimit structure corresponds to limiting kernel hugepages
+    properties:
+      limit:
+        description: Limit is the limit of "hugepagesize" hugetlb usage
+        format: uint64
+        type: integer
+        x-go-name: Limit
+      pageSize:
+        description: |-
+          Pagesize is the hugepage size
+          Format: "<size><unit-prefix>B' (e.g. 64KB, 2MB, 1GB, etc.)
+        type: string
+        x-go-name: Pagesize
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxInterfacePriority:
+    description: LinuxInterfacePriority for network interfaces
+    properties:
+      name:
+        description: Name is the name of the network interface
+        type: string
+        x-go-name: Name
+      priority:
+        description: Priority for the interface
+        format: uint32
+        type: integer
+        x-go-name: Priority
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxMemory:
+    description: LinuxMemory for Linux cgroup 'memory' resource management
+    properties:
+      disableOOMKiller:
+        description: DisableOOMKiller disables the OOM killer for out of memory conditions
+        type: boolean
+        x-go-name: DisableOOMKiller
+      kernel:
+        description: Kernel memory limit (in bytes).
+        format: int64
+        type: integer
+        x-go-name: Kernel
+      kernelTCP:
+        description: Kernel memory limit for tcp (in bytes)
+        format: int64
+        type: integer
+        x-go-name: KernelTCP
+      limit:
+        description: Memory limit (in bytes).
+        format: int64
+        type: integer
+        x-go-name: Limit
+      reservation:
+        description: Memory reservation or soft_limit (in bytes).
+        format: int64
+        type: integer
+        x-go-name: Reservation
+      swap:
+        description: Total memory limit (memory + swap).
+        format: int64
+        type: integer
+        x-go-name: Swap
+      swappiness:
+        description: How aggressive the kernel will swap memory pages.
+        format: uint64
+        type: integer
+        x-go-name: Swappiness
+      useHierarchy:
+        description: Enables hierarchical memory accounting
+        type: boolean
+        x-go-name: UseHierarchy
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxNetwork:
+    description: LinuxNetwork identification and priority configuration
+    properties:
+      classID:
+        description: Set class identifier for container's network packets
+        format: uint32
+        type: integer
+        x-go-name: ClassID
+      priorities:
+        description: Set priority of network traffic for container
+        items:
+          $ref: '#/definitions/LinuxInterfacePriority'
+        type: array
+        x-go-name: Priorities
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxPids:
+    description: LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3)
+    properties:
+      limit:
+        description: Maximum number of PIDs. Default is "no limit".
+        format: int64
+        type: integer
+        x-go-name: Limit
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxRdma:
+    description: LinuxRdma for Linux cgroup 'rdma' resource management (Linux 4.11)
+    properties:
+      hcaHandles:
+        description: Maximum number of HCA handles that can be opened. Default is
+          "no limit".
+        format: uint32
+        type: integer
+        x-go-name: HcaHandles
+      hcaObjects:
+        description: Maximum number of HCA objects that can be created. Default is
+          "no limit".
+        format: uint32
+        type: integer
+        x-go-name: HcaObjects
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxResources:
+    description: LinuxResources has container runtime resource constraints
+    properties:
+      blockIO:
+        $ref: '#/definitions/LinuxBlockIO'
+      cpu:
+        $ref: '#/definitions/LinuxCPU'
+      devices:
+        description: Devices configures the device whitelist.
+        items:
+          $ref: '#/definitions/LinuxDeviceCgroup'
+        type: array
+        x-go-name: Devices
+      hugepageLimits:
+        description: Hugetlb limit (in bytes)
+        items:
+          $ref: '#/definitions/LinuxHugepageLimit'
+        type: array
+        x-go-name: HugepageLimits
+      memory:
+        $ref: '#/definitions/LinuxMemory'
+      network:
+        $ref: '#/definitions/LinuxNetwork'
+      pids:
+        $ref: '#/definitions/LinuxPids'
+      rdma:
+        additionalProperties:
+          $ref: '#/definitions/LinuxRdma'
+        description: |-
+          Rdma resource restriction configuration.
+          Limits are a set of key value pairs that define RDMA resource limits,
+          where the key is device name and value is resource limits.
+        type: object
+        x-go-name: Rdma
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxThrottleDevice:
+    description: LinuxThrottleDevice struct holds a `major:minor rate_per_second`
+      pair
+    properties:
+      major:
+        description: Major is the device's major number.
+        format: int64
+        type: integer
+        x-go-name: Major
+      minor:
+        description: Minor is the device's minor number.
+        format: int64
+        type: integer
+        x-go-name: Minor
+      rate:
+        description: Rate is the IO rate limit per cgroup per device
+        format: uint64
+        type: integer
+        x-go-name: Rate
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  LinuxWeightDevice:
+    description: LinuxWeightDevice struct holds a `major:minor weight` pair for weightDevice
+    properties:
+      leafWeight:
+        description: LeafWeight is the bandwidth rate for the device while competing
+          with the cgroup's child cgroups, CFQ scheduler only
+        format: uint16
+        type: integer
+        x-go-name: LeafWeight
+      major:
+        description: Major is the device's major number.
+        format: int64
+        type: integer
+        x-go-name: Major
+      minor:
+        description: Minor is the device's minor number.
+        format: int64
+        type: integer
+        x-go-name: Minor
+      weight:
+        description: Weight is the bandwidth rate for the device.
+        format: uint16
+        type: integer
+        x-go-name: Weight
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  List:
+    description: |-
+      Callers can either use this abstract interface without understanding the details of the formats,
+      or instantiate a specific implementation (e.g. manifest.OCI1Index) and access the public members
+      directly.
+    properties:
+      Clone:
+        $ref: '#/definitions/List'
+      Instances:
+        description: Instances returns a list of the manifests that this list knows
+          of, other than its own.
+        items:
+          $ref: '#/definitions/Digest'
+        type: array
+      MIMEType:
+        description: MIMEType returns the MIME type of this particular manifest list.
+        type: string
+    title: List is an interface for parsing, modifying lists of image manifests.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/containers/image/v5/manifest
+  ListContainer:
+    description: Listcontainer describes a container suitable for listing
+    properties:
+      Command:
+        description: Container command
+        items:
+          type: string
+        type: array
+      Created:
+        description: Container creation time
+        format: int64
+        type: integer
+      CreatedAt:
+        description: Human readable container creation time.
+        type: string
+      ExitCode:
+        description: If container has exited, the return code from the command
+        format: int32
+        type: integer
+      Exited:
+        description: If container has exited/stopped
+        type: boolean
+      ExitedAt:
+        description: Time container exited
+        format: int64
+        type: integer
+      Id:
+        description: The unique identifier for the container
+        type: string
+        x-go-name: ID
+      Image:
+        description: Container image
+        type: string
+      ImageID:
+        description: Container image ID
+        type: string
+      IsInfra:
+        description: If this container is a Pod infra container
+        type: boolean
+      Labels:
+        additionalProperties:
+          type: string
+        description: Labels for container
+        type: object
+      Mounts:
+        description: User volume mounts
+        items:
+          type: string
+        type: array
+      Names:
+        description: The names assigned to the container
+        items:
+          type: string
+        type: array
+      Namespaces:
+        $ref: '#/definitions/ListContainerNamespaces'
+      Pid:
+        description: The process id of the container
+        format: int64
+        type: integer
+      Pod:
+        description: |-
+          If the container is part of Pod, the Pod ID. Requires the pod
+          boolean to be set
+        type: string
+      PodName:
+        description: |-
+          If the container is part of Pod, the Pod name. Requires the pod
+          boolean to be set
+        type: string
+      Ports:
+        description: Port mappings
+        items:
+          $ref: '#/definitions/PortMapping'
+        type: array
+      Size:
+        $ref: '#/definitions/ContainerSize'
+      StartedAt:
+        description: Time when container started
+        format: int64
+        type: integer
+      State:
+        description: State of container
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  ListContainerNamespaces:
+    description: ListContainer Namespaces contains the identifiers of the container's
+      Linux namespaces
+    properties:
+      Cgroup:
+        description: Cgroup namespace
+        type: string
+      Ipc:
+        description: IPC namespace
+        type: string
+        x-go-name: IPC
+      Mnt:
+        description: Mount namespace
+        type: string
+        x-go-name: MNT
+      Net:
+        description: Network namespace
+        type: string
+        x-go-name: NET
+      Pidns:
+        description: PID namespace
+        type: string
+        x-go-name: PIDNS
+      User:
+        description: User namespace
+        type: string
+      Uts:
+        description: UTS namespace
+        type: string
+        x-go-name: UTS
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  ListPodContainer:
+    properties:
+      Id:
+        type: string
+      Names:
+        type: string
+      Status:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  ListPodsReport:
+    properties:
+      Cgroup:
+        type: string
+      Containers:
+        items:
+          $ref: '#/definitions/ListPodContainer'
+        type: array
+      Created:
+        format: date-time
+        type: string
+      Id:
+        type: string
+      InfraId:
+        type: string
+      Labels:
+        additionalProperties:
+          type: string
+        type: object
+      Name:
+        type: string
+      Namespace:
+        type: string
+      Status:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  ListRegistriesReport:
+    description: |-
+      ListRegistriesReport is the report when querying for a sorted list of
+      registries which may be contacted during certain operations.
+    properties:
+      Registries:
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  LogConfig:
+    description: LogConfig describes the logging characteristics for a container
+    properties:
+      driver:
+        description: |-
+          LogDriver is the container's log driver.
+          Optional.
+        type: string
+        x-go-name: Driver
+      options:
+        additionalProperties:
+          type: string
+        description: |-
+          A set of options to accompany the log driver.
+          Optional.
+        type: object
+        x-go-name: Options
+      path:
+        description: |-
+          LogPath is the path the container's logs will be stored at.
+          Only available if LogDriver is set to "json-file" or "k8s-file".
+          Optional.
+        type: string
+        x-go-name: Path
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  ManifestAddOpts:
+    description: Options for adding a manifest
+    properties:
+      all:
+        type: boolean
+        x-go-name: All
+      annotation:
+        additionalProperties:
+          type: string
+        type: object
+        x-go-name: Annotation
+      arch:
+        type: string
+        x-go-name: Arch
+      features:
+        items:
+          type: string
+        type: array
+        x-go-name: Features
+      images:
+        items:
+          type: string
+        type: array
+        x-go-name: Images
+      os:
+        type: string
+        x-go-name: OS
+      os_version:
+        type: string
+        x-go-name: OSVersion
+      variant:
+        type: string
+        x-go-name: Variant
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/image
+  Mount:
+    properties:
+      destination:
+        description: Destination is the absolute path where the mount will be placed
+          in the container.
+        type: string
+        x-go-name: Destination
+      options:
+        description: Options are fstab style mount options.
+        items:
+          type: string
+        type: array
+        x-go-name: Options
+      source:
+        description: Source specifies the source path of the mount.
+        type: string
+        x-go-name: Source
+      type:
+        description: Type specifies the mount kind.
+        type: string
+        x-go-name: Type
+    title: Mount specifies a mount for a container.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  MountPoint:
+    description: This is used for reporting the mountpoints in use by a container.
+    properties:
+      Destination:
+        type: string
+      Driver:
+        type: string
+      Mode:
+        type: string
+      Name:
+        type: string
+      Propagation:
+        $ref: '#/definitions/Propagation'
+      RW:
+        type: boolean
+      Source:
+        type: string
+      Type:
+        $ref: '#/definitions/Type'
+    title: MountPoint represents a mount point configuration inside the container.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  NamedVolume:
+    description: |-
+      NamedVolume holds information about a named volume that will be mounted into
+      the container.
+    properties:
+      Dest:
+        description: |-
+          Destination to mount the named volume within the container. Must be
+          an absolute path. Path will be created if it does not exist.
+        type: string
+      Name:
+        description: |-
+          Name is the name of the named volume to be mounted. May be empty.
+          If empty, a new named volume with a pseudorandomly generated name
+          will be mounted at the given destination.
+        type: string
+      Options:
+        description: Options are options that the named volume will be mounted with.
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  Namespace:
+    description: Namespace describes the namespace
+    properties:
+      nsmode:
+        $ref: '#/definitions/NamespaceMode'
+      string:
+        type: string
+        x-go-name: Value
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  NamespaceMode:
+    type: string
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  NetworkConfig:
+    description: NetworkConfig configures the network namespace for the container
+    properties:
+      DNSOpt:
+        items:
+          type: string
+        type: array
+      DNSSearch:
+        items:
+          type: string
+        type: array
+      DNSServers:
+        items:
+          type: string
+        type: array
+      ExposedPorts:
+        additionalProperties:
+          type: object
+        type: object
+      HTTPProxy:
+        type: boolean
+      IP6Address:
+        type: string
+      IPAddress:
+        type: string
+      LinkLocalIP:
+        items:
+          type: string
+        type: array
+      MacAddress:
+        type: string
+      NetMode:
+        $ref: '#/definitions/NetworkMode'
+      Network:
+        type: string
+      NetworkAlias:
+        items:
+          type: string
+        type: array
+      PortBindings:
+        $ref: '#/definitions/PortMap'
+      Publish:
+        items:
+          type: string
+        type: array
+      PublishAll:
+        type: boolean
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/spec
+  NetworkCreate:
+    description: NetworkCreate is the expected body of the "create network" http request
+      message
+    properties:
+      Attachable:
+        type: boolean
+      CheckDuplicate:
+        description: |-
+          Check for networks with duplicate names.
+          Network is primarily keyed based on a random ID and not on the name.
+          Network name is strictly a user-friendly alias to the network
+          which is uniquely identified using ID.
+          And there is no guaranteed way to check for duplicates.
+          Option CheckDuplicate is there to provide a best effort checking of any networks
+          which has the same name but it is not guaranteed to catch all name collisions.
+        type: boolean
+      ConfigFrom:
+        $ref: '#/definitions/ConfigReference'
+      ConfigOnly:
+        type: boolean
+      Driver:
+        type: string
+      EnableIPv6:
+        type: boolean
+      IPAM:
+        $ref: '#/definitions/IPAM'
+      Ingress:
+        type: boolean
+      Internal:
+        type: boolean
+      Labels:
+        additionalProperties:
+          type: string
+        type: object
+      Options:
+        additionalProperties:
+          type: string
+        type: object
+      Scope:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  NetworkCreateOptions:
+    description: NetworkCreateOptions describes options to create a network
+    properties:
+      DisableDNS:
+        type: boolean
+      Driver:
+        type: string
+      Gateway:
+        $ref: '#/definitions/IP'
+      Internal:
+        type: boolean
+      MacVLAN:
+        type: string
+      Range:
+        $ref: '#/definitions/IPNet'
+      Subnet:
+        $ref: '#/definitions/IPNet'
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  NetworkCreateReport:
+    description: NetworkCreateReport describes a created network for the cli
+    properties:
+      Filename:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  NetworkCreateRequest:
+    properties:
+      Attachable:
+        type: boolean
+      CheckDuplicate:
+        description: |-
+          Check for networks with duplicate names.
+          Network is primarily keyed based on a random ID and not on the name.
+          Network name is strictly a user-friendly alias to the network
+          which is uniquely identified using ID.
+          And there is no guaranteed way to check for duplicates.
+          Option CheckDuplicate is there to provide a best effort checking of any networks
+          which has the same name but it is not guaranteed to catch all name collisions.
+        type: boolean
+      ConfigFrom:
+        $ref: '#/definitions/ConfigReference'
+      ConfigOnly:
+        type: boolean
+      Driver:
+        type: string
+      EnableIPv6:
+        type: boolean
+      IPAM:
+        $ref: '#/definitions/IPAM'
+      Ingress:
+        type: boolean
+      Internal:
+        type: boolean
+      Labels:
+        additionalProperties:
+          type: string
+        type: object
+      Name:
+        type: string
+      Options:
+        additionalProperties:
+          type: string
+        type: object
+      Scope:
+        type: string
+    title: NetworkCreateRequest is the request message sent to the server for network
+      create call.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  NetworkInspectReport:
+    additionalProperties:
+      type: object
+    description: NetworkInspectReport describes the results from inspect networks
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  NetworkListReport:
+    description: NetworkListReport describes the results from listing networks
+    properties:
+      Bytes:
+        items:
+          format: uint8
+          type: integer
+        type: array
+      CNIVersion:
+        type: string
+      DisableCheck:
+        type: boolean
+      Name:
+        type: string
+      Plugins:
+        items:
+          $ref: '#/definitions/NetworkConfig'
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  NetworkMode:
+    title: NetworkMode represents the container network stack.
+    type: string
+    x-go-package: github.com/containers/libpod/pkg/namespaces
+  NetworkResource:
+    description: NetworkResource is the body of the "get network" http response message
+    properties:
+      Attachable:
+        type: boolean
+      ConfigFrom:
+        $ref: '#/definitions/ConfigReference'
+      ConfigOnly:
+        type: boolean
+      Containers:
+        additionalProperties:
+          $ref: '#/definitions/EndpointResource'
+        type: object
+      Created:
+        format: date-time
+        type: string
+      Driver:
+        type: string
+      EnableIPv6:
+        type: boolean
+      IPAM:
+        $ref: '#/definitions/IPAM'
+      Id:
+        type: string
+        x-go-name: ID
+      Ingress:
+        type: boolean
+      Internal:
+        type: boolean
+      Labels:
+        additionalProperties:
+          type: string
+        type: object
+      Name:
+        type: string
+      Options:
+        additionalProperties:
+          type: string
+        type: object
+      Peers:
+        items:
+          $ref: '#/definitions/PeerInfo'
+        type: array
+      Scope:
+        type: string
+      Services:
+        additionalProperties:
+          $ref: '#/definitions/ServiceInfo'
+        type: object
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  NetworkRmReport:
+    description: NetworkRmReport describes the results of network removal
+    properties:
+      Err:
+        type: string
+      Name:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  NetworkSettings:
+    description: NetworkSettings exposes the network settings in the api
+    properties:
+      Bridge:
+        type: string
+      EndpointID:
+        type: string
+      Gateway:
+        type: string
+      GlobalIPv6Address:
+        type: string
+      GlobalIPv6PrefixLen:
+        format: int64
+        type: integer
+      HairpinMode:
+        type: boolean
+      IPAddress:
+        type: string
+      IPPrefixLen:
+        format: int64
+        type: integer
+      IPv6Gateway:
+        type: string
+      LinkLocalIPv6Address:
+        type: string
+      LinkLocalIPv6PrefixLen:
+        format: int64
+        type: integer
+      MacAddress:
+        type: string
+      Networks:
+        additionalProperties:
+          $ref: '#/definitions/EndpointSettings'
+        type: object
+      Ports:
+        $ref: '#/definitions/PortMap'
+      SandboxID:
+        type: string
+      SandboxKey:
+        type: string
+      SecondaryIPAddresses:
+        items:
+          $ref: '#/definitions/Address'
+        type: array
+      SecondaryIPv6Addresses:
+        items:
+          $ref: '#/definitions/Address'
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  OCIRuntimeInfo:
+    description: |-
+      OCIRuntimeInfo describes the runtime (crun or runc) being
+      used with podman
+    properties:
+      name:
+        type: string
+        x-go-name: Name
+      package:
+        type: string
+        x-go-name: Package
+      path:
+        type: string
+        x-go-name: Path
+      version:
+        type: string
+        x-go-name: Version
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  POSIXRlimit:
+    description: POSIXRlimit type and restrictions
+    properties:
+      hard:
+        description: Hard is the hard limit for the specified type
+        format: uint64
+        type: integer
+        x-go-name: Hard
+      soft:
+        description: Soft is the soft limit for the specified type
+        format: uint64
+        type: integer
+        x-go-name: Soft
+      type:
+        description: Type of the rlimit to set
+        type: string
+        x-go-name: Type
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+  PeerInfo:
+    description: PeerInfo represents one peer of an overlay network
+    properties:
+      IP:
+        type: string
+      Name:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/network
+  PidConfig:
+    description: PidConfig configures the pid namespace for the container
+    properties:
+      PidMode:
+        $ref: '#/definitions/PidMode'
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/spec
+  PidMode:
+    title: PidMode represents the pid namespace of the container.
+    type: string
+    x-go-package: github.com/containers/libpod/pkg/namespaces
+  PlayKubePod:
+    description: PlayKubePod represents a single pod and associated containers created
+      by play kube
+    properties:
+      Containers:
+        description: Containers - the IDs of the containers running in the created
+          pod.
+        items:
+          type: string
+        type: array
+      ID:
+        description: ID - ID of the pod created as a result of play kube.
+        type: string
+      Logs:
+        description: Logs - non-fatal erros and log messages while processing.
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  PlayKubeReport:
+    properties:
+      Pods:
+        description: Pods - pods created by play kube.
+        items:
+          $ref: '#/definitions/PlayKubePod'
+        type: array
+    title: PlayKubeReport contains the results of running play kube.
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  Plugin:
+    description: Plugin A plugin for the Engine API
+    properties:
+      Config:
+        $ref: '#/definitions/PluginConfig'
+      Enabled:
+        description: True if the plugin is running. False if the plugin is not running,
+          only installed.
+        type: boolean
+      Id:
+        description: Id
+        type: string
+        x-go-name: ID
+      Name:
+        description: name
+        type: string
+      PluginReference:
+        description: plugin remote reference used to push/pull the plugin
+        type: string
+      Settings:
+        $ref: '#/definitions/PluginSettings'
+    required:
+    - Config
+    - Enabled
+    - Name
+    - Settings
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginConfig:
+    properties:
+      Args:
+        $ref: '#/definitions/PluginConfigArgs'
+      Description:
+        description: description
+        type: string
+      DockerVersion:
+        description: Docker Version used to create the plugin
+        type: string
+      Documentation:
+        description: documentation
+        type: string
+      Entrypoint:
+        description: entrypoint
+        items:
+          type: string
+        type: array
+      Env:
+        description: env
+        items:
+          $ref: '#/definitions/PluginEnv'
+        type: array
+      Interface:
+        $ref: '#/definitions/PluginConfigInterface'
+      IpcHost:
+        description: ipc host
+        type: boolean
+      Linux:
+        $ref: '#/definitions/PluginConfigLinux'
+      Mounts:
+        description: mounts
+        items:
+          $ref: '#/definitions/PluginMount'
+        type: array
+      Network:
+        $ref: '#/definitions/PluginConfigNetwork'
+      PidHost:
+        description: pid host
+        type: boolean
+      PropagatedMount:
+        description: propagated mount
+        type: string
+      User:
+        $ref: '#/definitions/PluginConfigUser'
+      WorkDir:
+        description: work dir
+        type: string
+      rootfs:
+        $ref: '#/definitions/PluginConfigRootfs'
+    required:
+    - Args
+    - Description
+    - Documentation
+    - Entrypoint
+    - Env
+    - Interface
+    - IpcHost
+    - Linux
+    - Mounts
+    - Network
+    - PidHost
+    - PropagatedMount
+    - WorkDir
+    title: PluginConfig The config of a plugin.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginConfigArgs:
+    description: PluginConfigArgs plugin config args
+    properties:
+      Description:
+        description: description
+        type: string
+      Name:
+        description: name
+        type: string
+      Settable:
+        description: settable
+        items:
+          type: string
+        type: array
+      Value:
+        description: value
+        items:
+          type: string
+        type: array
+    required:
+    - Description
+    - Name
+    - Settable
+    - Value
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginConfigInterface:
+    description: PluginConfigInterface The interface between Docker and the plugin
+    properties:
+      ProtocolScheme:
+        description: Protocol to use for clients connecting to the plugin.
+        type: string
+      Socket:
+        description: socket
+        type: string
+      Types:
+        description: types
+        items:
+          $ref: '#/definitions/PluginInterfaceType'
+        type: array
+    required:
+    - Socket
+    - Types
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginConfigLinux:
+    description: PluginConfigLinux plugin config linux
+    properties:
+      AllowAllDevices:
+        description: allow all devices
+        type: boolean
+      Capabilities:
+        description: capabilities
+        items:
+          type: string
+        type: array
+      Devices:
+        description: devices
+        items:
+          $ref: '#/definitions/PluginDevice'
+        type: array
+    required:
+    - AllowAllDevices
+    - Capabilities
+    - Devices
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginConfigNetwork:
+    description: PluginConfigNetwork plugin config network
+    properties:
+      Type:
+        description: type
+        type: string
+    required:
+    - Type
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginConfigRootfs:
+    description: PluginConfigRootfs plugin config rootfs
+    properties:
+      diff_ids:
+        description: diff ids
+        items:
+          type: string
+        type: array
+        x-go-name: DiffIds
+      type:
+        description: type
+        type: string
+        x-go-name: Type
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginConfigUser:
+    description: PluginConfigUser plugin config user
+    properties:
+      GID:
+        description: g ID
+        format: uint32
+        type: integer
+      UID:
+        description: UID
+        format: uint32
+        type: integer
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginDevice:
+    description: PluginDevice plugin device
+    properties:
+      Description:
+        description: description
+        type: string
+      Name:
+        description: name
+        type: string
+      Path:
+        description: path
+        type: string
+      Settable:
+        description: settable
+        items:
+          type: string
+        type: array
+    required:
+    - Description
+    - Name
+    - Path
+    - Settable
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginEnv:
+    description: PluginEnv plugin env
+    properties:
+      Description:
+        description: description
+        type: string
+      Name:
+        description: name
+        type: string
+      Settable:
+        description: settable
+        items:
+          type: string
+        type: array
+      Value:
+        description: value
+        type: string
+    required:
+    - Description
+    - Name
+    - Settable
+    - Value
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginInterfaceType:
+    description: PluginInterfaceType plugin interface type
+    properties:
+      Capability:
+        description: capability
+        type: string
+      Prefix:
+        description: prefix
+        type: string
+      Version:
+        description: version
+        type: string
+    required:
+    - Capability
+    - Prefix
+    - Version
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginMount:
+    description: PluginMount plugin mount
+    properties:
+      Description:
+        description: description
+        type: string
+      Destination:
+        description: destination
+        type: string
+      Name:
+        description: name
+        type: string
+      Options:
+        description: options
+        items:
+          type: string
+        type: array
+      Settable:
+        description: settable
+        items:
+          type: string
+        type: array
+      Source:
+        description: source
+        type: string
+      Type:
+        description: type
+        type: string
+    required:
+    - Description
+    - Destination
+    - Name
+    - Options
+    - Settable
+    - Source
+    - Type
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PluginSettings:
+    properties:
+      Args:
+        description: args
+        items:
+          type: string
+        type: array
+      Devices:
+        description: devices
+        items:
+          $ref: '#/definitions/PluginDevice'
+        type: array
+      Env:
+        description: env
+        items:
+          type: string
+        type: array
+      Mounts:
+        description: mounts
+        items:
+          $ref: '#/definitions/PluginMount'
+        type: array
+    required:
+    - Args
+    - Devices
+    - Env
+    - Mounts
+    title: PluginSettings Settings that can be modified by users.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PodBasicConfig:
+    properties:
+      hostname:
+        description: |-
+          Hostname is the pod's hostname. If not set, the name of the pod will
+          be used (if a name was not provided here, the name auto-generated for
+          the pod will be used). This will be used by the infra container and
+          all containers in the pod as long as the UTS namespace is shared.
+          Optional.
+        type: string
+        x-go-name: Hostname
+      infra_command:
+        description: |-
+          InfraCommand sets the command that will be used to start the infra
+          container.
+          If not set, the default set in the Libpod configuration file will be
+          used.
+          Conflicts with NoInfra=true.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: InfraCommand
+      infra_conmon_pid_file:
+        description: |-
+          InfraConmonPidFile is a custom path to store the infra container's
+          conmon PID.
+        type: string
+        x-go-name: InfraConmonPidFile
+      infra_image:
+        description: |-
+          InfraImage is the image that will be used for the infra container.
+          If not set, the default set in the Libpod configuration file will be
+          used.
+          Conflicts with NoInfra=true.
+          Optional.
+        type: string
+        x-go-name: InfraImage
+      labels:
+        additionalProperties:
+          type: string
+        description: |-
+          Labels are key-value pairs that are used to add metadata to pods.
+          Optional.
+        type: object
+        x-go-name: Labels
+      name:
+        description: |-
+          Name is the name of the pod.
+          If not provided, a name will be generated when the pod is created.
+          Optional.
+        type: string
+        x-go-name: Name
+      no_infra:
+        description: |-
+          NoInfra tells the pod not to create an infra container. If this is
+          done, many networking-related options will become unavailable.
+          Conflicts with setting any options in PodNetworkConfig, and the
+          InfraCommand and InfraImages in this struct.
+          Optional.
+        type: boolean
+        x-go-name: NoInfra
+      shared_namespaces:
+        description: |-
+          SharedNamespaces instructs the pod to share a set of namespaces.
+          Shared namespaces will be joined (by default) by every container
+          which joins the pod.
+          If not set and NoInfra is false, the pod will set a default set of
+          namespaces to share.
+          Conflicts with NoInfra=true.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: SharedNamespaces
+    title: PodBasicConfig contains basic configuration options for pods.
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  PodCgroupConfig:
+    description: This will be expanded in future updates to pods.
+    properties:
+      cgroup_parent:
+        description: |-
+          CgroupParent is the parent for the CGroup that the pod will create.
+          This pod cgroup will, in turn, be the default cgroup parent for all
+          containers in the pod.
+          Optional.
+        type: string
+        x-go-name: CgroupParent
+    title: PodCgroupConfig contains configuration options about a pod's cgroups.
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  PodCreateConfig:
+    properties:
+      cgroup-parent:
+        type: string
+        x-go-name: CGroupParent
+      hostname:
+        type: string
+        x-go-name: Hostname
+      infra:
+        type: boolean
+        x-go-name: Infra
+      infra-command:
+        type: string
+        x-go-name: InfraCommand
+      infra-image:
+        type: string
+        x-go-name: InfraImage
+      labels:
+        items:
+          type: string
+        type: array
+        x-go-name: Labels
+      name:
+        type: string
+        x-go-name: Name
+      publish:
+        items:
+          type: string
+        type: array
+        x-go-name: Publish
+      share:
+        type: string
+        x-go-name: Share
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/api/handlers
+  PodKillReport:
+    properties:
+      Errs:
+        items:
+          type: string
+        type: array
+      Id:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  PodNetworkConfig:
+    properties:
+      cni_networks:
+        description: |-
+          CNINetworks is a list of CNI networks that the infra container will
+          join. As, by default, containers share their network with the infra
+          container, these networks will effectively be joined by the
+          entire pod.
+          Only available when NetNS is set to Bridge, the default for root.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: CNINetworks
+      dns_option:
+        description: |-
+          DNSOption is a set of DNS options that will be used in the infra
+          container's resolv.conf, which will, by default, be shared with all
+          containers in the pod.
+          Conflicts with NoInfra=true.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: DNSOption
+      dns_search:
+        description: |-
+          DNSSearch is a set of DNS search domains that will be used in the
+          infra container's resolv.conf, which will, by default, be shared with
+          all containers in the pod.
+          If not provided, DNS search domains from the host's resolv.conf will
+          be used.
+          Conflicts with NoInfra=true.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: DNSSearch
+      dns_server:
+        description: |-
+          DNSServer is a set of DNS servers that will be used in the infra
+          container's resolv.conf, which will, by default, be shared with all
+          containers in the pod.
+          If not provided, the host's DNS servers will be used, unless the only
+          server set is a localhost address. As the container cannot connect to
+          the host's localhost, a default server will instead be set.
+          Conflicts with NoInfra=true.
+          Optional.
+        items:
+          $ref: '#/definitions/IP'
+        type: array
+        x-go-name: DNSServer
+      hostadd:
+        description: |-
+          HostAdd is a set of hosts that will be added to the infra container's
+          etc/hosts that will, by default, be shared with all containers in
+          the pod.
+          Conflicts with NoInfra=true and NoManageHosts.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: HostAdd
+      netns:
+        $ref: '#/definitions/Namespace'
+      no_manage_hosts:
+        description: |-
+          NoManageHosts indicates that /etc/hosts should not be managed by the
+          pod. Instead, each container will create a separate /etc/hosts as
+          they would if not in a pod.
+          Conflicts with HostAdd.
+        type: boolean
+        x-go-name: NoManageHosts
+      no_manage_resolv_conf:
+        description: |-
+          NoManageResolvConf indicates that /etc/resolv.conf should not be
+          managed by the pod. Instead, each container will create and manage a
+          separate resolv.conf as if they had not joined a pod.
+          Conflicts with NoInfra=true and DNSServer, DNSSearch, DNSOption.
+          Optional.
+        type: boolean
+        x-go-name: NoManageResolvConf
+      portmappings:
+        description: |-
+          PortMappings is a set of ports to map into the infra container.
+          As, by default, containers share their network with the infra
+          container, this will forward the ports to the entire pod.
+          Only available if NetNS is set to Bridge or Slirp.
+          Optional.
+        items:
+          $ref: '#/definitions/PortMapping'
+        type: array
+        x-go-name: PortMappings
+      static_ip:
+        $ref: '#/definitions/IP'
+      static_mac:
+        $ref: '#/definitions/HardwareAddr'
+    title: PodNetworkConfig contains networking configuration for a pod.
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  PodPauseReport:
+    properties:
+      Errs:
+        items:
+          type: string
+        type: array
+      Id:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  PodPruneReport:
+    properties:
+      Err:
+        type: string
+      Id:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  PodRestartReport:
+    properties:
+      Errs:
+        items:
+          type: string
+        type: array
+      Id:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  PodRmReport:
+    properties:
+      Err:
+        type: string
+      Id:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  PodSpecGenerator:
+    description: PodSpecGenerator describes options to create a pod
+    properties:
+      cgroup_parent:
+        description: |-
+          CgroupParent is the parent for the CGroup that the pod will create.
+          This pod cgroup will, in turn, be the default cgroup parent for all
+          containers in the pod.
+          Optional.
+        type: string
+        x-go-name: CgroupParent
+      cni_networks:
+        description: |-
+          CNINetworks is a list of CNI networks that the infra container will
+          join. As, by default, containers share their network with the infra
+          container, these networks will effectively be joined by the
+          entire pod.
+          Only available when NetNS is set to Bridge, the default for root.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: CNINetworks
+      dns_option:
+        description: |-
+          DNSOption is a set of DNS options that will be used in the infra
+          container's resolv.conf, which will, by default, be shared with all
+          containers in the pod.
+          Conflicts with NoInfra=true.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: DNSOption
+      dns_search:
+        description: |-
+          DNSSearch is a set of DNS search domains that will be used in the
+          infra container's resolv.conf, which will, by default, be shared with
+          all containers in the pod.
+          If not provided, DNS search domains from the host's resolv.conf will
+          be used.
+          Conflicts with NoInfra=true.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: DNSSearch
+      dns_server:
+        description: |-
+          DNSServer is a set of DNS servers that will be used in the infra
+          container's resolv.conf, which will, by default, be shared with all
+          containers in the pod.
+          If not provided, the host's DNS servers will be used, unless the only
+          server set is a localhost address. As the container cannot connect to
+          the host's localhost, a default server will instead be set.
+          Conflicts with NoInfra=true.
+          Optional.
+        items:
+          $ref: '#/definitions/IP'
+        type: array
+        x-go-name: DNSServer
+      hostadd:
+        description: |-
+          HostAdd is a set of hosts that will be added to the infra container's
+          etc/hosts that will, by default, be shared with all containers in
+          the pod.
+          Conflicts with NoInfra=true and NoManageHosts.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: HostAdd
+      hostname:
+        description: |-
+          Hostname is the pod's hostname. If not set, the name of the pod will
+          be used (if a name was not provided here, the name auto-generated for
+          the pod will be used). This will be used by the infra container and
+          all containers in the pod as long as the UTS namespace is shared.
+          Optional.
+        type: string
+        x-go-name: Hostname
+      infra_command:
+        description: |-
+          InfraCommand sets the command that will be used to start the infra
+          container.
+          If not set, the default set in the Libpod configuration file will be
+          used.
+          Conflicts with NoInfra=true.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: InfraCommand
+      infra_conmon_pid_file:
+        description: |-
+          InfraConmonPidFile is a custom path to store the infra container's
+          conmon PID.
+        type: string
+        x-go-name: InfraConmonPidFile
+      infra_image:
+        description: |-
+          InfraImage is the image that will be used for the infra container.
+          If not set, the default set in the Libpod configuration file will be
+          used.
+          Conflicts with NoInfra=true.
+          Optional.
+        type: string
+        x-go-name: InfraImage
+      labels:
+        additionalProperties:
+          type: string
+        description: |-
+          Labels are key-value pairs that are used to add metadata to pods.
+          Optional.
+        type: object
+        x-go-name: Labels
+      name:
+        description: |-
+          Name is the name of the pod.
+          If not provided, a name will be generated when the pod is created.
+          Optional.
+        type: string
+        x-go-name: Name
+      netns:
+        $ref: '#/definitions/Namespace'
+      no_infra:
+        description: |-
+          NoInfra tells the pod not to create an infra container. If this is
+          done, many networking-related options will become unavailable.
+          Conflicts with setting any options in PodNetworkConfig, and the
+          InfraCommand and InfraImages in this struct.
+          Optional.
+        type: boolean
+        x-go-name: NoInfra
+      no_manage_hosts:
+        description: |-
+          NoManageHosts indicates that /etc/hosts should not be managed by the
+          pod. Instead, each container will create a separate /etc/hosts as
+          they would if not in a pod.
+          Conflicts with HostAdd.
+        type: boolean
+        x-go-name: NoManageHosts
+      no_manage_resolv_conf:
+        description: |-
+          NoManageResolvConf indicates that /etc/resolv.conf should not be
+          managed by the pod. Instead, each container will create and manage a
+          separate resolv.conf as if they had not joined a pod.
+          Conflicts with NoInfra=true and DNSServer, DNSSearch, DNSOption.
+          Optional.
+        type: boolean
+        x-go-name: NoManageResolvConf
+      portmappings:
+        description: |-
+          PortMappings is a set of ports to map into the infra container.
+          As, by default, containers share their network with the infra
+          container, this will forward the ports to the entire pod.
+          Only available if NetNS is set to Bridge or Slirp.
+          Optional.
+        items:
+          $ref: '#/definitions/PortMapping'
+        type: array
+        x-go-name: PortMappings
+      shared_namespaces:
+        description: |-
+          SharedNamespaces instructs the pod to share a set of namespaces.
+          Shared namespaces will be joined (by default) by every container
+          which joins the pod.
+          If not set and NoInfra is false, the pod will set a default set of
+          namespaces to share.
+          Conflicts with NoInfra=true.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: SharedNamespaces
+      static_ip:
+        $ref: '#/definitions/IP'
+      static_mac:
+        $ref: '#/definitions/HardwareAddr'
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  PodStartReport:
+    properties:
+      Errs:
+        items:
+          type: string
+        type: array
+      Id:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  PodStatsReport:
+    properties:
+      BlockIO:
+        type: string
+      CID:
+        type: string
+      CPU:
+        type: string
+      Mem:
+        type: string
+      MemUsage:
+        type: string
+      Name:
+        type: string
+      NetIO:
+        type: string
+      PIDS:
+        type: string
+      Pod:
+        type: string
+    title: PodStatsReport includes pod-resource statistics data.
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  PodStopReport:
+    properties:
+      Errs:
+        items:
+          type: string
+        type: array
+      Id:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  PodUnpauseReport:
+    properties:
+      Errs:
+        items:
+          type: string
+        type: array
+      Id:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  Policy:
+    format: int64
+    title: Policy denotes a seccomp policy.
+    type: integer
+    x-go-package: github.com/containers/libpod/pkg/seccomp
+  Port:
+    description: Port An open port on a container
+    properties:
+      IP:
+        description: Host IP address that the container's port is mapped to
+        type: string
+      PrivatePort:
+        description: Port on the container
+        format: uint16
+        type: integer
+      PublicPort:
+        description: Port exposed on the host
+        format: uint16
+        type: integer
+      Type:
+        description: type
+        type: string
+    required:
+    - PrivatePort
+    - Type
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  PortBinding:
+    description: PortBinding represents a binding between a Host IP address and a
+      Host Port
+    properties:
+      HostIp:
+        description: HostIP is the host IP Address
+        type: string
+        x-go-name: HostIP
+      HostPort:
+        description: HostPort is the host port number
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/go-connections/nat
+  PortMap:
+    additionalProperties:
+      items:
+        $ref: '#/definitions/PortBinding'
+      type: array
+    description: PortMap is a collection of PortBinding indexed by Port
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/go-connections/nat
+  PortMapping:
+    properties:
+      container_port:
+        description: |-
+          ContainerPort is the port number that will be exposed from the
+          container.
+          Mandatory.
+        format: uint16
+        type: integer
+        x-go-name: ContainerPort
+      host_ip:
+        description: |-
+          HostIP is the IP that we will bind to on the host.
+          If unset, assumed to be 0.0.0.0 (all interfaces).
+        type: string
+        x-go-name: HostIP
+      host_port:
+        description: |-
+          HostPort is the port number that will be forwarded from the host into
+          the container.
+          If omitted, will be assumed to be identical to
+        format: uint16
+        type: integer
+        x-go-name: HostPort
+      protocol:
+        description: |-
+          Protocol is the protocol forward.
+          Must be either "tcp", "udp", and "sctp", or some combination of these
+          separated by commas.
+          If unset, assumed to be TCP.
+        type: string
+        x-go-name: Protocol
+      range:
+        description: |-
+          Range is the number of ports that will be forwarded, starting at
+          HostPort and ContainerPort and counting up.
+          This is 1-indexed, so 1 is assumed to be a single port (only the
+          Hostport:Containerport mapping will be added), 2 is two ports (both
+          Hostport:Containerport and Hostport+1:Containerport+1), etc.
+          If unset, assumed to be 1 (a single port).
+          Both hostport + range and containerport + range must be less than
+          65536.
+        format: uint16
+        type: integer
+        x-go-name: Range
+    title: PortMapping is one or more ports that will be mapped into the container.
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  PortSet:
+    additionalProperties:
+      type: object
+    description: PortSet is a collection of structs indexed by Port
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/go-connections/nat
+  Propagation:
+    title: Propagation represents the propagation of a mount.
+    type: string
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/mount
+  RemoteSocket:
+    description: RemoteSocket describes information about the API socket
+    properties:
+      exists:
+        type: boolean
+        x-go-name: Exists
+      path:
+        type: string
+        x-go-name: Path
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  Report:
+    properties:
+      Err:
+        additionalProperties:
+          type: string
+        type: object
+      Id:
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  RestartPolicy:
+    properties:
+      MaximumRetryCount:
+        format: int64
+        type: integer
+      Name:
+        type: string
+    title: RestartPolicy represents the restart policies of the container.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/container
+  RootFS:
+    description: RootFS holds the root fs information of an image
+    properties:
+      Layers:
+        items:
+          $ref: '#/definitions/Digest'
+          type: string
+        type: array
+      Type:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/inspect
+  Schema2HealthConfig:
+    description: |-
+      Schema2HealthConfig is a HealthConfig, which holds configuration settings
+      for the HEALTHCHECK feature, from docker/docker/api/types/container.
+    properties:
+      Interval:
+        $ref: '#/definitions/Duration'
+      Retries:
+        description: |-
+          Retries is the number of consecutive failures needed to consider a container as unhealthy.
+          Zero means inherit.
+        format: int64
+        type: integer
+      StartPeriod:
+        $ref: '#/definitions/Duration'
+      Test:
+        description: |-
+          Test is the test to perform to check that the container is healthy.
+          An empty slice means to inherit the default.
+          The options are:
+          {} : inherit healthcheck
+          {"NONE"} : disable healthcheck
+          {"CMD", args...} : exec arguments directly
+          {"CMD-SHELL", command} : run command with system's default shell
+        items:
+          type: string
+        type: array
+      Timeout:
+        $ref: '#/definitions/Duration'
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/containers/image/v5/manifest
+  SecurityConfig:
+    description: SecurityConfig configures the security features for the container
+    properties:
+      ApparmorProfile:
+        type: string
+      CapAdd:
+        items:
+          type: string
+        type: array
+      CapDrop:
+        items:
+          type: string
+        type: array
+      CapRequired:
+        items:
+          type: string
+        type: array
+      LabelOpts:
+        items:
+          type: string
+        type: array
+      NoNewPrivs:
+        type: boolean
+      Privileged:
+        type: boolean
+      ReadOnlyRootfs:
+        type: boolean
+      ReadOnlyTmpfs:
+        type: boolean
+      SeccompPolicy:
+        $ref: '#/definitions/Policy'
+      SeccompProfileFromImage:
+        type: string
+      SeccompProfilePath:
+        type: string
+      SecurityOpts:
+        items:
+          type: string
+        type: array
+      Sysctl:
+        additionalProperties:
+          type: string
+        type: object
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/spec
+  ServiceInfo:
+    description: ServiceInfo represents service parameters with the list of service's
+      tasks
+    properties:
+      LocalLBIndex:
+        format: int64
+        type: integer
+      Ports:
+        items:
+          type: string
+        type: array
+      Tasks:
+        items:
+          $ref: '#/definitions/Task'
+        type: array
+      VIP:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/network
+  ServiceUpdateResponse:
+    description: ServiceUpdateResponse service update response
+    properties:
+      Warnings:
+        description: Optional warning messages
+        items:
+          type: string
+        type: array
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  Signal:
+    description: It implements the os.Signal interface.
+    format: int64
+    title: A Signal is a number describing a process signal.
+    type: integer
+    x-go-package: syscall
+  SlirpInfo:
+    description: |-
+      SlirpInfo describes the slirp executable that
+      is being being used.
+    properties:
+      executable:
+        type: string
+        x-go-name: Executable
+      package:
+        type: string
+        x-go-name: Package
+      version:
+        type: string
+        x-go-name: Version
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  SpecGenerator:
+    description: |-
+      SpecGenerator creates an OCI spec and Libpod configuration options to create
+      a container based on the given configuration.
+    properties:
+      annotations:
+        additionalProperties:
+          type: string
+        description: |-
+          Annotations are key-value options passed into the container runtime
+          that can be used to trigger special behavior.
+          Optional.
+        type: object
+        x-go-name: Annotations
+      apparmor_profile:
+        description: |-
+          ApparmorProfile is the name of the Apparmor profile the container
+          will use.
+          Optional.
+        type: string
+        x-go-name: ApparmorProfile
+      cap_add:
+        description: |-
+          CapAdd are capabilities which will be added to the container.
+          Conflicts with Privileged.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: CapAdd
+      cap_drop:
+        description: |-
+          CapDrop are capabilities which will be removed from the container.
+          Conflicts with Privileged.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: CapDrop
+      cgroup_parent:
+        description: |-
+          CgroupParent is the container's CGroup parent.
+          If not set, the default for the current cgroup driver will be used.
+          Optional.
+        type: string
+        x-go-name: CgroupParent
+      cgroupns:
+        $ref: '#/definitions/Namespace'
+      cgroups_mode:
+        description: |-
+          CgroupsMode sets a policy for how cgroups will be created in the
+          container, including the ability to disable creation entirely.
+        type: string
+        x-go-name: CgroupsMode
+      cni_networks:
+        description: |-
+          CNINetworks is a list of CNI networks to join the container to.
+          If this list is empty, the default CNI network will be joined
+          instead. If at least one entry is present, we will not join the
+          default network (unless it is part of this list).
+          Only available if NetNS is set to bridge.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: CNINetworks
+      command:
+        description: |-
+          Command is the container's command.
+          If not given and Image is specified, this will be populated by the
+          image's configuration.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: Command
+      conmon_pid_file:
+        description: |-
+          ConmonPidFile is a path at which a PID file for Conmon will be
+          placed.
+          If not given, a default location will be used.
+          Optional.
+        type: string
+        x-go-name: ConmonPidFile
+      devices:
+        description: |-
+          Devices are devices that will be added to the container.
+          Optional.
+        items:
+          $ref: '#/definitions/LinuxDevice'
+        type: array
+        x-go-name: Devices
+      dns_option:
+        description: |-
+          DNSOptions is a set of DNS options that will be used in the
+          container's resolv.conf, replacing the host's DNS options which are
+          used by default.
+          Conflicts with UseImageResolvConf.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: DNSOptions
+      dns_search:
+        description: |-
+          DNSSearch is a set of DNS search domains that will be used in the
+          container's resolv.conf, replacing the host's DNS search domains
+          which are used by default.
+          Conflicts with UseImageResolvConf.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: DNSSearch
+      dns_server:
+        description: |-
+          DNSServers is a set of DNS servers that will be used in the
+          container's resolv.conf, replacing the host's DNS Servers which are
+          used by default.
+          Conflicts with UseImageResolvConf.
+          Optional.
+        items:
+          $ref: '#/definitions/IP'
+        type: array
+        x-go-name: DNSServers
+      entrypoint:
+        description: |-
+          Entrypoint is the container's entrypoint.
+          If not given and Image is specified, this will be populated by the
+          image's configuration.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: Entrypoint
+      env:
+        additionalProperties:
+          type: string
+        description: |-
+          Env is a set of environment variables that will be set in the
+          container.
+          Optional.
+        type: object
+        x-go-name: Env
+      expose:
+        description: |-
+          Expose is a number of ports that will be forwarded to the container
+          if PublishExposedPorts is set.
+          Expose is a map of uint16 (port number) to a string representing
+          protocol. Allowed protocols are "tcp", "udp", and "sctp", or some
+          combination of the three separated by commas.
+          If protocol is set to "" we will assume TCP.
+          Only available if NetNS is set to Bridge or Slirp, and
+          PublishExposedPorts is set.
+          Optional.
+        x-go-name: Expose
+      groups:
+        description: |-
+          Groups are a list of supplemental groups the container's user will
+          be granted access to.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: Groups
+      healthconfig:
+        $ref: '#/definitions/Schema2HealthConfig'
+      hostadd:
+        description: |-
+          HostAdd is a set of hosts which will be added to the container's
+          etc/hosts file.
+          Conflicts with UseImageHosts.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: HostAdd
+      hostname:
+        description: |-
+          Hostname is the container's hostname. If not set, the hostname will
+          not be modified (if UtsNS is not private) or will be set to the
+          container ID (if UtsNS is private).
+          Conflicts with UtsNS if UtsNS is not set to private.
+          Optional.
+        type: string
+        x-go-name: Hostname
+      idmappings:
+        $ref: '#/definitions/IDMappingOptions'
+      image:
+        description: |-
+          Image is the image the container will be based on. The image will be
+          used as the container's root filesystem, and its environment vars,
+          volumes, and other configuration will be applied to the container.
+          Conflicts with Rootfs.
+          At least one of Image or Rootfs must be specified.
+        type: string
+        x-go-name: Image
+      image_volume_mode:
+        description: |-
+          ImageVolumeMode indicates how image volumes will be created.
+          Supported modes are "ignore" (do not create), "tmpfs" (create as
+          tmpfs), and "anonymous" (create as anonymous volumes).
+          The default if unset is anonymous.
+          Optional.
+        type: string
+        x-go-name: ImageVolumeMode
+      init:
+        description: |-
+          Init specifies that an init binary will be mounted into the
+          container, and will be used as PID1.
+        type: boolean
+        x-go-name: Init
+      init_path:
+        description: |-
+          InitPath specifies the path to the init binary that will be added if
+          Init is specified above. If not specified, the default set in the
+          Libpod config will be used. Ignored if Init above is not set.
+          Optional.
+        type: string
+        x-go-name: InitPath
+      ipcns:
+        $ref: '#/definitions/Namespace'
+      labels:
+        additionalProperties:
+          type: string
+        description: |-
+          Labels are key-value pairs that are used to add metadata to
+          containers.
+          Optional.
+        type: object
+        x-go-name: Labels
+      log_configuration:
+        $ref: '#/definitions/LogConfig'
+      mounts:
+        description: |-
+          Mounts are mounts that will be added to the container.
+          These will supersede Image Volumes and VolumesFrom volumes where
+          there are conflicts.
+          Optional.
+        items:
+          $ref: '#/definitions/Mount'
+        type: array
+        x-go-name: Mounts
+      name:
+        description: |-
+          Name is the name the container will be given.
+          If no name is provided, one will be randomly generated.
+          Optional.
+        type: string
+        x-go-name: Name
+      namespace:
+        description: |-
+          Namespace is the libpod namespace the container will be placed in.
+          Optional.
+        type: string
+        x-go-name: Namespace
+      netns:
+        $ref: '#/definitions/Namespace'
+      no_new_privileges:
+        description: |-
+          NoNewPrivileges is whether the container will set the no new
+          privileges flag on create, which disables gaining additional
+          privileges (e.g. via setuid) in the container.
+        type: boolean
+        x-go-name: NoNewPrivileges
+      oci_runtime:
+        description: |-
+          OCIRuntime is the name of the OCI runtime that will be used to create
+          the container.
+          If not specified, the default will be used.
+          Optional.
+        type: string
+        x-go-name: OCIRuntime
+      oom_score_adj:
+        description: |-
+          OOMScoreAdj adjusts the score used by the OOM killer to determine
+          processes to kill for the container's process.
+          Optional.
+        format: int64
+        type: integer
+        x-go-name: OOMScoreAdj
+      pidns:
+        $ref: '#/definitions/Namespace'
+      pod:
+        description: |-
+          Pod is the ID of the pod the container will join.
+          Optional.
+        type: string
+        x-go-name: Pod
+      portmappings:
+        description: |-
+          PortBindings is a set of ports to map into the container.
+          Only available if NetNS is set to bridge or slirp.
+          Optional.
+        items:
+          $ref: '#/definitions/PortMapping'
+        type: array
+        x-go-name: PortMappings
+      privileged:
+        description: |-
+          Privileged is whether the container is privileged.
+          Privileged does the following:
+          Adds all devices on the system to the container.
+          Adds all capabilities to the container.
+          Disables Seccomp, SELinux, and Apparmor confinement.
+          (Though SELinux can be manually re-enabled).
+          TODO: this conflicts with things.
+          TODO: this does more.
+        type: boolean
+        x-go-name: Privileged
+      publish_image_ports:
+        description: |-
+          PublishExposedPorts will publish ports specified in the image to
+          random unused ports (guaranteed to be above 1024) on the host.
+          This is based on ports set in Expose below, and any ports specified
+          by the Image (if one is given).
+          Only available if NetNS is set to Bridge or Slirp.
+        type: boolean
+        x-go-name: PublishExposedPorts
+      r_limits:
+        description: |-
+          Rlimits are POSIX rlimits to apply to the container.
+          Optional.
+        items:
+          $ref: '#/definitions/POSIXRlimit'
+        type: array
+        x-go-name: Rlimits
+      read_only_filesystem:
+        description: |-
+          ReadOnlyFilesystem indicates that everything will be mounted
+          as read-only
+        type: boolean
+        x-go-name: ReadOnlyFilesystem
+      remove:
+        description: |-
+          Remove indicates if the container should be removed once it has been started
+          and exits
+        type: boolean
+        x-go-name: Remove
+      resource_limits:
+        $ref: '#/definitions/LinuxResources'
+      restart_policy:
+        description: |-
+          RestartPolicy is the container's restart policy - an action which
+          will be taken when the container exits.
+          If not given, the default policy, which does nothing, will be used.
+          Optional.
+        type: string
+        x-go-name: RestartPolicy
+      restart_tries:
+        description: |-
+          RestartRetries is the number of attempts that will be made to restart
+          the container.
+          Only available when RestartPolicy is set to "on-failure".
+          Optional.
+        format: uint64
+        type: integer
+        x-go-name: RestartRetries
+      rootfs:
+        description: |-
+          Rootfs is the path to a directory that will be used as the
+          container's root filesystem. No modification will be made to the
+          directory, it will be directly mounted into the container as root.
+          Conflicts with Image.
+          At least one of Image or Rootfs must be specified.
+        type: string
+        x-go-name: Rootfs
+      rootfs_propagation:
+        description: |-
+          RootfsPropagation is the rootfs propagation mode for the container.
+          If not set, the default of rslave will be used.
+          Optional.
+        type: string
+        x-go-name: RootfsPropagation
+      seccomp_policy:
+        description: |-
+          SeccompPolicy determines which seccomp profile gets applied
+          the container. valid values: empty,default,image
+        type: string
+        x-go-name: SeccompPolicy
+      seccomp_profile_path:
+        description: |-
+          SeccompProfilePath is the path to a JSON file containing the
+          container's Seccomp profile.
+          If not specified, no Seccomp profile will be used.
+          Optional.
+        type: string
+        x-go-name: SeccompProfilePath
+      selinux_opts:
+        description: |-
+          SelinuxProcessLabel is the process label the container will use.
+          If SELinux is enabled and this is not specified, a label will be
+          automatically generated if not specified.
+          Optional.
+        items:
+          type: string
+        type: array
+        x-go-name: SelinuxOpts
+      shm_size:
+        description: |-
+          ShmSize is the size of the tmpfs to mount in at /dev/shm, in bytes.
+          Conflicts with ShmSize if IpcNS is not private.
+          Optional.
+        format: int64
+        type: integer
+        x-go-name: ShmSize
+      static_ip:
+        $ref: '#/definitions/IP'
+      static_ipv6:
+        $ref: '#/definitions/IP'
+      static_mac:
+        $ref: '#/definitions/HardwareAddr'
+      stdin:
+        description: Stdin is whether the container will keep its STDIN open.
+        type: boolean
+        x-go-name: Stdin
+      stop_signal:
+        $ref: '#/definitions/Signal'
+      stop_timeout:
+        description: |-
+          StopTimeout is a timeout between the container's stop signal being
+          sent and SIGKILL being sent.
+          If not provided, the default will be used.
+          If 0 is used, stop signal will not be sent, and SIGKILL will be sent
+          instead.
+          Optional.
+        format: uint64
+        type: integer
+        x-go-name: StopTimeout
+      sysctl:
+        additionalProperties:
+          type: string
+        description: Sysctl sets kernel parameters for the container
+        type: object
+        x-go-name: Sysctl
+      systemd:
+        description: |-
+          Systemd is whether the container will be started in systemd mode.
+          Valid options are "true", "false", and "always".
+          "true" enables this mode only if the binary run in the container is
+          sbin/init or systemd. "always" unconditionally enables systemd mode.
+          "false" unconditionally disables systemd mode.
+          If enabled, mounts and stop signal will be modified.
+          If set to "always" or set to "true" and conditionally triggered,
+          conflicts with StopSignal.
+          If not specified, "false" will be assumed.
+          Optional.
+        type: string
+        x-go-name: Systemd
+      terminal:
+        description: |-
+          Terminal is whether the container will create a PTY.
+          Optional.
+        type: boolean
+        x-go-name: Terminal
+      throttleReadBpsDevice:
+        additionalProperties:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        description: IO read rate limit per cgroup per device, bytes per second
+        type: object
+        x-go-name: ThrottleReadBpsDevice
+      throttleReadIOPSDevice:
+        additionalProperties:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        description: IO read rate limit per cgroup per device, IO per second
+        type: object
+        x-go-name: ThrottleReadIOPSDevice
+      throttleWriteBpsDevice:
+        additionalProperties:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        description: IO write rate limit per cgroup per device, bytes per second
+        type: object
+        x-go-name: ThrottleWriteBpsDevice
+      throttleWriteIOPSDevice:
+        additionalProperties:
+          $ref: '#/definitions/LinuxThrottleDevice'
+        description: IO write rate limit per cgroup per device, IO per second
+        type: object
+        x-go-name: ThrottleWriteIOPSDevice
+      use_image_hosts:
+        description: |-
+          UseImageHosts indicates that /etc/hosts should not be managed by
+          Podman, and instead sourced from the image.
+          Conflicts with HostAdd.
+        type: boolean
+        x-go-name: UseImageHosts
+      use_image_resolve_conf:
+        description: |-
+          UseImageResolvConf indicates that resolv.conf should not be managed
+          by Podman, but instead sourced from the image.
+          Conflicts with DNSServer, DNSSearch, DNSOption.
+        type: boolean
+        x-go-name: UseImageResolvConf
+      user:
+        description: |-
+          User is the user the container will be run as.
+          Can be given as a UID or a username; if a username, it will be
+          resolved within the container, using the container's /etc/passwd.
+          If unset, the container will be run as root.
+          Optional.
+        type: string
+        x-go-name: User
+      userns:
+        $ref: '#/definitions/Namespace'
+      utsns:
+        $ref: '#/definitions/Namespace'
+      volumes:
+        description: |-
+          Volumes are named volumes that will be added to the container.
+          These will supersede Image Volumes and VolumesFrom volumes where
+          there are conflicts.
+          Optional.
+        items:
+          $ref: '#/definitions/NamedVolume'
+        type: array
+        x-go-name: Volumes
+      volumes_from:
+        description: |-
+          VolumesFrom is a set of containers whose volumes will be added to
+          this container. The name or ID of the container must be provided, and
+          may optionally be followed by a : and then one or more
+          comma-separated options. Valid options are 'ro', 'rw', and 'z'.
+          Options will be used for all volumes sourced from the container.
+        items:
+          type: string
+        type: array
+        x-go-name: VolumesFrom
+      weightDevice:
+        additionalProperties:
+          $ref: '#/definitions/LinuxWeightDevice'
+        description: Weight per cgroup per device, can override BlkioWeight
+        type: object
+        x-go-name: WeightDevice
+      work_dir:
+        description: |-
+          WorkDir is the container's working directory.
+          If unset, the default, /, will be used.
+          Optional.
+        type: string
+        x-go-name: WorkDir
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/specgen
+  StoreInfo:
+    description: |-
+      StoreInfo describes the container storage and its
+      attributes
+    properties:
+      configFile:
+        type: string
+        x-go-name: ConfigFile
+      containerStore:
+        $ref: '#/definitions/ContainerStore'
+      graphDriverName:
+        type: string
+        x-go-name: GraphDriverName
+      graphOptions:
+        additionalProperties:
+          type: object
+        type: object
+        x-go-name: GraphOptions
+      graphRoot:
+        type: string
+        x-go-name: GraphRoot
+      graphStatus:
+        additionalProperties:
+          type: string
+        type: object
+        x-go-name: GraphStatus
+      imageStore:
+        $ref: '#/definitions/ImageStore'
+      runRoot:
+        type: string
+        x-go-name: RunRoot
+      volumePath:
+        type: string
+        x-go-name: VolumePath
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  StrSlice:
+    description: We need to override the json decoder to accept both options.
+    items:
+      type: string
+    title: StrSlice represents a string or an array of strings.
+    type: array
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/strslice
+  SystemDfContainerReport:
+    description: SystemDfContainerReport describes a container for use with df
+    properties:
+      Command:
+        items:
+          type: string
+        type: array
+      ContainerID:
+        type: string
+      Created:
+        format: date-time
+        type: string
+      Image:
+        type: string
+      LocalVolumes:
+        format: int64
+        type: integer
+      Names:
+        type: string
+      RWSize:
+        format: int64
+        type: integer
+      Size:
+        format: int64
+        type: integer
+      Status:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  SystemDfImageReport:
+    description: SystemDfImageReport describes an image for use with df
+    properties:
+      Containers:
+        format: int64
+        type: integer
+      Created:
+        format: date-time
+        type: string
+      ImageID:
+        type: string
+      Repository:
+        type: string
+      SharedSize:
+        format: int64
+        type: integer
+      Size:
+        format: int64
+        type: integer
+      Tag:
+        type: string
+      UniqueSize:
+        format: int64
+        type: integer
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  SystemDfVolumeReport:
+    description: SystemDfVolumeReport describes a volume and its size
+    properties:
+      Links:
+        format: int64
+        type: integer
+      Size:
+        format: int64
+        type: integer
+      VolumeName:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  Task:
+    description: Task carries the information about one backend task
+    properties:
+      EndpointID:
+        type: string
+      EndpointIP:
+        type: string
+      Info:
+        additionalProperties:
+          type: string
+        type: object
+      Name:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/network
+  ThrottleDevice:
+    description: ThrottleDevice is a structure that holds device:rate_per_second pair
+    properties:
+      Path:
+        type: string
+      Rate:
+        format: uint64
+        type: integer
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/blkiodev
+  Type:
+    title: Type represents the type of a mount.
+    type: string
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/mount
+  UTSMode:
+    title: UTSMode represents the UTS namespace of the container.
+    type: string
+    x-go-package: github.com/containers/libpod/pkg/namespaces
+  Ulimit:
+    properties:
+      Hard:
+        format: int64
+        type: integer
+      Name:
+        type: string
+      Soft:
+        format: int64
+        type: integer
+    title: Ulimit is a human friendly version of Rlimit.
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/go-units
+  UserConfig:
+    description: UserConfig configures the user namespace for the container
+    properties:
+      GroupAdd:
+        items:
+          type: string
+        type: array
+      IDMappings:
+        $ref: '#/definitions/IDMappingOptions'
+      User:
+        type: string
+      UsernsMode:
+        $ref: '#/definitions/UsernsMode'
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/spec
+  UsernsMode:
+    title: UsernsMode represents userns mode in the container.
+    type: string
+    x-go-package: github.com/containers/libpod/pkg/namespaces
+  UtsConfig:
+    description: UtsConfig configures the uts namespace for the container
+    properties:
+      HostAdd:
+        items:
+          type: string
+        type: array
+      Hostname:
+        type: string
+      NoHosts:
+        type: boolean
+      UtsMode:
+        $ref: '#/definitions/UTSMode'
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/spec
+  Version:
+    description: Version is an output struct for varlink
+    properties:
+      APIVersion:
+        format: int64
+        type: integer
+      Built:
+        format: int64
+        type: integer
+      BuiltTime:
+        type: string
+      GitCommit:
+        type: string
+      GoVersion:
+        type: string
+      OsArch:
+        type: string
+      Version:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/libpod/define
+  Volume:
+    description: Volume volume
+    properties:
+      CreatedAt:
+        description: Date/Time the volume was created.
+        type: string
+      Driver:
+        description: Name of the volume driver used by the volume.
+        type: string
+      Labels:
+        additionalProperties:
+          type: string
+        description: User-defined key/value metadata.
+        type: object
+      Mountpoint:
+        description: Mount path of the volume on the host.
+        type: string
+      Name:
+        description: Name of the volume.
+        type: string
+      Options:
+        additionalProperties:
+          type: string
+        description: The driver specific options used when creating the volume.
+        type: object
+      Scope:
+        description: The level at which the volume exists. Either `global` for cluster-wide,
+          or `local` for machine level.
+        type: string
+      Status:
+        additionalProperties:
+          type: object
+        description: |-
+          Low-level details about the volume, provided by the volume driver.
+          Details are returned as a map with key/value pairs:
+          `{"key":"value","key2":"value2"}`.
+
+          The `Status` field is optional, and is omitted if the volume driver
+          does not support this feature.
+        type: object
+      UsageData:
+        $ref: '#/definitions/VolumeUsageData'
+    required:
+    - Driver
+    - Labels
+    - Mountpoint
+    - Name
+    - Options
+    - Scope
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  VolumeCreate:
+    properties:
+      Driver:
+        description: Volume driver to use
+        type: string
+      Label:
+        additionalProperties:
+          type: string
+        description: User-defined key/value metadata.
+        type: object
+      Name:
+        description: New volume's name. Can be left blank
+        type: string
+      Options:
+        additionalProperties:
+          type: string
+        description: Mapping of driver options and values.
+        type: object
+    type: object
+    x-go-name: VolumeCreateOptions
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  VolumeCreateBody:
+    description: VolumeCreateBody Volume configuration
+    properties:
+      Driver:
+        description: Name of the volume driver to use.
+        type: string
+      DriverOpts:
+        additionalProperties:
+          type: string
+        description: A mapping of driver options and values. These options are passed
+          directly to the driver and are driver specific.
+        type: object
+      Labels:
+        additionalProperties:
+          type: string
+        description: User-defined key/value metadata.
+        type: object
+      Name:
+        description: The new volume's name. If not specified, Docker generates a name.
+        type: string
+    required:
+    - Driver
+    - DriverOpts
+    - Labels
+    - Name
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/volume
+  VolumeListOKBody:
+    description: VolumeListOKBody Volume list response
+    properties:
+      Volumes:
+        description: List of volumes
+        items:
+          $ref: '#/definitions/Volume'
+        type: array
+      Warnings:
+        description: Warnings that occurred when fetching the list of volumes
+        items:
+          type: string
+        type: array
+    required:
+    - Volumes
+    - Warnings
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/volume
+  VolumePruneReport:
+    properties:
+      Err:
+        type: string
+      Id:
+        type: string
+    type: object
+    x-go-package: github.com/containers/libpod/pkg/domain/entities
+  VolumeUsageData:
+    description: |-
+      VolumeUsageData Usage details about the volume. This information is used by the
+      `GET /system/df` endpoint, and omitted in other endpoints.
+    properties:
+      RefCount:
+        description: |-
+          The number of containers referencing this volume. This field
+          is set to `-1` if the reference-count is not available.
+        format: int64
+        type: integer
+      Size:
+        description: |-
+          Amount of disk space used by the volume (in bytes). This information
+          is only available for volumes created with the `"local"` volume
+          driver. For volumes created with other volume drivers, this field
+          is set to `-1` ("not available")
+        format: int64
+        type: integer
+    required:
+    - RefCount
+    - Size
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types
+  WeightDevice:
+    description: WeightDevice is a structure that holds device:weight pair
+    properties:
+      Path:
+        type: string
+      Weight:
+        format: uint16
+        type: integer
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/docker/docker/api/types/blkiodev
+  linuxBlockIODevice:
+    description: linuxBlockIODevice holds major:minor format supported in blkio cgroup
+    properties:
+      major:
+        description: Major is the device's major number.
+        format: int64
+        type: integer
+        x-go-name: Major
+      minor:
+        description: Minor is the device's minor number.
+        format: int64
+        type: integer
+        x-go-name: Minor
+    type: object
+    x-go-package: github.com/containers/libpod/vendor/github.com/opencontainers/runtime-spec/specs-go
+host: podman.io
+info:
+  contact:
+    email: podman@lists.podman.io
+    name: Podman
+    url: https://podman.io/community/
+  description: |-
+    This documentation describes the HTTP Libpod interface.  It is to be considered
+    only as experimental as this point.  The endpoints, parameters, inputs, and
+    return values can all change.
+
+    To start the service and keep it running for 5,000 seconds (-t 0 runs forever):
+
+    podman system service -t 5000 &
+
+    You can then use cURL on the socket using requests documented below.
+
+    NOTE: if you install the package podman-docker, it will create a symbolic
+    link for /var/run/docker.sock to /run/podman/podman.sock
+
+    See podman-service(1) for more information.
+
+    Quick Examples:
+
+    'podman info'
+
+    curl --unix-socket /run/podman/podman.sock http://d/v1.0.0/libpod/info
+
+    'podman pull quay.io/containers/podman'
+
+    curl -XPOST --unix-socket /run/podman/podman.sock -v 'http://d/v1.0.0/images/create?fromImage=quay.io%2Fcontainers%2Fpodman'
+
+    'podman list images'
+
+    curl --unix-socket /run/podman/podman.sock -v 'http://d/v1.0.0/libpod/images/json' | jq
+  license:
+    name: Apache-2.0
+    url: https://opensource.org/licenses/Apache-2.0
+  title: Provides a container compatible interface. (Experimental)
+  version: 0.0.1
+  x-logo:
+  - url: https://raw.githubusercontent.com/containers/libpod/master/logo/podman-logo.png
+  - altText: Podman logo
+paths:
+  /build:
+    post:
+      description: Build an image from the given Dockerfile(s)
+      operationId: buildImage
+      parameters:
+      - default: Dockerfile
+        description: |
+          Path within the build context to the `Dockerfile`.
+          This is ignored if remote is specified and points to an external `Dockerfile`.
+        in: query
+        name: dockerfile
+        type: string
+      - default: latest
+        description: A name and optional tag to apply to the image in the `name:tag`
+          format. If you omit the tag the default latest value is assumed. You can
+          provide several t parameters.
+        in: query
+        name: t
+        type: string
+      - description: |
+          TBD Extra hosts to add to /etc/hosts
+          (As of version 1.xx)
+        in: query
+        name: extrahosts
+        type: string
+      - description: |
+          A Git repository URI or HTTP/HTTPS context URI.
+          If the URI points to a single text file, the file’s contents are placed
+          into a file called Dockerfile and the image is built from that file. If
+          the URI points to a tarball, the file is downloaded by the daemon and the
+          contents therein used as the context for the build. If the URI points to a
+          tarball and the dockerfile parameter is also specified, there must be a file
+          with the corresponding path inside the tarball.
+          (As of version 1.xx)
+        in: query
+        name: remote
+        type: string
+      - default: false
+        description: |
+          Suppress verbose build output
+        in: query
+        name: q
+        type: boolean
+      - default: false
+        description: |
+          Do not use the cache when building the image
+          (As of version 1.xx)
+        in: query
+        name: nocache
+        type: boolean
+      - description: |
+          JSON array of images used to build cache resolution
+          (As of version 1.xx)
+        in: query
+        name: cachefrom
+        type: string
+      - default: false
+        description: |
+          Attempt to pull the image even if an older image exists locally
+          (As of version 1.xx)
+        in: query
+        name: pull
+        type: boolean
+      - default: true
+        description: |
+          Remove intermediate containers after a successful build
+          (As of version 1.xx)
+        in: query
+        name: rm
+        type: boolean
+      - default: false
+        description: |
+          Always remove intermediate containers, even upon failure
+          (As of version 1.xx)
+        in: query
+        name: forcerm
+        type: boolean
+      - description: |
+          Memory is the upper limit (in bytes) on how much memory running containers can use
+          (As of version 1.xx)
+        in: query
+        name: memory
+        type: integer
+      - description: |
+          MemorySwap limits the amount of memory and swap together
+          (As of version 1.xx)
+        in: query
+        name: memswap
+        type: integer
+      - description: |
+          CPUShares (relative weight
+          (As of version 1.xx)
+        in: query
+        name: cpushares
+        type: integer
+      - description: |
+          CPUSetCPUs in which to allow execution (0-3, 0,1)
+          (As of version 1.xx)
+        in: query
+        name: cpusetcpus
+        type: string
+      - description: |
+          CPUPeriod limits the CPU CFS (Completely Fair Scheduler) period
+          (As of version 1.xx)
+        in: query
+        name: cpuperiod
+        type: integer
+      - description: |
+          CPUQuota limits the CPU CFS (Completely Fair Scheduler) quota
+          (As of version 1.xx)
+        in: query
+        name: cpuquota
+        type: integer
+      - description: |
+          JSON map of string pairs denoting build-time variables.
+          For example, the build argument `Foo` with the value of `bar` would be encoded in JSON as `["Foo":"bar"]`.
+
+          For example, buildargs={"Foo":"bar"}.
+
+          Note(s):
+          * This should not be used to pass secrets.
+          * The value of buildargs should be URI component encoded before being passed to the API.
+
+          (As of version 1.xx)
+        in: query
+        name: buildargs
+        type: string
+      - default: 67108864
+        description: |
+          ShmSize is the "size" value to use when mounting an shmfs on the container's /dev/shm directory.
+          Default is 64MB
+          (As of version 1.xx)
+        in: query
+        name: shmsize
+        type: integer
+      - default: false
+        description: |
+          Silently ignored.
+          Squash the resulting images layers into a single layer
+          (As of version 1.xx)
+        in: query
+        name: squash
+        type: boolean
+      - description: |
+          JSON map of key, value pairs to set as labels on the new image
+          (As of version 1.xx)
+        in: query
+        name: labels
+        type: string
+      - default: bridge
+        description: |
+          Sets the networking mode for the run commands during build.
+          Supported standard values are:
+            * `bridge` limited to containers within a single host, port mapping required for external access
+            * `host` no isolation between host and containers on this network
+            * `none` disable all networking for this container
+            * container:<nameOrID> share networking with given container
+            ---All other values are assumed to be a custom network's name
+          (As of version 1.xx)
+        in: query
+        name: networkmode
+        type: string
+      - description: |
+          Platform format os[/arch[/variant]]
+          (As of version 1.xx)
+        in: query
+        name: platform
+        type: string
+      - description: |
+          Target build stage
+          (As of version 1.xx)
+        in: query
+        name: target
+        type: string
+      - description: |
+          output configuration TBD
+          (As of version 1.xx)
+        in: query
+        name: outputs
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK (As of version 1.xx)
+          schema:
+            properties:
+              stream:
+                description: output from build process
+                example: |
+                  (build details...)
+                  Successfully built 8ba084515c724cbf90d447a63600c0a6
+                type: string
+            required:
+            - stream
+            type: object
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create image
+      tags:
+      - images (compat)
+  /commit:
+    post:
+      description: Create a new image from a container
+      operationId: commitContainer
+      parameters:
+      - description: the name or ID of a container
+        in: query
+        name: container
+        type: string
+      - description: the repository name for the created image
+        in: query
+        name: repo
+        type: string
+      - description: tag name for the created image
+        in: query
+        name: tag
+        type: string
+      - description: commit message
+        in: query
+        name: comment
+        type: string
+      - description: author of the image
+        in: query
+        name: author
+        type: string
+      - description: pause the container before committing it
+        in: query
+        name: pause
+        type: boolean
+      - description: instructions to apply while committing in Dockerfile format
+        in: query
+        name: changes
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: New Image
+      tags:
+      - containers (compat)
+  /containers/{name}:
+    delete:
+      operationId: removeContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - default: false
+        description: If the container is running, kill it before removing it.
+        in: query
+        name: force
+        type: boolean
+      - default: false
+        description: Remove the volumes associated with the container.
+        in: query
+        name: v
+        type: boolean
+      - description: not supported
+        in: query
+        name: link
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Remove a container
+      tags:
+      - containers (compat)
+  /containers/{name}/archive:
+    get:
+      description: Get a tar archive of files from a container
+      operationId: getArchive
+      parameters:
+      - description: container name or id
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Path to a directory in the container to extract
+        in: query
+        name: path
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+          schema:
+            format: binary
+            type: string
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Get files from a container
+      tags:
+      - containers (compat)
+    post:
+      description: Put a tar archive of files into a container
+      operationId: putArchive
+      parameters:
+      - description: container name or id
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Path to a directory in the container to extract
+        in: query
+        name: path
+        required: true
+        type: string
+      - description: if unpacking the given content would cause an existing directory
+          to be replaced with a non-directory and vice versa (1 or true)
+        in: query
+        name: noOverwriteDirNonDir
+        type: string
+      - description: copy UID/GID maps to the dest file or di (1 or true)
+        in: query
+        name: copyUIDGID
+        type: string
+      - description: tarfile of files to copy into the container
+        in: body
+        name: request
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+        "400":
+          $ref: '#/responses/BadParamError'
+        "403":
+          description: the container rootfs is read-only
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Put files into a container
+      tags:
+      - containers (compat)
+  /containers/{name}/attach:
+    post:
+      description: Hijacks the connection to forward the container's standard streams
+        to the client.
+      operationId: attachContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: keys to use for detaching from the container
+        in: query
+        name: detachKeys
+        type: string
+      - description: Stream all logs from the container across the connection. Happens
+          before streaming attach (if requested). At least one of logs or stream must
+          be set
+        in: query
+        name: logs
+        type: boolean
+      - default: true
+        description: Attach to the container. If unset, and logs is set, only the
+          container's logs will be sent. At least one of stream or logs must be set
+        in: query
+        name: stream
+        type: boolean
+      - description: Attach to container STDOUT
+        in: query
+        name: stdout
+        type: boolean
+      - description: Attach to container STDERR
+        in: query
+        name: stderr
+        type: boolean
+      - description: Attach to container STDIN
+        in: query
+        name: stdin
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "101":
+          description: No error, connection has been hijacked for transporting streams.
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Attach to a container
+      tags:
+      - containers (compat)
+  /containers/{name}/exec:
+    post:
+      description: Create an exec session to run a command inside a running container.
+        Exec sessions will be automatically removed 5 minutes after they exit.
+      operationId: createExec
+      parameters:
+      - description: name of container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Attributes for create
+        in: body
+        name: control
+        schema:
+          properties:
+            AttachStderr:
+              description: Attach to stderr of the exec command
+              type: boolean
+            AttachStdin:
+              description: Attach to stdin of the exec command
+              type: boolean
+            AttachStdout:
+              description: Attach to stdout of the exec command
+              type: boolean
+            Cmd:
+              description: Command to run, as a string or array of strings.
+              items:
+                type: string
+              type: array
+            DetachKeys:
+              description: |
+                "Override the key sequence for detaching a container. Format is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _."
+              type: string
+            Env:
+              description: A list of environment variables in the form ["VAR=value",
+                ...]
+              items:
+                type: string
+              type: array
+            Privileged:
+              default: false
+              description: Runs the exec process with extended privileges
+              type: boolean
+            Tty:
+              description: Allocate a pseudo-TTY
+              type: boolean
+            User:
+              description: |
+                "The user, and optionally, group to run the exec process inside the container. Format is one of: user, user:group, uid, or uid:gid."
+              type: string
+            WorkingDir:
+              description: The working directory for the exec process inside the container.
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "409":
+          description: container is paused
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create an exec instance
+      tags:
+      - exec (compat)
+  /containers/{name}/export:
+    get:
+      description: Export the contents of a container as a tarball.
+      operationId: exportContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: tarball is returned in body
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Export a container
+      tags:
+      - containers (compat)
+  /containers/{name}/json:
+    get:
+      description: Return low-level information about a container.
+      operationId: getContainer
+      parameters:
+      - description: the name or id of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - default: false
+        description: include the size of the container
+        in: query
+        name: size
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsContainerInspectResponse'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Inspect container
+      tags:
+      - containers (compat)
+  /containers/{name}/kill:
+    post:
+      description: Signal to send to the container as an integer or string (e.g. SIGINT)
+      operationId: killContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - default: SIGKILL
+        description: signal to be sent to container
+        in: query
+        name: signal
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Kill container
+      tags:
+      - containers (compat)
+  /containers/{name}/logs:
+    get:
+      description: Get stdout and stderr logs from a container.
+      operationId: logsFromContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Keep connection after returning logs.
+        in: query
+        name: follow
+        type: boolean
+      - description: Return logs from stdout
+        in: query
+        name: stdout
+        type: boolean
+      - description: Return logs from stderr
+        in: query
+        name: stderr
+        type: boolean
+      - description: Only return logs since this time, as a UNIX timestamp
+        in: query
+        name: since
+        type: string
+      - description: Only return logs before this time, as a UNIX timestamp
+        in: query
+        name: until
+        type: string
+      - default: false
+        description: Add timestamps to every log line
+        in: query
+        name: timestamps
+        type: boolean
+      - default: all
+        description: Only return this number of log lines from the end of the logs
+        in: query
+        name: tail
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: logs returned as a stream in response body.
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Get container logs
+      tags:
+      - containers (compat)
+  /containers/{name}/pause:
+    post:
+      description: Use the cgroups freezer to suspend all processes in a container.
+      operationId: pauseContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Pause container
+      tags:
+      - containers (compat)
+  /containers/{name}/resize:
+    post:
+      description: Resize the terminal attached to a container (for use with Attach).
+      operationId: resizeContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Height to set for the terminal, in characters
+        in: query
+        name: h
+        type: integer
+      - description: Width to set for the terminal, in characters
+        in: query
+        name: w
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/ok'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Resize a container's TTY
+      tags:
+      - containers (compat)
+  /containers/{name}/restart:
+    post:
+      operationId: restartContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: timeout before sending kill signal to container
+        in: query
+        name: t
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Restart container
+      tags:
+      - containers (compat)
+  /containers/{name}/start:
+    post:
+      operationId: startContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - default: ctrl-p,ctrl-q
+        description: 'Override the key sequence for detaching a container. Format
+          is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z,
+          @, ^, [, , or _.'
+        in: query
+        name: detachKeys
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "304":
+          $ref: '#/responses/ContainerAlreadyStartedError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Start a container
+      tags:
+      - containers (compat)
+  /containers/{name}/stats:
+    get:
+      description: This returns a live stream of a container’s resource usage statistics.
+      operationId: statsContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - default: true
+        description: Stream the output
+        in: query
+        name: stream
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Get stats for a container
+      tags:
+      - containers (compat)
+  /containers/{name}/stop:
+    post:
+      description: Stop a container
+      operationId: stopContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: number of seconds to wait before killing container
+        in: query
+        name: t
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "304":
+          $ref: '#/responses/ContainerAlreadyStoppedError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Stop a container
+      tags:
+      - containers (compat)
+  /containers/{name}/top:
+    get:
+      operationId: topContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: arguments to pass to ps such as aux. Requires ps(1) to be installed
+          in the container if no ps(1) compatible AIX descriptors are used.
+        in: query
+        name: ps_args
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsContainerTopResponse'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: List processes running inside a container
+      tags:
+      - containers (compat)
+  /containers/{name}/unpause:
+    post:
+      description: Resume a paused container
+      operationId: unpauseContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Unpause container
+      tags:
+      - containers (compat)
+  /containers/{name}/wait:
+    post:
+      description: Block until a container stops or given condition is met.
+      operationId: waitContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: |
+          wait until container is to a given condition. default is stopped. valid conditions are:
+            - configured
+            - created
+            - exited
+            - paused
+            - running
+            - stopped
+        in: query
+        name: condition
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/ContainerWaitResponse'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Wait on a container
+      tags:
+      - containers (compat)
+  /containers/create:
+    post:
+      operationId: createContainer
+      parameters:
+      - description: container name
+        in: query
+        name: name
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          $ref: '#/responses/ContainerCreateResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create a container
+      tags:
+      - containers (compat)
+  /containers/json:
+    get:
+      description: Returns a list of containers
+      operationId: listContainers
+      parameters:
+      - default: false
+        description: Return all containers. By default, only running containers are
+          shown
+        in: query
+        name: all
+        type: boolean
+      - description: Return this number of most recently created containers, including
+          non-running ones.
+        in: query
+        name: limit
+        type: integer
+      - default: false
+        description: Return the size of container as fields SizeRw and SizeRootFs.
+        in: query
+        name: size
+        type: boolean
+      - description: |
+          Returns a list of containers.
+           - ancestor=(<image-name>[:<tag>], <image id>, or <image@digest>)
+           - before=(<container id> or <container name>)
+           - expose=(<port>[/<proto>]|<startport-endport>/[<proto>])
+           - exited=<int> containers with exit code of <int>
+           - health=(starting|healthy|unhealthy|none)
+           - id=<ID> a container's ID
+           - is-task=(true|false)
+           - label=key or label="key=value" of a container label
+           - name=<name> a container's name
+           - network=(<network id> or <network name>)
+           - publish=(<port>[/<proto>]|<startport-endport>/[<proto>])
+           - since=(<container id> or <container name>)
+           - status=(created|restarting|running|removing|paused|exited|dead)
+           - volume=(<volume name> or <mount point destination>)
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsListContainer'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: List containers
+      tags:
+      - containers (compat)
+  /containers/prune:
+    post:
+      description: Remove containers not in use
+      operationId: pruneContainers
+      parameters:
+      - description: |
+          Filters to process on the prune list, encoded as JSON (a `map[string][]string`).  Available filters:
+           - `until=<timestamp>` Prune containers created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+           - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune containers with (or without, in case `label!=...` is used) the specified labels.
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsContainerPruneReport'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Delete stopped containers
+      tags:
+      - containers (compat)
+  /events:
+    get:
+      description: Returns events filtered on query parameters
+      operationId: getEvents
+      parameters:
+      - description: start streaming events from this time
+        in: query
+        name: since
+        type: string
+      - description: stop streaming events later than this
+        in: query
+        name: until
+        type: string
+      - description: JSON encoded map[string][]string of constraints
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: returns a string of json data describing an event
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Get events
+      tags:
+      - system (compat)
+  /exec/{id}/json:
+    get:
+      description: Return low-level information about an exec instance.
+      operationId: inspectExec
+      parameters:
+      - description: Exec instance ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchExecInstance'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Inspect an exec instance
+      tags:
+      - exec (compat)
+  /exec/{id}/resize:
+    post:
+      description: |
+        Resize the TTY session used by an exec instance. This endpoint only works if tty was specified as part of creating and starting the exec instance.
+      operationId: resizeExec
+      parameters:
+      - description: Exec instance ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Height of the TTY session in characters
+        in: query
+        name: h
+        type: integer
+      - description: Width of the TTY session in characters
+        in: query
+        name: w
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchExecInstance'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Resize an exec instance
+      tags:
+      - exec (compat)
+  /exec/{id}/start:
+    post:
+      description: Starts a previously set up exec instance. If detach is true, this
+        endpoint returns immediately after starting the command. Otherwise, it sets
+        up an interactive session with the command.
+      operationId: startExec
+      parameters:
+      - description: Exec instance ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Attributes for start
+        in: body
+        name: control
+        schema:
+          properties:
+            Detach:
+              description: Detach from the command. Not presently supported.
+              type: boolean
+            Tty:
+              description: Allocate a pseudo-TTY. Presently ignored.
+              type: boolean
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchExecInstance'
+        "409":
+          description: container is not running
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Start an exec instance
+      tags:
+      - exec (compat)
+  /images/{name:.*}:
+    delete:
+      description: Delete an image from local storage
+      operationId: removeImage
+      parameters:
+      - description: name or ID of image to delete
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - description: remove the image even if used by containers or has other tags
+        in: query
+        name: force
+        type: boolean
+      - description: not supported. will be logged as an invalid parameter if enabled
+        in: query
+        name: noprune
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsImageDeleteResponse'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Remove Image
+      tags:
+      - images (compat)
+  /images/{name:.*}/get:
+    get:
+      description: Export an image in tarball format
+      operationId: exportImage
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+          schema:
+            format: binary
+            type: string
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Export an image
+      tags:
+      - images (compat)
+  /images/{name:.*}/history:
+    get:
+      description: Return parent layers of an image.
+      operationId: imageHistory
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsHistory'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: History of an image
+      tags:
+      - images (compat)
+  /images/{name:.*}/json:
+    get:
+      description: Return low-level information about an image.
+      operationId: inspectImage
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsImageInspect'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Inspect an image
+      tags:
+      - images (compat)
+  /images/{name:.*}/push:
+    post:
+      description: Push an image to a container registry
+      operationId: pushImage
+      parameters:
+      - description: Name of image to push.
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - description: The tag to associate with the image on the registry.
+        in: query
+        name: tag
+        type: string
+      - description: A base64-encoded auth configuration.
+        in: header
+        name: X-Registry-Auth
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+          schema:
+            format: binary
+            type: string
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Push Image
+      tags:
+      - images (compat)
+  /images/{name:.*}/tag:
+    post:
+      description: Tag an image so that it becomes part of a repository.
+      operationId: tagImage
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - description: the repository to tag in
+        in: query
+        name: repo
+        type: string
+      - description: the name of the new tag
+        in: query
+        name: tag
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: no error
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Tag an image
+      tags:
+      - images (compat)
+  /images/create:
+    post:
+      description: Create an image by either pulling it from a registry or importing
+        it.
+      operationId: createImage
+      parameters:
+      - description: needs description
+        in: query
+        name: fromImage
+        type: string
+      - description: needs description
+        in: query
+        name: fromSrc
+        type: string
+      - description: needs description
+        in: query
+        name: tag
+        type: string
+      - description: A base64-encoded auth configuration.
+        in: header
+        name: X-Registry-Auth
+        type: string
+      - description: Image content if fromSrc parameter was used
+        in: body
+        name: request
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/ok'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create an image
+      tags:
+      - images (compat)
+  /images/json:
+    get:
+      description: Returns a list of images on the server. Note that it uses a different,
+        smaller representation of an image than inspecting a single image.
+      operationId: listImages
+      parameters:
+      - default: false
+        description: Show all images. Only images from a final layer (no children)
+          are shown by default.
+        in: query
+        name: all
+        type: boolean
+      - description: |
+          A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
+          - `before`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
+          - `dangling=true`
+          - `label=key` or `label="key=value"` of an image label
+          - `reference`=(`<image-name>[:<tag>]`)
+          - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
+        in: query
+        name: filters
+        type: string
+      - default: false
+        description: Not supported
+        in: query
+        name: digests
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DockerImageSummary'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: List Images
+      tags:
+      - images (compat)
+  /images/load:
+    post:
+      description: Load a set of images and tags into a repository.
+      operationId: importImage
+      parameters:
+      - description: not supported
+        in: query
+        name: quiet
+        type: boolean
+      - description: tarball of container image
+        in: body
+        name: request
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Import image
+      tags:
+      - images (compat)
+  /images/prune:
+    post:
+      description: Remove images from local storage that are not being used by a container
+      operationId: pruneImages
+      parameters:
+      - description: |
+          filters to apply to image pruning, encoded as JSON (map[string][]string). Available filters:
+            - `dangling=<boolean>` When set to `true` (or `1`), prune only
+               unused *and* untagged images. When set to `false`
+               (or `0`), all unused images are pruned.
+            - `until=<string>` Prune images created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+            - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune images with (or without, in case `label!=...` is used) the specified labels.
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsImageDeleteResponse'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Prune unused images
+      tags:
+      - images (compat)
+  /images/search:
+    get:
+      description: Search registries for an image
+      operationId: searchImages
+      parameters:
+      - description: term to search
+        in: query
+        name: term
+        type: string
+      - description: maximum number of results
+        in: query
+        name: limit
+        type: integer
+      - description: |
+          A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
+          - `is-automated=(true|false)`
+          - `is-official=(true|false)`
+          - `stars=<number>` Matches images that has at least 'number' stars.
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsSearchResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Search images
+      tags:
+      - images (compat)
+  /info:
+    get:
+      description: Returns information on the system and libpod configuration
+      operationId: getInfo
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: to be determined
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Get info
+      tags:
+      - system (compat)
+  /libpod/_ping:
+    get:
+      description: |
+        Return protocol information in response headers.
+        `HEAD /libpod/_ping` is also supported.
+        `/_ping` is available for compatibility with other engines.
+        The '_ping' endpoints are not versioned.
+      operationId: libpodPingGet
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: Success
+          headers:
+            API-Version:
+              description: Max compatibility API Version the server supports
+              type: string
+            BuildKit-Version:
+              description: Default version of docker image builder
+              type: string
+            Cache-Control:
+              description: always no-cache
+              type: string
+            Docker-Experimental:
+              description: If the server is running with experimental mode enabled,
+                always true
+              type: boolean
+            Libpod-API-Version:
+              description: |
+                Max Podman API Version the server supports.
+                Available if service is backed by Podman, therefore may be used to
+                determine if talking to Podman engine or another engine
+              type: string
+            Libpod-Buildha-Version:
+              description: |
+                Default version of libpod image builder.
+                  Available if service is backed by Podman, therefore may be used to
+                  determine if talking to Podman engine or another engine
+              type: string
+            Pragma:
+              description: always no-cache
+              type: string
+          schema:
+            description: OK
+            example: OK
+            type: string
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Ping service
+      tags:
+      - system (compat)
+      - system
+  /libpod/build:
+    post:
+      description: Build an image from the given Dockerfile(s)
+      operationId: libpodBuildImage
+      parameters:
+      - default: Dockerfile
+        description: |
+          Path within the build context to the `Dockerfile`.
+          This is ignored if remote is specified and points to an external `Dockerfile`.
+        in: query
+        name: dockerfile
+        type: string
+      - default: latest
+        description: A name and optional tag to apply to the image in the `name:tag`
+          format.  If you omit the tag the default latest value is assumed. You can
+          provide several t parameters.
+        in: query
+        name: t
+        type: string
+      - description: |
+          TBD Extra hosts to add to /etc/hosts
+          (As of version 1.xx)
+        in: query
+        name: extrahosts
+        type: string
+      - description: |
+          A Git repository URI or HTTP/HTTPS context URI.
+          If the URI points to a single text file, the file’s contents are placed
+          into a file called Dockerfile and the image is built from that file. If
+          the URI points to a tarball, the file is downloaded by the daemon and the
+          contents therein used as the context for the build. If the URI points to a
+          tarball and the dockerfile parameter is also specified, there must be a file
+          with the corresponding path inside the tarball.
+          (As of version 1.xx)
+        in: query
+        name: remote
+        type: string
+      - default: false
+        description: |
+          Suppress verbose build output
+        in: query
+        name: q
+        type: boolean
+      - default: false
+        description: |
+          Do not use the cache when building the image
+          (As of version 1.xx)
+        in: query
+        name: nocache
+        type: boolean
+      - description: |
+          JSON array of images used to build cache resolution
+          (As of version 1.xx)
+        in: query
+        name: cachefrom
+        type: string
+      - default: false
+        description: |
+          Attempt to pull the image even if an older image exists locally
+          (As of version 1.xx)
+        in: query
+        name: pull
+        type: boolean
+      - default: true
+        description: |
+          Remove intermediate containers after a successful build
+          (As of version 1.xx)
+        in: query
+        name: rm
+        type: boolean
+      - default: false
+        description: |
+          Always remove intermediate containers, even upon failure
+          (As of version 1.xx)
+        in: query
+        name: forcerm
+        type: boolean
+      - description: |
+          Memory is the upper limit (in bytes) on how much memory running containers can use
+          (As of version 1.xx)
+        in: query
+        name: memory
+        type: integer
+      - description: |
+          MemorySwap limits the amount of memory and swap together
+          (As of version 1.xx)
+        in: query
+        name: memswap
+        type: integer
+      - description: |
+          CPUShares (relative weight
+          (As of version 1.xx)
+        in: query
+        name: cpushares
+        type: integer
+      - description: |
+          CPUSetCPUs in which to allow execution (0-3, 0,1)
+          (As of version 1.xx)
+        in: query
+        name: cpusetcpus
+        type: string
+      - description: |
+          CPUPeriod limits the CPU CFS (Completely Fair Scheduler) period
+          (As of version 1.xx)
+        in: query
+        name: cpuperiod
+        type: integer
+      - description: |
+          CPUQuota limits the CPU CFS (Completely Fair Scheduler) quota
+          (As of version 1.xx)
+        in: query
+        name: cpuquota
+        type: integer
+      - description: |
+          JSON map of string pairs denoting build-time variables.
+          For example, the build argument `Foo` with the value of `bar` would be encoded in JSON as `["Foo":"bar"]`.
+
+          For example, buildargs={"Foo":"bar"}.
+
+          Note(s):
+          * This should not be used to pass secrets.
+          * The value of buildargs should be URI component encoded before being passed to the API.
+
+          (As of version 1.xx)
+        in: query
+        name: buildargs
+        type: string
+      - default: 67108864
+        description: |
+          ShmSize is the "size" value to use when mounting an shmfs on the container's /dev/shm directory.
+          Default is 64MB
+          (As of version 1.xx)
+        in: query
+        name: shmsize
+        type: integer
+      - default: false
+        description: |
+          Silently ignored.
+          Squash the resulting images layers into a single layer
+          (As of version 1.xx)
+        in: query
+        name: squash
+        type: boolean
+      - description: |
+          JSON map of key, value pairs to set as labels on the new image
+          (As of version 1.xx)
+        in: query
+        name: labels
+        type: string
+      - default: bridge
+        description: |
+          Sets the networking mode for the run commands during build.
+          Supported standard values are:
+            * `bridge` limited to containers within a single host, port mapping required for external access
+            * `host` no isolation between host and containers on this network
+            * `none` disable all networking for this container
+            * container:<nameOrID> share networking with given container
+            ---All other values are assumed to be a custom network's name
+          (As of version 1.xx)
+        in: query
+        name: networkmode
+        type: string
+      - description: |
+          Platform format os[/arch[/variant]]
+          (As of version 1.xx)
+        in: query
+        name: platform
+        type: string
+      - description: |
+          Target build stage
+          (As of version 1.xx)
+        in: query
+        name: target
+        type: string
+      - description: |
+          output configuration TBD
+          (As of version 1.xx)
+        in: query
+        name: outputs
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK (As of version 1.xx)
+          schema:
+            properties:
+              stream:
+                description: output from build process
+                example: |
+                  (build details...)
+                  Successfully built 8ba084515c724cbf90d447a63600c0a6
+                type: string
+            required:
+            - stream
+            type: object
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create image
+      tags:
+      - images
+  /libpod/commit:
+    post:
+      description: Create a new image from a container
+      operationId: libpodCommitContainer
+      parameters:
+      - description: the name or ID of a container
+        in: query
+        name: container
+        required: true
+        type: string
+      - description: the repository name for the created image
+        in: query
+        name: repo
+        type: string
+      - description: tag name for the created image
+        in: query
+        name: tag
+        type: string
+      - description: commit message
+        in: query
+        name: comment
+        type: string
+      - description: author of the image
+        in: query
+        name: author
+        type: string
+      - description: pause the container before committing it
+        in: query
+        name: pause
+        type: boolean
+      - description: instructions to apply while committing in Dockerfile format (i.e.
+          "CMD=/bin/foo")
+        in: query
+        items:
+          type: string
+        name: changes
+        type: array
+      - description: format of the image manifest and metadata (default "oci")
+        in: query
+        name: format
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Commit
+      tags:
+      - containers
+  /libpod/containers/{name:.*}/healthcheck:
+    get:
+      description: Execute the defined healthcheck and return information about the
+        results
+      operationId: libpodRunHealthCheck
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/HealthcheckRun'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "409":
+          description: container has no healthcheck or is not running
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Run a container's healthcheck
+      tags:
+      - containers
+  /libpod/containers/{name}:
+    delete:
+      description: Delete container
+      operationId: libpodRemoveContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: need something
+        in: query
+        name: force
+        type: boolean
+      - description: delete volumes
+        in: query
+        name: v
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Delete container
+      tags:
+      - containers
+  /libpod/containers/{name}/attach:
+    post:
+      description: Hijacks the connection to forward the container's standard streams
+        to the client.
+      operationId: libpodAttachContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: keys to use for detaching from the container
+        in: query
+        name: detachKeys
+        type: string
+      - description: Stream all logs from the container across the connection. Happens
+          before streaming attach (if requested). At least one of logs or stream must
+          be set
+        in: query
+        name: logs
+        type: boolean
+      - default: true
+        description: Attach to the container. If unset, and logs is set, only the
+          container's logs will be sent. At least one of stream or logs must be set
+        in: query
+        name: stream
+        type: boolean
+      - description: Attach to container STDOUT
+        in: query
+        name: stdout
+        type: boolean
+      - description: Attach to container STDERR
+        in: query
+        name: stderr
+        type: boolean
+      - description: Attach to container STDIN
+        in: query
+        name: stdin
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "101":
+          description: No error, connection has been hijacked for transporting streams.
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Attach to a container
+      tags:
+      - containers
+  /libpod/containers/{name}/changes:
+    get:
+      description: |
+        Returns which files in a container's filesystem have been added, deleted, or modified. The Kind of modification can be one of:
+
+        0: Modified
+        1: Added
+        2: Deleted
+      operationId: changesContainer
+      parameters:
+      - description: the name or id of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Array of Changes
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Report on changes to container's filesystem; adds, deletes or modifications.
+      tags:
+      - containers
+      - containers (compat)
+  /libpod/containers/{name}/checkpoint:
+    post:
+      operationId: libpodCheckpointContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: keep all temporary checkpoint files
+        in: query
+        name: keep
+        type: boolean
+      - description: leave the container running after writing checkpoint to disk
+        in: query
+        name: leaveRunning
+        type: boolean
+      - description: checkpoint a container with established TCP connections
+        in: query
+        name: tcpEstablished
+        type: boolean
+      - description: export the checkpoint image to a tar.gz
+        in: query
+        name: export
+        type: boolean
+      - description: do not include root file-system changes when exporting
+        in: query
+        name: ignoreRootFS
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: tarball is returned in body if exported
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Checkpoint a container
+      tags:
+      - containers
+  /libpod/containers/{name}/copy:
+    get:
+      description: Copy a tar archive of files from a container
+      operationId: libpodGetArchive
+      parameters:
+      - description: container name or id
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Path to a directory in the container to extract
+        in: query
+        name: path
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+          schema:
+            format: binary
+            type: string
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Copy files from a container
+      tags:
+      - containers (compat)
+    post:
+      description: Copy a tar archive of files into a container
+      operationId: libpodPutArchive
+      parameters:
+      - description: container name or id
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Path to a directory in the container to extract
+        in: query
+        name: path
+        required: true
+        type: string
+      - default: true
+        description: pause the container while copying (defaults to true)
+        in: query
+        name: pause
+        type: boolean
+      - description: tarfile of files to copy into the container
+        in: body
+        name: request
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+        "400":
+          $ref: '#/responses/BadParamError'
+        "403":
+          description: the container rootfs is read-only
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Copy files into a container
+      tags:
+      - containers
+  /libpod/containers/{name}/exec:
+    post:
+      description: Create an exec session to run a command inside a running container.
+        Exec sessions will be automatically removed 5 minutes after they exit.
+      operationId: libpodCreateExec
+      parameters:
+      - description: name of container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Attributes for create
+        in: body
+        name: control
+        schema:
+          properties:
+            AttachStderr:
+              description: Attach to stderr of the exec command
+              type: boolean
+            AttachStdin:
+              description: Attach to stdin of the exec command
+              type: boolean
+            AttachStdout:
+              description: Attach to stdout of the exec command
+              type: boolean
+            Cmd:
+              description: Command to run, as a string or array of strings.
+              items:
+                type: string
+              type: array
+            DetachKeys:
+              description: |
+                "Override the key sequence for detaching a container. Format is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z, @, ^, [, , or _."
+              type: string
+            Env:
+              description: A list of environment variables in the form ["VAR=value",
+                ...]
+              items:
+                type: string
+              type: array
+            Privileged:
+              default: false
+              description: Runs the exec process with extended privileges
+              type: boolean
+            Tty:
+              description: Allocate a pseudo-TTY
+              type: boolean
+            User:
+              description: |
+                "The user, and optionally, group to run the exec process inside the container. Format is one of: user, user:group, uid, or uid:gid."
+              type: string
+            WorkingDir:
+              description: The working directory for the exec process inside the container.
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "409":
+          description: container is paused
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create an exec instance
+      tags:
+      - exec
+  /libpod/containers/{name}/exists:
+    get:
+      description: Quick way to determine if a container exists by name or ID
+      operationId: libpodContainerExists
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: container exists
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Check if container exists
+      tags:
+      - containers
+  /libpod/containers/{name}/export:
+    get:
+      description: Export the contents of a container as a tarball.
+      operationId: libpodExportContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: tarball is returned in body
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Export a container
+      tags:
+      - containers
+  /libpod/containers/{name}/init:
+    post:
+      description: Performs all tasks necessary for initializing the container but
+        does not start the container.
+      operationId: libpodInitContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "304":
+          description: container already initialized
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Initialize a container
+      tags:
+      - containers
+  /libpod/containers/{name}/json:
+    get:
+      description: Return low-level information about a container.
+      operationId: libpodGetContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: display filesystem usage
+        in: query
+        name: size
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/LibpodInspectContainerResponse'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Inspect container
+      tags:
+      - containers
+  /libpod/containers/{name}/kill:
+    post:
+      description: send a signal to a container, defaults to killing the container
+      operationId: libpodKillContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - default: TERM
+        description: signal to be sent to container, either by integer or SIG_ name
+        in: query
+        name: signal
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Kill container
+      tags:
+      - containers
+  /libpod/containers/{name}/logs:
+    get:
+      description: Get stdout and stderr logs from a container.
+      operationId: libpodLogsFromContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Keep connection after returning logs.
+        in: query
+        name: follow
+        type: boolean
+      - description: Return logs from stdout
+        in: query
+        name: stdout
+        type: boolean
+      - description: Return logs from stderr
+        in: query
+        name: stderr
+        type: boolean
+      - description: Only return logs since this time, as a UNIX timestamp
+        in: query
+        name: since
+        type: string
+      - description: Only return logs before this time, as a UNIX timestamp
+        in: query
+        name: until
+        type: string
+      - default: false
+        description: Add timestamps to every log line
+        in: query
+        name: timestamps
+        type: boolean
+      - default: all
+        description: Only return this number of log lines from the end of the logs
+        in: query
+        name: tail
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: logs returned as a stream in response body.
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Get container logs
+      tags:
+      - containers
+  /libpod/containers/{name}/mount:
+    post:
+      description: Mount a container to the filesystem
+      operationId: libpodMountContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: mounted container
+          schema:
+            description: id
+            example: /var/lib/containers/storage/overlay/f3f693bd88872a1e3193f4ebb925f4c282e8e73aadb8ab3e7492754dda3a02a4/merged
+            type: string
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Mount a container
+      tags:
+      - containers
+  /libpod/containers/{name}/pause:
+    post:
+      description: Use the cgroups freezer to suspend all processes in a container.
+      operationId: libpodPauseContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Pause a container
+      tags:
+      - containers
+  /libpod/containers/{name}/resize:
+    post:
+      description: Resize the terminal attached to a container (for use with Attach).
+      operationId: libpodResizeContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Height to set for the terminal, in characters
+        in: query
+        name: h
+        type: integer
+      - description: Width to set for the terminal, in characters
+        in: query
+        name: w
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/ok'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Resize a container's TTY
+      tags:
+      - containers
+  /libpod/containers/{name}/restart:
+    post:
+      operationId: libpodRestartContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: timeout before sending kill signal to container
+        in: query
+        name: t
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Restart a container
+      tags:
+      - containers
+  /libpod/containers/{name}/restore:
+    post:
+      description: Restore a container from a checkpoint.
+      operationId: libpodRestoreContainer
+      parameters:
+      - description: the name or id of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: the name of the container when restored from a tar. can only
+          be used with import
+        in: query
+        name: name
+        type: string
+      - description: keep all temporary checkpoint files
+        in: query
+        name: keep
+        type: boolean
+      - description: leave the container running after writing checkpoint to disk
+        in: query
+        name: leaveRunning
+        type: boolean
+      - description: checkpoint a container with established TCP connections
+        in: query
+        name: tcpEstablished
+        type: boolean
+      - description: import the restore from a checkpoint tar.gz
+        in: query
+        name: import
+        type: boolean
+      - description: do not include root file-system changes when exporting
+        in: query
+        name: ignoreRootFS
+        type: boolean
+      - description: ignore IP address if set statically
+        in: query
+        name: ignoreStaticIP
+        type: boolean
+      - description: ignore MAC address if set statically
+        in: query
+        name: ignoreStaticMAC
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: tarball is returned in body if exported
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Restore a container
+      tags:
+      - containers
+  /libpod/containers/{name}/start:
+    post:
+      operationId: libpodStartContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - default: ctrl-p,ctrl-q
+        description: 'Override the key sequence for detaching a container. Format
+          is a single character [a-Z] or ctrl-<value> where <value> is one of: a-z,
+          @, ^, [, , or _.'
+        in: query
+        name: detachKeys
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "304":
+          $ref: '#/responses/ContainerAlreadyStartedError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Start a container
+      tags:
+      - containers
+  /libpod/containers/{name}/stats:
+    get:
+      description: This returns a live stream of a container’s resource usage statistics.
+      operationId: libpodStatsContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - default: true
+        description: Stream the output
+        in: query
+        name: stream
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Get stats for a container
+      tags:
+      - containers
+  /libpod/containers/{name}/stop:
+    post:
+      operationId: libpodStopContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: number of seconds to wait before killing container
+        in: query
+        name: t
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "304":
+          $ref: '#/responses/ContainerAlreadyStoppedError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Stop a container
+      tags:
+      - containers
+  /libpod/containers/{name}/top:
+    get:
+      description: List processes running inside a container
+      operationId: libpodTopContainer
+      parameters:
+      - description: |
+          Name of container to query for processes
+          (As of version 1.xx)
+        in: path
+        name: name
+        required: true
+        type: string
+      - default: true
+        description: Stream the output
+        in: query
+        name: stream
+        type: boolean
+      - default: -ef
+        description: arguments to pass to ps such as aux. Requires ps(1) to be installed
+          in the container if no ps(1) compatible AIX descriptors are used.
+        in: query
+        name: ps_args
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsContainerTopResponse'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: List processes
+      tags:
+      - containers
+  /libpod/containers/{name}/unmount:
+    post:
+      description: Unmount a container from the filesystem
+      operationId: libpodUnmountContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: ok
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Unmount a container
+      tags:
+      - containers
+  /libpod/containers/{name}/unpause:
+    post:
+      operationId: libpodUnpauseContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Unpause Container
+      tags:
+      - containers
+  /libpod/containers/{name}/wait:
+    post:
+      description: Wait on a container to met a given condition
+      operationId: libpodWaitContainer
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: |
+          wait until container is to a given condition. default is stopped. valid conditions are:
+            - configured
+            - created
+            - exited
+            - paused
+            - running
+            - stopped
+        in: query
+        name: condition
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/ContainerWaitResponse'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Wait on a container
+      tags:
+      - containers
+  /libpod/containers/create:
+    post:
+      operationId: libpodCreateContainer
+      parameters:
+      - description: attributes for creating a container
+        in: body
+        name: create
+        schema:
+          $ref: '#/definitions/SpecGenerator'
+      produces:
+      - application/json
+      responses:
+        "201":
+          $ref: '#/responses/ContainerCreateResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create a container
+      tags:
+      - containers
+  /libpod/containers/json:
+    get:
+      description: Returns a list of containers
+      operationId: libpodListContainers
+      parameters:
+      - default: false
+        description: Return all containers. By default, only running containers are
+          shown
+        in: query
+        name: all
+        type: boolean
+      - description: Return this number of most recently created containers, including
+          non-running ones.
+        in: query
+        name: limit
+        type: integer
+      - default: false
+        description: Include namespace information
+        in: query
+        name: namespace
+        type: boolean
+      - default: false
+        description: Include Pod ID and Name if applicable
+        in: query
+        name: pod
+        type: boolean
+      - default: false
+        description: Return the size of container as fields SizeRw and SizeRootFs.
+        in: query
+        name: size
+        type: boolean
+      - default: false
+        description: Sync container state with OCI runtime
+        in: query
+        name: sync
+        type: boolean
+      - description: |
+          A JSON encoded value of the filters (a `map[string][]string`) to process on the containers list. Available filters:
+          - `ancestor`=(`<image-name>[:<tag>]`, `<image id>`, or `<image@digest>`)
+          - `before`=(`<container id>` or `<container name>`)
+          - `expose`=(`<port>[/<proto>]` or `<startport-endport>/[<proto>]`)
+          - `exited=<int>` containers with exit code of `<int>`
+          - `health`=(`starting`, `healthy`, `unhealthy` or `none`)
+          - `id=<ID>` a container's ID
+          - `is-task`=(`true` or `false`)
+          - `label`=(`key` or `"key=value"`) of an container label
+          - `name=<name>` a container's name
+          - `network`=(`<network id>` or `<network name>`)
+          - `publish`=(`<port>[/<proto>]` or `<startport-endport>/[<proto>]`)
+          - `since`=(`<container id>` or `<container name>`)
+          - `status`=(`created`, `restarting`, `running`, `removing`, `paused`, `exited` or `dead`)
+          - `volume`=(`<volume name>` or `<mount point destination>`)
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/ListContainers'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: List containers
+      tags:
+      - containers
+  /libpod/containers/prune:
+    post:
+      description: Remove containers not in use
+      operationId: libpodPruneContainers
+      parameters:
+      - description: |
+          Filters to process on the prune list, encoded as JSON (a `map[string][]string`).  Available filters:
+           - `until=<timestamp>` Prune containers created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+           - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune containers with (or without, in case `label!=...` is used) the specified labels.
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsLibpodPruneResponse'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Delete stopped containers
+      tags:
+      - containers
+  /libpod/containers/showmounted:
+    get:
+      description: Lists all mounted containers mount points
+      operationId: libpodShowMountedContainers
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: mounted containers
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Show mounted containers
+      tags:
+      - containers
+  /libpod/events:
+    get:
+      description: Returns events filtered on query parameters
+      operationId: libpodGetEvents
+      parameters:
+      - description: start streaming events from this time
+        in: query
+        name: since
+        type: string
+      - description: stop streaming events later than this
+        in: query
+        name: until
+        type: string
+      - description: JSON encoded map[string][]string of constraints
+        in: query
+        name: filters
+        type: string
+      - default: true
+        description: when false, do not follow events
+        in: query
+        name: stream
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: returns a string of json data describing an event
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Get events
+      tags:
+      - system
+  /libpod/exec/{id}/json:
+    get:
+      description: Return low-level information about an exec instance.
+      operationId: libpodInspectExec
+      parameters:
+      - description: Exec instance ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchExecInstance'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Inspect an exec instance
+      tags:
+      - exec
+  /libpod/exec/{id}/resize:
+    post:
+      description: |
+        Resize the TTY session used by an exec instance. This endpoint only works if tty was specified as part of creating and starting the exec instance.
+      operationId: libpodResizeExec
+      parameters:
+      - description: Exec instance ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Height of the TTY session in characters
+        in: query
+        name: h
+        type: integer
+      - description: Width of the TTY session in characters
+        in: query
+        name: w
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchExecInstance'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Resize an exec instance
+      tags:
+      - exec
+  /libpod/exec/{id}/start:
+    post:
+      description: Starts a previously set up exec instance. If detach is true, this
+        endpoint returns immediately after starting the command. Otherwise, it sets
+        up an interactive session with the command.
+      operationId: libpodStartExec
+      parameters:
+      - description: Exec instance ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Attributes for start
+        in: body
+        name: control
+        schema:
+          properties:
+            Detach:
+              description: Detach from the command. Not presently supported.
+              type: boolean
+            Tty:
+              description: Allocate a pseudo-TTY. Presently ignored.
+              type: boolean
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchExecInstance'
+        "409":
+          description: container is not running.
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Start an exec instance
+      tags:
+      - exec
+  /libpod/generate/{name:.*}/kube:
+    get:
+      description: Create and run pods based on a Kubernetes YAML file (pod or service
+        kind).
+      operationId: libpodGenerateKube
+      parameters:
+      - description: Name or ID of the container or pod.
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - default: false
+        description: Generate YAML for a Kubernetes service object.
+        in: query
+        name: service
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+          schema:
+            format: binary
+            type: string
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Play a Kubernetes YAML file.
+      tags:
+      - containers
+      - pods
+  /libpod/images/{name:.*}:
+    delete:
+      description: Remove an image from the local storage.
+      operationId: libpodRemoveImage
+      parameters:
+      - description: name or ID of image to remove
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - description: remove the image even if used by containers or has other tags
+        in: query
+        name: force
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsImageDeleteResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Remove an image from the local storage.
+      tags:
+      - images
+  /libpod/images/{name:.*}/exists:
+    get:
+      description: Check if image exists in local store
+      operationId: libpodImageExists
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: image exists
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Image exists
+      tags:
+      - images
+  /libpod/images/{name:.*}/get:
+    get:
+      description: Export an image
+      operationId: libpodExportImage
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - description: format for exported image
+        in: query
+        name: format
+        type: string
+      - description: use compression on image
+        in: query
+        name: compress
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+          schema:
+            format: binary
+            type: string
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Export an image
+      tags:
+      - images
+  /libpod/images/{name:.*}/history:
+    get:
+      description: Return parent layers of an image.
+      operationId: libpodImageHistory
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsHistory'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: History of an image
+      tags:
+      - images
+  /libpod/images/{name:.*}/json:
+    get:
+      description: Obtain low-level information about an image
+      operationId: libpodInspectImage
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsLibpodInspectImageResponse'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Inspect an image
+      tags:
+      - images
+  /libpod/images/{name:.*}/push:
+    post:
+      description: Push an image to a container registry
+      operationId: libpodPushImage
+      parameters:
+      - description: Name of image to push.
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - description: Allows for pushing the image to a different destintation than
+          the image refers to.
+        in: query
+        name: destination
+        type: string
+      - default: true
+        description: Require TLS verification.
+        in: query
+        name: tlsVerify
+        type: boolean
+      - description: A base64-encoded auth configuration.
+        in: header
+        name: X-Registry-Auth
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: no error
+          schema:
+            format: binary
+            type: string
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Push Image
+      tags:
+      - images (libpod)
+  /libpod/images/{name:.*}/tag:
+    post:
+      description: Tag an image so that it becomes part of a repository.
+      operationId: libpodTagImage
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - description: the repository to tag in
+        in: query
+        name: repo
+        type: string
+      - description: the name of the new tag
+        in: query
+        name: tag
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: no error
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Tag an image
+      tags:
+      - images
+  /libpod/images/{name:.*}/tree:
+    get:
+      description: Retrieve the image tree for the provided image name or ID
+      operationId: libpodImageTree
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - description: show all child images and layers of the specified image
+        in: query
+        name: whatrequires
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/LibpodImageTreeResponse'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Image tree
+      tags:
+      - images
+  /libpod/images/{name:.*}/untag:
+    post:
+      description: Untag an image
+      operationId: libpodUntagImage
+      parameters:
+      - description: the name or ID of the container
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - description: the repository to untag
+        in: query
+        name: repo
+        type: string
+      - description: the name of the tag to untag
+        in: query
+        name: tag
+        type: string
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: no error
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Untag an image
+      tags:
+      - images
+  /libpod/images/{name}/changes:
+    get:
+      description: |
+        Returns which files in a images's filesystem have been added, deleted, or modified. The Kind of modification can be one of:
+
+        0: Modified
+        1: Added
+        2: Deleted
+      operationId: libpodChangesImages
+      parameters:
+      - description: the name or id of the container
+        in: path
+        name: name
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Array of Changes
+        "404":
+          $ref: '#/responses/NoSuchContainer'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Report on changes to images's filesystem; adds, deletes or modifications.
+      tags:
+      - images
+  /libpod/images/import:
+    post:
+      description: Import a previously exported tarball as an image.
+      operationId: libpodImagesImport
+      parameters:
+      - description: 'Apply the following possible instructions to the created image:
+          CMD | ENTRYPOINT | ENV | EXPOSE | LABEL | STOPSIGNAL | USER | VOLUME | WORKDIR.  JSON
+          encoded string'
+        in: query
+        items:
+          type: string
+        name: changes
+        type: array
+      - description: Set commit message for imported image
+        in: query
+        name: message
+        type: string
+      - description: Optional Name[:TAG] for the image
+        in: query
+        name: reference
+        type: string
+      - description: Load image from the specified URL
+        in: query
+        name: url
+        type: string
+      - description: tarball for imported image
+        in: formData
+        name: upload
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsLibpodImagesImportResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Import image
+      tags:
+      - images
+  /libpod/images/json:
+    get:
+      description: Returns a list of images on the server
+      operationId: libpodListImages
+      parameters:
+      - default: false
+        description: Show all images. Only images from a final layer (no children)
+          are shown by default.
+        in: query
+        name: all
+        type: boolean
+      - description: |
+          A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
+          - `before`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
+          - `dangling=true`
+          - `label=key` or `label="key=value"` of an image label
+          - `reference`=(`<image-name>[:<tag>]`)
+          - `id`=(`<image-id>`)
+          - `since`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DockerImageSummary'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: List Images
+      tags:
+      - images
+  /libpod/images/load:
+    post:
+      description: Load an image (oci-archive or docker-archive) stream.
+      operationId: libpodImagesLoad
+      parameters:
+      - description: Optional Name[:TAG] for the image
+        in: query
+        name: reference
+        type: string
+      - description: tarball of container image
+        in: formData
+        name: upload
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsLibpodImagesLoadResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Load image
+      tags:
+      - images
+  /libpod/images/prune:
+    post:
+      description: Remove images that are not being used by a container
+      operationId: libpodPruneImages
+      parameters:
+      - description: |
+          filters to apply to image pruning, encoded as JSON (map[string][]string). Available filters:
+            - `dangling=<boolean>` When set to `true` (or `1`), prune only
+               unused *and* untagged images. When set to `false`
+               (or `0`), all unused images are pruned.
+            - `until=<string>` Prune images created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
+            - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune images with (or without, in case `label!=...` is used) the specified labels.
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsImageDeleteResponse'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Prune unused images
+      tags:
+      - images
+  /libpod/images/pull:
+    post:
+      description: Pull one or more images from a container registry.
+      operationId: libpodImagesPull
+      parameters:
+      - description: Mandatory reference to the image (e.g., quay.io/image/name:tag)
+        in: query
+        name: reference
+        type: string
+      - description: username:password for the registry
+        in: query
+        name: credentials
+        type: string
+      - description: Pull image for the specified operating system.
+        in: query
+        name: overrideOS
+        type: string
+      - description: Pull image for the specified architecture.
+        in: query
+        name: overrideArch
+        type: string
+      - default: true
+        description: Require TLS verification.
+        in: query
+        name: tlsVerify
+        type: boolean
+      - description: Pull all tagged images in the repository.
+        in: query
+        name: allTags
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsLibpodImagesPullResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Pull images
+      tags:
+      - images
+  /libpod/images/remove:
+    delete:
+      description: Remove one or more images from the storage.
+      operationId: libpodImagesRemove
+      parameters:
+      - description: Images IDs or names to remove.
+        in: query
+        items:
+          type: string
+        name: images
+        type: array
+      - default: true
+        description: Remove all images.
+        in: query
+        name: all
+        type: boolean
+      - description: Force image removal (including containers using the images).
+        in: query
+        name: force
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsLibpodImagesRemoveResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Remove one or more images from the storage.
+      tags:
+      - images
+  /libpod/images/search:
+    get:
+      description: Search registries for images
+      operationId: libpodSearchImages
+      parameters:
+      - description: term to search
+        in: query
+        name: term
+        type: string
+      - description: maximum number of results
+        in: query
+        name: limit
+        type: integer
+      - description: |
+          A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
+          - `is-automated=(true|false)`
+          - `is-official=(true|false)`
+          - `stars=<number>` Matches images that has at least 'number' stars.
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsSearchResponse'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Search images
+      tags:
+      - images
+  /libpod/info:
+    get:
+      description: Returns information on the system and libpod configuration
+      operationId: libpodGetInfo
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/InfoResponse'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Get info
+      tags:
+      - system
+  /libpod/manifests/{name:.*}:
+    delete:
+      description: Remove an image from a manifest list
+      operationId: RemoveManifest
+      parameters:
+      - description: the image associated with the manifest
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - description: image digest to be removed
+        in: query
+        name: digest
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/definitions/IDResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchManifest'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Remove
+      tags:
+      - manifests
+  /libpod/manifests/{name:.*}/add:
+    post:
+      description: Add an image to a manifest list
+      operationId: AddManifest
+      parameters:
+      - description: the name or ID of the manifest
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      - description: options for creating a manifest
+        in: body
+        name: options
+        schema:
+          $ref: '#/definitions/ManifestAddOpts'
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/definitions/IDResponse'
+        "404":
+          $ref: '#/responses/NoSuchManifest'
+        "409":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      tags:
+      - manifests
+  /libpod/manifests/{name:.*}/json:
+    get:
+      description: Display a manifest list
+      operationId: Inspect
+      parameters:
+      - description: the name or ID of the manifest
+        in: path
+        name: name:.*
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/InspectManifest'
+        "404":
+          $ref: '#/responses/NoSuchManifest'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Inspect
+      tags:
+      - manifests
+  /libpod/manifests/{name}/push:
+    post:
+      description: Push a manifest list or image index to a registry
+      operationId: PushManifest
+      parameters:
+      - description: the name or ID of the manifest
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: the destination for the manifest
+        in: query
+        name: destination
+        required: true
+        type: string
+      - description: push all images
+        in: query
+        name: all
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/definitions/IDResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchManifest'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Push
+      tags:
+      - manifests
+  /libpod/manifests/create:
+    post:
+      description: Create a manifest list
+      operationId: Create
+      parameters:
+      - description: manifest list name
+        in: query
+        name: name
+        required: true
+        type: string
+      - description: name of the image
+        in: query
+        name: image
+        type: string
+      - description: add all contents if given list
+        in: query
+        name: all
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/definitions/IDResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchImage'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create
+      tags:
+      - manifests
+  /libpod/networks/{name}:
+    delete:
+      description: Remove a CNI configured network
+      operationId: libpodRemoveNetwork
+      parameters:
+      - description: the name of the network
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: remove containers associated with network
+        in: query
+        name: Force
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/NetworkRmReport'
+        "404":
+          $ref: '#/responses/NoSuchNetwork'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Remove a network
+      tags:
+      - networks
+  /libpod/networks/{name}/json:
+    get:
+      description: Display low level configuration for a CNI network
+      operationId: libpodInspectNetwork
+      parameters:
+      - description: the name of the network
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/NetworkInspectReport'
+        "404":
+          $ref: '#/responses/NoSuchNetwork'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Inspect a network
+      tags:
+      - networks
+  /libpod/networks/create:
+    post:
+      description: Create a new CNI network configuration
+      operationId: libpodCreateNetwork
+      parameters:
+      - description: optional name for new network
+        in: query
+        name: name
+        type: string
+      - description: attributes for creating a container
+        in: body
+        name: create
+        schema:
+          $ref: '#/definitions/NetworkCreateOptions'
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/NetworkCreateReport'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create network
+      tags:
+      - networks
+  /libpod/networks/json:
+    get:
+      description: Display summary of network configurations
+      operationId: libpodListNetwork
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/NetworkListReport'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: List networks
+      tags:
+      - networks
+  /libpod/play/kube:
+    post:
+      description: Create and run pods based on a Kubernetes YAML file (pod or service
+        kind).
+      operationId: libpodPlayKube
+      parameters:
+      - description: Connect the pod to this network.
+        in: query
+        name: network
+        type: string
+      - default: true
+        description: Require HTTPS and verify signatures when contating registries.
+        in: query
+        name: tlsVerify
+        type: boolean
+      - description: Kubernetes YAML file.
+        in: body
+        name: request
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsLibpodPlayKubeResponse'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Play a Kubernetes YAML file.
+      tags:
+      - containers
+      - pods
+  /libpod/pods/{name}:
+    delete:
+      operationId: removePod
+      parameters:
+      - description: the name or ID of the pod
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: force removal of a running pod by first stopping all containers,
+          then removing all containers in the pod
+        in: query
+        name: force
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/PodRmReport'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchPod'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Remove pod
+      tags:
+      - pods
+  /libpod/pods/{name}/exists:
+    get:
+      description: Check if a pod exists by name or ID
+      operationId: podExists
+      parameters:
+      - description: the name or ID of the pod
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: pod exists
+        "404":
+          $ref: '#/responses/NoSuchPod'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Pod exists
+      tags:
+      - pods
+  /libpod/pods/{name}/json:
+    get:
+      operationId: inspectPod
+      parameters:
+      - description: the name or ID of the pod
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/InspectPodResponse'
+        "404":
+          $ref: '#/responses/NoSuchPod'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Inspect pod
+      tags:
+      - pods
+  /libpod/pods/{name}/kill:
+    post:
+      operationId: killPod
+      parameters:
+      - description: the name or ID of the pod
+        in: path
+        name: name
+        required: true
+        type: string
+      - default: SIGKILL
+        description: signal to be sent to pod
+        in: query
+        name: signal
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/PodKillReport'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchPod'
+        "409":
+          $ref: '#/responses/ConflictError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Kill a pod
+      tags:
+      - pods
+  /libpod/pods/{name}/pause:
+    post:
+      description: Pause a pod
+      operationId: pausePod
+      parameters:
+      - description: the name or ID of the pod
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/PodPauseReport'
+        "404":
+          $ref: '#/responses/NoSuchPod'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Pause a pod
+      tags:
+      - pods
+  /libpod/pods/{name}/restart:
+    post:
+      operationId: restartPod
+      parameters:
+      - description: the name or ID of the pod
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/PodRestartReport'
+        "404":
+          $ref: '#/responses/NoSuchPod'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Restart a pod
+      tags:
+      - pods
+  /libpod/pods/{name}/start:
+    post:
+      operationId: startPod
+      parameters:
+      - description: the name or ID of the pod
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/PodStartReport'
+        "304":
+          $ref: '#/responses/PodAlreadyStartedError'
+        "404":
+          $ref: '#/responses/NoSuchPod'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Start a pod
+      tags:
+      - pods
+  /libpod/pods/{name}/stop:
+    post:
+      operationId: stopPod
+      parameters:
+      - description: the name or ID of the pod
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: timeout
+        in: query
+        name: t
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/PodStopReport'
+        "304":
+          $ref: '#/responses/PodAlreadyStoppedError'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "404":
+          $ref: '#/responses/NoSuchPod'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Stop a pod
+      tags:
+      - pods
+  /libpod/pods/{name}/top:
+    get:
+      description: List processes running inside a pod
+      operationId: topPod
+      parameters:
+      - description: |
+          Name of pod to query for processes
+        in: path
+        name: name
+        required: true
+        type: string
+      - default: true
+        description: Stream the output
+        in: query
+        name: stream
+        type: boolean
+      - default: -ef
+        description: arguments to pass to ps such as aux. Requires ps(1) to be installed
+          in the container if no ps(1) compatible AIX descriptors are used.
+        in: query
+        name: ps_args
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsPodTopResponse'
+        "404":
+          $ref: '#/responses/NoSuchPod'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: List processes
+      tags:
+      - pods
+  /libpod/pods/{name}/unpause:
+    post:
+      operationId: unpausePod
+      parameters:
+      - description: the name or ID of the pod
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/PodUnpauseReport'
+        "404":
+          $ref: '#/responses/NoSuchPod'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Unpause a pod
+      tags:
+      - pods
+  /libpod/pods/create:
+    post:
+      operationId: CreatePod
+      parameters:
+      - description: attributes for creating a pod
+        in: body
+        name: create
+        schema:
+          $ref: '#/definitions/PodSpecGenerator'
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/definitions/IdResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create a pod
+      tags:
+      - pods
+  /libpod/pods/json:
+    get:
+      operationId: ListPods
+      parameters:
+      - description: needs description and plumbing for filters
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/ListPodsResponse'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: List pods
+      tags:
+      - pods
+  /libpod/pods/prune:
+    post:
+      operationId: PrunePods
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/PodPruneReport'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "409":
+          description: pod already exists
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Prune unused pods
+      tags:
+      - pods
+  /libpod/pods/stats:
+    get:
+      description: Display a live stream of resource usage statistics for the containers
+        in one or more pods
+      operationId: statsPod
+      parameters:
+      - description: Provide statistics for all running pods.
+        in: query
+        name: all
+        type: boolean
+      - description: Names or IDs of pods.
+        in: query
+        items:
+          type: string
+        name: namesOrIDs
+        type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/DocsPodTopResponse'
+        "404":
+          $ref: '#/responses/NoSuchPod'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Get stats for one or more pods
+      tags:
+      - pods
+  /libpod/system/df:
+    get:
+      description: Return information about disk usage for containers, images, and
+        volumes
+      operationId: df
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/SystemDiskUse'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Show disk usage
+      tags:
+      - system
+  /libpod/system/prune:
+    post:
+      operationId: pruneSystem
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/SystemPruneReport'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Prune unused data
+      tags:
+      - system
+  /libpod/version:
+    get:
+      operationId: SystemVersion
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/Version'
+      summary: Component Version information
+      tags:
+      - system
+  /libpod/volumes/{name}:
+    delete:
+      operationId: removeVolume
+      parameters:
+      - description: the name or ID of the volume
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: force removal
+        in: query
+        name: force
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchVolume'
+        "409":
+          description: Volume is in use and cannot be removed
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Remove volume
+      tags:
+      - volumes
+  /libpod/volumes/{name}/json:
+    get:
+      operationId: inspectVolume
+      parameters:
+      - description: the name or ID of the volume
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/VolumeCreateResponse'
+        "404":
+          $ref: '#/responses/NoSuchVolume'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Inspect volume
+      tags:
+      - volumes
+  /libpod/volumes/create:
+    post:
+      operationId: createVolume
+      parameters:
+      - description: attributes for creating a container
+        in: body
+        name: create
+        schema:
+          $ref: '#/definitions/VolumeCreate'
+      produces:
+      - application/json
+      responses:
+        "201":
+          $ref: '#/responses/VolumeCreateResponse'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create a volume
+      tags:
+      - volumes
+  /libpod/volumes/json:
+    get:
+      description: Returns a list of volumes
+      operationId: listVolumes
+      parameters:
+      - description: |
+          JSON encoded value of the filters (a map[string][]string) to process on the volumes list. Available filters:
+            - driver=<volume-driver-name> Matches volumes based on their driver.
+            - label=<key> or label=<key>:<value> Matches volumes based on the presence of a label alone or a label and a value.
+            - name=<volume-name> Matches all of volume name.
+            - opt=<driver-option> Matches a storage driver options
+        in: query
+        name: filters
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/VolumeList'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: List volumes
+      tags:
+      - volumes
+  /libpod/volumes/prune:
+    post:
+      operationId: pruneVolumes
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/VolumePruneResponse'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Prune volumes
+      tags:
+      - volumes
+  /networks:
+    get:
+      description: Display summary of network configurations
+      operationId: compatListNetwork
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/CompatNetworkList'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: List networks
+      tags:
+      - networks (compat)
+  /networks/{name}:
+    delete:
+      description: Remove a network
+      operationId: compatRemoveNetwork
+      parameters:
+      - description: the name of the network
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: no error
+        "404":
+          $ref: '#/responses/NoSuchNetwork'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Remove a network
+      tags:
+      - networks (compat)
+    get:
+      description: Display low level configuration network
+      operationId: compatInspectNetwork
+      parameters:
+      - description: the name of the network
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/CompatNetworkInspect'
+        "404":
+          $ref: '#/responses/NoSuchNetwork'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Inspect a network
+      tags:
+      - networks (compat)
+  /networks/create:
+    post:
+      description: Create a network configuration
+      operationId: compatCreateNetwork
+      parameters:
+      - description: attributes for creating a container
+        in: body
+        name: create
+        schema:
+          $ref: '#/definitions/NetworkCreateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/CompatNetworkCreate'
+        "400":
+          $ref: '#/responses/BadParamError'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Create network
+      tags:
+      - networks (compat)
+  /version:
+    get:
+      operationId: CompatSystemVersion
+      produces:
+      - application/json
+      responses:
+        "200":
+          $ref: '#/responses/Version'
+      summary: Component Version information
+      tags:
+      - system (compat)
+produces:
+- application/json
+- text/plain
+- text/html
+responses:
+  BadParamError:
+    description: Bad parameter in request
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  Changes:
+    description: Object Changes
+    schema:
+      properties:
+        Changes:
+          items:
+            $ref: '#/definitions/Change'
+          type: array
+      type: object
+  CompatNetworkCreate:
+    description: Network create
+    schema:
+      properties:
+        Attachable:
+          type: boolean
+        CheckDuplicate:
+          description: |-
+            Check for networks with duplicate names.
+            Network is primarily keyed based on a random ID and not on the name.
+            Network name is strictly a user-friendly alias to the network
+            which is uniquely identified using ID.
+            And there is no guaranteed way to check for duplicates.
+            Option CheckDuplicate is there to provide a best effort checking of any networks
+            which has the same name but it is not guaranteed to catch all name collisions.
+          type: boolean
+        ConfigFrom:
+          $ref: '#/definitions/ConfigReference'
+        ConfigOnly:
+          type: boolean
+        Driver:
+          type: string
+        EnableIPv6:
+          type: boolean
+        IPAM:
+          $ref: '#/definitions/IPAM'
+        Ingress:
+          type: boolean
+        Internal:
+          type: boolean
+        Labels:
+          additionalProperties:
+            type: string
+          type: object
+        Options:
+          additionalProperties:
+            type: string
+          type: object
+        Scope:
+          type: string
+      type: object
+  CompatNetworkInspect:
+    description: Network inspect
+    schema:
+      $ref: '#/definitions/NetworkResource'
+  CompatNetworkList:
+    description: Network list
+    schema:
+      items:
+        $ref: '#/definitions/NetworkResource'
+      type: array
+  ConflictError:
+    description: Conflict error in operation
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  ContainerAlreadyStartedError:
+    description: Container already started
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  ContainerAlreadyStoppedError:
+    description: Container already stopped
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  ContainerCreateResponse:
+    description: Create container
+    schema:
+      properties:
+        Id:
+          description: ID of the container created
+          type: string
+          x-go-name: ID
+        Warnings:
+          description: Warnings during container creation
+          items:
+            type: string
+          type: array
+      type: object
+  ContainerWaitResponse:
+    description: Wait container
+    schema:
+      properties:
+        Error:
+          properties:
+            Message:
+              type: string
+          type: object
+        StatusCode:
+          description: container exit code
+          format: int64
+          type: integer
+      type: object
+  DockerImageSummary:
+    description: Image summary
+    schema:
+      items:
+        $ref: '#/definitions/ImageSummary'
+      type: array
+  DocsContainerInspectResponse:
+    description: Inspect container
+    schema:
+      properties:
+        AppArmorProfile:
+          type: string
+        Args:
+          items:
+            type: string
+          type: array
+        Config:
+          $ref: '#/definitions/Config'
+        Created:
+          type: string
+        Driver:
+          type: string
+        ExecIDs:
+          items:
+            type: string
+          type: array
+        GraphDriver:
+          $ref: '#/definitions/GraphDriverData'
+        HostConfig:
+          $ref: '#/definitions/HostConfig'
+        HostnamePath:
+          type: string
+        HostsPath:
+          type: string
+        Id:
+          type: string
+          x-go-name: ID
+        Image:
+          type: string
+        LogPath:
+          type: string
+        MountLabel:
+          type: string
+        Mounts:
+          items:
+            $ref: '#/definitions/MountPoint'
+          type: array
+        Name:
+          type: string
+        NetworkSettings:
+          $ref: '#/definitions/NetworkSettings'
+        Node:
+          $ref: '#/definitions/ContainerNode'
+        Path:
+          type: string
+        Platform:
+          type: string
+        ProcessLabel:
+          type: string
+        ResolvConfPath:
+          type: string
+        RestartCount:
+          format: int64
+          type: integer
+        SizeRootFs:
+          format: int64
+          type: integer
+        SizeRw:
+          format: int64
+          type: integer
+        State:
+          $ref: '#/definitions/ContainerState'
+      type: object
+  DocsContainerPruneReport:
+    description: Prune containers
+    schema:
+      items:
+        $ref: '#/definitions/ContainersPruneReport'
+      type: array
+  DocsContainerTopResponse:
+    description: List processes in container
+    schema:
+      properties:
+        Processes:
+          description: Each process running in the container, where each is process
+            is an array of values corresponding to the titles
+          items:
+            items:
+              type: string
+            type: array
+          type: array
+        Titles:
+          description: The ps column titles
+          items:
+            type: string
+          type: array
+      required:
+      - Processes
+      - Titles
+      type: object
+  DocsHistory:
+    description: History response
+    schema:
+      properties:
+        Comment:
+          type: string
+        Created:
+          format: int64
+          type: integer
+        CreatedBy:
+          type: string
+        Id:
+          type: string
+          x-go-name: ID
+        Size:
+          format: int64
+          type: integer
+        Tags:
+          items:
+            type: string
+          type: array
+      type: object
+  DocsImageDeleteResponse:
+    description: Delete response
+    schema:
+      items:
+        $ref: '#/definitions/ImageDeleteResponse'
+      type: array
+  DocsImageInspect:
+    description: Inspect response
+    schema:
+      properties:
+        Architecture:
+          type: string
+        Author:
+          type: string
+        Comment:
+          type: string
+        Config:
+          $ref: '#/definitions/Config'
+        Container:
+          type: string
+        ContainerConfig:
+          $ref: '#/definitions/Config'
+        Created:
+          type: string
+        DockerVersion:
+          type: string
+        GraphDriver:
+          $ref: '#/definitions/GraphDriverData'
+        Id:
+          type: string
+          x-go-name: ID
+        Metadata:
+          $ref: '#/definitions/ImageMetadata'
+        Os:
+          type: string
+        OsVersion:
+          type: string
+        Parent:
+          type: string
+        RepoDigests:
+          items:
+            type: string
+          type: array
+        RepoTags:
+          items:
+            type: string
+          type: array
+        RootFS:
+          $ref: '#/definitions/RootFS'
+        Size:
+          format: int64
+          type: integer
+        Variant:
+          type: string
+        VirtualSize:
+          format: int64
+          type: integer
+      type: object
+  DocsLibpodImagesImportResponse:
+    description: Import response
+    schema:
+      $ref: '#/definitions/ImageImportReport'
+  DocsLibpodImagesLoadResponse:
+    description: Load response
+    schema:
+      $ref: '#/definitions/ImageLoadReport'
+  DocsLibpodImagesPullResponse:
+    description: Pull response
+    schema:
+      $ref: '#/definitions/LibpodImagesPullReport'
+  DocsLibpodImagesRemoveResponse:
+    description: Remove response
+    schema:
+      $ref: '#/definitions/LibpodImagesRemoveReport'
+  DocsLibpodInspectImageResponse:
+    description: Inspect image
+    schema:
+      properties:
+        Annotations:
+          additionalProperties:
+            type: string
+          type: object
+        Architecture:
+          type: string
+        Author:
+          type: string
+        Comment:
+          type: string
+        Config:
+          $ref: '#/definitions/ImageConfig'
+        Created:
+          format: date-time
+          type: string
+        Digest:
+          $ref: '#/definitions/Digest'
+        GraphDriver:
+          $ref: '#/definitions/Data'
+        Healthcheck:
+          $ref: '#/definitions/Schema2HealthConfig'
+        History:
+          items:
+            $ref: '#/definitions/History'
+          type: array
+        Id:
+          type: string
+          x-go-name: ID
+        Labels:
+          additionalProperties:
+            type: string
+          type: object
+        ManifestType:
+          type: string
+        NamesHistory:
+          items:
+            type: string
+          type: array
+        Os:
+          type: string
+        Parent:
+          type: string
+        RepoDigests:
+          items:
+            type: string
+          type: array
+        RepoTags:
+          items:
+            type: string
+          type: array
+        RootFS:
+          $ref: '#/definitions/RootFS'
+        Size:
+          format: int64
+          type: integer
+        User:
+          type: string
+        Version:
+          type: string
+        VirtualSize:
+          format: int64
+          type: integer
+      type: object
+  DocsLibpodPlayKubeResponse:
+    description: PlayKube response
+    schema:
+      $ref: '#/definitions/PlayKubeReport'
+  DocsLibpodPruneResponse:
+    description: Prune containers
+    schema:
+      items:
+        $ref: '#/definitions/LibpodContainersPruneReport'
+      type: array
+  DocsListContainer:
+    description: List Containers
+    schema:
+      type: object
+  DocsPodStatsResponse:
+    description: List processes in pod
+    schema:
+      items:
+        $ref: '#/definitions/PodStatsReport'
+      type: array
+  DocsPodTopResponse:
+    description: List processes in pod
+    schema:
+      properties:
+        Processes:
+          description: Each process running in the container, where each is process
+            is an array of values corresponding to the titles
+          items:
+            items:
+              type: string
+            type: array
+          type: array
+        Titles:
+          description: The ps column titles
+          items:
+            type: string
+          type: array
+      required:
+      - Processes
+      - Titles
+      type: object
+  DocsRegistriesList:
+    description: Registries summary
+    schema:
+      $ref: '#/definitions/ListRegistriesReport'
+  DocsSearchResponse:
+    description: Search results
+    schema:
+      properties:
+        Automated:
+          description: Automated indicates if the image was created by an automated
+            build.
+          type: string
+        Description:
+          description: Description of the image.
+          type: string
+        Index:
+          description: Index is the image index (e.g., "docker.io" or "quay.io")
+          type: string
+        Name:
+          description: Name is the canoncical name of the image (e.g., "docker.io/library/alpine").
+          type: string
+        Official:
+          description: Official indicates if it's an official image.
+          type: string
+        Stars:
+          description: Stars is the number of stars of the image.
+          format: int64
+          type: integer
+      type: object
+  HealthcheckRun:
+    description: Healthcheck
+    schema:
+      properties:
+        FailingStreak:
+          description: FailingStreak is the number of consecutive failed healthchecks
+          format: int64
+          type: integer
+        Log:
+          description: Log describes healthcheck attempts and results
+          items:
+            $ref: '#/definitions/HealthCheckLog'
+          type: array
+        Status:
+          description: Status healthy or unhealthy
+          type: string
+      type: object
+  InfoResponse:
+    description: Info
+    schema:
+      $ref: '#/definitions/Info'
+  InspectManifest:
+    description: Inspect Manifest
+    schema:
+      $ref: '#/definitions/List'
+  InspectPodResponse:
+    description: Inspect pod
+    schema:
+      properties:
+        CgroupParent:
+          description: CgroupParent is the parent of the pod's CGroup.
+          type: string
+        CgroupPath:
+          description: CgroupPath is the path to the pod's CGroup.
+          type: string
+        Containers:
+          description: |-
+            Containers gives a brief summary of all containers in the pod and
+            their current status.
+          items:
+            $ref: '#/definitions/InspectPodContainerInfo'
+          type: array
+        CreateCgroup:
+          description: |-
+            CreateCgroup is whether this pod will create its own CGroup to group
+            containers under.
+          type: boolean
+        CreateCommand:
+          description: |-
+            CreateCommand is the full command plus arguments of the process the
+            container has been created with.
+          items:
+            type: string
+          type: array
+        CreateInfra:
+          description: |-
+            CreateInfra is whether this pod will create an infra container to
+            share namespaces.
+          type: boolean
+        Created:
+          description: Created is the time when the pod was created.
+          format: date-time
+          type: string
+        Hostname:
+          description: Hostname is the hostname that the pod will set.
+          type: string
+        Id:
+          description: ID is the ID of the pod.
+          type: string
+          x-go-name: ID
+        InfraConfig:
+          $ref: '#/definitions/InspectPodInfraConfig'
+        InfraContainerID:
+          description: |-
+            InfraContainerID is the ID of the pod's infra container, if one is
+            present.
+          type: string
+        Labels:
+          additionalProperties:
+            type: string
+          description: |-
+            Labels is a set of key-value labels that have been applied to the
+            pod.
+          type: object
+        Name:
+          description: Name is the name of the pod.
+          type: string
+        Namespace:
+          description: Namespace is the Libpod namespace the pod is placed in.
+          type: string
+        NumContainers:
+          description: |-
+            NumContainers is the number of containers in the pod, including the
+            infra container.
+          format: uint64
+          type: integer
+        SharedNamespaces:
+          description: |-
+            SharedNamespaces contains a list of namespaces that will be shared by
+            containers within the pod. Can only be set if CreateInfra is true.
+          items:
+            type: string
+          type: array
+        State:
+          description: State represents the current state of the pod.
+          type: string
+      type: object
+  InspectVolumeResponse:
+    description: Inspect volume
+    schema:
+      properties:
+        Anonymous:
+          description: |-
+            Anonymous indicates that the volume was created as an anonymous
+            volume for a specific container, and will be be removed when any
+            container using it is removed.
+          type: boolean
+        CreatedAt:
+          description: |-
+            CreatedAt is the date and time the volume was created at. This is not
+            stored for older Libpod volumes; if so, it will be omitted.
+          format: date-time
+          type: string
+        Driver:
+          description: |-
+            Driver is the driver used to create the volume.
+            This will be properly implemented in a future version.
+          type: string
+        GID:
+          description: GID is the GID that the volume was created with.
+          format: int64
+          type: integer
+        Labels:
+          additionalProperties:
+            type: string
+          description: |-
+            Labels includes the volume's configured labels, key:value pairs that
+            can be passed during volume creation to provide information for third
+            party tools.
+          type: object
+        Mountpoint:
+          description: Mountpoint is the path on the host where the volume is mounted.
+          type: string
+        Name:
+          description: Name is the name of the volume.
+          type: string
+        Options:
+          additionalProperties:
+            type: string
+          description: |-
+            Options is a set of options that were used when creating the volume.
+            It is presently not used.
+          type: object
+        Scope:
+          description: |-
+            Scope is unused and provided solely for Docker compatibility. It is
+            unconditionally set to "local".
+          type: string
+        Status:
+          additionalProperties:
+            type: string
+          description: |-
+            Status is presently unused and provided only for Docker compatibility.
+            In the future it will be used to return information on the volume's
+            current state.
+          type: object
+        UID:
+          description: UID is the UID that the volume was created with.
+          format: int64
+          type: integer
+      type: object
+  InternalError:
+    description: Internal server error
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  LibpodImageTreeResponse:
+    description: Image tree response
+    schema:
+      properties:
+        id:
+          type: string
+          x-go-name: ID
+        layers:
+          items:
+            $ref: '#/definitions/ImageLayer'
+          type: array
+          x-go-name: Layers
+        size:
+          type: string
+          x-go-name: Size
+        tags:
+          items:
+            type: string
+          type: array
+          x-go-name: Tags
+      type: object
+  LibpodInspectContainerResponse:
+    description: Inspect container
+    schema:
+      properties:
+        AppArmorProfile:
+          type: string
+        Args:
+          items:
+            type: string
+          type: array
+        BoundingCaps:
+          items:
+            type: string
+          type: array
+        Config:
+          $ref: '#/definitions/InspectContainerConfig'
+        ConmonPidFile:
+          type: string
+        Created:
+          format: date-time
+          type: string
+        Dependencies:
+          items:
+            type: string
+          type: array
+        Driver:
+          type: string
+        EffectiveCaps:
+          items:
+            type: string
+          type: array
+        ExecIDs:
+          items:
+            type: string
+          type: array
+        ExitCommand:
+          items:
+            type: string
+          type: array
+        GraphDriver:
+          $ref: '#/definitions/Data'
+        HostConfig:
+          $ref: '#/definitions/InspectContainerHostConfig'
+        HostnamePath:
+          type: string
+        HostsPath:
+          type: string
+        Id:
+          type: string
+          x-go-name: ID
+        Image:
+          type: string
+        ImageName:
+          type: string
+        IsInfra:
+          type: boolean
+        LogPath:
+          type: string
+        LogTag:
+          type: string
+        MountLabel:
+          type: string
+        Mounts:
+          items:
+            $ref: '#/definitions/InspectMount'
+          type: array
+        Name:
+          type: string
+        Namespace:
+          type: string
+        NetworkSettings:
+          $ref: '#/definitions/InspectNetworkSettings'
+        OCIConfigPath:
+          type: string
+        OCIRuntime:
+          type: string
+        Path:
+          type: string
+        Pod:
+          type: string
+        ProcessLabel:
+          type: string
+        ResolvConfPath:
+          type: string
+        RestartCount:
+          format: int32
+          type: integer
+        Rootfs:
+          type: string
+        SizeRootFs:
+          format: int64
+          type: integer
+        SizeRw:
+          format: int64
+          type: integer
+        State:
+          $ref: '#/definitions/InspectContainerState'
+        StaticDir:
+          type: string
+      type: object
+  ListContainers:
+    description: List Containers
+    schema:
+      items:
+        $ref: '#/definitions/ListContainer'
+      type: array
+  ListPodsResponse:
+    description: List pods
+    schema:
+      items:
+        $ref: '#/definitions/ListPodsReport'
+      type: array
+  NetworkCreateReport:
+    description: Network create
+    schema:
+      $ref: '#/definitions/NetworkCreateReport'
+  NetworkInspectReport:
+    description: Network inspect
+    schema:
+      items:
+        $ref: '#/definitions/NetworkInspectReport'
+      type: array
+  NetworkListReport:
+    description: Network list
+    schema:
+      items:
+        $ref: '#/definitions/NetworkListReport'
+      type: array
+  NetworkRmReport:
+    description: Network rm
+    schema:
+      $ref: '#/definitions/NetworkRmReport'
+  NoSuchContainer:
+    description: No such container
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  NoSuchExecInstance:
+    description: No such exec instance
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  NoSuchImage:
+    description: No such image
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  NoSuchManifest:
+    description: No such manifest
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  NoSuchNetwork:
+    description: No such network
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  NoSuchPod:
+    description: No such pod
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  NoSuchVolume:
+    description: No such volume
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  PodAlreadyStartedError:
+    description: Pod already started
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  PodAlreadyStoppedError:
+    description: Pod already stopped
+    schema:
+      properties:
+        cause:
+          description: API root cause formatted for automated parsing
+          example: API root cause
+          type: string
+          x-go-name: Because
+        message:
+          description: human error message, formatted for a human to read
+          example: human error message
+          type: string
+          x-go-name: Message
+        response:
+          description: http response code
+          format: int64
+          type: integer
+          x-go-name: ResponseCode
+      type: object
+  PodKillReport:
+    description: Kill Pod
+    schema:
+      $ref: '#/definitions/PodKillReport'
+  PodPauseReport:
+    description: Pause pod
+    schema:
+      $ref: '#/definitions/PodPauseReport'
+  PodPruneReport:
+    description: Prune pod
+    schema:
+      $ref: '#/definitions/PodPruneReport'
+  PodRestartReport:
+    description: Restart pod
+    schema:
+      $ref: '#/definitions/PodRestartReport'
+  PodRmReport:
+    description: Rm pod
+    schema:
+      $ref: '#/definitions/PodRmReport'
+  PodStartReport:
+    description: Start pod
+    schema:
+      $ref: '#/definitions/PodStartReport'
+  PodStopReport:
+    description: Stop pod
+    schema:
+      $ref: '#/definitions/PodStopReport'
+  PodUnpauseReport:
+    description: Unpause pod
+    schema:
+      $ref: '#/definitions/PodUnpauseReport'
+  SystemDiskUse:
+    description: Disk usage
+    schema:
+      properties:
+        Containers:
+          items:
+            $ref: '#/definitions/SystemDfContainerReport'
+          type: array
+        Images:
+          items:
+            $ref: '#/definitions/SystemDfImageReport'
+          type: array
+        Volumes:
+          items:
+            $ref: '#/definitions/SystemDfVolumeReport'
+          type: array
+      type: object
+  SystemPruneReport:
+    description: Prune report
+    schema:
+      properties:
+        Err:
+          additionalProperties:
+            type: string
+          type: object
+        ID:
+          additionalProperties:
+            format: int64
+            type: integer
+          type: object
+        PodPruneReport:
+          items:
+            $ref: '#/definitions/PodPruneReport'
+          type: array
+        Report:
+          $ref: '#/definitions/Report'
+        Size:
+          format: int64
+          type: integer
+        VolumePruneReport:
+          items:
+            $ref: '#/definitions/VolumePruneReport'
+          type: array
+      type: object
+  Version:
+    description: Version
+    schema:
+      properties:
+        Client:
+          $ref: '#/definitions/Version'
+        Server:
+          $ref: '#/definitions/Version'
+      type: object
+  VolumeCreateResponse:
+    description: Volume create response
+    schema:
+      properties:
+        Anonymous:
+          description: |-
+            Anonymous indicates that the volume was created as an anonymous
+            volume for a specific container, and will be be removed when any
+            container using it is removed.
+          type: boolean
+        CreatedAt:
+          description: |-
+            CreatedAt is the date and time the volume was created at. This is not
+            stored for older Libpod volumes; if so, it will be omitted.
+          format: date-time
+          type: string
+        Driver:
+          description: |-
+            Driver is the driver used to create the volume.
+            This will be properly implemented in a future version.
+          type: string
+        GID:
+          description: GID is the GID that the volume was created with.
+          format: int64
+          type: integer
+        Labels:
+          additionalProperties:
+            type: string
+          description: |-
+            Labels includes the volume's configured labels, key:value pairs that
+            can be passed during volume creation to provide information for third
+            party tools.
+          type: object
+        Mountpoint:
+          description: Mountpoint is the path on the host where the volume is mounted.
+          type: string
+        Name:
+          description: Name is the name of the volume.
+          type: string
+        Options:
+          additionalProperties:
+            type: string
+          description: |-
+            Options is a set of options that were used when creating the volume.
+            It is presently not used.
+          type: object
+        Scope:
+          description: |-
+            Scope is unused and provided solely for Docker compatibility. It is
+            unconditionally set to "local".
+          type: string
+        Status:
+          additionalProperties:
+            type: string
+          description: |-
+            Status is presently unused and provided only for Docker compatibility.
+            In the future it will be used to return information on the volume's
+            current state.
+          type: object
+        UID:
+          description: UID is the UID that the volume was created with.
+          format: int64
+          type: integer
+      type: object
+  VolumeList:
+    description: Volume list
+    schema:
+      items:
+        $ref: '#/definitions/Volume'
+      type: array
+  VolumePruneResponse:
+    description: Volume prune response
+    schema:
+      items:
+        $ref: '#/definitions/VolumePruneReport'
+      type: array
+  ok:
+    description: Success
+    schema:
+      type: object
+schemes:
+- http
+- https
+swagger: "2.0"
+tags:
+- description: Actions related to containers
+  name: containers
+- description: Actions related to exec
+  name: exec
+- description: Actions related to images
+  name: images
+- description: Actions related to manifests
+  name: manifests
+- description: Actions related to networks
+  name: networks
+- description: Actions related to pods
+  name: pods
+- description: Actions related to volumes
+  name: volumes
+- description: Actions related to Podman engine
+  name: system
+- description: Actions related to containers for the compatibility endpoints
+  name: containers (compat)
+- description: Actions related to exec for the compatibility endpoints
+  name: exec (compat)
+- description: Actions related to images for the compatibility endpoints
+  name: images (compat)
+- description: Actions related to compatibility networks
+  name: networks (compat)
+- description: Actions related to Podman and compatibility engines
+  name: system (compat)


### PR DESCRIPTION
Adding the swagger.yaml to the docs directory so that we can version the read-the-docs API information. also, change the links to be relative in nature and point to the new swagger.

Signed-off-by: Brent Baude <bbaude@redhat.com>