### PR TITLE
Created timesptamp returned by imagelist should be in unix format

### DIFF
--- a/cmd/podman/images/list.go
+++ b/cmd/podman/images/list.go
@@ -128,7 +128,7 @@ func writeID(imgs []imageReporter) error {
 func writeJSON(images []imageReporter) error {
 	type image struct {
 		entities.ImageSummary
-		Created   string
+		Created   int64
 		CreatedAt string
 	}
 
@@ -136,8 +136,8 @@ func writeJSON(images []imageReporter) error {
 	for _, e := range images {
 		var h image
 		h.ImageSummary = e.ImageSummary
-		h.Created = units.HumanDuration(time.Since(e.ImageSummary.Created)) + " ago"
-		h.CreatedAt = e.ImageSummary.Created.Format(time.RFC3339Nano)
+		h.Created = e.ImageSummary.Created
+		h.CreatedAt = e.created().Format(time.RFC3339Nano)
 		h.RepoTags = nil
 
 		imgs = append(imgs, h)
@@ -284,11 +284,11 @@ func (i imageReporter) ID() string {
 }
 
 func (i imageReporter) Created() string {
-	return units.HumanDuration(time.Since(i.ImageSummary.Created)) + " ago"
+	return units.HumanDuration(time.Since(i.created())) + " ago"
 }
 
 func (i imageReporter) created() time.Time {
-	return i.ImageSummary.Created
+	return time.Unix(i.ImageSummary.Created, 0).UTC()
 }
 
 func (i imageReporter) Size() string {
@@ -302,7 +302,7 @@ func (i imageReporter) History() string {
 }
 
 func (i imageReporter) CreatedAt() string {
-	return i.ImageSummary.Created.String()
+	return i.created().String()
 }
 
 func (i imageReporter) CreatedSince() string {

--- a/pkg/api/handlers/libpod/images.go
+++ b/pkg/api/handlers/libpod/images.go
@@ -112,7 +112,6 @@ func GetImages(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// libpod has additional fields that we need to populate.
-		is.Created = img.Created()
 		is.ReadOnly = img.IsReadOnly()
 		summaries[j] = is
 	}

--- a/pkg/api/handlers/types.go
+++ b/pkg/api/handlers/types.go
@@ -221,7 +221,7 @@ func ImageToImageSummary(l *libpodImage.Image) (*entities.ImageSummary, error) {
 		ID:           l.ID(),
 		ParentId:     l.Parent,
 		RepoTags:     repoTags,
-		Created:      l.Created(),
+		Created:      l.Created().Unix(),
 		Size:         int64(*size),
 		SharedSize:   0,
 		VirtualSize:  l.VirtualSize,

--- a/pkg/domain/entities/images.go
+++ b/pkg/domain/entities/images.go
@@ -53,7 +53,7 @@ type ImageSummary struct {
 	ID          string            `json:"Id"`
 	ParentId    string            `json:",omitempty"` // nolint
 	RepoTags    []string          `json:",omitempty"`
-	Created     time.Time         `json:",omitempty"`
+	Created     int64             `json:",omitempty"`
 	Size        int64             `json:",omitempty"`
 	SharedSize  int               `json:",omitempty"`
 	VirtualSize int64             `json:",omitempty"`

--- a/pkg/domain/infra/abi/images_list.go
+++ b/pkg/domain/infra/abi/images_list.go
@@ -52,7 +52,7 @@ func (ir *ImageEngine) List(ctx context.Context, opts entities.ImageListOptions)
 			ID: img.ID(),
 
 			ConfigDigest: string(img.ConfigDigest),
-			Created:      img.Created(),
+			Created:      img.Created().Unix(),
 			Dangling:     img.Dangling(),
 			Digest:       string(img.Digest()),
 			Digests:      digests,


### PR DESCRIPTION
In the API, we are currently returning the image time of creation
as a string, in time.Time format. The API is for a 64 bit integer
representing Unix time.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>