### PR TITLE
Add support for Filter query parameter to list images api

### DIFF
--- a/pkg/api/handlers/utils/images.go
+++ b/pkg/api/handlers/utils/images.go
@@ -60,6 +60,7 @@ func GetImages(w http.ResponseWriter, r *http.Request) ([]*image.Image, error) {
 		All     bool
 		Filters map[string][]string `schema:"filters"`
 		Digests bool
+		Filter  string // Docker 1.24 compatibility
 	}{
 		// This is where you can override the golang default value for one of fields
 	}
@@ -76,8 +77,16 @@ func GetImages(w http.ResponseWriter, r *http.Request) ([]*image.Image, error) {
 		err    error
 	)
 
-	if len(query.Filters) > 0 {
-		for k, v := range query.Filters {
+	queryFilters := query.Filters
+	if !IsLibpodRequest(r) && len(query.Filter) > 0 { // Docker 1.24 compatibility
+		if queryFilters == nil {
+			queryFilters = make(map[string][]string)
+		}
+		queryFilters["reference"] = append(queryFilters["reference"], query.Filter)
+	}
+
+	if len(queryFilters) > 0 {
+		for k, v := range queryFilters {
 			filters = append(filters, fmt.Sprintf("%s=%s", k, strings.Join(v, "=")))
 		}
 		images, err = runtime.ImageRuntime().GetImagesWithFilters(filters)

--- a/test/apiv2/10-images.at
+++ b/test/apiv2/10-images.at
@@ -26,6 +26,14 @@ t GET libpod/images/${iid:0:12}/json 200 \
   .Id=$iid \
   .RepoTags[0]=$IMAGE
 
+# Docker API V1.24 filter parameter compatibility
+t GET images/json?filter=$IMAGE 200 \
+  length=1 \
+  .[0].Names[0]=$IMAGE
+
+# Negative test case
+t GET images/json?filter=nonesuch 200 length=0
+
 # FIXME: docker API incompatibility: libpod returns 'id', docker 'sha256:id'
 t GET images/$iid/json 200 \
   .Id=sha256:$iid \


### PR DESCRIPTION
Docker api version 1.24 uses a query parameter named Filter for filtering images by names. In more recent versions of api name filter is in filters query parameter with other filters

This patch adds a mapping that translates Filter query parameter to Filters={"reference": [""]}

Patch resolves issue: #6797