### PR TITLE
auto-update: clarify systemd-unit requirements

### DIFF
--- a/cmd/podman/auto-update.go
+++ b/cmd/podman/auto-update.go
@@ -16,6 +16,8 @@ var (
 	autoUpdateDescription = `Auto update containers according to their auto-update policy.
 
   Auto-update policies are specified with the "io.containers.autoupdate" label.
+  Containers are expected to run in systemd units created with "podman-generate-systemd --new",
+  or similar units that create new containers in order to run the updated images.
   Note that this command is experimental. Please refer to the podman-auto-update(1) man page for details.`
 	autoUpdateCommand = &cobra.Command{
 		Use:   "auto-update [flags]",

--- a/docs/source/markdown/podman-auto-update.1.md
+++ b/docs/source/markdown/podman-auto-update.1.md
@@ -23,6 +23,9 @@ Note that `podman auto-update` relies on systemd and requires a fully-qualified 
 This enforcement is necessary to know which image to actually check and pull.
 If an image ID was used, Podman would not know which image to check/pull anymore.
 
+Moreover, the systemd units are expected to be generated with `podman-generate-systemd --new`, or similar units that create new containers in order to run the updated images.
+Systemd units that start and stop a container cannot run a new image.
+
 ## OPTIONS
 
 **--authfile**=*path*


### PR DESCRIPTION
Clarify in the help message and the man page that auto updates only work
with systemd units that are similar to the ones from `generate systemd
--new`.  Units that merely start/stop a container do not work as they
will use the same image.

Fixes: #6793
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>