### PR TITLE
Bump imagebuilder to v1.1.6 in upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
 	github.com/opencontainers/runtime-tools v0.9.0
 	github.com/opencontainers/selinux v1.5.2
+	github.com/openshift/imagebuilder v1.1.6 // indirect
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/opencontainers/selinux v1.5.2 h1:F6DgIsjgBIcDksLW4D5RG9bXok6oqZ3nvMwj
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift/imagebuilder v1.1.5 h1:WAIHV6cGF9e0AcLBA7RIi7XbFoB7R+e/MWu1I+1NUOM=
 github.com/openshift/imagebuilder v1.1.5/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
+github.com/openshift/imagebuilder v1.1.6 h1:1+YzRxIIefY4QqtCImx6rg+75QrKNfBoPAKxgMo/khM=
+github.com/openshift/imagebuilder v1.1.6/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913 h1:TnbXhKzrTOyuvWrjI8W6pcoI9XPbLHFXCdN2dtUw7Rw=

--- a/vendor/github.com/openshift/imagebuilder/builder.go
+++ b/vendor/github.com/openshift/imagebuilder/builder.go
@@ -334,7 +334,7 @@ func ParseFile(path string) (*parser.Node, error) {
 func (b *Builder) Step() *Step {
 	argsMap := make(map[string]string)
 	for _, argsVal := range b.Arguments() {
-		val := strings.Split(argsVal, "=")
+		val := strings.SplitN(argsVal, "=", 2)
 		if len(val) > 1 {
 			argsMap[val[0]] = val[1]
 		}

--- a/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
+++ b/vendor/github.com/openshift/imagebuilder/imagebuilder.spec
@@ -12,7 +12,7 @@
 #
 
 %global golang_version 1.8.1
-%{!?version: %global version 1.1.5}
+%{!?version: %global version 1.1.6}
 %{!?release: %global release 1}
 %global package_name imagebuilder
 %global product_name Container Image Builder

--- a/vendor/github.com/openshift/imagebuilder/internals.go
+++ b/vendor/github.com/openshift/imagebuilder/internals.go
@@ -103,7 +103,7 @@ func makeUserArgs(bEnv []string, bArgs map[string]string) (userArgs []string) {
 	userArgs = bEnv
 	envMap := make(map[string]string)
 	for _, envVal := range bEnv {
-		val := strings.Split(envVal, "=")
+		val := strings.SplitN(envVal, "=", 2)
 		if len(val) > 1 {
 			envMap[val[0]] = val[1]
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -431,7 +431,7 @@ github.com/opencontainers/runtime-tools/validate
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
-# github.com/openshift/imagebuilder v1.1.5
+# github.com/openshift/imagebuilder v1.1.6
 github.com/openshift/imagebuilder
 github.com/openshift/imagebuilder/dockerfile/command
 github.com/openshift/imagebuilder/dockerfile/parser


### PR DESCRIPTION
Bump the imagebuilder package to v1.1.6 in
the upstream branch.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>