### PR TITLE
Set console mode for windows

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -16,7 +16,9 @@ import (
 	_ "github.com/containers/libpod/cmd/podman/system"
 	_ "github.com/containers/libpod/cmd/podman/volumes"
 	"github.com/containers/libpod/pkg/rootless"
+	"github.com/containers/libpod/pkg/terminal"
 	"github.com/containers/storage/pkg/reexec"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -52,6 +54,10 @@ func main() {
 				c.Command.SetUsageTemplate(usageTemplate)
 			}
 		}
+	}
+	if err := terminal.SetConsole(); err != nil {
+		logrus.Error(err)
+		os.Exit(1)
 	}
 
 	Execute()

--- a/pkg/terminal/console_unix.go
+++ b/pkg/terminal/console_unix.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package terminal
+
+// SetConsole for non-windows environments is a no-op
+func SetConsole() error {
+	return nil
+}

--- a/pkg/terminal/console_windows.go
+++ b/pkg/terminal/console_windows.go
@@ -1,0 +1,37 @@
+// +build windows
+
+package terminal
+
+import (
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+// SetConsole switches the windows terminal mode to be able to handle colors, etc
+func SetConsole() error {
+	if err := setConsoleMode(windows.Stdout, windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {
+		return err
+	}
+	if err := setConsoleMode(windows.Stderr, windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {
+		return err
+	}
+	if err := setConsoleMode(windows.Stdin, windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setConsoleMode(handle windows.Handle, flags uint32) error {
+	var mode uint32
+	err := windows.GetConsoleMode(handle, &mode)
+	if err != nil {
+		return err
+	}
+	if err := windows.SetConsoleMode(handle, mode|flags); err != nil {
+		// In similar code, it is not considered an error if we cannot set the
+		// console mode.  Following same line of thinking here.
+		logrus.WithError(err).Error("Failed to set console mode for cli")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Windows terminal handling is different than darwin and linux.  It needs to have the terminal mode set to enable virtual terminal processing.  This allows colors and other things to work.

Signed-off-by: Brent Baude <bbaude@redhat.com>