### PR TITLE
test.apiv2: add testing for container initializing

### DIFF
--- a/test/apiv2/20-containers.at
+++ b/test/apiv2/20-containers.at
@@ -98,9 +98,41 @@ t GET libpod/images/newrepo:v2/json 200 \
   .Comment=bar \
   .Config.Cmd[-1]="/bin/foo"
 
+# Create a container for testing the container initializing later
+podman create -t -i --name myctr $IMAGE ls
+
+# Check configuration before initializing
+t GET libpod/containers/myctr/json 200 \
+  .Id~[0-9a-f]\\{64\\} \
+  .State.Status="configured" \
+  .State.Pid=0 \
+  .ResolvConfPath="" \
+  .HostnamePath="" \
+  .HostsPath="" \
+  .NetworkSettings.SandboxKey=""
+
+cpid_file=$(jq -r '.ConmonPidFile' <<<"$output")
+userdata_path=$(dirname $cpid_file)
+
+# Initializing the container
+t POST libpod/containers/myctr/init '' 204
+
+# Check configuration after initializing
+t GET libpod/containers/myctr/json 200 \
+  .Id~[0-9a-f]\\{64\\} \
+  .State.Status="created" \
+  .State.Pid~[0-9]\\{1\,8\\} \
+  .ResolvConfPath=$userdata_path/resolv.conf \
+  .HostnamePath=$userdata_path/hostname \
+  .HostsPath=$userdata_path/hosts \
+  .NetworkSettings.SandboxKey~.*/netns/cni- \
+  .OCIConfigPath~.*config\.json \
+  .GraphDriver.Data.MergedDir~.*merged
+
 t DELETE images/localhost/newrepo:latest?force=true 200
 t DELETE images/localhost/newrepo:v1?force=true 200
 t DELETE images/localhost/newrepo:v2?force=true 200
 t DELETE libpod/containers/$cid 204
+t DELETE libpod/containers/myctr 204
 
 # vim: filetype=sh


### PR DESCRIPTION
```shell
-----------------8<--------------------
ok 55 [20-containers] GET libpod/containers/myctr/json : status=200
ok 56 [20-containers] GET libpod/containers/myctr/json : .Id~[0-9a-f]\{64\}
ok 57 [20-containers] GET libpod/containers/myctr/json : .State.Status=configured
ok 58 [20-containers] GET libpod/containers/myctr/json : .State.Pid=0
ok 59 [20-containers] GET libpod/containers/myctr/json : .ResolvConfPath=
ok 60 [20-containers] GET libpod/containers/myctr/json : .HostnamePath=
ok 61 [20-containers] GET libpod/containers/myctr/json : .HostsPath=
ok 62 [20-containers] GET libpod/containers/myctr/json : .NetworkSettings.SandboxKey=
ok 63 [20-containers] POST libpod/containers/myctr/init [] : status=204
ok 64 [20-containers] GET libpod/containers/myctr/json : status=200
ok 65 [20-containers] GET libpod/containers/myctr/json : .Id~[0-9a-f]\{64\}
ok 66 [20-containers] GET libpod/containers/myctr/json : .State.Status=created
ok 67 [20-containers] GET libpod/containers/myctr/json : .State.Pid~[0-9]\{5\}
ok 68 [20-containers] GET libpod/containers/myctr/json : .ResolvConfPath=/run/user/1000/containers/overlay-containers/46964e693d23f98732cf1602233115c98f55d57f65b83e2eae1d360e8aa4d5cb/userdata/resolv.conf
ok 69 [20-containers] GET libpod/containers/myctr/json : .HostnamePath=/run/user/1000/containers/overlay-containers/46964e693d23f98732cf1602233115c98f55d57f65b83e2eae1d360e8aa4d5cb/userdata/hostname
ok 70 [20-containers] GET libpod/containers/myctr/json : .HostsPath=/run/user/1000/containers/overlay-containers/46964e693d23f98732cf1602233115c98f55d57f65b83e2eae1d360e8aa4d5cb/userdata/hosts
ok 71 [20-containers] GET libpod/containers/myctr/json : .NetworkSettings.SandboxKey~/run/user/1000/netns/cni-
ok 72 [20-containers] GET libpod/containers/myctr/json : .OCIConfigPath~.*config.json
ok 73 [20-containers] GET libpod/containers/myctr/json : .GraphDriver.Data.MergedDir~.*merged
ok 74 [20-containers] DELETE images/localhost/newrepo:latest?force=true : status=200
ok 75 [20-containers] DELETE images/localhost/newrepo:v1?force=true : status=200
ok 76 [20-containers] DELETE images/localhost/newrepo:v2?force=true : status=200
ok 77 [20-containers] DELETE libpod/containers/6cb202e0a48a5b6c33d21109d2716f876c2c66f285a82ccef6606f7ecc1d1586 : status=204
ok 78 [20-containers] DELETE libpod/containers/myctr : status=204
```

Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>