### PR TITLE
Fix bug where `podman mount` didn't error as rootless

### DIFF
--- a/cmd/podman/containers/mount.go
+++ b/cmd/podman/containers/mount.go
@@ -30,13 +30,18 @@ var (
 		Args: func(cmd *cobra.Command, args []string) error {
 			return validate.CheckAllLatestAndCIDFile(cmd, args, true, false)
 		},
+		Annotations: map[string]string{
+			registry.ParentNSRequired: "",
+		},
 	}
 
 	containerMountCommmand = &cobra.Command{
-		Use:   mountCommand.Use,
-		Short: mountCommand.Short,
-		Long:  mountCommand.Long,
-		RunE:  mountCommand.RunE,
+		Use:         mountCommand.Use,
+		Short:       mountCommand.Short,
+		Long:        mountCommand.Long,
+		RunE:        mountCommand.RunE,
+		Args:        mountCommand.Args,
+		Annotations: mountCommand.Annotations,
 	}
 )
 

--- a/test/e2e/mount_test.go
+++ b/test/e2e/mount_test.go
@@ -18,6 +18,7 @@ var _ = Describe("Podman mount", func() {
 	)
 
 	BeforeEach(func() {
+		SkipIfRootless()
 		tempdir, err = CreateTempDirInTempDir()
 		if err != nil {
 			os.Exit(1)


### PR DESCRIPTION
We require that rootless `podman mount` be run inside a shell spawned by `podman unshare` (which gives us a mount namespace which actually lets other commands use the mounted filesystem).

The fix is simple - we need to mark the command as requiring the rootless user namespace not be configured, so we can test for it later as part of the mount code and error if we needed to make one.

Fixes #6856