### PR TITLE
APIv2 tests: usability: better test logging

### DIFF
--- a/test/apiv2/test-apiv2
+++ b/test/apiv2/test-apiv2
@@ -84,7 +84,7 @@ function like() {
 
     if expr "$actual" : "$expect" &>/dev/null; then
         # On success, include expected value; this helps readers understand
-        _show_ok 1 "$testname~$expect"
+        _show_ok 1 "$testname ('$actual') ~ $expect"
         return
     fi
     _show_ok 0 "$testname" "~ $expect" "$actual"


### PR DESCRIPTION
test-apiv2 has two basic comparisons of returned JSON:
equality and likeness ('=' and '\~'). When logging failures,
the test runner shows both actual and expected values. When
logging success, for '=' there's no need to show both actual
and expected. But for '\~', it can be helpful (for verifying
test correctness) to show the actual returned value.

To be specific:

   old: ok ... .MemTotal~[0-9]\+
   new: ok ... .MemTotal ('33509068800') ~ [0-9]\+

   old: ok ... .[0].State~\(exited\|stopped\)
   new: ok ... .[0].State ('exited') ~ \(exited\|stopped\)

The main benefit is that a developer or end user can
easily see precisely what was returned; this can help
confirm that the test is working as intended, and/or
help fine-tune how the test is written.

Signed-off-by: Ed Santiago <santiago@redhat.com>