### PR TITLE
Set TMPDIR to /var/tmp by default if not set

### DIFF
--- a/cmd/podman/main.go
+++ b/cmd/podman/main.go
@@ -29,6 +29,11 @@ func main() {
 		return
 	}
 
+	// Hard code TMPDIR functions to use /var/tmp, if user did not override
+	if _, ok := os.LookupEnv("TMPDIR"); !ok {
+		os.Setenv("TMPDIR", "/var/tmp")
+	}
+
 	cfg := registry.PodmanConfig()
 	for _, c := range registry.Commands {
 		for _, m := range c.Mode {


### PR DESCRIPTION
Containers/image will use TMPDIR for the location of pulled layer blobs.
If TMPDIR is not set, it will use /tmp.  Since this is known to be of
limited space on most systems, we change the default to /var/tmp
if the user has not told the tools where to store temporary files.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>