### PR TITLE
podman ps truncate the command

### DIFF
--- a/cmd/podman/containers/ps.go
+++ b/cmd/podman/containers/ps.go
@@ -309,7 +309,13 @@ func (l psReporter) Status() string {
 
 // Command returns the container command in string format
 func (l psReporter) Command() string {
-	return strings.Join(l.ListContainer.Command, " ")
+	command := strings.Join(l.ListContainer.Command, " ")
+	if !noTrunc {
+		if len(command) > 17 {
+			return command[0:17] + "..."
+		}
+	}
+	return command
 }
 
 // Size returns the rootfs and virtual sizes in human duration in

--- a/test/e2e/ps_test.go
+++ b/test/e2e/ps_test.go
@@ -466,4 +466,15 @@ var _ = Describe("Podman ps", func() {
 		Expect(ps.ExitCode()).To(Equal(0))
 		Expect(ps.OutputToString()).To(ContainSubstring("0.0.0.0:8080->80/tcp"))
 	})
+
+	It("podman ps truncate long create commad", func() {
+		session := podmanTest.Podman([]string{"run", ALPINE, "echo", "very", "long", "create", "command"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.ExitCode()).To(Equal(0))
+
+		session = podmanTest.Podman([]string{"ps", "-a"})
+		session.WaitWithDefaultTimeout()
+		Expect(session.OutputToString()).To(ContainSubstring("echo very long cr..."))
+	})
+
 })


### PR DESCRIPTION
With a long create command the output from ps is basically unreadable.

This is a regression that was introduced with Podman 2.0.

Signed-off-by: Paul Holzinger <paul.holzinger@web.de>