### PR TITLE
Account for non-default port number in image name (backported from master)

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -193,7 +193,7 @@ func sortImages(imageS []*entities.ImageSummary) []imageReporter {
 }
 
 func tokenRepoTag(tag string) (string, string) {
-	tokens := strings.SplitN(tag, ":", 2)
+	tokens := strings.Split(tag, ":")
 	switch len(tokens) {
 	case 0:
 		return tag, ""
@@ -201,6 +201,8 @@ func tokenRepoTag(tag string) (string, string) {
 		return tokens[0], ""
 	case 2:
 		return tokens[0], tokens[1]
+	case 3:
+		return tokens[0] + ":" + tokens[1], tokens[2]
 	default:
 		return "<N/A>", ""
 	}


### PR DESCRIPTION
Previously, if an image was tagged with the format
$REGISTRY:$PORT/$REPO:$TAG,
then `podman images` would display $PORT/$REPO:$TAG under the "TAG"
field.

This commit correctly displays $REGISTRY:$PORT/$REPO under the
"REPOSITORY" field while the "TAG" field only displays $TAG.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

Fixes: gh#6665
(cherry picked from commit 71f6dd47ddce82545865739cb3382c0beb3f65a4)

@mheon @baude @rhatdan @jwhonce 