### PR TITLE
systemd system test: run auto-update

### DIFF
--- a/test/system/250-systemd.bats
+++ b/test/system/250-systemd.bats
@@ -41,7 +41,7 @@ function teardown() {
     fi
 
     cname=$(random_string)
-    run_podman create --name $cname --detach $IMAGE top
+    run_podman create --name $cname --label "io.containers.autoupdate=image" --detach $IMAGE top
 
     run_podman generate systemd --new $cname
     echo "$output" > "$UNIT_FILE"
@@ -63,6 +63,12 @@ function teardown() {
     sleep 2
     run_podman logs $cname
     is "$output" ".*Load average:.*" "running container 'top'-like output"
+
+    # Exercise `podman auto-update`.
+    # TODO: this will at least run auto-update code but won't perform an update
+    #       since the image didn't change.  We need to improve on that and run
+    #       an image from a local registry instead.
+    run_podman auto-update
 
     # All good. Stop service, clean up.
     run $SYSTEMCTL stop "$SERVICE_NAME"


### PR DESCRIPTION
Run `podman auto-update` in the systemd system tests.  Note that this is
a first step to at least exercise parts of `auto-update` in the CI.  The
service won't get updated just yet as we need to set up a local
registry, and push a new image.  I do not have enough time at the moment
to do that but consider this change already as an improvement.

We are experiencing some issues in #6793 w.r.t. to auto-updates but
couldn't track down the root cause yet.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>