### PR TITLE
Disable SELinux labeling if privileged and user does not specify labels

### DIFF
--- a/cmd/podman/shared/create.go
+++ b/cmd/podman/shared/create.go
@@ -196,9 +196,7 @@ func CreateContainer(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 }
 
 func parseSecurityOpt(config *cc.CreateConfig, securityOpts []string, runtime *libpod.Runtime) error {
-	var (
-		labelOpts []string
-	)
+	var labelOpts []string
 
 	if config.PidMode.IsHost() {
 		labelOpts = append(labelOpts, label.DisableSecOpt()...)
@@ -794,11 +792,11 @@ func ParseCreateOpts(ctx context.Context, c *GenericCLIResults, runtime *libpod.
 		Syslog:        c.Bool("syslog"),
 	}
 
-	if config.Privileged {
-		config.LabelOpts = label.DisableSecOpt()
-	}
 	if err := parseSecurityOpt(config, c.StringArray("security-opt"), runtime); err != nil {
 		return nil, err
+	}
+	if config.Privileged && len(config.LabelOpts) == 0 {
+		config.LabelOpts = label.DisableSecOpt()
 	}
 	config.SecurityOpts = c.StringArray("security-opt")
 	warnings, err := verifyContainerResources(config, false)


### PR DESCRIPTION
The previous patch mistakenly turned on SELinux even when --privileged.

This patch will disable SELinux, if the user specified --privileged and
did not specify any SELinux options.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>