### PR TITLE
Add username to /etc/passwd inside of container if --userns keep-id

### DIFF
--- a/cmd/podman/common/specgen.go
+++ b/cmd/podman/common/specgen.go
@@ -241,6 +241,8 @@ func FillOutSpecGen(s *specgen.SpecGenerator, c *ContainerCLIOpts, args []string
 	// If some mappings are specified, assume a private user namespace
 	if userNS.IsDefaultValue() && (!s.IDMappings.HostUIDMapping || !s.IDMappings.HostGIDMapping) {
 		s.UserNS.NSMode = specgen.Private
+	} else {
+		s.UserNS.NSMode = specgen.NamespaceMode(userNS)
 	}
 
 	s.Terminal = c.TTY

--- a/libpod/container.go
+++ b/libpod/container.go
@@ -278,6 +278,9 @@ type ContainerConfig struct {
 	User string `json:"user,omitempty"`
 	// Additional groups to add
 	Groups []string `json:"groups,omitempty"`
+	// AddCurrentUserPasswdEntry indicates that the current user passwd entry
+	// should be added to the /etc/passwd within the container
+	AddCurrentUserPasswdEntry bool `json:"addCurrentUserPasswdEntry,omitempty"`
 
 	// Namespace Config
 	// IDs of container to share namespaces with
@@ -786,7 +789,10 @@ func (c *Container) Hostname() string {
 
 // WorkingDir returns the containers working dir
 func (c *Container) WorkingDir() string {
-	return c.config.Spec.Process.Cwd
+	if c.config.Spec.Process != nil {
+		return c.config.Spec.Process.Cwd
+	}
+	return "/"
 }
 
 // State Accessors

--- a/libpod/container_internal_linux_test.go
+++ b/libpod/container_internal_linux_test.go
@@ -1,0 +1,42 @@
+// +build linux
+
+package libpod
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateUserPasswdEntry(t *testing.T) {
+	dir, err := ioutil.TempDir("", "libpod_test_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	c := Container{
+		config: &ContainerConfig{
+			User: "123:456",
+			Spec: &spec.Spec{},
+		},
+		state: &ContainerState{
+			Mountpoint: "/does/not/exist/tmp/",
+		},
+	}
+	user, err := c.generateUserPasswdEntry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, user, "123:x:123:456:container user:/:/bin/sh\n")
+
+	c.config.User = "567"
+	user, err = c.generateUserPasswdEntry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, user, "567:x:567:0:container user:/:/bin/sh\n")
+}

--- a/libpod/options.go
+++ b/libpod/options.go
@@ -866,6 +866,20 @@ func WithPIDNSFrom(nsCtr *Container) CtrCreateOption {
 	}
 }
 
+// WithAddCurrentUserPasswdEntry indicates that container should add current
+// user entry to /etc/passwd, since the UID will be mapped into the container,
+// via user namespace
+func WithAddCurrentUserPasswdEntry() CtrCreateOption {
+	return func(ctr *Container) error {
+		if ctr.valid {
+			return define.ErrCtrFinalized
+		}
+
+		ctr.config.AddCurrentUserPasswdEntry = true
+		return nil
+	}
+}
+
 // WithUserNSFrom indicates the the container should join the user namespace of
 // the given container.
 // If the container has joined a pod, it can only join the namespaces of

--- a/pkg/specgen/generate/namespaces.go
+++ b/pkg/specgen/generate/namespaces.go
@@ -153,7 +153,9 @@ func namespaceOptions(ctx context.Context, s *specgen.SpecGenerator, rt *libpod.
 	// User
 	switch s.UserNS.NSMode {
 	case specgen.KeepID:
-		if !rootless.IsRootless() {
+		if rootless.IsRootless() {
+			toReturn = append(toReturn, libpod.WithAddCurrentUserPasswdEntry())
+		} else {
 			// keep-id as root doesn't need a user namespace
 			s.UserNS.NSMode = specgen.Host
 		}

--- a/test/e2e/run_userns_test.go
+++ b/test/e2e/run_userns_test.go
@@ -89,6 +89,16 @@ var _ = Describe("Podman UserNS support", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("podman --userns=keep-id check passwd", func() {
+		session := podmanTest.Podman([]string{"run", "--userns=keep-id", "alpine", "id", "-un"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+		u, err := user.Current()
+		Expect(err).To(BeNil())
+		ok, _ := session.GrepString(u.Name)
+		Expect(ok).To(BeTrue())
+	})
+
 	It("podman --userns=keep-id root owns /usr", func() {
 		session := podmanTest.Podman([]string{"run", "--userns=keep-id", "alpine", "stat", "-c%u", "/usr"})
 		session.WaitWithDefaultTimeout()


### PR DESCRIPTION
If I enter a continer with --userns keep-id, my UID will be present
inside of the container, but most likely my user will not be defined.

This patch will take information about the user and stick it into the
container.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>