### PR TITLE
fix: Don't override entrypoint if it's `nil`

### DIFF
--- a/pkg/spec/createconfig.go
+++ b/pkg/spec/createconfig.go
@@ -287,10 +287,11 @@ func (c *CreateConfig) getContainerCreateOptions(runtime *libpod.Runtime, pod *l
 		options = append(options, libpod.WithCommand(c.UserCommand))
 	}
 
-	// Add entrypoint unconditionally
-	// If it's empty it's because it was explicitly set to "" or the image
-	// does not have one
-	options = append(options, libpod.WithEntrypoint(c.Entrypoint))
+	// Add entrypoint if it was set
+	// If it's empty it's because it was explicitly set to ""
+	if c.Entrypoint != nil {
+		options = append(options, libpod.WithEntrypoint(c.Entrypoint))
+	}
 
 	// TODO: MNT, USER, CGROUP
 	options = append(options, libpod.WithStopSignal(c.StopSignal))


### PR DESCRIPTION
This change ensures that we only override a container's entrypoint if
it is set to something other than `nil`.

Fixes #6565