### PR TITLE
Pids-limit should only be set if the user set it

### DIFF
--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -329,8 +329,7 @@ func GetCreateFlags(cf *ContainerCLIOpts) *pflag.FlagSet {
 		"pid", "",
 		"PID namespace to use",
 	)
-	createFlags.Int64Var(
-		&cf.PIDsLimit,
+	createFlags.Int64(
 		"pids-limit", containerConfig.PidsLimit(),
 		"Tune container pids limit (set 0 for unlimited, -1 for server defaults)",
 	)

--- a/cmd/podman/common/create_opts.go
+++ b/cmd/podman/common/create_opts.go
@@ -66,7 +66,7 @@ type ContainerCLIOpts struct {
 	OverrideArch      string
 	OverrideOS        string
 	PID               string
-	PIDsLimit         int64
+	PIDsLimit         *int64
 	Pod               string
 	PodIDFile         string
 	Privileged        bool

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/containers/common/pkg/config"
@@ -194,12 +195,17 @@ func createInit(c *cobra.Command) error {
 	cliVals.UTS = c.Flag("uts").Value.String()
 	cliVals.PID = c.Flag("pid").Value.String()
 	cliVals.CGroupsNS = c.Flag("cgroupns").Value.String()
-	if !c.Flag("pids-limit").Changed {
-		cliVals.PIDsLimit = -1
-	}
 	if c.Flag("entrypoint").Changed {
 		val := c.Flag("entrypoint").Value.String()
 		cliVals.Entrypoint = &val
+	}
+	if c.Flags().Changed("pids-limit") {
+		val := c.Flag("pids-limit").Value.String()
+		pidsLimit, err := strconv.ParseInt(val, 0, 10)
+		if err != nil {
+			return err
+		}
+		cliVals.PIDsLimit = &pidsLimit
 	}
 	if c.Flags().Changed("env") {
 		env, err := c.Flags().GetStringArray("env")


### PR DESCRIPTION
Currently we are sending over pids-limits from the user even if they
never modified the defaults.  The pids limit should be set at the server
side unless modified by the user.

This issue has led to failures on systems that were running with cgroups V1.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>